### PR TITLE
Give default volumeScalar to unknown dynamics

### DIFF
--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -165,7 +165,7 @@ class Dynamic(base.Music21Object):
     >>> myDyn.value
     'rfzsfmp'
     >>> print(myDyn.volumeScalar)
-    None
+    0.5
     >>> myDyn.volumeScalar = 0.87
     >>> myDyn.volumeScalar
     0.87

--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -273,10 +273,18 @@ class Dynamic(base.Music21Object):
         # use default
         elif self._value in dynamicStrToScalar:
             return dynamicStrToScalar[self._value]
-        # ignore subito
-        elif self._value[0] == 's' and self._value[1:] in dynamicStrToScalar:
-            return dynamicStrToScalar[self._value[1:]]
-        return 
+        else:
+            this_dynmaic = self._value
+            # ignore leading s like in sf
+            if 's' in this_dynmaic:
+                this_dynmaic = this_dynmaic[1:]
+            # ignore closing z like in fz
+            if this_dynmaic[-1] == 'z':
+                this_dynmaic = this_dynmaic[:-1]
+            if this_dynmaic in dynamicStrToScalar:
+                return dynamicStrToScalar[this_dynmaic]
+            else:
+                return dynamicStrToScalar[None]
 
     def _setVolumeScalar(self, value):
         # we can manually set this to be anything, overriding defaults


### PR DESCRIPTION
I made a simple fix to give the default volumeScalar to any dynamic string that is unknown. Related issue: #121. Example:

    from music21 import *
    d = dynamics.Dynamic('sfz')
    n = note.Note('C4')
    s = stream.Stream()
    s.append(d)
    s.append(n)
    n.volume

Before this returned an error, now it returns `<music21.volume.Volume realized=0.99>`.