### PR TITLE
custom consonance function for simplifyMultipleEnharmonics

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -1394,10 +1394,10 @@ class Chord(note.NotRest):
         '''Return a Z relation if it exists, otherwise return None.
 
         >>> chord.fromIntervalVector((1,1,1,1,1,1))
-        <music21.chord.Chord C C# E F#>
+         <music21.chord.Chord C D- F- G->
 
         >>> chord.fromIntervalVector((1,1,1,1,1,1)).getZRelation()
-        <music21.chord.Chord C C# E- G>
+        <music21.chord.Chord C D- E- G>
 
 
         >>> chord.Chord('C E G').getZRelation() is None
@@ -4399,7 +4399,7 @@ def fromForteClass(notation):
     <music21.chord.Chord C E- G>
 
     >>> chord.fromForteClass((11,1))
-    <music21.chord.Chord C C# D E- E F F# G G# A B->
+    <music21.chord.Chord C D- D E- E F G- G A- A B->
 
     '''
     card = None
@@ -4446,13 +4446,13 @@ def fromIntervalVector(notation, getZRelation=False):
     True
 
     >>> chord.fromIntervalVector((1,1,1,1,1,1))
-    <music21.chord.Chord C C# E F#>
+    <music21.chord.Chord C D- F- G->
 
     >>> chord.fromIntervalVector((1,1,1,1,1,1), getZRelation=True)
-    <music21.chord.Chord C C# E- G>
+    <music21.chord.Chord C D- E- G>
 
     >>> chord.fromIntervalVector((1,1,1,1,1,1)).getZRelation()
-    <music21.chord.Chord C C# E- G>
+    <music21.chord.Chord C D- E- G>
 
     '''
     addressList = None

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -1394,7 +1394,7 @@ class Chord(note.NotRest):
         '''Return a Z relation if it exists, otherwise return None.
 
         >>> chord.fromIntervalVector((1,1,1,1,1,1))
-         <music21.chord.Chord C D- F- G->
+        <music21.chord.Chord C D- F- G->
 
         >>> chord.fromIntervalVector((1,1,1,1,1,1)).getZRelation()
         <music21.chord.Chord C D- E- G>
@@ -4905,7 +4905,7 @@ class Test(unittest.TestCase):
     def testPostTonalChordsB(self):
         c1 = Chord([1, 4, 7, 10])
         self.assertEqual(c1.commonName, 'diminished seventh chord')
-        self.assertEqual(c1.pitchedCommonName, 'C#-diminished seventh chord')
+        self.assertEqual(c1.pitchedCommonName, 'A#-diminished seventh chord')
 
     def testScaleDegreesA(self):
         from music21 import key

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -27,7 +27,7 @@ from music21 import base
 from music21 import common 
 from music21 import exceptions21
 
-from music21 import pitch # SHOULD NOT, b/c of enharmonics
+#from music21 import pitch # SHOULD NOT, b/c of enharmonics
 
 from music21 import environment
 _MOD = "interval.py"
@@ -445,7 +445,8 @@ def convertSemitoneToSpecifierGeneric(count):
 def intervalToPythagoreanRatio(intervalObj):
     r''' Returns the interval ratio in pythagorean tuning.
 
-    >>> [interval.intervalToPythagoreanRatio(interval.Interval(name)) for name in ['P4', 'P5', 'M7']]
+    >>> [interval.intervalToPythagoreanRatio(interval.Interval(name))
+    ... for name in ['P4', 'P5', 'M7']]
     [Fraction(4, 3), Fraction(3, 2), Fraction(243, 128)]
     '''
 
@@ -481,7 +482,8 @@ def intervalToPythagoreanRatio(intervalObj):
                 not_found_direction = False
 
     while return_direction['note'].octave != end_note.octave:
-        return_direction['note'] = return_direction['note'].transpose(return_direction['transpose_interval2'])
+        return_direction['note'] = \
+            return_direction['note'].transpose(return_direction['transpose_interval2']) 
         return_direction['ratio'] *= return_direction['transpose_ratio2']
 
     return return_direction['ratio']    

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -451,6 +451,14 @@ def intervalToPythagoreanRatio(intervalObj):
     >>> [interval.intervalToPythagoreanRatio(interval.Interval(name))
     ... for name in ['P4', 'P5', 'M7']]
     [Fraction(4, 3), Fraction(3, 2), Fraction(243, 128)]
+
+    Returns `nan` if no ratio could be found:
+
+    >>> p1, p2 = pitch.Pitch('C1'), pitch.Pitch('C1')
+    >>> p2.accidental = 'half-sharp'
+    >>> interval.intervalToPythagoreanRatio(interval.Interval(p1, p2))
+    Could not find a pythagorean ratio for <music21.interval.Interval A1 (-50c)>.
+    nan
     '''
     from music21.pitch import Pitch
 
@@ -466,21 +474,26 @@ def intervalToPythagoreanRatio(intervalObj):
         counter = 0
         not_found_flag = True
 
-        while not_found_flag:
+        # when counter == 36, it wraps back to 'C' because of
+        # music21's limiting of accidentals
+        while counter < 37:
             if end_pitch_up.name == end_pitch_wanted.name:
                 ratio = Fraction(3, 2) ** counter
                 end_pitch = end_pitch_up
-                not_found_flag = False
+                break
                 
             elif end_pitch_down.name == end_pitch_wanted.name:
                 ratio = Fraction(2, 3) ** counter
                 end_pitch = end_pitch_down
-                not_found_flag = False
+                break
 
             else:
                 end_pitch_up = end_pitch_up.transpose('P5')
                 end_pitch_down = end_pitch_down.transpose('-P5')
                 counter += 1
+        else:
+            print('Could not find a pythagorean ratio for {}.'.format(intervalObj))
+            return float('Nan')
 
         _pythagorean_cache[end_pitch_wanted.name] = end_pitch, ratio
 

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -452,13 +452,13 @@ def intervalToPythagoreanRatio(intervalObj):
     ... for name in ['P4', 'P5', 'M7']]
     [Fraction(4, 3), Fraction(3, 2), Fraction(243, 128)]
 
-    Returns `nan` if no ratio could be found:
+    Throws an exception if no ratio can be found:
 
     >>> p1, p2 = pitch.Pitch('C1'), pitch.Pitch('C1')
     >>> p2.accidental = 'half-sharp'
     >>> interval.intervalToPythagoreanRatio(interval.Interval(p1, p2))
-    Could not find a pythagorean ratio for <music21.interval.Interval A1 (-50c)>.
-    nan
+    Traceback (most recent call last):
+    IntervalException: Could not find a pythagorean ratio for <music21.interval.Interval A1 (-50c)>.
     '''
     from music21.pitch import Pitch
 
@@ -490,8 +490,8 @@ def intervalToPythagoreanRatio(intervalObj):
                 end_pitch_up = end_pitch_up.transpose('P5')
                 end_pitch_down = end_pitch_down.transpose('-P5')
         else:
-            print('Could not find a pythagorean ratio for {}.'.format(intervalObj))
-            return float('Nan')
+            raise IntervalException(
+                'Could not find a pythagorean ratio for {}.'.format(intervalObj))
 
         _pythagorean_cache[end_pitch_wanted.name] = end_pitch, ratio
 

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -471,12 +471,11 @@ def intervalToPythagoreanRatio(intervalObj):
     else:
         end_pitch_up = start_pitch
         end_pitch_down = start_pitch
-        counter = 0
         not_found_flag = True
 
         # when counter == 36, it wraps back to 'C' because of
         # music21's limiting of accidentals
-        while counter < 37:
+        for counter in range(37):
             if end_pitch_up.name == end_pitch_wanted.name:
                 ratio = Fraction(3, 2) ** counter
                 end_pitch = end_pitch_up
@@ -490,7 +489,6 @@ def intervalToPythagoreanRatio(intervalObj):
             else:
                 end_pitch_up = end_pitch_up.transpose('P5')
                 end_pitch_down = end_pitch_down.transpose('-P5')
-                counter += 1
         else:
             print('Could not find a pythagorean ratio for {}.'.format(intervalObj))
             return float('Nan')

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -448,7 +448,8 @@ _pythagorean_cache = {}
 def intervalToPythagoreanRatio(intervalObj):
     r''' Returns the interval ratio in pythagorean tuning.
 
-    >>> [interval.intervalToPythagoreanRatio(interval.Interval(name)) for name in ['P4', 'P5', 'M7']]
+    >>> [interval.intervalToPythagoreanRatio(interval.Interval(name))
+    ... for name in ['P4', 'P5', 'M7']]
     [Fraction(4, 3), Fraction(3, 2), Fraction(243, 128)]
     '''
     from music21.pitch import Pitch

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -400,7 +400,8 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyCont
 
                 for j, interval_candidate in enumerate(intervals):
                     ratio_candidate = interval.intervalToPythagoreanRatio(interval_candidate)
-                    consonant_counter[j] += 1./(ratio_candidate.numerator * ratio_candidate.denominator)
+                    consonant_counter[j] += \
+                         1./(ratio_candidate.numerator * ratio_candidate.denominator)
 
             # order the candidates by their consonant count
             candidates_by_consonants = sorted(zip(consonant_counter, 

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -346,19 +346,6 @@ def _convertHarmonicToCents(value):
         value = 1.0/(abs(value))
     return int(round(1200*math.log(value, 2), 0))
 
-def _simple_consonance_value(interval):
-    r'''Simple consonance value for an interval.
-    '''
-    simpleName = interval.simpleName
-    if simpleName in ['P1', 'P4', 'P5']:
-        return 3
-    elif simpleName in ['m3', 'M3', 'm6', 'M6']:
-        return 2
-    elif simpleName in ['m2', 'M2', 'm7', 'M7']:
-        return 1
-    else:
-        return 0
-
 def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyContext=None):
     r'''Tries to simplify the enharmonic spelling of a list of pitches, pitch-
     or pitch-class numbers according to a given criterion. 
@@ -368,6 +355,9 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyCont
 
     >>> pitch.simplifyMultipleEnharmonics([11, 3, 6])
     [<music21.pitch.Pitch B>, <music21.pitch.Pitch D#>, <music21.pitch.Pitch F#>]
+
+    >>> pitch.simplifyMultipleEnharmonics([3, 8, 0])
+    [<music21.pitch.Pitch E->, <music21.pitch.Pitch A->, <music21.pitch.Pitch C>]
     
     >>> pitch.simplifyMultipleEnharmonics([pitch.Pitch('G3'), 
     ...                                    pitch.Pitch('C-4'), 
@@ -388,8 +378,6 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyCont
     >>> pitch.simplifyMultipleEnharmonics([6, 10, 1], keyContext=key.Key('C-'))
     [<music21.pitch.Pitch G->, <music21.pitch.Pitch B->, <music21.pitch.Pitch D->]
 
-    >>> pitch.simplifyMultipleEnharmonics([3, 8, 0])
-    [<music21.pitch.Pitch E->, <music21.pitch.Pitch A->, <music21.pitch.Pitch C>]
     '''
 
     oldPitches = [p if isinstance(p, Pitch) else Pitch(p) for p in pitches]
@@ -411,7 +399,8 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyCont
                                                noteEnd=context_pitch) for candidate in candidates]
 
                 for j, interval_candidate in enumerate(intervals):
-                    consonant_counter[j] += _simple_consonance_value(interval_candidate)
+                    ratio_candidate = interval.intervalToPythagoreanRatio(interval_candidate)
+                    consonant_counter[j] += 1./(ratio_candidate.numerator * ratio_candidate.denominator)
 
             # order the candidates by their consonant count
             candidates_by_consonants = sorted(zip(consonant_counter, 

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -346,6 +346,18 @@ def _convertHarmonicToCents(value):
         value = 1.0/(abs(value))
     return int(round(1200*math.log(value, 2), 0))
 
+def _simple_consonance_value(interval):
+    r'''Simple consonance value for an interval.
+    '''
+    simpleName = interval.simpleName
+    if simpleName in ['P1', 'P4', 'P5']:
+        return 3
+    elif simpleName in ['m3', 'M3', 'm6', 'M6']:
+        return 2
+    elif simpleName in ['m2', 'M2', 'm7', 'M7']:
+        return 1
+    else:
+        return 0
 
 def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyContext=None):
     r'''Tries to simplify the enharmonic spelling of a list of pitches, pitch-
@@ -375,6 +387,9 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyCont
     
     >>> pitch.simplifyMultipleEnharmonics([6, 10, 1], keyContext=key.Key('C-'))
     [<music21.pitch.Pitch G->, <music21.pitch.Pitch B->, <music21.pitch.Pitch D->]
+
+    >>> pitch.simplifyMultipleEnharmonics([3, 8, 0])
+    [<music21.pitch.Pitch E->, <music21.pitch.Pitch A->, <music21.pitch.Pitch C>]
     '''
 
     oldPitches = [p if isinstance(p, Pitch) else Pitch(p) for p in pitches]
@@ -394,9 +409,9 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyCont
             for context_pitch in simplifiedPitches[::-1]:
                 intervals = [interval.Interval(noteStart=candidate, 
                                                noteEnd=context_pitch) for candidate in candidates]
+
                 for j, interval_candidate in enumerate(intervals):
-                    if interval_candidate.isConsonant():
-                        consonant_counter[j] += 1
+                    consonant_counter[j] += _simple_consonance_value(interval_candidate)
 
             # order the candidates by their consonant count
             candidates_by_consonants = sorted(zip(consonant_counter, 

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -351,7 +351,9 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyCont
     or pitch-class numbers according to a given criterion. 
 
     Currently `maximizeConsonance` is the only criterion, that tries to
-    maximize the consonances in a greedy left-to-right fashion.
+    maximize the consonances in a greedy left-to-right fashion. The dissonance
+    of an interval is quantified by the product of numerator and denominator of its
+    pythagorean ratio (see :func:`~music21.interval.intervalToPythagoreanRatio`).
 
     >>> pitch.simplifyMultipleEnharmonics([11, 3, 6])
     [<music21.pitch.Pitch B>, <music21.pitch.Pitch D#>, <music21.pitch.Pitch F#>]
@@ -400,8 +402,9 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyCont
 
                 for j, interval_candidate in enumerate(intervals):
                     ratio_candidate = interval.intervalToPythagoreanRatio(interval_candidate)
-                    consonant_counter[j] += \
-                         1./(ratio_candidate.numerator * ratio_candidate.denominator)
+                    if ratio_candidate is not float('nan'):
+                        consonant_counter[j] += \
+                            1./(ratio_candidate.numerator * ratio_candidate.denominator)
 
             # order the candidates by their consonant count
             candidates_by_consonants = sorted(zip(consonant_counter, 

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -401,10 +401,12 @@ def simplifyMultipleEnharmonics(pitches, criterion='maximizeConsonance', keyCont
                                                noteEnd=context_pitch) for candidate in candidates]
 
                 for j, interval_candidate in enumerate(intervals):
-                    ratio_candidate = interval.intervalToPythagoreanRatio(interval_candidate)
-                    if ratio_candidate is not float('nan'):
+                    try:
+                        ratio_candidate = interval.intervalToPythagoreanRatio(interval_candidate)
                         consonant_counter[j] += \
                             1./(ratio_candidate.numerator * ratio_candidate.denominator)
+                    except IntervalException:
+                        pass
 
             # order the candidates by their consonant count
             candidates_by_consonants = sorted(zip(consonant_counter, 


### PR DESCRIPTION
I spot an undesirable behaviour in `simplifyMultipleEnharmonics`. Since it relied on `interval.isConsonant()`, e.g. it considered a perfect fourth and an augmented third equal -- both are non-consonant. So I wrote a simple custom consonance function.

Before:

    In [1]: pitch.simplifyMultipleEnharmonics([3, 8, 0])
    Out[1]: [<music21.pitch.Pitch E->, <music21.pitch.Pitch G#>, <music21.pitch.Pitch C>]

Now:

    In [1]: pitch.simplifyMultipleEnharmonics([3, 8, 0])
    [<music21.pitch.Pitch E->, <music21.pitch.Pitch A->, <music21.pitch.Pitch C>]
