### PR TITLE
Fix xml serialization of fingering articulations

### DIFF
--- a/music21/articulations.py
+++ b/music21/articulations.py
@@ -465,6 +465,13 @@ class Fingering(TechnicalIndication):
     fingering:
 
     >>> f.alternate = True
+
+    Fingerings are the only articulations that apply per note in a chord.
+    Other articulations, e.g., accents, apply to the whole chord and will,
+    therefore, only be associated with the first note of a chord when serializing.
+    Since chords store all articulations in an ordered list, Fingerings
+    are mapped implicitly to the notes of a chord in order. Superfluous
+    Fingerings will be ignored and may be discarded when serializaing.
     '''
     def __init__(self, fingerNumber=None):
         super().__init__()


### PR DESCRIPTION
Unlike other articulations, fingers should not only be applied to the first note of a chord. Fingerings must be applied in orderd, one each to one note respectively. This commit fixes this behavior.