### PR TITLE
Distribute .mei and .nwc files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-global-include *.py *.txt *.xml *.krn *.mxl *.pdf *.html *.css *.js *.png *.tiff *.jpg *.xls *.mid *.abc *.json *.md *.zip *.rntxt *.command *.scl *.nwctxt *.wav 
+global-include *.py *.txt *.xml *.krn *.mxl *.pdf *.html *.css *.js *.png *.tiff *.jpg *.xls *.mid *.abc *.json *.md *.zip *.rntxt *.command *.scl *nwc *.nwctxt *.wav *.mei
 prune dist
 prune buildDoc
 prune obsolete


### PR DESCRIPTION
The tests were failing when run from the installed package,
because those files were missing:

```
======================================================================
ERROR: testImportMei3 (converter.subConverters.Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "music21/converter/subConverters.py", line 1096, in testImportMei3
    testConverter.parseFile(testPath)
  File "music21/converter/subConverters.py", line 988, in parseFile
    with open(filePath) as f:
IOError: [Errno 2] No such file or directory: music21/mei/test/notes_in_utf16.mei

======================================================================
ERROR: testImportMei4 (converter.subConverters.Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "music21/converter/subConverters.py", line 1118, in testImportMei4
    testConverter.parseFile(testPath)
  File "music21/converter/subConverters.py", line 988, in parseFile
    with open(filePath) as f:
IOError: [Errno 2] No such file or directory: music21/mei/test/notes_in_utf8.mei

======================================================================
FAIL: parseFile (noteworthy.binaryTranslate.NWCConverter)
Doctest: noteworthy.binaryTranslate.NWCConverter.parseFile
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/python2.7/doctest.py", line 2226, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for noteworthy.binaryTranslate.NWCConverter.parseFile
  File "music21/noteworthy/binaryTranslate.py", line 146, in parseFile

----------------------------------------------------------------------
File "music21/noteworthy/binaryTranslate.py", line 155, in noteworthy.binaryTranslate.NWCConverter.parseFile
Failed example:
    streamObj = nwcc.parseFile()
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest noteworthy.binaryTranslate.NWCConverter.parseFile[4]>", line 1, in <module>
        streamObj = nwcc.parseFile()
      File "music21/noteworthy/binaryTranslate.py", line 165, in parseFile
        with open(fp, rb) as f:
    IOError: [Errno 2] No such file or directory: music21/noteworthy/cuthbert_test1.nwc
```