### PR TITLE
Show proper launchKey in SubConverter message

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -141,6 +141,7 @@ class SubConverter(object):
                 launchKey = self.launchKey
                 app = environLocal[launchKey]
             else:
+                launchKey = environLocal.formatToKey(fmt)
                 app = environLocal.formatToApp(fmt)
 
         platform = common.getPlatform()


### PR DESCRIPTION
Currently attempt to run following code on Unix platform without .music21rc config
```python
>>> from music21 import environment
>>> from music21.note import Note
>>> Note('D#3').show()
```
causes following error message to appear:

```
SubConverterException: Cannot find a valid application path for format musicxml. Specify this in your Environment by calling environment.set(None, '/path/to/application')
```
which is misleading because running suggested call causes
```
AttributeError: 'NoneType' object has no attribute 'lower'
```
Provided fix makes initial error message correct, namely
```
SubConverterException: Cannot find a valid application path for format musicxml. Specify this in your Environment by calling environment.set('musicxmlPath', '/path/to/application')
```