### PR TITLE
Fixed wrong b to - conversion (shouldn't convert lowercase pitch b)

### DIFF
--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -284,6 +284,7 @@ def parseTokens(mh, dst, p, useMeasures):
                 cs_name = t.chordSymbols[0]
                 cs_name = re.sub('["]','', cs_name).lstrip().rstrip()
                 cs_name = re.sub('[()]', '', cs_name)
+                cs_name = common.cleanedFlatNotation(cs_name)
                 try:
                     cs = harmony.ChordSymbol(cs_name)
                     dst.coreAppend(cs, setActiveSite=False)
@@ -928,6 +929,32 @@ class Test(unittest.TestCase):
             s = corpus.parse(fn)
             assert s is not None
             #s.show()
+
+    def testCleanFlat(self):
+        from music21 import harmony, pitch
+
+        cs = harmony.ChordSymbol(root='eb', bass='bb', kind='dominant')
+        self.assertEquals(cs.bass(), pitch.Pitch('B-'))
+        self.assertEquals(cs.pitches[0], pitch.Pitch('B-2'))
+
+        cs = harmony.ChordSymbol('e-7/b-')
+        self.assertEquals(cs.root(), pitch.Pitch('E-3'))
+        self.assertEquals(cs.bass(), pitch.Pitch('B-2'))
+        self.assertEquals(cs.pitches[0], pitch.Pitch('B-2'))
+
+        # common.cleanedFlatNotation() shouldn't be called by
+        # the following calls, which what is being tested here:
+
+        cs = harmony.ChordSymbol('b-3')
+        self.assertEquals(cs.root(), pitch.Pitch('b-3'))
+        self.assertEquals(cs.pitches[0], pitch.Pitch('B-3'))
+        self.assertEquals(cs.pitches[1], pitch.Pitch('D4'))
+
+        cs = harmony.ChordSymbol('bb3')
+        self.assertEquals(cs.root(), pitch.Pitch('b3'))
+        self.assertEquals(cs.pitches[0], pitch.Pitch('B3'))
+        self.assertEquals(cs.pitches[1], pitch.Pitch('D#4'))
+
 
     def xtestTranslateB(self):
         '''

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -284,9 +284,6 @@ def parseTokens(mh, dst, p, useMeasures):
                 cs_name = t.chordSymbols[0]
                 cs_name = re.sub('["]','', cs_name).lstrip().rstrip()
                 cs_name = re.sub('[()]', '', cs_name)
-                cs_name = re.sub('[ /].*', '', cs_name)
-                cs_name = re.sub('([A-Ga-g])b', r'\1-', cs_name) # Replace b
-                #  with - in malformed chord names
                 try:
                     cs = harmony.ChordSymbol(cs_name)
                     dst.coreAppend(cs, setActiveSite=False)

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -830,6 +830,23 @@ class Test(unittest.TestCase):
 
         #sMerged.show()
 
+    def testChordSymbols(self):
+
+        from music21 import corpus, pitch
+        o = corpus.parse('nottingham-dataset/reelsa-c')
+        self.assertEqual(len(o), 2)
+        # each score in the opus is a Stream that contains a Part and metadata
+
+        p1 = o.getScoreByNumber(81).parts[0]
+        self.assertEqual(p1.offset, 0.0)
+        self.assertEqual(len(p1.flat.notesAndRests), 77)
+        self.assertEqual(len(list(p1.flat.getElementsByClass('ChordSymbol'))), 25)
+        # Am/C
+        self.assertEqual(list(p1.flat.getElementsByClass('ChordSymbol'))[7].root(), pitch.Pitch('A3'))
+        self.assertEqual(list(p1.flat.getElementsByClass('ChordSymbol'))[7].bass(), pitch.Pitch('C3'))
+        # G7/B
+        self.assertEqual(list(p1.flat.getElementsByClass('ChordSymbol'))[14].root(), pitch.Pitch('G3'))
+        self.assertEqual(list(p1.flat.getElementsByClass('ChordSymbol'))[14].bass(), pitch.Pitch('B2'))
 
     def testLocaleOfCompositionImport(self):
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -537,9 +537,6 @@ class Chord(note.NotRest):
         else:
             return [n.pitch for n in deleteComponents]
 
-    def _cleanedFlatNotation(self, music_str):
-        return re.sub('([A-Ga-g])b', r'\1-', music_str)
-
     ### PUBLIC METHODS ###
     def _add_core_or_init(self, notes, *, useDuration=None):
         '''
@@ -891,7 +888,7 @@ class Chord(note.NotRest):
         '''
         if newbass:
             if isinstance(newbass, str):
-                newbass = self._cleanedFlatNotation(newbass)
+                newbass = common.cleanedFlatNotation(newbass)
                 newbass = pitch.Pitch(newbass)
 
             self._overrides['bass'] = newbass
@@ -3001,7 +2998,7 @@ class Chord(note.NotRest):
         '''
         if newroot:
             if isinstance(newroot, str):
-                newroot = self._cleanedFlatNotation(newroot)
+                newroot = common.cleanedFlatNotation(newroot)
                 newroot = pitch.Pitch(newroot)
 
             self._overrides['root'] = newroot

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -17,6 +17,7 @@ __all__ = ['tables', 'Chord']
 
 import copy
 import unittest
+import re
 
 from music21 import beam
 from music21 import common
@@ -536,6 +537,9 @@ class Chord(note.NotRest):
         else:
             return [n.pitch for n in deleteComponents]
 
+    def _cleanedFlatNotation(self, music_str):
+        return re.sub('([A-Ga-g])b', r'\1-', music_str)
+
     ### PUBLIC METHODS ###
     def _add_core_or_init(self, notes, *, useDuration=None):
         '''
@@ -887,7 +891,7 @@ class Chord(note.NotRest):
         '''
         if newbass:
             if isinstance(newbass, str):
-                newbass = newbass.replace('b', '-')
+                newbass = self._cleanedFlatNotation(newbass)
                 newbass = pitch.Pitch(newbass)
 
             self._overrides['bass'] = newbass
@@ -2997,7 +3001,7 @@ class Chord(note.NotRest):
         '''
         if newroot:
             if isinstance(newroot, str):
-                newroot = newroot.replace('b', '-')
+                newroot = self._cleanedFlatNotation(newroot)
                 newroot = pitch.Pitch(newroot)
 
             self._overrides['root'] = newroot

--- a/music21/common/misc.py
+++ b/music21/common/misc.py
@@ -12,6 +12,7 @@
 '''
 If it doesn't fit anywhere else in the common directory, you'll find it here...
 '''
+import re
 
 __all__ = ['flattenList',
            'getMissingImportStr',
@@ -20,6 +21,7 @@ __all__ = ['flattenList',
            'pitchList',
            'runningUnderIPython',
            'defaultDeepcopy',
+           'cleanedFlatNotation'
            ]
 
 import copy
@@ -200,6 +202,16 @@ def defaultDeepcopy(obj, memo, callInit=True):
 
     return new
 
+def cleanedFlatNotation(music_str):
+    """
+    Returns a copy of the given string where each occurrence of a flat note
+    specified with a 'b' is replaced by a '-'.
+    :param music_str: a string containing a note specified (for example in a chord)
+    :return: a new string with flats only specified with '-'.
+    >>> common.cleanedFlatNotation('Cb')
+    'C-'
+    """
+    return re.sub('([A-Ga-g])b', r'\1-', music_str)
 
 if __name__ == '__main__':
     import music21

--- a/music21/common/pathTools.py
+++ b/music21/common/pathTools.py
@@ -80,7 +80,7 @@ def getCorpusContentDirs():
     ['airdsAirs', 'bach', 'beach', 'beethoven', 'chopin', 
      'ciconia', 'corelli', 'cpebach',
      'demos', 'essenFolksong', 'handel', 'haydn', 'joplin', 'josquin', 
-     'leadSheet', 'luca', 'miscFolk', 'monteverdi', 'mozart', 
+     'leadSheet', 'luca', 'miscFolk', 'monteverdi', 'mozart', 'nottingham-dataset',
      'oneills1850', 'palestrina',
      'ryansMammoth', 'schoenberg', 'schubert', 'schumann', 'schumann_clara',
      'theoryExercises', 'trecento', 'verdi', 'weber']

--- a/music21/corpus/corpora.py
+++ b/music21/corpus/corpora.py
@@ -522,6 +522,7 @@ class CoreCorpus(Corpus):
         ('miscFolk', 'Miscellaneous Folk', False),
         ('monteverdi', 'Claudio Monteverdi', True),
         ('mozart', 'Wolfgang Amadeus Mozart', True),
+        ('nottingham-dataset', 'Nottingham Music Database (partial)', False),
         ('oneills1850', 'Oneill\'s 1850 Collection', False),
         ('palestrina', 'Giovanni Palestrina', True),
         ('ryansMammoth', 'Ryan\'s Mammoth Collection', False),

--- a/music21/corpus/nottingham-dataset/reelsa-c.abc
+++ b/music21/corpus/nottingham-dataset/reelsa-c.abc
@@ -1,0 +1,31 @@
+
+X: 80
+T:Cuckoo's Nest
+% Nottingham Music Database
+S:Scottish, via EF
+M:4/4
+L:1/4
+K:D
+A|"D"A/2d/2d/2c/2 d/2e/2f/2d/2|"Em"e/2d/2c/2B/2 "A"AA/2B/2|\
+"C"=c/2B/2A/2B/2 c/2e/2d/2c/2|"Em"B/2A/2G/2F/2 "A7"GA/2G/2|
+"D"F/2D/2F/2A/2 d/2f/2e/2d/2|"Em"c/2A/2G/2F/2 "A7"GA/2G/2|\
+"D"FD "A7"C/2D/2E/2G/2|"D"FD D:|
+F/2G/2|"D"A/2F/2D/2F/2 A/2F/2D/2F/2|"D"A/2G/2F/2E/2 DE/2=F/2|\
+"C"G/2E/2=C/2E/2 G/2E/2C/2E/2|
+"C"G/2=F/2E/2D/2 =CD/2E/2|"D"F/2D/2F/2A/2 d/2f/2e/2d/2|\
+"A7"c/2A/2G/2F/2 GA/2G/2|"D"FD "A7"C/2D/2E/2G/2|"D"FD D:|
+"G"B/2c/2d/2e/2 "A7"d/2c/2B/2A/2|
+
+
+X: 81
+T:Little Czech Number
+% Nottingham Music Database
+S:Joy, via EF
+M:4/4
+L:1/4
+K:Am
+|:E|"Am"A^G A"E7"B|"Am"cB c"E7"d|"Am"e^d e"Dm"f|"Am"e2 -"Am/c"e2|"Dm"d^c de|\
+"Am/e"cB cd|"E7"B^A Bc|[1"Am"A3:|[2 "Am" A4|||:
+"Am"a2 "G7/b"e2|"C"ef g2|"D"dd "E7"ed|"Am"cB A2:|:
+"Am"AB "Am/g"c2|"D/f+"AB "F"c2|"E7"ed Bc|"Am"A4:|
+

--- a/music21/corpus/nottingham-dataset/reelsa-c.abc
+++ b/music21/corpus/nottingham-dataset/reelsa-c.abc
@@ -1,4 +1,3 @@
-
 X: 80
 T:Cuckoo's Nest
 % Nottingham Music Database
@@ -6,15 +5,16 @@ S:Scottish, via EF
 M:4/4
 L:1/4
 K:D
+P:A
 A|"D"A/2d/2d/2c/2 d/2e/2f/2d/2|"Em"e/2d/2c/2B/2 "A"AA/2B/2|\
 "C"=c/2B/2A/2B/2 c/2e/2d/2c/2|"Em"B/2A/2G/2F/2 "A7"GA/2G/2|
 "D"F/2D/2F/2A/2 d/2f/2e/2d/2|"Em"c/2A/2G/2F/2 "A7"GA/2G/2|\
 "D"FD "A7"C/2D/2E/2G/2|"D"FD D:|
+P:B
 F/2G/2|"D"A/2F/2D/2F/2 A/2F/2D/2F/2|"D"A/2G/2F/2E/2 DE/2=F/2|\
 "C"G/2E/2=C/2E/2 G/2E/2C/2E/2|
 "C"G/2=F/2E/2D/2 =CD/2E/2|"D"F/2D/2F/2A/2 d/2f/2e/2d/2|\
 "A7"c/2A/2G/2F/2 GA/2G/2|"D"FD "A7"C/2D/2E/2G/2|"D"FD D:|
-"G"B/2c/2d/2e/2 "A7"d/2c/2B/2A/2|
 
 
 X: 81
@@ -24,8 +24,8 @@ S:Joy, via EF
 M:4/4
 L:1/4
 K:Am
+P:A
 |:E|"Am"A^G A"E7"B|"Am"cB c"E7"d|"Am"e^d e"Dm"f|"Am"e2 -"Am/c"e2|"Dm"d^c de|\
-"Am/e"cB cd|"E7"B^A Bc|[1"Am"A3:|[2 "Am" A4|||:
-"Am"a2 "G7/b"e2|"C"ef g2|"D"dd "E7"ed|"Am"cB A2:|:
+"Am/e"cB cd|"E7"B^A Bc|[1"Am"A3:|[2 "Am" A4|
+"Am"a2 "G7/b"e2|"C"ef g2|"D"dd "E7"ed|"Am"cB A2:|
 "Am"AB "Am/g"c2|"D/f+"AB "F"c2|"E7"ed Bc|"Am"A4:|
-

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -247,13 +247,13 @@ class Harmony(chord.Chord):
         for kw in keywords:
             if kw == 'root':
                 if isinstance(keywords[kw], str):
-                    keywords[kw] = self._cleanedFlatNotation(keywords[kw])
+                    keywords[kw] = common.cleanedFlatNotation(keywords[kw])
                     self.root(pitch.Pitch(keywords[kw]))
                 else:
                     self.root(keywords[kw])
             elif kw == 'bass':
                 if isinstance(keywords[kw], str):
-                    keywords[kw] = self._cleanedFlatNotation(keywords[kw])
+                    keywords[kw] = common.cleanedFlatNotation(keywords[kw])
                     self.bass(pitch.Pitch(keywords[kw]))
                 else:
                     self.bass(keywords[kw])
@@ -677,6 +677,14 @@ def addNewChordSymbol(chordTypeName, fbNotationString, AbbreviationList):
      <music21.pitch.Pitch E-3>, <music21.pitch.Pitch A--3>)
 
     OMIT_FROM_DOCS
+
+    >>> harmony.ChordSymbol(root='Cb', kind='BethChord').pitches
+    (<music21.pitch.Pitch C-3>, <music21.pitch.Pitch D3>,
+     <music21.pitch.Pitch E-3>, <music21.pitch.Pitch A--3>)
+
+    >>> harmony.ChordSymbol(root='C-', kind='BethChord').pitches
+    (<music21.pitch.Pitch C-3>, <music21.pitch.Pitch D3>,
+     <music21.pitch.Pitch E-3>, <music21.pitch.Pitch A--3>)
 
     >>> harmony.removeChordSymbols('BethChord')
     '''

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -246,13 +246,13 @@ class Harmony(chord.Chord):
         for kw in keywords:
             if kw == 'root':
                 if isinstance(keywords[kw], str):
-                    keywords[kw].replace('b', '-')
+                    keywords[kw] = self._cleanedFlatNotation(keywords[kw])
                     self.root(pitch.Pitch(keywords[kw]))
                 else:
                     self.root(keywords[kw])
             elif kw == 'bass':
                 if isinstance(keywords[kw], str):
-                    keywords[kw].replace('b', '-')
+                    keywords[kw] = self._cleanedFlatNotation(keywords[kw])
                     self.bass(pitch.Pitch(keywords[kw]))
                 else:
                     self.bass(keywords[kw])


### PR DESCRIPTION
We fixed a bug where pitch 'b' was converted to a '-' (ultimately raising an exception), when the intention was to convert a flat specified with a 'b'. This bug affected the creation of a chord that contained pitch 'b' either in its root or its bass.

Incidentally, the calls to replace() in music21/harmony.py lines 249 and 255 had not effect, so the bug wasn't always manifesting itself, depending on how the chords were instantiated.

Co-authored-by: Vincent Degroote <1230888+vinzentt@users.noreply.github.com>
Co-authored-by: Alexandre Papadopoulos <32906275+a-papadopoulos@users.noreply.github.com>