### PR TITLE
Chord offset

### DIFF
--- a/music21/musicxml/testChordOffset.xml
+++ b/music21/musicxml/testChordOffset.xml
@@ -79,20 +79,20 @@
         </attributes>
       <harmony print-frame="no">
         <root>
-          <root-step>C</root-step>
+          <root-step>E</root-step>
           </root>
-        <kind>major</kind>
+        <kind>minor-seventh</kind>
         </harmony>
       <harmony print-frame="no">
         <root>
-          <root-step>D</root-step>
+          <root-step>G</root-step>
           </root>
         <kind>major</kind>
         <offset>2</offset>
         </harmony>
       <note default-x="75.17" default-y="-15.00">
         <pitch>
-          <step>C</step>
+          <step>E</step>
           <octave>5</octave>
           </pitch>
         <duration>4</duration>
@@ -105,11 +105,11 @@
         <root>
           <root-step>E</root-step>
           </root>
-        <kind>major</kind>
+        <kind>minor-seventh</kind>
         </harmony>
       <note default-x="12.00" default-y="-15.00">
         <pitch>
-          <step>C</step>
+          <step>E</step>
           <octave>5</octave>
           </pitch>
         <duration>2</duration>
@@ -119,13 +119,13 @@
         </note>
       <harmony print-frame="no">
         <root>
-          <root-step>F</root-step>
+          <root-step>G</root-step>
           </root>
         <kind>major</kind>
         </harmony>
       <note default-x="259.24" default-y="-15.00">
         <pitch>
-          <step>C</step>
+          <step>E</step>
           <octave>5</octave>
           </pitch>
         <duration>2</duration>
@@ -133,9 +133,41 @@
         <type>half</type>
         <stem>down</stem>
         </note>
-      <barline location="right">
-        <bar-style>light-heavy</bar-style>
-        </barline>
+      </measure>
+      <measure width="215" number="8">
+          <harmony font-size="10.25" default-y="34">
+              <root>
+                  <root-step>C</root-step>
+              </root>
+              <kind halign="center" use-symbols="yes">diminished-seventh</kind>
+          </harmony>
+          <note default-x="17">
+              <pitch>
+                  <step>E</step>
+                  <octave>4</octave>
+              </pitch>
+              <duration>3</duration>
+              <voice>1</voice>
+              <type>half</type>
+              <dot/>
+              <stem default-y="-4.5">up</stem>
+          </note>
+          <harmony font-size="10.25" default-y="34">
+              <root>
+                  <root-step>E</root-step>
+              </root>
+              <kind halign="center" text="7">dominant</kind>
+              <bass>
+                  <bass-step>B</bass-step>
+              </bass>
+              <offset>-1</offset>
+          </harmony>
+          <note default-x="152">
+              <rest/>
+              <duration>1</duration>
+              <voice>1</voice>
+              <type>quarter</type>
+          </note>
       </measure>
     </part>
   </score-partwise>

--- a/music21/musicxml/testChordOffset.xml
+++ b/music21/musicxml/testChordOffset.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <identification>
+    <encoding>
+      <software>MuseScore 2.3.2</software>
+      <encoding-date>2018-12-05</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.36</page-height>
+      <page-width>1190.88</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="560.05">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>-0.00</right-margin>
+            </system-margins>
+          <top-system-distance>70.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <harmony print-frame="no">
+        <root>
+          <root-step>C</root-step>
+          </root>
+        <kind>major</kind>
+        </harmony>
+      <harmony print-frame="no">
+        <root>
+          <root-step>D</root-step>
+          </root>
+        <kind>major</kind>
+        <offset>2</offset>
+        </harmony>
+      <note default-x="75.17" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="2" width="517.45">
+      <harmony print-frame="no">
+        <root>
+          <root-step>E</root-step>
+          </root>
+        <kind>major</kind>
+        </harmony>
+      <note default-x="12.00" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        </note>
+      <harmony print-frame="no">
+        <root>
+          <root-step>F</root-step>
+          </root>
+        <kind>major</kind>
+        </harmony>
+      <note default-x="259.24" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4333,10 +4333,10 @@ class MeasureParser(XMLParserBase):
         '''
         h = self.xmlToChordSymbol(mxHarmony)
         chordOffset = self.xmlToOffset(mxHarmony)
-        if chordOffset > 0:
-            self.insertCoreAndRef(chordOffset, mxHarmony, h)
-        else:
-            self.insertCoreAndRef(self.offsetMeasureNote, mxHarmony, h)
+        if chordOffset != 0:
+            print(chordOffset)
+        self.insertCoreAndRef(self.offsetMeasureNote + chordOffset,
+                              mxHarmony, h)
 
     def xmlToChordSymbol(self, mxHarmony):
         '''

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4332,7 +4332,11 @@ class MeasureParser(XMLParserBase):
         Create a ChordSymbol object and insert it to the core and staff reference.
         '''
         h = self.xmlToChordSymbol(mxHarmony)
-        self.insertCoreAndRef(self.offsetMeasureNote, mxHarmony, h)
+        chordOffset = self.xmlToOffset(mxHarmony)
+        if chordOffset > 0:
+            self.insertCoreAndRef(chordOffset, mxHarmony, h)
+        else:
+            self.insertCoreAndRef(self.offsetMeasureNote, mxHarmony, h)
 
     def xmlToChordSymbol(self, mxHarmony):
         '''
@@ -6463,6 +6467,14 @@ class Test(unittest.TestCase):
         self.assertEqual('N.C.', str(s.flat.getElementsByClass('NoChord')[
                                          1].chordKindStr))
 
+    def testChordOffset(self):
+        from music21 import converter
+
+        thisDir = common.getSourceFilePath() / 'musicxml'
+        testFp = thisDir / 'testChordOffset.xml'
+        s = converter.parse(testFp, forceSource=True)
+
+        s.show()
 
 
 if __name__ == '__main__':

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -6484,7 +6484,7 @@ class Test(unittest.TestCase):
 
         thisDir = common.getSourceFilePath() / 'musicxml'
         testFp = thisDir / 'testChordOffset.xml'
-        s = converter.parse(testFp, forceSource=True)
+        s = converter.parse(testFp)
 
         offsets = [0.0, 2.0, 0.0, 2.0, 0.0, 2.0]
         for ch, offset in zip(s.recurse().getElementsByClass('ChordSymbol'),

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4333,8 +4333,6 @@ class MeasureParser(XMLParserBase):
         '''
         h = self.xmlToChordSymbol(mxHarmony)
         chordOffset = self.xmlToOffset(mxHarmony)
-        if chordOffset != 0:
-            print(chordOffset)
         self.insertCoreAndRef(self.offsetMeasureNote + chordOffset,
                               mxHarmony, h)
 
@@ -6468,14 +6466,18 @@ class Test(unittest.TestCase):
                                          1].chordKindStr))
 
     def testChordOffset(self):
+        import pathlib
         from music21 import converter
+        from music21 import musicxml
 
         thisDir = common.getSourceFilePath() / 'musicxml'
         testFp = thisDir / 'testChordOffset.xml'
         s = converter.parse(testFp, forceSource=True)
 
-        s.show()
-
+        offsets = [0.0, 2.0, 0.0, 2.0, 0.0, 2.0]
+        for ch, offset in zip(s.recurse().getElementsByClass('ChordSymbol'),
+                              offsets):
+            self.assertEqual(ch.offset, offset)
 
 if __name__ == '__main__':
     import music21


### PR DESCRIPTION
This solves #350. I didn't have a lot of data to test this, but there's a few scores in wikifonia with `<harmony>` objects that have an `<offset>` component. Obviously I can't include them here, but things look fine.
(edit: escaped xml tags)