### PR TITLE
Add 7sus4 chords

### DIFF
--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -95,8 +95,7 @@ CHORD_TYPES = collections.OrderedDict([
     # other
     ('suspended-second',            ['1,2,5', ['sus2']]),                        # Y
     ('suspended-fourth',            ['1,4,5', ['sus', 'sus4']]),                 # Y
-	('seventh-suspended-fourth',    ['1,4,5,-7', ['7sus4', '7sus']]),            # Y
-	('minor-seventh-added-fourth',  ['1,-3,4,-7', ['m7add4']]),                  # Y
+	('seventh-suspended-fourth',    ['1,4,5,-7', ['7sus', '7sus4']]),            # Y
     ('Neapolitan',                  ['1,2-,3,5-', ['N6']]),                      # Y
     ('Italian',                     ['1,#4,-6', ['It+6', 'It']]),                # Y
     ('French',                      ['1,2,#4,-6', ['Fr+6', 'Fr']]),              # Y
@@ -778,6 +777,13 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
     >>> harmony.chordSymbolFigureFromChord(c, True)
     ('B-dom7dim5', 'seventh-flat-five')
 
+    The root has to be specified for 7sus4 chords
+    otherwise music21 analyses the root of the chord to be the fifth
+    >>> c = chord.Chord(['C3', 'F3', 'G3', 'B-3'])
+    >>> c.root('C3')
+    >>> harmony.chordSymbolFigureFromChord(c, True)
+    ('C7sus4', 'seventh-suspended-fourth')
+
     NINTHS
 
     >>> c = chord.Chord(['C3', 'E3', 'G3', 'B3', 'D3'])
@@ -1220,11 +1226,6 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
                 inChord.root(inChord.bass())
                 kindStr = 'sus'
                 kind = 'suspended-fourth'
-                cs = inChord.root().name + kindStr
-            elif kindStr == 'm7add4':
-                inChord.root(inChord.bass())
-                kindStr = '7sus4'
-                kind = 'seventh-suspended-fourth'
                 cs = inChord.root().name + kindStr
             else:
                 cs = inChord.root().name + kindStr + '/' + inChord.bass().name

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -96,6 +96,7 @@ CHORD_TYPES = collections.OrderedDict([
     ('suspended-second',            ['1,2,5', ['sus2']]),                        # Y
     ('suspended-fourth',            ['1,4,5', ['sus', 'sus4']]),                 # Y
 	('seventh-suspended-fourth',    ['1,4,5,-7', ['7sus', '7sus4']]),            # Y
+	('ninth-suspended-fourth',      ['1,4,5,-7,9', ['9sus', '9sus4']]),          # Y
     ('Neapolitan',                  ['1,2-,3,5-', ['N6']]),                      # Y
     ('Italian',                     ['1,#4,-6', ['It+6', 'It']]),                # Y
     ('French',                      ['1,2,#4,-6', ['Fr+6', 'Fr']]),              # Y
@@ -1183,7 +1184,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
                     kind = chordKind
                     kindStr = chordKindStr[0]
             elif len(chordDegrees) == 5 and d11 and not d13:
-                if compare((d3, d5, d7, d9, d11), chordDegrees, permittedOmitions=(3, 5)):
+                if compare((d3, d5, d7, d9, d11), chordDegrees, permittedOmitions=(5,)):
                     kind = chordKind
                     kindStr = chordKindStr[0]
             elif len(chordDegrees) == 6 and d13:

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -60,7 +60,7 @@ CHORD_TYPES = collections.OrderedDict([
     ('augmented-seventh',           ['1,3,#5,-7', ['7+', '+7', 'aug7']]),    # Y
     ('half-diminished-seventh',     ['1,-3,-5,-7', ['/o7', 'm7b5']]),        # Y: 'half-diminished'
     ('diminished-seventh',          ['1,-3,-5,--7', ['o7', 'dim7']]),        # Y
-    ('seventh-flat-five',           ['1,3,-5,-7', ['dom7dim5']]),            # N
+    ('seventh-flat-five',           ['1,3,-5,-7', ['7b5', 'dom7dim5']]),        # N
     # sixths
     ('major-sixth',                 ['1,3,5,6', ['6']]),                         # Y
     ('minor-sixth',                 ['1,-3,5,6', ['m6', 'min6']]),               # Y
@@ -68,6 +68,7 @@ CHORD_TYPES = collections.OrderedDict([
     ('major-ninth',                 ['1,3,5,7,9', ['M9', 'Maj9']]),              # Y
     ('dominant-ninth',              ['1,3,5,-7,9', ['9', 'dom9']]),              # Y
 	('dominant-minor-ninth',        ['1,3,5,-7,-9', ['7b9']]),                   # Y
+	('dominant-altered-ninth',      ['1,3,5,-7,#9', ['7#9']]),                   # Y
     ('minor-major-ninth',           ['1,-3,5,7,9', ['mM9', 'minmaj9']]),         # N
     ('minor-ninth',                 ['1,-3,5,-7,9', ['m9', 'min9']]),            # N
     ('augmented-major-ninth',       ['1,3,#5,7,9', ['+M9', 'augmaj9']]),         # Y

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Name:         harmony.py
 # Purpose:      music21 classes for representing harmonies and chord symbols
 #
@@ -9,7 +9,7 @@
 #
 # Copyright:    Copyright © 2011-2012, 2016 Michael Scott Cuthbert and the music21 Project
 # License:      LGPL or BSD, see license.txt
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 '''
 An object representation of harmony, a subclass of chord, as encountered as chord symbols or
 roman numerals, or other chord representations with a defined root.
@@ -30,11 +30,11 @@ from music21 import style
 from music21.figuredBass import realizerScale
 
 from music21 import environment
+
 _MOD = 'harmony'
 environLocal = environment.Environment(_MOD)
 
-
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 
 # Y indicates this chord_type is an official XML chord typ
@@ -47,84 +47,85 @@ environLocal = environment.Environment(_MOD)
 
 
 CHORD_TYPES = collections.OrderedDict([
-    ('major',                       ['1,3,5', ['', 'M', 'maj']]),                # Y
-    ('minor',                       ['1,-3,5', ['m', 'min']]),                   # Y
-    ('augmented',                   ['1,3,#5', ['+', 'aug']]),                   # Y
-    ('diminished',                  ['1,-3,-5', ['dim', 'o']]),                  # Y
+    ('major', ['1,3,5', ['', 'M', 'maj']]),  # Y
+    ('minor', ['1,-3,5', ['m', 'min']]),  # Y
+    ('augmented', ['1,3,#5', ['+', 'aug']]),  # Y
+    ('diminished', ['1,-3,-5', ['dim', 'o']]),  # Y
     # sevenths
-    ('dominant-seventh',            ['1,3,5,-7', ['7', 'dom7',]]),           # Y: 'dominant'
-    ('major-seventh',               ['1,3,5,7', ['maj7', 'M7']]),            # Y
-    ('minor-major-seventh',         ['1,-3,5,7', ['mM7', 'm#7', 'minmaj7']]),# Y: 'major-minor'
-    ('minor-seventh',               ['1,-3,5,-7', ['m7', 'min7']]),          # Y
-    ('augmented-major seventh',     ['1,3,#5,7', ['+M7', 'augmaj7']]),       # N
-    ('augmented-seventh',           ['1,3,#5,-7', ['7+', '+7', 'aug7']]),    # Y
-    ('half-diminished-seventh',     ['1,-3,-5,-7', ['m7b5', '/o7']]),
+    ('dominant-seventh', ['1,3,5,-7', ['7', 'dom7', ]]),  # Y: 'dominant'
+    ('major-seventh', ['1,3,5,7', ['maj7', 'M7']]),  # Y
+    ('minor-major-seventh', ['1,-3,5,7', ['mM7', 'm#7', 'minmaj7']]),  # Y: 'major-minor'
+    ('minor-seventh', ['1,-3,5,-7', ['m7', 'min7']]),  # Y
+    ('augmented-major seventh', ['1,3,#5,7', ['+M7', 'augmaj7']]),  # N
+    ('augmented-seventh', ['1,3,#5,-7', ['7+', '+7', 'aug7']]),  # Y
+    ('half-diminished-seventh', ['1,-3,-5,-7', ['m7b5', '/o7']]),
     # Y: 'half-diminished'
-    ('diminished-seventh',          ['1,-3,-5,--7', ['o7', 'dim7']]),        # Y
-    ('seventh-flat-five',           ['1,3,-5,-7', ['7b5', 'dom7dim5']]),        # N
+    ('diminished-seventh', ['1,-3,-5,--7', ['o7', 'dim7']]),  # Y
+    ('seventh-flat-five', ['1,3,-5,-7', ['7b5', 'dom7dim5']]),  # N
     # sixths
-    ('major-sixth',                 ['1,3,5,6', ['6']]),                         # Y
-    ('minor-sixth',                 ['1,-3,5,6', ['m6', 'min6']]),               # Y
+    ('major-sixth', ['1,3,5,6', ['6']]),  # Y
+    ('minor-sixth', ['1,-3,5,6', ['m6', 'min6']]),  # Y
     # ninths
-    ('major-ninth',                 ['1,3,5,7,9', ['M9', 'Maj9']]),              # Y
-    ('dominant-ninth',              ['1,3,5,-7,9', ['9', 'dom9']]),              # Y
-	('dominant-minor-ninth',        ['1,3,5,-7,-9', ['7b9']]),                   # Y
-    ('dominant-minor-ninth-flat-fifth', ['1,3,-5,-7,-9', ['7b9b5']]),            # Y
-	('dominant-altered-ninth',      ['1,3,5,-7,#9', ['7#9']]),                   # Y
-    ('minor-major-ninth',           ['1,-3,5,7,9', ['mM9', 'minmaj9']]),         # N
-    ('minor-ninth',                 ['1,-3,5,-7,9', ['m9', 'min9']]),            # N
-    ('augmented-major-ninth',       ['1,3,#5,7,9', ['+M9', 'augmaj9']]),         # Y
-    ('augmented-dominant-ninth',    ['1,3,#5,-7,9', ['9#5', '+9', 'aug9']]),     # N
-    ('half-diminished-ninth',       ['1,-3,-5,-7,9', ['/o9']]),                  # N
-    ('half-diminished-minor-ninth', ['1,-3,-5,-7,-9', ['/ob9']]),                # N
-    ('diminished-ninth',            ['1,-3,-5,--7,9', ['o9', 'dim9']]),          # N
-    ('diminished-minor-ninth',      ['1,-3,-5,--7,-9', ['ob9', 'dimb9']]),       # N
+    ('major-ninth', ['1,3,5,7,9', ['M9', 'Maj9']]),  # Y
+    ('dominant-ninth', ['1,3,5,-7,9', ['9', 'dom9']]),  # Y
+    ('dominant-minor-ninth', ['1,3,5,-7,-9', ['7b9']]),  # Y
+    ('dominant-minor-ninth-flat-fifth', ['1,3,-5,-7,-9', ['7b9b5']]),  # Y
+    ('dominant-altered-ninth', ['1,3,5,-7,#9', ['7#9']]),  # Y
+    ('minor-major-ninth', ['1,-3,5,7,9', ['mM9', 'minmaj9']]),  # N
+    ('minor-ninth', ['1,-3,5,-7,9', ['m9', 'min9']]),  # N
+    ('augmented-major-ninth', ['1,3,#5,7,9', ['+M9', 'augmaj9']]),  # Y
+    ('augmented-dominant-ninth', ['1,3,#5,-7,9', ['9#5', '+9', 'aug9']]),  # N
+    ('half-diminished-ninth', ['1,-3,-5,-7,9', ['/o9']]),  # N
+    ('half-diminished-minor-ninth', ['1,-3,-5,-7,-9', ['/ob9']]),  # N
+    ('diminished-ninth', ['1,-3,-5,--7,9', ['o9', 'dim9']]),  # N
+    ('diminished-minor-ninth', ['1,-3,-5,--7,-9', ['ob9', 'dimb9']]),  # N
     # elevenths
-    ('dominant-11th',               ['1,3,5,-7,9,11', ['11', 'dom11']]),         # Y
-    ('major-11th',                  ['1,3,5,7,9,11', ['M11', 'Maj11']]),         # Y
-    ('minor-major-11th',            ['1,-3,5,7,9,11', ['mM11', 'minmaj11']]),    # N
-    ('minor-11th',                  ['1,-3,5,-7,9,11', ['m11', 'min11']]),       # Y
-    ('augmented-major-11th',        ['1,3,#5,7,9,11', ['+M11', 'augmaj11']]),    # N
-    ('augmented-11th',              ['1,3,#5,-7,9,11', ['+11', 'aug11']]),       # N
-    ('half-diminished-11th',        ['1,-3,-5,-7,-9,11', ['/o11']]),             # N
-    ('diminished-11th',             ['1,-3,-5,--7,-9,-11', ['o11', 'dim11']]),   # N
+    ('dominant-11th', ['1,3,5,-7,9,11', ['11', 'dom11']]),  # Y
+    ('major-11th', ['1,3,5,7,9,11', ['M11', 'Maj11']]),  # Y
+    ('minor-major-11th', ['1,-3,5,7,9,11', ['mM11', 'minmaj11']]),  # N
+    ('minor-11th', ['1,-3,5,-7,9,11', ['m11', 'min11']]),  # Y
+    ('augmented-major-11th', ['1,3,#5,7,9,11', ['+M11', 'augmaj11']]),  # N
+    ('augmented-11th', ['1,3,#5,-7,9,11', ['+11', 'aug11']]),  # N
+    ('half-diminished-11th', ['1,-3,-5,-7,-9,11', ['/o11']]),  # N
+    ('diminished-11th', ['1,-3,-5,--7,-9,-11', ['o11', 'dim11']]),  # N
     # thirteenths
-    ('major-13th',                  ['1,3,5,7,9,11,13', ['M13', 'Maj13']]),      # Y
-    ('dominant-13th',               ['1,3,5,-7,9,11,13', ['13', 'dom13']]),      # Y
-    ('minor-major-13th',            ['1,-3,5,7,9,11,13', ['mM13', 'minmaj13']]), # N
-    ('minor-13th',                  ['1,-3,5,-7,9,11,13', ['m13', 'min13']]),    # Y
-    ('augmented-major-13th',        ['1,3,#5,7,9,11,13', ['+M13', 'augmaj13']]), # N
-    ('augmented-dominant-13th',     ['1,3,#5,-7,9,11,13', ['+13', 'aug13']]),    # N
-    ('half-diminished-13th',        ['1,-3,-5,-7,9,11,13', ['/o13']]),           # N
+    ('major-13th', ['1,3,5,7,9,11,13', ['M13', 'Maj13']]),  # Y
+    ('dominant-13th', ['1,3,5,-7,9,11,13', ['13', 'dom13']]),  # Y
+    ('minor-major-13th', ['1,-3,5,7,9,11,13', ['mM13', 'minmaj13']]),  # N
+    ('minor-13th', ['1,-3,5,-7,9,11,13', ['m13', 'min13']]),  # Y
+    ('augmented-major-13th', ['1,3,#5,7,9,11,13', ['+M13', 'augmaj13']]),  # N
+    ('augmented-dominant-13th', ['1,3,#5,-7,9,11,13', ['+13', 'aug13']]),  # N
+    ('half-diminished-13th', ['1,-3,-5,-7,9,11,13', ['/o13']]),  # N
     # other
-    ('suspended-second',            ['1,2,5', ['sus2']]),                        # Y
-    ('suspended-fourth',            ['1,4,5', ['sus', 'sus4']]),                 # Y
-	('seventh-suspended-fourth',    ['1,4,5,-7', ['7sus4', '7sus']]),            # Y
-	('ninth-suspended-fourth',      ['1,4,5,-7,9', ['9sus', '9sus4']]),          # Y
-    ('Neapolitan',                  ['1,2-,3,5-', ['N6']]),                      # Y
-    ('Italian',                     ['1,#4,-6', ['It+6', 'It']]),                # Y
-    ('French',                      ['1,2,#4,-6', ['Fr+6', 'Fr']]),              # Y
-    ('German',                      ['1,-3,#4,-6', ['Gr+6', 'Ger']]),            # Y
-    ('pedal',                       ['1', ['pedal']]),                           # Y
-    ('power',                       ['1,5', ['power']]),                         # Y
-    ('Tristan',                     ['1,#4,#6,#9', ['tristan']]),                # Y
-    ])
+    ('suspended-second', ['1,2,5', ['sus2']]),  # Y
+    ('suspended-fourth', ['1,4,5', ['sus', 'sus4']]),  # Y
+    ('seventh-suspended-fourth', ['1,4,5,-7', ['7sus4', '7sus']]),  # Y
+    ('ninth-suspended-fourth', ['1,4,5,-7,9', ['9sus', '9sus4']]),  # Y
+    ('Neapolitan', ['1,2-,3,5-', ['N6']]),  # Y
+    ('Italian', ['1,#4,-6', ['It+6', 'It']]),  # Y
+    ('French', ['1,2,#4,-6', ['Fr+6', 'Fr']]),  # Y
+    ('German', ['1,-3,#4,-6', ['Gr+6', 'Ger']]),  # Y
+    ('pedal', ['1', ['pedal']]),  # Y
+    ('power', ['1,5', ['power']]),  # Y
+    ('Tristan', ['1,#4,#6,#9', ['tristan']]),  # Y
+])
 
 # these are different names used by MusicXML and others,
 # and the authoritative name that they resolve to
-CHORD_ALIASES = {'dominant': 'dominant-seventh',
-                 'major-minor': 'major-minor-seventh',
+CHORD_ALIASES = {'dominant':        'dominant-seventh',
+                 'major-minor':     'major-minor-seventh',
                  'half-diminished': 'half-diminished-seventh',
                  }
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 
 
 class HarmonyException(exceptions21.Music21Exception):
     pass
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 
 class Harmony(chord.Chord):
@@ -194,9 +195,9 @@ class Harmony(chord.Chord):
         self._degreesList = []
         self._key = None
         self._updateBasedOnXMLInput(keywords)
-        #figure is the string representation of a Harmony object
-        #for example, for Chord Symbols the figure might be 'Cm7'
-        #for roman numerals, the figure might be 'I7'
+        # figure is the string representation of a Harmony object
+        # for example, for Chord Symbols the figure might be 'Cm7'
+        # for roman numerals, the figure might be 'I7'
         self._figure = figure
         if self._figure is not None:
             self._parseFigure()
@@ -208,7 +209,7 @@ class Harmony(chord.Chord):
 
         updatePitches = keywords.get('updatePitches', True)
         if (updatePitches and self._figure is not None
-                or 'root' in self._overrides or 'bass' in self._overrides):
+            or 'root' in self._overrides or 'bass' in self._overrides):
             self._updatePitches()
         self._updateBasedOnXMLInput(keywords)
 
@@ -224,9 +225,9 @@ class Harmony(chord.Chord):
             summary += ': '
             summary += ' '.join([p.name for p in self.pitches])
         return '<music21.harmony.{0} {1}>'.format(
-                self.__class__.__name__,
-                summary,
-                )
+            self.__class__.__name__,
+            summary,
+        )
 
     ### PRIVATE METHODS ###
     def _parseFigure(self):
@@ -240,7 +241,6 @@ class Harmony(chord.Chord):
         subclass this in extensions (SO WHY IS IT PRIVATE???)
         '''
         return
-
 
     def _updateBasedOnXMLInput(self, keywords):
         '''
@@ -268,7 +268,6 @@ class Harmony(chord.Chord):
                 self.duration = duration.Duration(keywords[kw])
             else:
                 pass
-
 
     ### PUBLIC PROPERTIES ###
 
@@ -407,7 +406,7 @@ class Harmony(chord.Chord):
             self._roman = value
             return
         from music21 import roman
-        try: # try to create
+        try:  # try to create
             self._roman = roman.RomanNumeral(value)
             return
         except exceptions21.Music21Exception:
@@ -465,13 +464,14 @@ class Harmony(chord.Chord):
         return self.chordStepModifications
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 
 class ChordStepModificationException(exceptions21.Music21Exception):
     pass
 
-#-------------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------------
 
 
 class ChordStepModification:
@@ -501,38 +501,37 @@ class ChordStepModification:
         degree=3 interval=<music21.interval.Interval A1>>
     '''
 
-#     FROM MUSIC XML DOCUMENTATION - FOR DEVELOPER'S REFERENCE
-#     The degree element is used to add, alter, or subtract
-#     individual notes in the chord. The degree-value element
-#     is a number indicating the degree of the chord (1 for
-#     the root, 3 for third, etc). The degree-alter element
-#     is like the alter element in notes: 1 for sharp, -1 for
-#     flat, etc. The degree-type element can be add, alter, or
-#     subtract. If the degree-type is alter or subtract, the
-#     degree-alter is relative to the degree already in the
-#     chord based on its kind element. If the degree-type is
-#     add, the degree-alter is relative to a dominant chord
-#     (major and perfect intervals except for a minor
-#     seventh). The print-object attribute can be used to
-#     keep the degree from printing separately when it has
-#     already taken into account in the text attribute of
-#     the kind element. The plus-minus attribute is used to
-#     indicate if plus and minus symbols should be used
-#     instead of sharp and flat symbols to display the degree
-#     alteration; it is no by default. The degree-value and
-#     degree-type text attributes specify how the value and
-#     type of the degree should be displayed.
-#
-#     A harmony of kind "other" can be spelled explicitly by
-#     using a series of degree elements together with a root.
-
+    #     FROM MUSIC XML DOCUMENTATION - FOR DEVELOPER'S REFERENCE
+    #     The degree element is used to add, alter, or subtract
+    #     individual notes in the chord. The degree-value element
+    #     is a number indicating the degree of the chord (1 for
+    #     the root, 3 for third, etc). The degree-alter element
+    #     is like the alter element in notes: 1 for sharp, -1 for
+    #     flat, etc. The degree-type element can be add, alter, or
+    #     subtract. If the degree-type is alter or subtract, the
+    #     degree-alter is relative to the degree already in the
+    #     chord based on its kind element. If the degree-type is
+    #     add, the degree-alter is relative to a dominant chord
+    #     (major and perfect intervals except for a minor
+    #     seventh). The print-object attribute can be used to
+    #     keep the degree from printing separately when it has
+    #     already taken into account in the text attribute of
+    #     the kind element. The plus-minus attribute is used to
+    #     indicate if plus and minus symbols should be used
+    #     instead of sharp and flat symbols to display the degree
+    #     alteration; it is no by default. The degree-value and
+    #     degree-type text attributes specify how the value and
+    #     type of the degree should be displayed.
+    #
+    #     A harmony of kind "other" can be spelled explicitly by
+    #     using a series of degree elements together with a root.
 
     ### INITIALIZER ###
 
     def __init__(self, modType=None, degree=None, intervalObj=None):
-        self._modType = None # add, alter, subtract
-        self._interval = None # alteration of degree, alter ints in mxl
-        self._degree = None # the degree number, where 3 is the third
+        self._modType = None  # add, alter, subtract
+        self._interval = None  # alteration of degree, alter ints in mxl
+        self._degree = None  # the degree number, where 3 is the third
         # use properties if defined
         if modType is not None:
             self.modType = modType
@@ -550,7 +549,7 @@ class ChordStepModification:
             self.modType,
             self.degree,
             self.interval,
-            )
+        )
 
     ### PUBLIC PROPERTIES ###
 
@@ -574,7 +573,7 @@ class ChordStepModification:
     @degree.setter
     def degree(self, expr):
         if expr is not None and common.isNum(expr):
-            self._degree = int(expr) # should always be an integer
+            self._degree = int(expr)  # should always be an integer
             return
         raise ChordStepModificationException(
             'not a valid degree: {0}'.format(expr))
@@ -631,9 +630,8 @@ class ChordStepModification:
                 if value < 0:
                     aStr += '-'
                 self._interval = interval.Interval(aStr)
-            else: # try to create interval object
+            else:  # try to create interval object
                 self._interval = interval.Interval(value)
-
 
     @property
     def modType(self):
@@ -662,7 +660,7 @@ class ChordStepModification:
             'not a valid degree modification type: {0}'.format(expr))
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 
 def addNewChordSymbol(chordTypeName, fbNotationString, AbbreviationList):
@@ -1091,7 +1089,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
     try:
         inChord.root()
     except Exception as e:
-        raise HarmonyException(e )
+        raise HarmonyException(e)
 
     if len(inChord.pitches) == 1:
         if includeChordType:
@@ -1099,12 +1097,12 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
         else:
             return inChord.root().name.replace('-', 'b') + 'pedal'
 
-    d3 = inChord.semitonesFromChordStep(3) #4  #triad
-    d5 = inChord.semitonesFromChordStep(5) #7  #triad
-    d7 = inChord.semitonesFromChordStep(7) #11 #seventh
-    d9 = inChord.semitonesFromChordStep(2) #2  #ninth
-    d11 = inChord.semitonesFromChordStep(4) #5  #eleventh
-    d13 = inChord.semitonesFromChordStep(6) #9  #thirteenth
+    d3 = inChord.semitonesFromChordStep(3)  # 4  #triad
+    d5 = inChord.semitonesFromChordStep(5)  # 7  #triad
+    d7 = inChord.semitonesFromChordStep(7)  # 11 #seventh
+    d9 = inChord.semitonesFromChordStep(2)  # 2  #ninth
+    d11 = inChord.semitonesFromChordStep(4)  # 5  #eleventh
+    d13 = inChord.semitonesFromChordStep(6)  # 9  #thirteenth
 
     d2 = d9
     d4 = d11
@@ -1150,7 +1148,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
 
     def convertFBNotationStringToDegrees(kind, fbNotation):
         # convert the fbnotation string provided in CHORD_TYPES to chordDegrees notation
-        types = {3:4, 5:7, 7:11, 9:2, 11:5, 13:9, 2:2, 4:5, 6:9}
+        types = {3: 4, 5: 7, 7: 11, 9: 2, 11: 5, 13: 9, 2: 2, 4: 5, 6: 9}
         chordDegrees = []
         if kind in CHORD_ALIASES:
             kind = CHORD_ALIASES[kind]
@@ -1164,7 +1162,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
                 else:
                     alt = char.count('#')
                 degree = int(char.replace('-', '').replace('#', ''))
-                chordDegrees.append( types[degree] + alt)
+                chordDegrees.append(types[degree] + alt)
         return chordDegrees
 
     for chordKind in CHORD_TYPES:
@@ -1196,7 +1194,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
                     kind = chordKind
                     kindStr = chordKindStr[0]
 
-    if not kind: # if, after all that, no chord has been found, try to match by degree instead
+    if not kind:  # if, after all that, no chord has been found, try to match by degree instead
         numberOfMatchedDegrees = 0
         for chordKind in CHORD_TYPES:
             chordKindStr = getAbbreviationListGivenChordType(chordKind)
@@ -1211,7 +1209,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
                 degrees = [int(x) for x in degrees]
                 degrees.sort()
 
-                data = {2:d2, 3:d3, 4:d4, 5:d5, 6:d6, 7:d7, 9:d9, 11:d11, 13:d13}
+                data = {2: d2, 3: d3, 4: d4, 5: d5, 6: d6, 7: d7, 9: d9, 11: d11, 13: d13}
                 toCompare = []
                 for x in degrees:
                     if x != 1:
@@ -1239,7 +1237,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
         perfect = set([p.name for p in ChordSymbol(cs).pitches])
         inPitches = set([p.name for p in inChord.pitches])
 
-        if not perfect.issuperset(inPitches): #must be subtraction or deletion....
+        if not perfect.issuperset(inPitches):  # must be subtraction or deletion....
             additions = inPitches.difference(perfect)
             subtractions = perfect.difference(inPitches)
             if additions:
@@ -1320,10 +1318,11 @@ def removeChordSymbols(chordType):
     del CHORD_TYPES[chordType]
 
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 realizerScaleCache = {}
 
-#---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 
 
 class ChordSymbol(Harmony):
@@ -1511,8 +1510,8 @@ class ChordSymbol(Harmony):
     ### INITIALIZER ###
 
     def __init__(self, figure=None, **keywords):
-        self.chordKind = '' # a string from defined list of chord symbol harmonies
-        self.chordKindStr = '' # the presentation of the kind or label of symbol
+        self.chordKind = ''  # a string from defined list of chord symbol harmonies
+        self.chordKindStr = ''  # the presentation of the kind or label of symbol
 
         for kw in keywords:
             if kw == 'kind':
@@ -1524,6 +1523,25 @@ class ChordSymbol(Harmony):
         if 'duration' not in keywords and 'quarterLength' not in keywords:
             self.duration = duration.Duration(0)
 
+    def transpose(self, value, *, inPlace=False):
+        if inPlace:
+            root = self.root()
+            super(ChordSymbol, self).transpose(value=value,
+                                               inPlace=inPlace)
+            self.root(root.transpose(value=value, inPlace=False))
+            self = chordSymbolFromChord(self)
+            return None
+        else:
+            root = self.root()
+            transposition = super(ChordSymbol, self).transpose(
+                value=value,
+                inPlace=inPlace)
+            transposition.root(root.transpose(value=value, inPlace=False))
+            transposition = chordSymbolFromChord(
+                transposition)
+            return transposition
+
+
 
     ### PRIVATE METHODS ###
 
@@ -1531,9 +1549,9 @@ class ChordSymbol(Harmony):
         if not isinstance(pitches, list):
             pitches = list(pitches)
 
-        #do this for all ninth, thirteenth, and eleventh chords...
-        #this must be done to get octave spacing right
-        #possibly rewrite figured bass function with this integrated????....
+        # do this for all ninth, thirteenth, and eleventh chords...
+        # this must be done to get octave spacing right
+        # possibly rewrite figured bass function with this integrated????....
         ninths = ['dominant-ninth', 'major-ninth', 'minor-ninth']
         elevenths = ['dominant-11th', 'major-11th', 'minor-11th']
         thirteenths = ['dominant-13th', 'major-13th', 'minor-13th']
@@ -1624,29 +1642,30 @@ class ChordSymbol(Harmony):
                         pitches.append(pitchToAppend)
             else:
                 pitches.append(pitchToAppend)
-#                 # for now I won't worry about the octave of the added note
-#                 #if self.bass() != None:
-#                 #    p = sc.pitchFromDegree(hD.degree, self.bass())
-#                 # else:
-#                 #     p = sc.pitchFromDegree(hD.degree, self.root())
-#                 if hD.degree == 7 and self.chordKind != None and self.chordKind != '':
-#                     #don't know why anyone would want
-#                     #to add a seventh to a dominant chord already...but according to documentation
-#                     #added degrees are relative to dominant chords, which have all major degrees
-#                     #except for the seventh which is minor, thus the transposition down
-#                     #one half step
-#                     p = p.transpose(-1)
-#                     self._degreesList.append('-7')
-#                     #degreeForList = '-7'
-#                 else:
-#                     self._degreesList.append(hD.degree)
-#                     #degreeForList = str(hD.degree)
-#                 #adjust the added pitch by degree-alter interval
-#                 if hD.interval:
-#                     p = p.transpose(hD.interval)
-#                     if hD.degree >= 7:
-#                         p.octave = p.octave + 1
-#                 pitches.append(p)
+
+        #                 # for now I won't worry about the octave of the added note
+        #                 #if self.bass() != None:
+        #                 #    p = sc.pitchFromDegree(hD.degree, self.bass())
+        #                 # else:
+        #                 #     p = sc.pitchFromDegree(hD.degree, self.root())
+        #                 if hD.degree == 7 and self.chordKind != None and self.chordKind != '':
+        #                     #don't know why anyone would want
+        #                     #to add a seventh to a dominant chord already...but according to documentation
+        #                     #added degrees are relative to dominant chords, which have all major degrees
+        #                     #except for the seventh which is minor, thus the transposition down
+        #                     #one half step
+        #                     p = p.transpose(-1)
+        #                     self._degreesList.append('-7')
+        #                     #degreeForList = '-7'
+        #                 else:
+        #                     self._degreesList.append(hD.degree)
+        #                     #degreeForList = str(hD.degree)
+        #                 #adjust the added pitch by degree-alter interval
+        #                 if hD.interval:
+        #                     p = p.transpose(hD.interval)
+        #                     if hD.degree >= 7:
+        #                         p.octave = p.octave + 1
+        #                 pitches.append(p)
 
         def typeSubtract(hD):
             '''
@@ -1660,7 +1679,7 @@ class ChordSymbol(Harmony):
             for p, degree in zip(pitches, degrees):
                 degree = degree.replace('-', '')
                 degree = degree.replace('#', '')
-                degree = degree.replace('A', '') # A is for 'Altered'
+                degree = degree.replace('A', '')  # A is for 'Altered'
                 if hD.degree == int(degree):
                     pitches.remove(p)
                     pitchFound = True
@@ -1669,9 +1688,9 @@ class ChordSymbol(Harmony):
                         if str(hD.degree) in degreeString:
                             self._degreesList.remove(degreeString)
                             break
-                    #if hD.degree not in string,
-                    #should we throw an exception???? for now yes, but maybe later we
-                    #will be more lenient....
+                    # if hD.degree not in string,
+                    # should we throw an exception???? for now yes, but maybe later we
+                    # will be more lenient....
             if not pitchFound:
                 raise ChordStepModificationException(
                     'Degree not in specified chord: %s' % hD.degree)
@@ -1686,24 +1705,23 @@ class ChordSymbol(Harmony):
             for p, degree in zip(pitches, degrees):
                 degree = degree.replace('-', '')
                 degree = degree.replace('#', '')
-                degree = degree.replace('A', '') #A is for 'Altered'
+                degree = degree.replace('A', '')  # A is for 'Altered'
                 if hD.degree == int(degree):
                     # transpose by semitones (positive for up, negative for down)
                     p = p.transpose(hD.interval)
                     pitchFound = True
 
-#                         for degreeString in self._degreesList:
-#                             if str(hD.degree) in degreeString:
-#                                 self._degreesList = self._degreesList.replace(
-#                                            degreeString, ('A' + str(hD.degree)))
-#                                 #the 'A' stands for altered...
-#                                 break
-#                         #if hD.degree not in string:
-#                         #should we throw an exception???? for now yes, but maybe later we should.
+            #                         for degreeString in self._degreesList:
+            #                             if str(hD.degree) in degreeString:
+            #                                 self._degreesList = self._degreesList.replace(
+            #                                            degreeString, ('A' + str(hD.degree)))
+            #                                 #the 'A' stands for altered...
+            #                                 break
+            #                         #if hD.degree not in string:
+            #                         #should we throw an exception???? for now yes, but maybe later we should.
             if not pitchFound:
                 raise ChordStepModificationException(
-                        'Degree not in specified chord: %s' % hD.degree)
-
+                    'Degree not in specified chord: %s' % hD.degree)
 
         # main routines...
         for hD in chordStepModifications:
@@ -1736,13 +1754,13 @@ class ChordSymbol(Harmony):
 
     def _hasPitchAboveC4(self, pitches):
         for p in pitches:
-            if p.diatonicNoteNum > 30: # if there are pitches above middle C, bump the octave down
+            if p.diatonicNoteNum > 30:  # if there are pitches above middle C, bump the octave down
                 return True
         return False
 
     def _hasPitchBelowA1(self, pitches):
         for p in pitches:
-            if p.diatonicNoteNum < 13: # anything below this is just obnoxious
+            if p.diatonicNoteNum < 13:  # anything below this is just obnoxious
                 return True
         return False
 
@@ -1770,55 +1788,54 @@ class ChordSymbol(Harmony):
 
         return notationString
 
-
     def _parseFigure(self):
         '''
         Translate the figure string (regular expression) into a meaningful
         Harmony object by identifying the root, bass, inversion, kind, and
         kindStr.
         '''
-        #remove spaces from prelim Figure...
+        # remove spaces from prelim Figure...
         prelimFigure = self.figure
         prelimFigure = re.sub(r'\s', '', prelimFigure)
-        #Get Root:
+        # Get Root:
         if ',' in prelimFigure:
             root = prelimFigure[0:prelimFigure.index(',')]
             st = prelimFigure.replace(',', '')
             st = st.replace(root, '')
             prelimFigure = prelimFigure.replace(',', '')
         else:
-            m1 = re.match(r'[A-Ga-g][#-]*', prelimFigure) #match not case sensitive,
+            m1 = re.match(r'[A-Ga-g][#-]*', prelimFigure)  # match not case sensitive,
             if m1:
                 root = m1.group()
-                #remove the root and bass from the string and any additions/omitions/alterations/
+                # remove the root and bass from the string and any additions/omitions/alterations/
                 st = prelimFigure.replace(m1.group(), '')
 
         if root:
             self.root(pitch.Pitch(root))
 
-        #Get optional Bass:
-        m2 = re.search(r'/[A-Ga-g][#-]*', prelimFigure) #match not case sensitive
+        # Get optional Bass:
+        m2 = re.search(r'/[A-Ga-g][#-]*', prelimFigure)  # match not case sensitive
         remaining = st
         if m2:
             bass = m2.group()
             bass = bass.replace('/', '')
             self.bass(bass)
-            #remove the root and bass from the string and any additions/omitions/alterations/
+            # remove the root and bass from the string and any additions/omitions/alterations/
             remaining = st.replace(m2.group(), '')
 
         st = self._getKindFromShortHand(remaining)
         # 'add', 'alter' and 'omit' in the chordString is kinda broken, not a high
         # priority since there is no well defined nomenclature
         if 'add' in remaining:
-            degree = remaining[remaining.index('add') + 3: ]
+            degree = remaining[remaining.index('add') + 3:]
             self.addChordStepModification(ChordStepModification('add', int(degree)))
             return
         if 'alter' in remaining:
-            degree = remaining[remaining.index('alter') + 5: ]
+            degree = remaining[remaining.index('alter') + 5:]
             self.addChordStepModification(ChordStepModification('alter', int(degree)))
             return
         if 'omit' in remaining or 'subtract' in remaining:
-            degree = remaining[remaining.index('omit') + 4: ]
+            degree = remaining[remaining.index('omit') + 4:]
             self.addChordStepModification(ChordStepModification('subtract', int(degree)))
             return
 
@@ -1836,7 +1853,7 @@ class ChordSymbol(Harmony):
                 continue
             justints = itemString.replace('b', '')
             justints = justints.replace('#', '')
-            if int(justints) > 20: # MSC: what is this doing?
+            if int(justints) > 20:  # MSC: what is this doing?
                 skipNext = False
                 i = 0
                 charString = ''
@@ -1920,7 +1937,7 @@ class ChordSymbol(Harmony):
             'minor-11th',
             'minor-13th',
             'minor-ninth',
-            )
+        )
 
         if 'root' not in self._overrides or self.chordKind is None:
             return
@@ -1950,12 +1967,12 @@ class ChordSymbol(Harmony):
             inversionNum = self.inversion()
 
             if not self.inversionIsValid(inversionNum):
-                #there is a bass, yet no normal inversion was found....must be added note
+                # there is a bass, yet no normal inversion was found....must be added note
 
                 inversionNum = None
                 self._overrides['bass'].octave = 2
-                    # arbitrary octave, must be below root,
-                    # which was arbitrarily chosen as 3 above
+                # arbitrary octave, must be below root,
+                # which was arbitrarily chosen as 3 above
                 pitches.append(self._overrides['bass'])
         else:
             self.inversion(None, transposeOnSet=False)
@@ -1964,31 +1981,31 @@ class ChordSymbol(Harmony):
         if inversionNum not in (0, None):
             for p in pitches[0:inversionNum]:
                 if self.chordKind in nineElevenThirteen:
-                    #bump octave up by two for nineths,elevenths, and thirteenths
+                    # bump octave up by two for nineths,elevenths, and thirteenths
                     p.octave = p.octave + 2
-                    #this creates more spacing....
+                    # this creates more spacing....
                 else:
-                    #only bump up by one for triads and sevenths.
+                    # only bump up by one for triads and sevenths.
                     p.octave = p.octave + 1
 
-            #if after bumping up the octaves, there are still pitches below bass pitch
-            #bump up their octaves
-            #bassPitch = pitches[inversionNum]
+            # if after bumping up the octaves, there are still pitches below bass pitch
+            # bump up their octaves
+            # bassPitch = pitches[inversionNum]
 
-            #self.bass(bassPitch)
+            # self.bass(bassPitch)
             for p in pitches:
                 if p.diatonicNoteNum < self._overrides['bass'].diatonicNoteNum:
                     p.octave = p.octave + 1
 
         pitches = list(self._adjustPitchesForChordStepModifications(pitches))
 
-        while self._hasPitchAboveC4(pitches) :
+        while self._hasPitchAboveC4(pitches):
             for thisPitch in pitches:
                 thisPitch.octave -= 1
 
-        #but if this has created pitches below lowest note (the A 3 octaves below middle C)
-        #on a standard piano, we're going to have to bump all the octaves back up
-        while self._hasPitchBelowA1(pitches) :
+        # but if this has created pitches below lowest note (the A 3 octaves below middle C)
+        # on a standard piano, we're going to have to bump all the octaves back up
+        while self._hasPitchBelowA1(pitches):
             for thisPitch in pitches:
                 thisPitch.octave += 1
 
@@ -2091,11 +2108,11 @@ class ChordSymbol(Harmony):
          <music21.pitch.Pitch G3>)
         '''
         if self.chordStepModifications or self.chordKind:
-            #there is no hope to determine the chord from pitches
+            # there is no hope to determine the chord from pitches
             # if it's been modified, so we'll just have to try this route....
 
             if self.root() is None:
-                raise HarmonyException('Cannot find figure. No root to the chord found' , self)
+                raise HarmonyException('Cannot find figure. No root to the chord found', self)
             else:
                 figure = self.root().name
             kind = self.chordKind
@@ -2118,13 +2135,13 @@ class ChordSymbol(Harmony):
                         s = 'b'
                     prefix = s * abs(numAlter)
 
-                    figure += ' ' + csmod.modType + ' ' +  prefix + str(csmod.degree)
+                    figure += ' ' + csmod.modType + ' ' + prefix + str(csmod.degree)
                 else:
                     figure += ' ' + csmod.modType + ' ' + str(csmod.degree)
 
             return figure
-        else: # if neither chordKind nor chordStepModifications, best bet is probably to
-            #try to deduce the figure from the chord
+        else:  # if neither chordKind nor chordStepModifications, best bet is probably to
+            # try to deduce the figure from the chord
             return chordSymbolFigureFromChord(self)
 
     def inversionIsValid(self, inversion):
@@ -2146,42 +2163,42 @@ class ChordSymbol(Harmony):
             'major-minor',
             'major-seventh',
             'minor-seventh',
-            )
+        )
         ninths = (
             'dominant-ninth',
             'major-ninth',
             'minor-ninth',
-            )
+        )
         elevenths = (
             'dominant-11th',
             'major-11th',
             'minor-11th',
-            )
+        )
         thirteenths = (
             'dominant-13th',
             'major-13th',
             'minor-13th',
-            )
+        )
         if inversion == 5 and (
             self.chordKind in thirteenths
             or self.chordKind in elevenths
-            ):
+        ):
             return True
         elif inversion == 4 and (
             self.chordKind in elevenths
             or self.chordKind in thirteenths
             or self.chordKind in ninths
-            ):
+        ):
             return True
         elif inversion == 3 and (
             self.chordKind in sevenths
             or self.chordKind in ninths
             or self.chordKind in elevenths
             or self.chordKind in thirteenths
-            ):
+        ):
             return True
         elif ((inversion == 2 or inversion == 1)
-                and not self.chordKind == 'pedal'):
+              and not self.chordKind == 'pedal'):
             return True
         elif inversion is None:
             return False
@@ -2189,7 +2206,7 @@ class ChordSymbol(Harmony):
             return False
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 
 def realizeChordSymbolDurations(piece):
@@ -2289,7 +2306,7 @@ def realizeChordSymbolDurations(piece):
         return piece
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 
 class Test(unittest.TestCase):
@@ -2302,7 +2319,7 @@ class Test(unittest.TestCase):
         cs = harmony.ChordSymbol('Cm')
         self.assertEqual(str(cs), '<music21.harmony.ChordSymbol Cm>')
         self.assertEqual(str(cs.pitches),
-            '(<music21.pitch.Pitch C3>, <music21.pitch.Pitch E-3>, <music21.pitch.Pitch G3>)')
+                         '(<music21.pitch.Pitch C3>, <music21.pitch.Pitch E-3>, <music21.pitch.Pitch G3>)')
         self.assertEqual(str(cs.bass()), 'C3')
         self.assertEqual(cs.isConsonant(), True)
 
@@ -2356,12 +2373,11 @@ class Test(unittest.TestCase):
 
         self.assertEqual(len(vector), 12)
 
-
     def testChordKindSetting(self):
         cs = ChordSymbol()
         cs.root('E-')
         cs.bass('B-')
-        cs.inversion(2, transposeOnSet = False)
+        cs.inversion(2, transposeOnSet=False)
         cs.romanNumeral = 'I64'
         cs.chordKind = 'major'
         cs.chordKindStr = 'M'
@@ -2380,7 +2396,7 @@ class Test(unittest.TestCase):
         self.assertEqual(b.nameWithOctave, 'E-3')
 
 
-class TestExternal(unittest.TestCase): # pragma: no cover
+class TestExternal(unittest.TestCase):  # pragma: no cover
 
     def runTest(self):
         pass
@@ -2390,10 +2406,9 @@ class TestExternal(unittest.TestCase): # pragma: no cover
         from music21 import corpus, stream
         testFile = corpus.parse('leadSheet/fosterBrownHair.xml')
 
-
         testFile.show('text')
         testFile = harmony.realizeChordSymbolDurations(testFile)
-        #testFile.show()
+        # testFile.show()
         chordSymbols = testFile.flat.getElementsByClass(harmony.ChordSymbol)
         s = stream.Stream()
 
@@ -2401,39 +2416,41 @@ class TestExternal(unittest.TestCase): # pragma: no cover
             cS.writeAsChord = False
             s.append(cS)
 
-        #csChords = s.flat.getElementsByClass(chord.Chord)
-        #s.show()
-        #self.assertEqual(len(csChords), 40)
-#
+        # csChords = s.flat.getElementsByClass(chord.Chord)
+        # s.show()
+        # self.assertEqual(len(csChords), 40)
+
+    #
     def testChordRealization(self):
         from music21 import harmony, corpus, note, stream
-        #There is a test file under demos called ComprehensiveChordSymbolsTestFile.xml
-        #that should contain a complete iteration of tests of chord symbol objects
-        #this test makes sure that no error exists, and checks that 57 chords were
-        #created out of that file....feel free to add to file if you find missing
-        #tests, and adjust 57 accordingly
+        # There is a test file under demos called ComprehensiveChordSymbolsTestFile.xml
+        # that should contain a complete iteration of tests of chord symbol objects
+        # this test makes sure that no error exists, and checks that 57 chords were
+        # created out of that file....feel free to add to file if you find missing
+        # tests, and adjust 57 accordingly
         testFile = corpus.parse('demos/ComprehensiveChordSymbolsTestFile.xml')
 
         testFile = harmony.realizeChordSymbolDurations(testFile)
         chords = testFile.flat.getElementsByClass(harmony.ChordSymbol)
-        #testFile.show()
+        # testFile.show()
         s = stream.Stream()
-#        i = 0
+        #        i = 0
         for x in chords:
             # print(x.pitches)
             x.quarterLength = 0
             s.insert(x.offset, x)
-            #i += 4
+            # i += 4
 
-            #x.show()
+            # x.show()
 
         s.makeRests(fillGaps=True, inPlace=True)
         s.append(note.Rest(quarterLength=4))
         unused_csChords = s.flat.getElementsByClass(chord.Chord)
-        #self.assertEqual(len(csChords), 57)
-        #s.show()
-        #s.show('text')
-    #def realizeCSwithFB(self):
+        # self.assertEqual(len(csChords), 57)
+        # s.show()
+        # s.show('text')
+
+    # def realizeCSwithFB(self):
     # see music21-demos : hadley.HarmonyRealizer
 
     def testALLchordKinds(self):
@@ -2441,38 +2458,38 @@ class TestExternal(unittest.TestCase): # pragma: no cover
         this is an outdated test
         '''
         chordKinds = {
-            'major': ('', 'Maj'),
-            'minor': ('m', '-', 'min'),
-            'augmented': ('+', '#5'),
-            'diminished': ('dim', 'o'),
-            'dominant': ('7'),
-            'major-seventh': ( 'M7', 'Maj7'),
-            'minor-seventh': ('m7', 'min7'),
+            'major':              ('', 'Maj'),
+            'minor':              ('m', '-', 'min'),
+            'augmented':          ('+', '#5'),
+            'diminished':         ('dim', 'o'),
+            'dominant':           ('7'),
+            'major-seventh':      ('M7', 'Maj7'),
+            'minor-seventh':      ('m7', 'min7'),
             'diminished-seventh': ('dim7', 'o7'),
-            'augmented-seventh': ('7+', '7#5'),
-            'half-diminished': ('m7b5'),
-            'major-minor': ('mMaj7'),
-            'major-sixth': ('6'),
-            'minor-sixth': ('m6', 'min6'),
-            'dominant-ninth': ('9'),
-            'major-ninth': ('M9', 'Maj9'),
-            'minor-ninth': ('m9', 'min9'),
-            'dominant-11th': ('11'),
-            'major-11th': ('M11', 'Maj11'),
-            'minor-11th': ('m11', 'min11'),
-            'dominant-13th': ('13'),
-            'major-13th': ('M13', 'Maj13'),
-            'minor-13th': ('m13', 'min13'),
-            'suspended-second': ('sus2'),
-            'suspended-fourth': ('sus', 'sus4'),
-            'Neapolitan': ('N6'),
-            'Italian': ('It+6'),
-            'French': ('Fr+6'),
-            'German': ('Gr+6'),
-            'pedal': ('pedal'),
-            'power': ('power'),
-            'Tristan': ('tristan'),
-            }
+            'augmented-seventh':  ('7+', '7#5'),
+            'half-diminished':    ('m7b5'),
+            'major-minor':        ('mMaj7'),
+            'major-sixth':        ('6'),
+            'minor-sixth':        ('m6', 'min6'),
+            'dominant-ninth':     ('9'),
+            'major-ninth':        ('M9', 'Maj9'),
+            'minor-ninth':        ('m9', 'min9'),
+            'dominant-11th':      ('11'),
+            'major-11th':         ('M11', 'Maj11'),
+            'minor-11th':         ('m11', 'min11'),
+            'dominant-13th':      ('13'),
+            'major-13th':         ('M13', 'Maj13'),
+            'minor-13th':         ('m13', 'min13'),
+            'suspended-second':   ('sus2'),
+            'suspended-fourth':   ('sus', 'sus4'),
+            'Neapolitan':         ('N6'),
+            'Italian':            ('It+6'),
+            'French':             ('Fr+6'),
+            'German':             ('Gr+6'),
+            'pedal':              ('pedal'),
+            'power':              ('power'),
+            'Tristan':            ('tristan'),
+        }
 
         notes = ['A', 'B', 'C', 'D', 'E', 'F', 'G']
         mod = ['', '-', '#']
@@ -2482,6 +2499,7 @@ class TestExternal(unittest.TestCase): # pragma: no cover
                     for harmony_type in val:
                         print(n + m + ',' + harmony_type,
                               ChordSymbol(n + m + ',' + harmony_type).pitches)
+
 
 #     def labelChordSymbols(self):
 #         '''
@@ -2538,16 +2556,15 @@ class TestExternal(unittest.TestCase): # pragma: no cover
 #         excerpt.show()
 
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 
 _DOC_ORDER = [Harmony, chordSymbolFigureFromChord, ChordSymbol, ChordStepModification]
 
-
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test) #, runTest='chordSymbolSetsBassOctave')
 
+    music21.mainTest(Test)  # , runTest='chordSymbolSetsBassOctave')
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # eof

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -95,6 +95,8 @@ CHORD_TYPES = collections.OrderedDict([
     # other
     ('suspended-second',            ['1,2,5', ['sus2']]),                        # Y
     ('suspended-fourth',            ['1,4,5', ['sus', 'sus4']]),                 # Y
+	('seventh-suspended-fourth',    ['1,4,5,-7', ['7sus4', '7sus']]),            # Y
+	('minor-seventh-added-fourth',  ['1,-3,4,-7', ['m7add4']]),                  # Y
     ('Neapolitan',                  ['1,2-,3,5-', ['N6']]),                      # Y
     ('Italian',                     ['1,#4,-6', ['It+6', 'It']]),                # Y
     ('French',                      ['1,2,#4,-6', ['Fr+6', 'Fr']]),              # Y
@@ -1218,6 +1220,11 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
                 inChord.root(inChord.bass())
                 kindStr = 'sus'
                 kind = 'suspended-fourth'
+                cs = inChord.root().name + kindStr
+            elif kindStr == 'm7add4':
+                inChord.root(inChord.bass())
+                kindStr = '7sus4'
+                kind = 'seventh-suspended-fourth'
                 cs = inChord.root().name + kindStr
             else:
                 cs = inChord.root().name + kindStr + '/' + inChord.bass().name

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -58,7 +58,8 @@ CHORD_TYPES = collections.OrderedDict([
     ('minor-seventh',               ['1,-3,5,-7', ['m7', 'min7']]),          # Y
     ('augmented-major seventh',     ['1,3,#5,7', ['+M7', 'augmaj7']]),       # N
     ('augmented-seventh',           ['1,3,#5,-7', ['7+', '+7', 'aug7']]),    # Y
-    ('half-diminished-seventh',     ['1,-3,-5,-7', ['/o7', 'm7b5']]),        # Y: 'half-diminished'
+    ('half-diminished-seventh',     ['1,-3,-5,-7', ['m7b5', '/o7']]),
+    # Y: 'half-diminished'
     ('diminished-seventh',          ['1,-3,-5,--7', ['o7', 'dim7']]),        # Y
     ('seventh-flat-five',           ['1,3,-5,-7', ['7b5', 'dom7dim5']]),        # N
     # sixths
@@ -68,6 +69,7 @@ CHORD_TYPES = collections.OrderedDict([
     ('major-ninth',                 ['1,3,5,7,9', ['M9', 'Maj9']]),              # Y
     ('dominant-ninth',              ['1,3,5,-7,9', ['9', 'dom9']]),              # Y
 	('dominant-minor-ninth',        ['1,3,5,-7,-9', ['7b9']]),                   # Y
+    ('dominant-minor-ninth-flat-fifth', ['1,3,-5,-7,-9', ['7b9b5']]),            # Y
 	('dominant-altered-ninth',      ['1,3,5,-7,#9', ['7#9']]),                   # Y
     ('minor-major-ninth',           ['1,-3,5,7,9', ['mM9', 'minmaj9']]),         # N
     ('minor-ninth',                 ['1,-3,5,-7,9', ['m9', 'min9']]),            # N
@@ -97,7 +99,7 @@ CHORD_TYPES = collections.OrderedDict([
     # other
     ('suspended-second',            ['1,2,5', ['sus2']]),                        # Y
     ('suspended-fourth',            ['1,4,5', ['sus', 'sus4']]),                 # Y
-	('seventh-suspended-fourth',    ['1,4,5,-7', ['7sus', '7sus4']]),            # Y
+	('seventh-suspended-fourth',    ['1,4,5,-7', ['7sus4', '7sus']]),            # Y
 	('ninth-suspended-fourth',      ['1,4,5,-7,9', ['9sus', '9sus4']]),          # Y
     ('Neapolitan',                  ['1,2-,3,5-', ['N6']]),                      # Y
     ('Italian',                     ['1,#4,-6', ['It+6', 'It']]),                # Y

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -67,6 +67,7 @@ CHORD_TYPES = collections.OrderedDict([
     # ninths
     ('major-ninth',                 ['1,3,5,7,9', ['M9', 'Maj9']]),              # Y
     ('dominant-ninth',              ['1,3,5,-7,9', ['9', 'dom9']]),              # Y
+	('dominant-minor-ninth',        ['1,3,5,-7,-9', ['7b9']]),                   # Y
     ('minor-major-ninth',           ['1,-3,5,7,9', ['mM9', 'minmaj9']]),         # N
     ('minor-ninth',                 ['1,-3,5,-7,9', ['m9', 'min9']]),            # N
     ('augmented-major-ninth',       ['1,3,#5,7,9', ['+M9', 'augmaj9']]),         # Y


### PR DESCRIPTION
7sus4 chords are the only sus4 chords (sus4, 7sus4, 9sus4) that could not be parsed with 
```
music21.harmony.chordSymbolFromChord
```
even when the root note is specified.
Solves #197 
