### PR TITLE
Added support for accid.ges on accid element

### DIFF
--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -1898,6 +1898,10 @@ def accidFromElement(elem, slurBundle=None):  # pylint: disable=unused-argument
     **Attributes/Elements Implemented:**
 
     - @accid (from att.accid.log)
+    - @accid.ges (from att.accid.ges)
+
+    .. note:: If set, the @accid.ges attribute is always imported as the music21 :class:`Accidental`
+        for this note. We assume it corresponds to the accidental implied by a key signature.
 
     **Attributes/Elements in Testing:** none
 
@@ -1916,11 +1920,14 @@ def accidFromElement(elem, slurBundle=None):  # pylint: disable=unused-argument
             - (att.staffident (@staff)) (att.layerident (@layer)))
 
     - att.accid.vis (all)
-    - att.accid.gesatt.accid.anl (all)
+    - att.accid.anl (all)
 
     **Contained Elements not Implemented:** none
     '''
-    return _accidentalFromAttr(elem.get('accid'))
+    if elem.get('accid.ges') is not None:
+        return _accidGesFromAttr(elem.get('accid.ges', ''))
+    else:
+        return _accidentalFromAttr(elem.get('accid'))
 
 
 def sylFromElement(elem, slurBundle=None):  # pylint: disable=unused-argument


### PR DESCRIPTION
Hello,

I've added a small change to support accid.ges on `<accid>` This is based on the support for accid.get on `<note>`.

Please let me know if there is anything more needed to properly contribute to the project.

We're hoping to use this fix in a workshop at the Digital Humanities Summer School at the University of Victoria this June 2018, so it would be awesome to have this integrated by then!