### PR TITLE
make documentation build on windows

### DIFF
--- a/music21/documentation/library/writers.py
+++ b/music21/documentation/library/writers.py
@@ -311,7 +311,7 @@ class IPythonNotebookReSTWriter(ReSTWriter):
                 return False
 
         self.runNBConvert(ipythonNotebookFilePath)
-        with open(rstFilePath, 'r') as f:
+        with open(rstFilePath, 'r', encoding='utf8') as f:
             oldLines = f.read().splitlines()
         lines = self.cleanConvertedNotebook(oldLines, ipythonNotebookFilePath)
         with open(rstFilePath, 'w') as f:


### PR DESCRIPTION
this is supposed to fix the following error when trying to build the documentation on windows.

```
[NbConvertApp] Writing 20437 bytes to c:\users\bagratte\source\repos\music21\music21\documentation\autogenerated\usersGuide\usersGuide_02_notes.rst
Traceback (most recent call last):
  File "make.py", line 141, in <module>
    main(runMode)
  File "make.py", line 88, in main
    documentation.IPythonNotebookReSTWriter().run()
  File "c:\users\bagratte\source\repos\music21\music21\documentation\library\writers.py", line 235, in run
    nbConvertReturnCode = self.convertOneNotebook(ipythonNotebookFilePath)
  File "c:\users\bagratte\source\repos\music21\music21\documentation\library\writers.py", line 315, in convertOneNotebook
    oldLines = f.read().splitlines()
  File "C:\Program Files\Python 3.5\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 538: character maps to <undefined>