### PR TITLE
guess best enharmonic name for notes in chords

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -3330,6 +3330,7 @@ class Chord(note.NotRest):
         (<music21.pitch.Pitch C#>, <music21.pitch.Pitch F>, <music21.pitch.Pitch G#>)
 
         >>> c.simplifyEnharmonics(inPlace=True)
+        <music21.chord.Chord C# E# G#>
         >>> c.pitches
         (<music21.pitch.Pitch C#>, <music21.pitch.Pitch E#>, <music21.pitch.Pitch G#>)
         '''

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -243,12 +243,17 @@ class Chord(note.NotRest):
                     self.duration = n.duration
                     del keywords['duration']
                     quickDuration = False
-            elif isinstance(n, six.string_types) or isinstance(n, int):
+            elif isinstance(n, six.string_types):
                 if 'duration' in keywords:
                     self._notes.append(note.Note(n, duration=keywords['duration']))
                 else:
                     self._notes.append(note.Note(n))
                 #self._notes.append({'pitch':music21.pitch.Pitch(n)})
+            elif isinstance(n, int):
+                if 'duration' in keywords:
+                    self._notes.append(note.Note(n, duration=keywords['duration'], context=self._notes))
+                else:
+                    self._notes.append(note.Note(n), context=self._notes)
             else:
                 raise ChordException("Could not process input argument %s" % n)
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -3333,19 +3333,15 @@ class Chord(note.NotRest):
         >>> c.pitches
         (<music21.pitch.Pitch C#>, <music21.pitch.Pitch E#>, <music21.pitch.Pitch G#>)
         '''
-        newPitches = pitch.simplifyMultipleEnharmonics(self.pitches, criterion='maximizeConsonance', key=None)
         if inPlace:
-            changes = 0
-            for i, newPitch in enumerate(newPitches):
-                if newPitch != self._notes[i].pitch:
-                    self._notes[i].pitch = newPitch
-                    changes += 1
-            if changes > 0:
-                self._chordTablesAddressNeedsUpdating = True
-                self._bass = None
-                self._root = None
+            returnObj = self
         else:
-            return Chord(newPitches)
+            returnObj = copy.deepcopy(self)
+
+        pitches = pitch.simplifyMultipleEnharmonics(self.pitches, criterion='maximizeConsonance', keyContext=None)
+        returnObj.pitches = pitches
+
+        return returnObj
 
     def sortAscending(self, inPlace=False):
         return self.sortDiatonicAscending(inPlace=inPlace)

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -347,12 +347,17 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyCont
 
     >>> pitch.simplifyMultipleEnharmonics([11, 3, 6])
     [<music21.pitch.Pitch B>, <music21.pitch.Pitch D#>, <music21.pitch.Pitch F#>]
-
     >>> pitch.simplifyMultipleEnharmonics([pitch.Pitch('G3'), pitch.Pitch('C-4'), pitch.Pitch('D4')])
     [<music21.pitch.Pitch G3>, <music21.pitch.Pitch B3>, <music21.pitch.Pitch D4>]
-
     >>> pitch.simplifyMultipleEnharmonics([pitch.Pitch('A3'), pitch.Pitch('B#3'), pitch.Pitch('E4')])
     [<music21.pitch.Pitch A3>, <music21.pitch.Pitch C4>, <music21.pitch.Pitch E4>] 
+
+    The attribute `keyContext` is for supplying a KeySignature or a Key which is used in the simplification:
+
+    >>> pitch.simplifyMultipleEnharmonics([6, 10, 1], keyContext=key.Key('B'))
+    [<music21.pitch.Pitch F#>, <music21.pitch.Pitch A#>, <music21.pitch.Pitch C#>]
+    >>> pitch.simplifyMultipleEnharmonics([6, 10, 1], keyContext=key.Key('C-'))
+    [<music21.pitch.Pitch G->, <music21.pitch.Pitch B->, <music21.pitch.Pitch D->]
     '''
 
     oldPitches = [p if isinstance(p, Pitch) else Pitch(p) for p in pitches]

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -338,7 +338,7 @@ def _convertHarmonicToCents(value):
     return int(round(1200*math.log(value, 2), 0))
 
 
-def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', key=None):
+def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyContext=None):
     r'''Tries to simplify the enharmonic spelling of a list of pitches, pitch-
     or pitch-class numbers according to a given criterion. 
 
@@ -355,18 +355,13 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', key=Non
     [<music21.pitch.Pitch A3>, <music21.pitch.Pitch C4>, <music21.pitch.Pitch E4>] 
     '''
 
-    from music21 import key as keyModule
-
     oldPitches = [p if isinstance(p, Pitch) else Pitch(p) for p in pitches]
     simplifiedPitches = []
 
     if criterion == 'maximizeConsonance':
 
-        if isinstance(key, keyModule.KeySignature):
-            simplifiedPitches.append(key.pitchAndMode[0])
-            remove_first = True
-        elif isinstance(key, keyModule.Key):
-            simplifiedPitches.append(key.tonic)
+        if keyContext:
+            simplifiedPitches.append(keyContext.pitchAndMode[0])
             remove_first = True
         else:
             remove_first = False
@@ -380,7 +375,10 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', key=Non
                     if interval_candidate.isConsonant():
                         consonant_counter[j] += 1
 
-            simplifiedPitches.append(sorted(zip(consonant_counter, candidates), key=lambda x: x[0], reverse=True)[0][1])
+            # order the candidates by their consonant count
+            candidates_by_consonants = sorted(zip(consonant_counter, candidates), key=lambda x: x[0], reverse=True)
+            # append the candidate with the maximum consonant count
+            simplifiedPitches.append(candidates_by_consonants[0][1])
 
         if remove_first:
             simplifiedPitches = simplifiedPitches[1:]


### PR DESCRIPTION
I fixed an issue that bothered me. I am not sure if it is solved in the best way, but maybe this could find its way into music21 somehow?

The issue is the following: If I give a chord only pitch classes or midi names, it could take it in a very a-musical way. Here is an example where a B/C- major triad is totally mistaken:

    >>> from music21 import *
    >>> c = chord.Chord([11,3,6])
    >>> c.pitches
    (<music21.pitch.Pitch B>, <music21.pitch.Pitch E->, <music21.pitch.Pitch F#>)
    >>> c.pitchedCommonName
    'E--major triad'

I fixed it, by giving the Pitch a 'context'-keyword. This keyword gets a list of pitches and it is used for finding the best name for a pitch by maximizing the consonant intervals of the pitch with its context:

    >>> c = chord.Chord([11,3,6])
    >>> c.pitches
    (<music21.pitch.Pitch B>, <music21.pitch.Pitch D#>, <music21.pitch.Pitch F#>)
    >>> c.pitchedCommonName
    'B-major triad'

Feedback appreciated!