### PR TITLE
Update translate.py

### DIFF
--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -36,7 +36,7 @@ class TranslateException(exceptions21.Music21Exception):
 #-------------------------------------------------------------------------------
 # Durations
 
-def offsetToMidi(o, addStartDelay=True):
+def offsetToMidi(o, addStartDelay=False):
     '''
     Helper function to convert a music21 offset value to MIDI ticks,
     depends on *defaults.ticksPerQuarter* and *defaults.ticksAtStart*.


### PR DESCRIPTION
This proposed change updates the translate.py script so that it no longer adds rests to the beginning of the midi file when translating from stream. It changes the default of addStartDelay = True to addStartDelay = False.