### PR TITLE
quoted filename arguments in musescore

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -822,7 +822,7 @@ class ConverterMusicXML(SubConverter):
         fpOut = fp[0:len(fp) - 3]
         fpOut += subformatExtension
 
-        musescoreRun = '"' + str(musescorePath) + '" ' + fp + " -o " + fpOut + " -T 0 "
+        musescoreRun = '"' + str(musescorePath) + '" "' + fp + '" -o "' + fpOut + '" -T 0 '
         if 'dpi' in keywords:
             musescoreRun += " -r " + str(keywords['dpi'])
 


### PR DESCRIPTION
In the runThroughMusescore() function, the filename arguments are not quoted, although the musescore command is.  This was causing problems because my temporary directory has spaces in it, so the command generated looked like this:

"/Applications/MuseScore 2.app/Contents/MacOS/mscore" /Users/pkirlin/Box Sync/projects/ragtime/scratch/tmpu886ehll.xml -o /Users/pkirlin/Box Sync/projects/ragtime/scratch/tmpu886ehll.png -T 0  -r 200

When it should look like this:

"/Applications/MuseScore 2.app/Contents/MacOS/mscore" "/Users/pkirlin/Box Sync/projects/ragtime/scratch/tmpu886ehll.xml" -o "/Users/pkirlin/Box Sync/projects/ragtime/scratch/tmpu886ehll.png" -T 0  -r 200