### PR TITLE
Fixed: installer.command updated to work on OS X

### DIFF
--- a/installer.command
+++ b/installer.command
@@ -3,7 +3,7 @@
 # this is a launcher for users of osx; double click to use
 
 # change to the current directory
-DIRFILE = $(dirname "$0")
+DIRFILE=$(dirname "$0")
 eval cd $DIRFILE
 python installer.py
 


### PR DESCRIPTION
Previously the installer command file was malformed and did not work on OSX (it complained of file not found). This was because the shell interpreted DIRFILE as a command, not a variable.

This commit fixes this by removing spaces around the DIRFILE variable assignment.