### PR TITLE
Added new procedures for pickling and unpickling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ documentation/source/tutorials/MersenneDemo_files/_fig_05.png
 .cache/v/cache/lastfailed
 
 .ropeproject/config.py
+music21/.ropeproject/
+music21/test/.ropeproject/

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -83,6 +83,7 @@ from music21 import derivation
 from music21 import exceptions21
 
 # these imports are for the sapo pickle module
+import importlib
 import copyreg
 import io
 import music21.converter
@@ -1361,8 +1362,13 @@ def load(file):
     return pickle.load(file)
 
 
-# register our methods to be used in multiprocessing lib
-multiprocessing.reduction.register(music21.stream.Stream, pickle_music21_stream)
+# this is needed because freezeThaw is loaded before than music21.stream is ready.
+# VERY UGLY!!!
+found = importlib.util.find_spec("stream", package="music21")
+if found:
+    # register our methods to be used in multiprocessing lib
+    multiprocessing.reduction.register(
+        music21.stream.Stream, pickle_music21_stream)
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -1259,8 +1259,6 @@ class Test(unittest.TestCase):
 
 # this is the code for the new sapo pickle procedures
 
-
-
 # COMPRESSION_LEVEL = -1
 COMPRESSION_METHOD = 'None'
 
@@ -1289,29 +1287,25 @@ def setCompressionMethod(method: str):
     objects """
     COMPRESSION_METHOD = method
 
+    global compressedFile
     if COMPRESSION_METHOD == 'lzma':
         from lzma import decompress, compress
-        from lzma import LZMAFile as CompressedFile
+        from lzma import LZMAFile as compressedFile
     elif COMPRESSION_METHOD == 'gzip':
         from gzip import decompress, compress
         from gzip import GzipFile
 
         # the following is needed due to a not coherent syntax in standard
         # python libs
-        global CompressedFile
-
-        def CompressedFile(f):
+        def compressedFile(f):
             return GzipFile(fileobj=f)
 
     elif COMPRESSION_METHOD == 'bz2':
         from bz2 import decompress, compress
-        from bz2 import BZ2File as CompressedFile
+        from bz2 import BZ2File as compressedFile
     elif COMPRESSION_METHOD == 'None':
         # defining dummy functions
-
-        global CompressedFile
-
-        def CompressedFile(arg):
+        def compressedFile(arg):
             return arg
 
         global compress
@@ -1363,7 +1357,7 @@ def loads(data):
 
 def load(file):
     """ Depickle a file object, already opened in byte mode"""
-    file = CompressedFile(file)
+    file = compressedFile(file)
     return pickle.load(file)
 
 

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -6,6 +6,7 @@
 #
 # Authors:      Michael Scott Cuthbert
 #               Christopher Ariza
+#               Federico Simonetta
 #
 # Copyright:    Copyright © 2011-2012 Michael Scott Cuthbert and the music21
 #               Project
@@ -16,7 +17,8 @@ This module contains objects for storing complete `Music21Objects`, especially
 `Stream` and `Score` objects on disk.  Freezing (or "pickling") refers to
 writing the object to a file on disk (or to a string).  Thawing (or
 "unpickling") refers to reading in a string or file and returning a Music21
-object.
+object. This is useful for both writing to file and exchanging data between
+processes (i.e. when using `multiprocessing` module).
 
 This module offers alternatives to writing a `Score` to `MusicXML` with
 `s.write('musicxml')`.  `FreezeThaw` has some advantages over using `.write()`:
@@ -66,6 +68,25 @@ The name freezeThaw comes from Perl's implementation of similar methods -- I
 like the idea of thawing something that's frozen; "unpickling" just doesn't
 seem possible.  In any event, I needed a name that wouldn't already
 exist in the Python namespace.
+
+New procedures are available now. You can simply import this module and use
+it like the standard `pickle` module to write/reading files and whitin parallel
+procedures. It also support compression formats.
+
+You can import this with
+`from music21 import freezeThaw as pickle`
+
+Then, the following functions will be available:
+* `pickle.dump()`, to serialize an object
+* `pickle.dumps()`, to write an object to file through its serialization
+* `pickle.load()`, to load a serialized object
+* `pickle.loads()`, to load a file containing a serialized object
+
+Use `pickle.setCompressionMethod(METHOD)` to use a particular compression
+method, available values are 'lzma', 'gzip', 'bz2', 'None'.
+
+Once loaded, you can import `multiprocessing` module and use `music21` in
+parallel computing applications.
 '''
 
 import copy

--- a/music21/test/testSerialization.py
+++ b/music21/test/testSerialization.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Name:         testSerialization.py
 # Purpose:      tests for serializing music21 objects
 #
@@ -8,11 +8,11 @@
 #
 # Copyright:    Copyright © 2012-13 Michael Scott Cuthbert and the music21 Project
 # License:      LGPL or BSD, see license.txt
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 
 import unittest
-import music21 # needed to do fully-qualified isinstance name checking
+import music21  # needed to do fully-qualified isinstance name checking
 
 from music21 import freezeThaw
 
@@ -21,10 +21,7 @@ _MOD = "test.testSerialization"
 environLocal = environment.Environment(_MOD)
 
 
-
-
-
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 class Test(unittest.TestCase):
 
     def runTest(self):
@@ -44,7 +41,6 @@ class Test(unittest.TestCase):
         post = converter.thawStr(temp)
         self.assertEqual(len(post.notes), 2)
         self.assertEqual(str(post.notes[0].pitch), 'D2')
-
 
     def testBasicD(self):
         from music21 import stream, note, converter, spanner
@@ -70,9 +66,10 @@ class Test(unittest.TestCase):
         self.assertEqual(len(post.notes), 2)
         self.assertEqual(str(post.notes[0].pitch), 'D2')
         spPost = post.spanners[0]
-        self.assertEqual(spPost.getSpannedElements(), [post.notes[0], post.notes[1]])
-        self.assertEqual(spPost.getSpannedElementIds(), [id(post.notes[0]), id(post.notes[1])])
-
+        self.assertEqual(spPost.getSpannedElements(), [
+                         post.notes[0], post.notes[1]])
+        self.assertEqual(spPost.getSpannedElementIds(), [
+                         id(post.notes[0]), id(post.notes[1])])
 
     def testBasicE(self):
         from music21 import corpus, converter
@@ -80,13 +77,12 @@ class Test(unittest.TestCase):
 
         temp = converter.freezeStr(s, fmt='pickle')
         sPost = converter.thawStr(temp)
-        #sPost.show()
+        # sPost.show()
         self.assertEqual(len(s.flat.notes), len(sPost.flat.notes))
 
         self.assertEqual(len(s.parts[0].notes), len(sPost.parts[0].notes))
-        #print s.parts[0].notes
-        #sPost.parts[0].notes
-
+        # print s.parts[0].notes
+        # sPost.parts[0].notes
 
     def testBasicF(self):
         from music21 import stream, note, converter, spanner
@@ -103,8 +99,7 @@ class Test(unittest.TestCase):
         data = converter.freezeStr(s, fmt='pickle')
         sPost = converter.thawStr(data)
         self.assertEqual(len(sPost.notes), 5)
-        #sPost.show()
-
+        # sPost.show()
 
     def testBasicJ(self):
         from music21 import stream, note, converter
@@ -126,7 +121,7 @@ class Test(unittest.TestCase):
         s = stream.Score()
         s.insert(0, p1)
         s.insert(0, p2)
-        #s.show()
+        # s.show()
 
         temp = converter.freezeStr(s, fmt='pickle')
         sPost = converter.thawStr(temp)
@@ -134,7 +129,6 @@ class Test(unittest.TestCase):
         self.assertEqual(len(sPost.parts[0].getElementsByClass('Measure')), 3)
         self.assertEqual(len(sPost.parts[1].getElementsByClass('Measure')), 3)
         self.assertEqual(len(sPost.flat.notes), 24)
-
 
     def testBasicI(self):
         from music21 import stream, note, converter
@@ -148,7 +142,7 @@ class Test(unittest.TestCase):
         s = stream.Score()
         s.insert(0, p1)
         s.insert(0, p2)
-        #s.show()
+        # s.show()
 
         temp = converter.freezeStr(s, fmt='pickle')
         sPost = converter.thawStr(temp)
@@ -156,7 +150,6 @@ class Test(unittest.TestCase):
         self.assertEqual(len(sPost.parts[0].getElementsByClass('Measure')), 3)
         self.assertEqual(len(sPost.parts[1].getElementsByClass('Measure')), 3)
         self.assertEqual(len(sPost.flat.notes), 24)
-
 
     def testSpannerSerializationOfNotesNotInPickle(self):
         '''
@@ -175,40 +168,105 @@ class Test(unittest.TestCase):
         data = converter.freezeStr(s, fmt='pickle')
 
         unused_s2 = converter.thawStr(data)
-        #s2.show('text')
-
+        # s2.show('text')
 
     def testBigCorpus(self):
         from music21 import corpus, converter
         #import time
-        #print time.time()  # 8.3 sec from pickle; 10.3 sec for forceSource...
-        #s = corpus.parse('beethoven/opus133') #, forceSource = True)
-        #print time.time()  # purePython: 33! sec; cPickle: 25 sec
+        # print time.time()  # 8.3 sec from pickle; 10.3 sec for forceSource...
+        # s = corpus.parse('beethoven/opus133') #, forceSource = True)
+        # print time.time()  # purePython: 33! sec; cPickle: 25 sec
         #data = converter.freezeStr(s, fmt='pickle')
-        #print time.time()  # cPickle: 5.5 sec!
+        # print time.time()  # cPickle: 5.5 sec!
         s = corpus.parse('corelli/opus3no1/1grave')
         sf = freezeThaw.StreamFreezer(s, fastButUnsafe=True)
         data = sf.writeStr()
 
-        #print time.time() # purePython: 9 sec; cPickle: 3.8 sec!
+        # print time.time() # purePython: 9 sec; cPickle: 3.8 sec!
         unused_s2 = converter.thawStr(data)
-        #print time.time()
+        # print time.time()
 #        s2.show()
 
+    def testSapoPickler(self):
+        from music21 import corpus
+        s = corpus.parse('beethoven/opus18no1/movement1.mxl')
+        print('Loaded movement 1 from op 18, n 1 by Beethoven!')
 
+        from timeit import default_timer as timer
+        start = timer()
+        from music21 import freezeThaw as pickle
+        end = timer()
+        print('* Importing picklem21 needed', end - start, 'seconds')
 
+        # test pickle and depickle to/from file
 
-#------------------------------------------------------------------------------
+        def test_file_rw():
+            for METHOD in ['lzma', 'gzip', 'bz2', 'None']:
+                pickle.setCompressionMethod(METHOD)
+                start = timer()
+                with open('pickle-test.pkl.' + METHOD, 'wb') as f:
+                    pickle.dump(s, f)
+                end = timer()
+                print('* Writing file using ' + METHOD +
+                      ' compression needed', end - start, 'seconds')
+
+                start = timer()
+                with open('pickle-test.pkl.' + METHOD, 'rb') as f:
+                    pickle.load(f)
+                end = timer()
+                print('* Reading file using ' + METHOD +
+                      ' compression needed', end - start, 'seconds')
+
+        # test multiprocessing
+
+        def test_multiprocessing():
+            import multiprocessing as mp
+
+            def parse_stream(s, start, end, tot_elements):
+                """ parse a stream and count objects """
+                count = 0
+                for i in s.recurse()[start:end]:
+                    count += 1
+
+                tot_elements.value += count
+
+            total_length = len(s.recurse())
+            nproc = 4
+            for METHOD in ['lzma', 'gzip', 'bz2', 'None']:
+                pickle.setCompressionMethod(METHOD)
+
+                tot_elements = mp.Value('i', 0)
+                start = 0
+                processes = []
+                for i in range(nproc):
+                    end = int(total_length / nproc * (i + 1))
+                    p = mp.Process(target=parse_stream, args=(
+                        s, start, end, tot_elements))
+                    processes.append(p)
+                    start = end
+
+                for p in processes:
+                    p.start()
+
+                for p in processes:
+                    p.join()
+
+                print('# multiprocessing with ' + METHOD +
+                      ' counted ', tot_elements.value, 'elements')
+
+            if len(s.recurse()) != tot_elements.value:
+                print('# ERROR!')
+                print('# actually the object has', len(s.recurse()), 'elements')
+
+        test_file_rw()
+        test_multiprocessing()
+
+# ------------------------------------------------------------------------------
+
 
 if __name__ == "__main__":
     music21.mainTest(Test)
 
 
-#------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # eof
-
-
-
-
-
-

--- a/music21/test/testSerialization.py
+++ b/music21/test/testSerialization.py
@@ -172,7 +172,7 @@ class Test(unittest.TestCase):
 
     def testBigCorpus(self):
         from music21 import corpus, converter
-        #import time
+        # import time
         # print time.time()  # 8.3 sec from pickle; 10.3 sec for forceSource...
         # s = corpus.parse('beethoven/opus133') #, forceSource = True)
         # print time.time()  # purePython: 33! sec; cPickle: 25 sec
@@ -190,32 +190,19 @@ class Test(unittest.TestCase):
     def testSapoPickler(self):
         from music21 import corpus
         s = corpus.parse('beethoven/opus18no1/movement1.mxl')
-        print('Loaded movement 1 from op 18, n 1 by Beethoven!')
 
-        from timeit import default_timer as timer
-        start = timer()
         from music21 import freezeThaw as pickle
-        end = timer()
-        print('* Importing picklem21 needed', end - start, 'seconds')
 
         # test pickle and depickle to/from file
 
         def test_file_rw():
             for METHOD in ['lzma', 'gzip', 'bz2', 'None']:
                 pickle.setCompressionMethod(METHOD)
-                start = timer()
                 with open('pickle-test.pkl.' + METHOD, 'wb') as f:
                     pickle.dump(s, f)
-                end = timer()
-                print('* Writing file using ' + METHOD +
-                      ' compression needed', end - start, 'seconds')
 
-                start = timer()
                 with open('pickle-test.pkl.' + METHOD, 'rb') as f:
                     pickle.load(f)
-                end = timer()
-                print('* Reading file using ' + METHOD +
-                      ' compression needed', end - start, 'seconds')
 
         # test multiprocessing
 
@@ -251,12 +238,8 @@ class Test(unittest.TestCase):
                 for p in processes:
                     p.join()
 
-                print('# multiprocessing with ' + METHOD +
-                      ' counted ', tot_elements.value, 'elements')
-
             if len(s.recurse()) != tot_elements.value:
-                print('# ERROR!')
-                print('# actually the object has', len(s.recurse()), 'elements')
+                raise Exception('multiprocessing failed!')
 
         test_file_rw()
         test_multiprocessing()


### PR DESCRIPTION
I added new methods to freezeThaw.py, as it was born in my master thesis. It allows to pickling and unpickling objects just like the standard `pickle` module. Now can use `from music21 import freezeThaw as pickle` to be compatible with other modules aimed at serialization. It also supports compression. Moreover, it works fine with the standard `multiprocessing` module.

I also added a bit of documentation, but I didn't manage to build it.

Line 1367 in `freezeThaw.py` is very ugly, but it is needed because `freezeThaw` is loaded before than `stream` module is ready.

This code was born from [this discussion on music21 google group](https://groups.google.com/d/msg/music21list/VTy1cA2D1yw/wLyq7IKqBQAJ)