### PR TITLE
Fix Lilypond detection

### DIFF
--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -182,19 +182,20 @@ class LilypondConverter(object):
 
     def setupTools(self):
         LILYEXEC = self.findLilyExec()
-        command = LILYEXEC + ' --version'
-        proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
-        versionString = proc.stdout.readline()
-        if six.PY3:
-            versionString = versionString.decode(encoding='utf-8')     
+        command = [LILYEXEC, '--version']
         try:
-            versionString = versionString.split()[-1]
-            versionString = versionString.strip()
-            versionPieces = versionString.split('.')
-        except KeyboardInterrupt:
+            proc = subprocess.Popen(command, stdout=subprocess.PIPE)
+        except OSError:
             raise LilyTranslateException("Cannot find a copy of Lilypond installed on your system. " +
                                          "Please be sure it is installed. And that your " +
                                          "environment.UserSettings()['lilypondPath'] is set to find it.")
+        stdout, _ = proc.communicate()
+        if six.PY3:
+            stdout = stdout.decode(encoding='utf-8')
+        versionString = stdout.split('\n')[0]
+        versionString = versionString.split()[-1]
+        versionString = versionString.strip()
+        versionPieces = versionString.split('.')
         
         self.majorVersion = versionPieces[0]
         self.minorVersion = versionPieces[1]

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -192,9 +192,7 @@ class LilypondConverter(object):
         stdout, _ = proc.communicate()
         if six.PY3:
             stdout = stdout.decode(encoding='utf-8')
-        versionString = stdout.split('\n')[0]
-        versionString = versionString.split()[-1]
-        versionString = versionString.strip()
+        versionString = stdout.split()[2]
         versionPieces = versionString.split('.')
         
         self.majorVersion = versionPieces[0]


### PR DESCRIPTION
I just stumbled upon `music21`, tried to run some examples from the documentation and got a weird error with no obvious error message. After some debugging it turned out that this was due to Lilypond not being installed on my system, but the missing Lilypond executable was not detected correctly.

Currently the logic in `music21/lily/translate.py` (line 194) assumes that a `KeyboardInterrupt` is thrown if Lilypond is not installed, but I don't see how this would ever be triggered by trying to split the version string (which is what happens in the `try...` block in line 190ff).

This PR implements a cleaner way. By avoiding to use `shell=True` in the call to `subprocess.Popen` an `OSError` is triggered if Lilypond is not found, which can be caught directly.