### PR TITLE
let binary fixup tests pass...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 python:
     - "2.7"
     - "3.3"
-    - "3.4"
+    - "3.5"
 
 before_install:
     - mkdir ~/Desktop

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -928,7 +928,7 @@ class LilypondConverter(object):
         >>> lpc.context = lpMusicList
         >>> lpc.context.contents
         []
-        >>> c = converter.parse('tinynotation: 3/4 c4 d- e#')
+        >>> c = converter.parse('tinynotation: 3/4 b4 d- e#')
         >>> lpc.appendObjectsToContextFromStream(c)
         >>> print(lpc.context.contents)
         [<music21.lily.lilyObjects.LyEmbeddedScm...>, 
@@ -938,7 +938,7 @@ class LilypondConverter(object):
         >>> print(lpc.context)
         \clef "treble" 
         \time 3/4
-        c' 4
+        b' 4
         des' 4
         eis' 4
         <BLANKLINE>

--- a/music21/metadata/caching.py
+++ b/music21/metadata/caching.py
@@ -65,15 +65,15 @@ def cacheMetadata(corpusNames=('local', 'core', 'virtual'),
     # virtual is on-line
     for corpusName in corpusNames:
         if corpusName == 'core':
-            metadataBundle = corpora.CoreCorpus()
+            metadataBundle = corpora.CoreCorpus().metadataBundle
             paths = corpus.getCorePaths()
             useCorpus = True
         elif corpusName == 'local':
-            metadataBundle = corpora.LocalCorpus()
+            metadataBundle = corpora.LocalCorpus().metadataBundle
             paths = corpus.getLocalPaths()
             useCorpus = False
         elif corpusName == 'virtual':
-            metadataBundle = corpora.VirtualCorpus()
+            metadataBundle = corpora.VirtualCorpus().metadataBundle
             paths = corpus.getVirtualPaths()
             useCorpus = False
         else:

--- a/music21/musedata/base40.py
+++ b/music21/musedata/base40.py
@@ -463,6 +463,24 @@ def quickEnharmonicString(nameStr, allowDoubleAccidentals=True):
 class Base40Exception(exceptions21.Music21Exception):
     pass
     
+
+
+class BaseN(object):        
+    def __init__(self, order=2):
+        self.order = order
+
+    def generateLetters(self):
+        outLetters = []
+        for letter in ('C', 'D', 'E', 'F', 'G', 'A', 'B'):
+            for i in range(self.order, 0, -1):
+                outLetters.append(letter + '-' * i)
+            outLetters.append(letter)
+            for i in range(self.order):
+                outLetters.append(letter + '#' * (i+1))
+            if letter not in ('E', 'B'):
+                outLetters.append(None)
+        return outLetters
+
 #-------------------------------------------------------------------------------
 class Test(unittest.TestCase):
 
@@ -475,6 +493,8 @@ _DOC_ORDER = [base40ActualInterval]
 
 
 if __name__ == "__main__":
+#     bn = BaseN(3)
+#     print(bn.generateLetters())
     import music21
     music21.mainTest(Test)
 

--- a/music21/test/testRunner.py
+++ b/music21/test/testRunner.py
@@ -52,6 +52,8 @@ if six.PY2:
     naive_single_quote_re = re.compile(r"(^|.)'((\\'|[^'])*?)'")
     naive_double_quote_re = re.compile(r'(^|.)"((\\"|[^"])*?)"')
     
+    # s = single; d = double; u = unicode; b = binary; 
+    # thus suquoteConv = single unicode quote converter
     suquoteConv = lambda m: (m.group(1) if m.group(1) != "u" else "") + "'" + m.group(2) + "'"
     duquoteConv = lambda m: (m.group(1) if m.group(1) != "u" else "") + '"' + m.group(2) + '"'
 
@@ -74,9 +76,11 @@ class Py3In2OutputChecker(doctest.OutputChecker):
         cannot use super with Py2 since we have old-style classes going on.
         '''
         if six.PY3:
-            return super(Py3In2OutputChecker, self).check_output(want, got, optionflags)
+            return super().check_output(want, got, optionflags)
         else:
             #x = [want, got]
+            wantOrig = want
+            gotOrig = got
             
             want = naive_single_quote_re.sub(sbquoteConv, want) # bytes in WANT disappear
             want = naive_double_quote_re.sub(dbquoteConv, want) # bytes in WANT disappear
@@ -86,7 +90,10 @@ class Py3In2OutputChecker(doctest.OutputChecker):
             
             #x.extend([want, got])
             #ALL_OUTPUT.append(x)
-            return doctest.OutputChecker.check_output(self, want, got, optionflags)
+            # if either the original output or the replaced output matches, then it's good.
+            return (doctest.OutputChecker.check_output(self, want, got, optionflags) or
+                    doctest.OutputChecker.check_output(self, wantOrig, gotOrig, optionflags)
+                    )
 
 ###### test related functions
 


### PR DESCRIPTION
Tests on Python2 now pass if the doctest output passes either after compensating for Py3->Py2 differences, OR if the unaltered code passes.

The main place where this was a bug was in Lilypond output of " b' " meaning b above middle c, but which was being read as the start of a Py3 binary string.

Now there could still be places where some strings should be read as binary and some as not, but this seems like a good start...