### PR TITLE
Fixed: key.mode was required in MEI import

### DIFF
--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -1016,8 +1016,9 @@ def _keySigFromAttrs(elem):
                        mode=elem.get('key.mode', ''))
     else:
         # @key.sig, @key.mode
+        # If @key.mode is null, assume it is a 'major' key (default for ks.asKey)
         ks = key.KeySignature(sharps=_sharpsFromAttr(elem.get('key.sig')))
-        return ks.asKey(mode=elem.get('key.mode'))
+        return ks.asKey(mode=elem.get('key.mode', 'major'))
 
 
 def _transpositionFromAttrs(elem):


### PR DESCRIPTION
Previously, the MEI importer could crash if @key.mode was not specified since it would pass in 'None' for the mode argument on KeySignature.asKey.

This commit fixes this by providing a default value so that if key.mode is None it assumes a 'major' mode.