### PR TITLE
Chord symbol Bass notes missing in MusicXML output

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -3536,7 +3536,7 @@ class MeasureExporter(XMLExporterBase):
         mxHarmony = Element('harmony')
 
         csRoot = cs.root()
-        csBass = cs.bass(find=False)
+        csBass = cs.bass()
         # TODO: do not look at ._attributes...
         if cs._roman is not None:
             mxFunction = SubElement(mxHarmony, 'function')


### PR DESCRIPTION
Chord symbol bass does not display in MuseScore with music21 V2 and V3.
(It worked fine in version 1.6) This definitely should be *Undun*!

Check out the bridge in this MusicXML file for testing:
[test file.zip](https://github.com/cuthbertLab/music21/files/439719/test.file.zip)
>>> s = converter.parse('Undun.xml')
>>> s.show()
