### PR TITLE
Adjust duration fields for stage1 musedata

### DIFF
--- a/music21/musedata/__init__.py
+++ b/music21/musedata/__init__.py
@@ -285,19 +285,10 @@ class MuseDataRecord(object):
         1.0
         '''
         if self.stage == 1:
-            divisions = int(self.src[5:7])
+            divisions = int(self.src[4:7])
         else:
             divisions = int(self.src[5:8])
 
-        shouldBeBlank = self.src[4:5]
-        if shouldBeBlank != ' ':
-            try:
-                divHundreds = int(shouldBeBlank)
-                divisions += 100 * divHundreds
-                print("Error in parsing: " + self.src + "\n   Column 5 must be blank. Parsing as a part of the divisions")
-            except ValueError:
-                raise MuseDataException("Error in parsing: " + self.src + "\n   Column 5 must be blank.")
-        
         # the parent is the measure, and the parent of that is the part
         if self.parent != None:
             dpq = self.parent.parent.getDivisionsPerQuarterNote()


### PR DESCRIPTION
According to craigsapp in
https://github.com/cuthbertLab/music21/issues/69
"""
Walter happened to be in just now, and I checked with him. All of
the Haydn string quartets are in the "Stage 1" MuseData format.
Stage 1 is functionally equivalent to MIDI files. Stage 1 is the
format into which data entry is entered via real-time performance
(such as Finale HyperScribe). The Stage 1 files are then typically
converted into Stage 2 MuseData files further edited for printing,
with Stage 2 files being functionally equivalent to MusicXML
files.

The confusion is that the duration field in Stage 2 files is in
columns 6-9 (indexed from 1), while in Stage 1 files duration is
stored in columns 5-8 (also indexed from 1). So in Stage 1 files,
"rest168" is correct, but it would be "rest 168" in Stage 2 files.
The main reason for this shift is to accommodate cue-sized rests
in Stage 2 files, which are indicated by the tag "crest" (which
takes up columns 1-5). Stage 1 files were not updated for "crest"
since it is only intended for MIDI-level data entry (which has no
need of cue-sized rests).

In other words, the example code should probably be (as Myke has
done):

if self.stage == 1:
    divisions = int(self.src[4:7])
else:
    divisions = int(self.src[5:8])
"""

This patch adjusts the musedata import to match the "example code"
mentioned by Craig.
