### PR TITLE
Key signature for multi voice score being exported

### DIFF
--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -497,6 +497,8 @@ def makeMeasures(
         # creating Measures; this clef is from getClefs, called above
         if measureCount == 0:
             m.clef = clefObj
+            if voiceCount > 0 and s.keySignature is not None:
+                m.insert(0, s.keySignature)
             # environLocal.printDebug(
             #    ['assigned clef to measure', measureCount, m.clef])
 

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -3905,6 +3905,55 @@ class Test(unittest.TestCase):
         self.assertEqual(len(post.flat.getElementsByClass('Clef')), 2)
 
 
+    def testMakeNotationKeySignatureOneVoice(self):
+        '''
+        The base-case: Stream should keep it's key.KeySignature element when a single-voice score is prepared for notation.
+        '''
+        sharpsInKey = 2
+        c = clef.TrebleClef()
+        ts = meter.TimeSignature('4/4')
+        ks = key.KeySignature(sharpsInKey)
+        s = Stream()
+        s.insert(0.0, c)
+        s.insert(0.0, ts)
+        s.insert(0.0, ks)
+        s.insert(0.0, note.Note('C'))
+        s.insert(2.0, note.Note('G'))
+
+        sPost = s.makeNotation()
+
+        self.assertEqual(len(sPost.getElementsByClass('Measure')), 1)
+        m1 = sPost.getElementsByClass('Measure')[0]
+        self.assertEqual(m1.keySignature.sharps, sharpsInKey)
+
+    def testMakeNotationKeySignatureMultiVoice(self):
+        '''
+        Stream should keep it's key.KeySignature element when a multi-voice score is prepared for notation.
+        '''
+
+        sharpsInKey = 2
+        c = clef.TrebleClef()
+        ts = meter.TimeSignature('4/4')
+        ks = key.KeySignature(2)
+        s = Stream()
+        s.insert(0.0, c)
+        s.insert(0.0, ts)
+        s.insert(0.0, ks)
+
+        # two notes at the same time create multi-voice
+        s.insert(2.0, note.Note('C'))
+        s.insert(2.0, note.Note('G'))
+
+        sPost = s.makeNotation()
+
+        # self.assertEqual(post.hasPartLikeStreams(), True)
+        # print("sPost.getElementsByClass('Measure')", sPost.getElementsByClass('Measure'))
+        self.assertEqual(len(sPost.getElementsByClass('Measure')), 1)
+        m1 = sPost.getElementsByClass('Measure')[0]
+        # print("sPost.getElementsByClass('Measure')[0]", m1)
+        # print('m1.keySignature',m1.keySignature.sharps)
+        assert(m1.keySignature is not None)
+        self.assertEqual(m1.keySignature.sharps, sharpsInKey)
 
     def testMakeTies(self):
 


### PR DESCRIPTION
When a score has multiple voices (i.e. two notes played at the same time and not combined into a Chord) then the KeySignature is lost when the score is run through 

```
        GEX = m21ToXml.GeneralObjectExporter(s)
        wellFormedObject = GEX.fromGeneralObject(s)
```

The bug presented as a missing key signature when I was using `score.show()` and looking at the output in MuseScore, or when I was exporting to `.musicxml` file.

My fix works, but it feels a tad hacky. I don't quite understand how or why the keySignature gets destroyed in a multi-voice situation. Code review is be appreciated!

I included tests-- one that started passing, and one that started broken.