### PR TITLE
Changed normalization in MelodicIntervalHistogramFeature histogram should sum to 1

### DIFF
--- a/music21/features/jSymbolic.py
+++ b/music21/features/jSymbolic.py
@@ -72,7 +72,7 @@ class MelodicIntervalHistogramFeature(featuresModule.FeatureExtractor):
     >>> fe = features.jSymbolic.MelodicIntervalHistogramFeature(s)
     >>> f = fe.extract()
     >>> f.vector[0:5]
-    [0.39..., 0.60..., 1.0,     0.17..., 0.13...]
+    [0.14..., 0.22..., 0.36..., 0.06..., 0.05...]
     '''
     id = 'M1'
     def __init__(self, dataOrStream=None, *arguments, **keywords):
@@ -82,14 +82,15 @@ class MelodicIntervalHistogramFeature(featuresModule.FeatureExtractor):
         self.description = 'A features array with bins corresponding to the values of the melodic interval histogram.'
         self.isSequential = True
         self.dimensions = 128
-        self.normalize = True
+        self.normalize = False
 
     def _process(self):
         '''Do processing necessary, storing result in _feature.
         '''
         histo = self.data['midiIntervalHistogram']
+        histo_sum = float(sum(histo))
         for i, value in enumerate(histo):
-            self._feature.vector[i] += value
+            self._feature.vector[i] += value/histo_sum
  
 
 class AverageMelodicIntervalFeature(featuresModule.FeatureExtractor):


### PR DESCRIPTION
In `features.jSymbolic.MelodicIntervalHistogramFeature` normalization was done the wrong way. Before it was done in such a way, that the maximum histogram-bin always was equal to one. Now it is done in such a way, that the sum of all histogram-bins is equal to one.

Relevant passage from the jMIR thesis:

> The histogram is then normalized, so that the magnitude of each bin indicates the fraction of all melodic intervals that correspond to the melodic interval of the given bin.

Cory McKay: *Automatic Music Classification with jMIR*, PhD 2010, p. 227, [PDF](http://www.music.mcgill.ca/~cmckay/papers/musictech/mckay10dissertation.pdf).