### PR TITLE
fixed issue for systems running headless, and better execution of musescore, better test for testXMLtoPNGtooLong

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1323,11 +1323,11 @@ class Test(unittest.TestCase):
         os.rename(tempfp, tempfp + "-0001.png")
         tempfp += "-0001.png"
         if six.PY3:
-            from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
+            from unittest import mock, MagicMock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
-            from music21.ext import mock # @Reimport
+            from music21.ext import mock, MagicMock # @Reimport
         with mock.patch('music21.converter.subConverters.findPNGfpFromXMLfp.found') as mockConv:
-            mockConv.__len__ = 1000
+            mockConv.__len__ = MagicMock(return_value=1000)
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -819,7 +819,7 @@ class ConverterMusicXML(SubConverter):
                              , stderr=subprocess.STDOUT, env=env)
         except subprocess.CalledProcessError as cpe:
             print("program error:", cpe, file=sys.stderr)
-            raise Exception(err)
+            raise Exception(cpe)
 
         if subformatExtension == 'png':
             return self.findPNGfpFromXMLfp(fpOut)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1326,8 +1326,11 @@ class Test(unittest.TestCase):
             from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
             from music21.ext import mock # @Reimport
-        with mock.patch('music21.converter.subConverters.ConverterMusicXML.findPNGfpFromXMLfp.found') as mockConv:
-            mockConv.__len__ = 1000
+        with mock.patch('music21.converter.subConverters.len') as mockConv:
+            mockConv.return_value = 1000
+            xmlconverter = ConverterMusicXML()
+            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
+            mockConv.return_value = 0
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1324,10 +1324,10 @@ class Test(unittest.TestCase):
         else:
             from music21.ext import mock # @Reimport
         with mock.patch('music21.converter.subConverters.glob.glob') as mockConv:
-            mockConv.return_value = [x for x in range(1)]
+            mockConv.return_value = [0]
             xmlconverter = ConverterMusicXML()
             xmlconverter.findPNGfpFromXMLfp(tempfp)
-            mockConv.return_value = [x for x in range(0)]
+            mockConv.return_value = []
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1323,11 +1323,11 @@ class Test(unittest.TestCase):
         os.rename(tempfp, tempfp + "-0001.png")
         tempfp += "-0001.png"
         if six.PY3:
-            from unittest import mock, MagicMock  # @UnusedImport # pylint: disable=no-name-in-module
+            from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
-            from music21.ext import mock, MagicMock # @Reimport
-        with mock.patch('music21.converter.subConverters.findPNGfpFromXMLfp.found') as mockConv:
-            mockConv.__len__ = MagicMock(return_value=1000)
+            from music21.ext import mock # @Reimport
+        with mock.patch('music21.converter.subConverters.ConverterMusicXML.findPNGfpFromXMLfp.found') as mockConv:
+            mockConv.__len__ = 1000
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -738,7 +738,6 @@ class ConverterMusicXML(SubConverter):
             pngfp = found[0]
         else:
             raise SubConverterFileIOException("png file of xml not found. Is your file >999 pages?")
-        print(found)
         return pngfp
 
     def parseData(self, xmlString, number=None):

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -734,7 +734,7 @@ class ConverterMusicXML(SubConverter):
         '''
         import glob
         found = sorted(glob.glob(xmlFilePath[0:len(xmlFilePath) - 4] + "-*.png"))
-        if found and len(found) < 999:
+        if len(found) > 0 and len(found) < 999:
             pngfp = found[0]
         else:
             raise SubConverterFileIOException("png file of xml not found. Is your file >999 pages?")

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -732,12 +732,10 @@ class ConverterMusicXML(SubConverter):
         Check whether total number of pngs is in 1-9, 10-99, or 100-999 range,
          then return appropriate fp. Raises and exception if png fp does not exist.
         '''
-        if os.path.exists(xmlFilePath[0:len(xmlFilePath) - 4] + "-1.png"):
-            pngfp = xmlFilePath[0:len(xmlFilePath) - 4] + "-1.png"
-        elif os.path.exists(xmlFilePath[0:len(xmlFilePath) - 4] + "-01.png"):
-            pngfp = xmlFilePath[0:len(xmlFilePath) - 4] + "-01.png"
-        elif os.path.exists(xmlFilePath[0:len(xmlFilePath) - 4] + "-001.png"):
-            pngfp = xmlFilePath[0:len(xmlFilePath) - 4] + "-001.png"
+        import glob
+        found = sorted(glob.glob(xmlFilePath[0:len(xmlFilePath) - 4] + "-*.png"))
+        if found and len(found) < 999:
+            pngfp = found[0]
         else:
             raise SubConverterFileIOException("png file of xml not found. Is your file >999 pages?")
         return pngfp
@@ -806,19 +804,22 @@ class ConverterMusicXML(SubConverter):
         fpOut = fp[0:len(fp) - 3]
         fpOut += subformatExtension
 
-        musescoreRun = '"' + musescorePath + '" ' + fp + " -o " + fpOut + " -T 0 "
+        musescoreRun = '' + musescorePath + ' ' + fp + " -o " + fpOut + " -T 0 "
         if 'dpi' in keywords:
             musescoreRun += " -r " + str(keywords['dpi'])
 
         if common.runningUnderIPython():
             musescoreRun += " -r " + str(defaults.ipythonImageDpi)
 
-        storedStrErr = sys.stderr
-        fileLikeOpen = six.StringIO()
-        sys.stderr = fileLikeOpen
-        os.system(musescoreRun)
-        fileLikeOpen.close()
-        sys.stderr = storedStrErr
+        import subprocess
+        command = musescoreRun.split()
+        try:
+            env = dict(os.environ, QT_QPA_PLATFORM='offscreen')
+            output = subprocess.check_output(command
+                             , stderr=subprocess.STDOUT, env=env)
+        except subprocess.CalledProcessError as cpe:
+            print("program error:", cpe, file=sys.stderr)
+            raise Exception(err)
 
         if subformatExtension == 'png':
             return self.findPNGfpFromXMLfp(fpOut)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -23,6 +23,7 @@ import io
 import os
 import sys
 import unittest
+import glob
 
 from music21.ext import six
 from music21 import common
@@ -722,7 +723,6 @@ class ConverterMusicXML(SubConverter):
     registerOutputSubformatExtensions = {'png': 'png',
                                          'pdf': 'pdf',
                                          }
-    glob = __import__('glob')
 
     def __init__(self, **keywords):
         SubConverter.__init__(self, **keywords)
@@ -733,11 +733,11 @@ class ConverterMusicXML(SubConverter):
         Check whether total number of pngs is in 1-9, 10-99, or 100-999 range,
          then return appropriate fp. Raises and exception if png fp does not exist.
         '''
-        found = sorted(self.glob.glob(xmlFilePath[0:len(xmlFilePath) - 4] + "-*.png"))
-        if len(found) > 0 and len(found) < 999:
+        found = sorted(glob.glob(xmlFilePath[0:len(xmlFilePath) - 4] + "-*.png"))
+        if found:
             pngfp = found[0]
         else:
-            raise SubConverterFileIOException("png file of xml not found. Is your file >999 pages?")
+            raise SubConverterFileIOException("png file of xml not found.")
         return pngfp
 
     def parseData(self, xmlString, number=None):
@@ -804,21 +804,20 @@ class ConverterMusicXML(SubConverter):
         fpOut = fp[0:len(fp) - 3]
         fpOut += subformatExtension
 
-        musescoreRun = '' + musescorePath + ' ' + fp + " -o " + fpOut + " -T 0 "
+        musescoreRun = [musescorePath, fp, "-o", fpOut, "-T", "0"]
         if 'dpi' in keywords:
-            musescoreRun += " -r " + str(keywords['dpi'])
+            musescoreRun.extend(["-r", str(keywords['dpi'])])
 
         if common.runningUnderIPython():
-            musescoreRun += " -r " + str(defaults.ipythonImageDpi)
+            musescoreRun.extend(["-r", str(defaults.ipythonImageDpi)])
 
         import subprocess
-        command = musescoreRun.split()
         try:
             env = dict(os.environ, QT_QPA_PLATFORM='offscreen')
-            output = subprocess.check_output(command
+            output = subprocess.check_output(musescoreRun
                              , stderr=subprocess.STDOUT, env=env)
         except subprocess.CalledProcessError as cpe:
-            print("program error:", cpe, file=sys.stderr)
+            environLocal.warn(str(cpe), header='Error: musescore')
             raise Exception(cpe)
 
         if subformatExtension == 'png':
@@ -1324,10 +1323,14 @@ class Test(unittest.TestCase):
             from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
             from music21.ext import mock # @Reimport
-        with mock.patch('music21.converter.subConverters.ConverterMusicXML.glob') as mockConv:
-            mockConv.return_value = [x for x in range(1000)]
+        with mock.patch('music21.converter.subConverters.glob.glob') as mockConv:
+            mockConv.return_value = [x for x in range(1)]
             xmlconverter = ConverterMusicXML()
-            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
+            try:
+                xmlconverter.findPNGfpFromXMLfp(tempfp)
+            except SubConverterFileIOException:
+                self.assertTrue(False)
+
             mockConv.return_value = [x for x in range(0)]
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1322,8 +1322,14 @@ class Test(unittest.TestCase):
         xmlfp = tempfp + ".xml"
         os.rename(tempfp, tempfp + "-0001.png")
         tempfp += "-0001.png"
-        xmlconverter = ConverterMusicXML()
-        self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
+        if six.PY3:
+            from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
+        else:
+            from music21.ext import mock # @Reimport
+        with mock.patch('music21.converter.subConverters.findPNGfpFromXMLfp.found') as mockConv:
+            mockConv.__len__ = 1000
+            xmlconverter = ConverterMusicXML()
+            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
 
 
 class TestExternal(unittest.TestCase):

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1325,7 +1325,7 @@ class Test(unittest.TestCase):
             from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
             from music21.ext import mock # @Reimport
-        with mock.patch('music21.len') as mockConv:
+        with mock.patch('music21.converter.subConverters.len') as mockConv:
             mockConv.return_value = 1000
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -722,6 +722,7 @@ class ConverterMusicXML(SubConverter):
     registerOutputSubformatExtensions = {'png': 'png',
                                          'pdf': 'pdf',
                                          }
+    glob = __import__('glob')
 
     def __init__(self, **keywords):
         SubConverter.__init__(self, **keywords)
@@ -732,8 +733,7 @@ class ConverterMusicXML(SubConverter):
         Check whether total number of pngs is in 1-9, 10-99, or 100-999 range,
          then return appropriate fp. Raises and exception if png fp does not exist.
         '''
-        import glob
-        found = sorted(glob.glob(xmlFilePath[0:len(xmlFilePath) - 4] + "-*.png"))
+        found = sorted(self.glob.glob(xmlFilePath[0:len(xmlFilePath) - 4] + "-*.png"))
         if len(found) > 0 and len(found) < 999:
             pngfp = found[0]
         else:
@@ -1325,11 +1325,11 @@ class Test(unittest.TestCase):
             from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
             from music21.ext import mock # @Reimport
-        with mock.patch('music21.converter.subConverters.len') as mockConv:
-            mockConv.return_value = 1000
+        with mock.patch('music21.converter.subConverters.ConverterMusicXML.glob') as mockConv:
+            mockConv.return_value = [x for x in range(1000)]
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
-            mockConv.return_value = 0
+            mockConv.return_value = [x for x in range(0)]
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1326,11 +1326,7 @@ class Test(unittest.TestCase):
         with mock.patch('music21.converter.subConverters.glob.glob') as mockConv:
             mockConv.return_value = [x for x in range(1)]
             xmlconverter = ConverterMusicXML()
-            try:
-                xmlconverter.findPNGfpFromXMLfp(tempfp)
-            except SubConverterFileIOException:
-                self.assertTrue(False)
-
+            xmlconverter.findPNGfpFromXMLfp(tempfp)
             mockConv.return_value = [x for x in range(0)]
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -738,6 +738,7 @@ class ConverterMusicXML(SubConverter):
             pngfp = found[0]
         else:
             raise SubConverterFileIOException("png file of xml not found. Is your file >999 pages?")
+        print(found)
         return pngfp
 
     def parseData(self, xmlString, number=None):
@@ -1319,20 +1320,18 @@ class Test(unittest.TestCase):
         '''
         env = environment.Environment()
         tempfp = env.getTempFile()
-        xmlfp = tempfp + ".xml"
-        os.rename(tempfp, tempfp + "-0001.png")
-        tempfp += "-0001.png"
+        tempfp += ".xml"
         if six.PY3:
             from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
             from music21.ext import mock # @Reimport
-        with mock.patch('music21.converter.subConverters.len') as mockConv:
+        with mock.patch('music21.len') as mockConv:
             mockConv.return_value = 1000
             xmlconverter = ConverterMusicXML()
-            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
+            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
             mockConv.return_value = 0
             xmlconverter = ConverterMusicXML()
-            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
+            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
 
 
 class TestExternal(unittest.TestCase):


### PR DESCRIPTION
I found a solution, to my problem in issue #230 it was a little difficult because all errors where being suppressed and by the time the execution got to the part where it checks for png output music21 had no idea something had gone wrong. I based this branch of master but the patch should also go into 3.*
