### PR TITLE
Musecore headless, with platform check.

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1328,11 +1328,11 @@ class Test(unittest.TestCase):
         os.rename(tempfp, tempfp + "-0001.png")
         tempfp += "-0001.png"
         if six.PY3:
-            from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
+            from unittest import mock, MagicMock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
-            from music21.ext import mock # @Reimport
+            from music21.ext import mock, MagicMock # @Reimport
         with mock.patch('music21.converter.subConverters.findPNGfpFromXMLfp.found') as mockConv:
-            mockConv.__len__ = 1000
+            mockConv.__len__ = MagicMock(return_value=1000)
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -746,7 +746,6 @@ class ConverterMusicXML(SubConverter):
             pngfp = found[0]
         else:
             raise SubConverterFileIOException("png file of xml not found. Is your file >999 pages?")
-        print(found)
         return pngfp
 
     def parseData(self, xmlString, number=None):

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -746,6 +746,7 @@ class ConverterMusicXML(SubConverter):
             pngfp = found[0]
         else:
             raise SubConverterFileIOException("png file of xml not found. Is your file >999 pages?")
+        print(found)
         return pngfp
 
     def parseData(self, xmlString, number=None):
@@ -1324,20 +1325,18 @@ class Test(unittest.TestCase):
         '''
         env = environment.Environment()
         tempfp = env.getTempFile()
-        xmlfp = tempfp + ".xml"
-        os.rename(tempfp, tempfp + "-0001.png")
-        tempfp += "-0001.png"
+        tempfp += ".xml"
         if six.PY3:
             from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
             from music21.ext import mock # @Reimport
-        with mock.patch('music21.converter.subConverters.len') as mockConv:
+        with mock.patch('music21.len') as mockConv:
             mockConv.return_value = 1000
             xmlconverter = ConverterMusicXML()
-            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
+            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
             mockConv.return_value = 0
             xmlconverter = ConverterMusicXML()
-            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
+            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
 
 
 class TestExternal(unittest.TestCase): # pragma: no cover

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -821,7 +821,11 @@ class ConverterMusicXML(SubConverter):
 
         import subprocess
         try:
-            env = dict(os.environ, QT_QPA_PLATFORM='offscreen')
+            if sys.platform == 'linux' and not os.environ.get('DISPLAY'):
+                env = dict(os.environ, QT_QPA_PLATFORM='offscreen')
+            else:
+                env = dict(os.environ)
+
             output = subprocess.check_output(musescoreRun
                              , stderr=subprocess.STDOUT, env=env)
         except subprocess.CalledProcessError as cpe:

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1331,11 +1331,7 @@ class Test(unittest.TestCase):
         with mock.patch('music21.converter.subConverters.glob.glob') as mockConv:
             mockConv.return_value = [x for x in range(1)]
             xmlconverter = ConverterMusicXML()
-            try:
-                xmlconverter.findPNGfpFromXMLfp(tempfp)
-            except SubConverterFileIOException:
-                self.assertTrue(False)
-
+            xmlconverter.findPNGfpFromXMLfp(tempfp)
             mockConv.return_value = [x for x in range(0)]
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -742,7 +742,7 @@ class ConverterMusicXML(SubConverter):
         '''
         import glob
         found = sorted(glob.glob(xmlFilePath[0:len(xmlFilePath) - 4] + "-*.png"))
-        if found and len(found) < 999:
+        if len(found) > 0 and len(found) < 999:
             pngfp = found[0]
         else:
             raise SubConverterFileIOException("png file of xml not found. Is your file >999 pages?")

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1330,7 +1330,7 @@ class Test(unittest.TestCase):
             from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
             from music21.ext import mock # @Reimport
-        with mock.patch('music21.len') as mockConv:
+        with mock.patch('music21.converter.subConverters.len') as mockConv:
             mockConv.return_value = 1000
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -827,7 +827,7 @@ class ConverterMusicXML(SubConverter):
                              , stderr=subprocess.STDOUT, env=env)
         except subprocess.CalledProcessError as cpe:
             print("program error:", cpe, file=sys.stderr)
-            raise Exception(err)
+            raise Exception(cpe)
 
         if subformatExtension == 'png':
             return self.findPNGfpFromXMLfp(fpOut)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1331,8 +1331,11 @@ class Test(unittest.TestCase):
             from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
             from music21.ext import mock # @Reimport
-        with mock.patch('music21.converter.subConverters.ConverterMusicXML.findPNGfpFromXMLfp.found') as mockConv:
-            mockConv.__len__ = 1000
+        with mock.patch('music21.converter.subConverters.len') as mockConv:
+            mockConv.return_value = 1000
+            xmlconverter = ConverterMusicXML()
+            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
+            mockConv.return_value = 0
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1328,11 +1328,11 @@ class Test(unittest.TestCase):
         os.rename(tempfp, tempfp + "-0001.png")
         tempfp += "-0001.png"
         if six.PY3:
-            from unittest import mock, MagicMock  # @UnusedImport # pylint: disable=no-name-in-module
+            from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
-            from music21.ext import mock, MagicMock # @Reimport
-        with mock.patch('music21.converter.subConverters.findPNGfpFromXMLfp.found') as mockConv:
-            mockConv.__len__ = MagicMock(return_value=1000)
+            from music21.ext import mock # @Reimport
+        with mock.patch('music21.converter.subConverters.ConverterMusicXML.findPNGfpFromXMLfp.found') as mockConv:
+            mockConv.__len__ = 1000
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1327,8 +1327,14 @@ class Test(unittest.TestCase):
         xmlfp = tempfp + ".xml"
         os.rename(tempfp, tempfp + "-0001.png")
         tempfp += "-0001.png"
-        xmlconverter = ConverterMusicXML()
-        self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
+        if six.PY3:
+            from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
+        else:
+            from music21.ext import mock # @Reimport
+        with mock.patch('music21.converter.subConverters.findPNGfpFromXMLfp.found') as mockConv:
+            mockConv.__len__ = 1000
+            xmlconverter = ConverterMusicXML()
+            self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, xmlfp)
 
 
 class TestExternal(unittest.TestCase): # pragma: no cover

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1329,10 +1329,10 @@ class Test(unittest.TestCase):
         else:
             from music21.ext import mock # @Reimport
         with mock.patch('music21.converter.subConverters.glob.glob') as mockConv:
-            mockConv.return_value = [x for x in range(1)]
+            mockConv.return_value = [0]
             xmlconverter = ConverterMusicXML()
             xmlconverter.findPNGfpFromXMLfp(tempfp)
-            mockConv.return_value = [x for x in range(0)]
+            mockConv.return_value = []
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -733,6 +733,7 @@ class ConverterMusicXML(SubConverter):
     registerOutputSubformatExtensions = {'png': 'png',
                                          'pdf': 'pdf',
                                          }
+    glob = __import__('glob')
 
     #---------------------------------------------------------------------------
     def findPNGfpFromXMLfp(self, xmlFilePath):
@@ -740,8 +741,7 @@ class ConverterMusicXML(SubConverter):
         Check whether total number of pngs is in 1-9, 10-99, or 100-999 range,
          then return appropriate fp. Raises and exception if png fp does not exist.
         '''
-        import glob
-        found = sorted(glob.glob(xmlFilePath[0:len(xmlFilePath) - 4] + "-*.png"))
+        found = sorted(self.glob.glob(xmlFilePath[0:len(xmlFilePath) - 4] + "-*.png"))
         if len(found) > 0 and len(found) < 999:
             pngfp = found[0]
         else:
@@ -1330,11 +1330,11 @@ class Test(unittest.TestCase):
             from unittest import mock  # @UnusedImport # pylint: disable=no-name-in-module
         else:
             from music21.ext import mock # @Reimport
-        with mock.patch('music21.converter.subConverters.len') as mockConv:
-            mockConv.return_value = 1000
+        with mock.patch('music21.converter.subConverters.ConverterMusicXML.glob') as mockConv:
+            mockConv.return_value = [x for x in range(1000)]
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
-            mockConv.return_value = 0
+            mockConv.return_value = [x for x in range(0)]
             xmlconverter = ConverterMusicXML()
             self.assertRaises(SubConverterFileIOException, xmlconverter.findPNGfpFromXMLfp, tempfp)
 


### PR DESCRIPTION
Since this is a a very specific case that only applies to unix systems running without a Xserver,
I included an if statement.
It checks for the platform and also the DISPLAY environment variable, If there is no DISPLAY set and the platform is 'linux' than QT_QPA_PLATFORM is set to 'offscreen' to hint to musescore that there is no display server.
 