### PR TITLE
Error with subito when getting scalar of dynamics

### DIFF
--- a/music21/documentation/source/usersGuide/usersGuide_04_stream1.ipynb
+++ b/music21/documentation/source/usersGuide/usersGuide_04_stream1.ipynb
@@ -173,7 +173,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But suppose you had thirty notes?  Then it'd be a pain to type \"`print noteX.step`\"\n",
+    "But suppose you had thirty notes?  Then it'd be a pain to type \"`print(noteX.step)`\"\n",
     "thirty times.  Fortunately, there's a solution: we can put each of the \n",
     "note objects into a `List` which is a built in Python object that stores multiple\n",
     "other objects (like Notes or Chords, or even things like numbers).  To create\n",

--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -271,8 +271,11 @@ class Dynamic(base.Music21Object):
         if self._volumeScalar is not None:
             return self._volumeScalar
         # use default
-        if self._value in dynamicStrToScalar:
+        elif self._value in dynamicStrToScalar:
             return dynamicStrToScalar[self._value]
+        # ignore subito
+        elif self._value[0] == 's' and self._value[1:] in dynamicStrToScalar:
+            return dynamicStrToScalar[self._value[1:]]
         return 
 
     def _setVolumeScalar(self, value):


### PR DESCRIPTION
In the case of subito dynamics I came across this little bug:

    d = dynamics.Dynamic('sfp')
    n = note.Note('C4')
    s = stream.Stream()
    s.append(d)
    s.append(n)
    n.volume # TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'

I fixed this by ignoring subito in any case. Not sure if this is the very best solution? It fixes the error anyway.

(The small fix in the documentation is unrelated.)