### PR TITLE
Fix interpolation function in audioSearch

### DIFF
--- a/music21/audioSearch/__init__.py
+++ b/music21/audioSearch/__init__.py
@@ -211,10 +211,8 @@ def interpolation(correlation, peak):
     >>> audioSearch.interpolation(f, peak)
     3.21428571...
     '''
-    if peak == 0:
-        return correlation[peak]
-    elif peak == len(correlation) - 1:
-        return correlation[peak]
+    if peak == 0 or peak == len(correlation) - 1:
+        return peak
     
     vertex = (correlation[peak - 1] - correlation[peak + 1]) / (
                 correlation[peak - 1] - 2.0 * correlation[peak] + correlation[peak + 1])


### PR DESCRIPTION
The interpolation returns the index of the peak, but for the edge cases when peak == 0 or peak == len(correlation) - 1, the function was returning the value instead of the index.