### PR TITLE
Fixed LilyPond colors

### DIFF
--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -89,10 +89,10 @@ class LilypondConverter(object):
     colorDef = \
     r'''
     color = #(define-music-function (parser location color) (string?) #{
-        \once \override NoteHead #'color = #(x11-color $color)
-        \once \override Stem #'color = #(x11-color $color)
-        \once \override Rest #'color = #(x11-color $color)
-        \once \override Beam #'color = #(x11-color $color)
+        \once \override NoteHead #'color = #(x11-color color)
+        \once \override Stem #'color = #(x11-color color)
+        \once \override Rest #'color = #(x11-color color)
+        \once \override Beam #'color = #(x11-color color)
      #})
     '''.lstrip()
     simplePaperDefinitionScm  = r'''
@@ -237,10 +237,10 @@ class LilypondConverter(object):
         \version "2..."
         \include "lilypond-book-preamble.ly"
         color = #(define-music-function (parser location color) (string?) #{
-                \once \override NoteHead #'color = #(x11-color $color)
-                \once \override Stem #'color = #(x11-color $color)
-                \once \override Rest #'color = #(x11-color $color)
-                \once \override Beam #'color = #(x11-color $color)
+                \once \override NoteHead #'color = #(x11-color color)
+                \once \override Stem #'color = #(x11-color color)
+                \once \override Rest #'color = #(x11-color color)
+                \once \override Beam #'color = #(x11-color color)
              #})
         \header { }
         \score  {


### PR DESCRIPTION
Hi, I noticed that the LilyPond output doesn't actually display colors in the `note.editorial.color` property. In fact, there were some errors on the current version, e.g.:

    >>> import music21.note
    >>> n = music21.note.Note('G')
    >>> n.editorial.color = 'red'
    >>> n.show('lily')
    GNU LilyPond 2.18.2
    Changing working directory to: `.../music21'
    Processing `.../music21/tmpyxX2wAly'
    Parsing...
    .../music21/tmpyxX2wAly:5:45: error: GUILE signaled an error for the expression beginning here
            \once \override NoteHead #'color = #
                                                (x11-color $color)
    ... (similar errors)

It still displays the note, but it is black. I'm not familiar with Scheme myself, but I changed the lines such as:

    \once \override NoteHead #'color = #(x11-color $color)

to use `color` instead of `$color` in the LilyPond output, and that seems to fix the errors and generate correct output.