### PR TITLE
Vexflow cleanup

### DIFF
--- a/music21/vexflow/indent.py
+++ b/music21/vexflow/indent.py
@@ -1,0 +1,19 @@
+def indent(text, prefix, predicate=None):
+    """Adds 'prefix' to the beginning of selected lines in 'text'.
+
+    If 'predicate' is provided, 'prefix' will only be added to the lines
+    where 'predicate(line)' is True. If 'predicate' is not provided,
+    it will default to adding 'prefix' to all non-empty lines that do not
+    consist solely of whitespace characters.
+
+    Backported from python 3.3 textwrap library
+    """
+    if predicate is None:
+        def predicate(line):
+            return line.strip()
+
+    def prefixed_lines():
+        for line in text.splitlines(True):
+            yield (prefix + line if predicate(line) else line)
+    return ''.join(prefixed_lines())
+


### PR DESCRIPTION
replacing some of the "".join([...]) with "".format(...)
Using a template library like "mako" would probably allow cleaner code generation,
but it would add an extra dependency to an external library, which I didn't want to do now.
