### PR TITLE
Add Interval.__str__() for more convenient pretty-printing of intervals

### DIFF
--- a/music21/interval.py
+++ b/music21/interval.py
@@ -1738,13 +1738,16 @@ class Interval(base.Music21Object):
             self.isStep = self.isChromaticStep or self.isDiatonicStep
 
     def __repr__(self):
+        return "<music21.interval.Interval {}>".format(self.__str__())
+
+    def __str__(self):
         from music21 import pitch
         shift = self._diatonicIntervalCentShift()
         if shift != 0:
             micro = pitch.Microtone(shift)
-            return "<music21.interval.Interval %s %s>" % (self.directedName, micro)
+            return "%s %s" % (self.directedName, micro)
         else:
-            return "<music21.interval.Interval %s>" % self.directedName
+            return "%s" % self.directedName
 
     def isConsonant(self):
         '''


### PR DESCRIPTION
Currently when printing intervals in a human-readable, concise form you have to write something like `print(interval.directedName)`, which is not very intuitive and a bit hard to discover.

This PR implements the `__str__()` method so that intervals can be easily printed via `print(interval)`. The default representation `<music21.interval.Interval ...>` is not changed. Example output:

```python
>>> from music21 import *
>>> note1 = note.Note('C3')
>>> note2 = note.Note('G3')
>>> interval = interval.Interval(note1, note2)
>>> interval
<music21.interval.Interval P5>
>>>print(interval)
P5
