### PR TITLE
Use proper exception for ISO-8859-1 fallback

### DIFF
--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -191,7 +191,7 @@ class ArchiveManager(object):
                     else:
                         try:
                             post.append(''.join([l.decode(encoding='UTF-8') for l in lines]))
-                        except:
+                        except UnicodeDecodeError:
                             # python3 UTF-8 fails to read corpus/haydn/opus103/movement1.zip
                             post.append(''.join([l.decode(encoding='ISO-8859-1') for l in lines]))
 


### PR DESCRIPTION
Don't know if you want to bother with this as a separate patch, but if you do, here it is.  :)
