### PR TITLE
Access to XML IDs for individual Notes in a Chord.

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -252,7 +252,7 @@ class Chord(note.NotRest):
         True if the it passes all `super()`
         equality tests and the pitches are the same
         (possibly in a different order)
-        
+
         >>> c1 = chord.Chord('C4 E4 G4')
         >>> c2 = chord.Chord('E4 C4 G4')
         >>> c1 == c2
@@ -268,7 +268,7 @@ class Chord(note.NotRest):
         False
         >>> c1 != c2
         True
-        
+
         '''
         if not super().__eq__(other):
             return False
@@ -277,8 +277,8 @@ class Chord(note.NotRest):
         if set(self.pitches) != set(other.pitches):
             return False
         return True
-    
-    
+
+
     def __deepcopy__(self, memo=None):
         '''As Chord objects have one or more Volume, objects, and Volume
         objects store weak refs to the to client object, need to specialize
@@ -926,7 +926,7 @@ class Chord(note.NotRest):
                         newbass = p
                         foundBassInChord = True
                         break
-                    
+
             if not foundBassInChord: # finally by name
                 for p in self.pitches:
                     if p.name == newbass.name:
@@ -2134,8 +2134,8 @@ class Chord(note.NotRest):
         as specified by intervalArray.  For instance `.isDiminishedSeventh()`
         is just a thin wrapper around `.isSeventhOfType([0, 3, 6, 9])`
         and `isDominantSeventh()` has intervalArray([0, 4, 7, 10])
-        
-        intervalArray can be any iterable.        
+
+        intervalArray can be any iterable.
         '''
         try:
             third = self.third
@@ -2143,7 +2143,7 @@ class Chord(note.NotRest):
             seventh = self.seventh
         except ChordException:
             return False
-        
+
         root = self.root()
 
         if third is None or fifth is None or seventh is None:
@@ -2153,8 +2153,8 @@ class Chord(note.NotRest):
             if thisInterval.chromatic.mod12 not in intervalArray:
                 return False
         return True
-        
-        
+
+
 
     def isDiminishedTriad(self):
         '''Returns True if chord is a Diminished Triad, that is,
@@ -3039,26 +3039,26 @@ class Chord(note.NotRest):
 
 
         To specify the root directly, pass the pitch to the root function:
-        
+
         >>> csus4 = chord.Chord('C4 F4 G4')
         >>> csus4.root() # considered to be an F9 chord in 2nd inversion
         <music21.pitch.Pitch F4>
         >>> csus4.root('C4')
         >>> csus4.root()
         <music21.pitch.Pitch C4>
-        
+
         Note that the root is set to a pitch in the chord if possible.
 
         >>> csus4.root() is csus4.pitches[0]
         True
-        
+
         Return to the original root() by setting find explicitly to True:
-        
+
         >>> csus4.root(find=True)
         <music21.pitch.Pitch F4>
 
         the find algorithm ensures that the overridden root is gone:
-                
+
         >>> csus4.root()
         <music21.pitch.Pitch F4>
 
@@ -3072,7 +3072,7 @@ class Chord(note.NotRest):
         Changed in v5.2 -- find is a keyword-only parameter, newroot finds pitch in chord
         '''
         # None value for find indicates: return override if overridden, cache if cached
-        # or find new value if neither is the case.        
+        # or find new value if neither is the case.
         if newroot:
             if isinstance(newroot, str):
                 newroot = common.cleanedFlatNotation(newroot)
@@ -3091,13 +3091,13 @@ class Chord(note.NotRest):
                         newroot = p
                         foundRootInChord = True
                         break
-                    
+
             if not foundRootInChord: # finally by name
                 for p in self.pitches:
                     if p.name == newroot.name:
                         newroot = p
                         break
-            
+
             self._overrides['root'] = newroot
             self._cache['root'] = newroot
 
@@ -3819,36 +3819,36 @@ class Chord(note.NotRest):
         >>> c3 = chord.Chord([0, 1, 2, 3, 4, 9])
         >>> c3.commonName
         'forte class 6-36B'
-        
+
         Dominant seventh and German/Swiss sixths are distinguished
-        
+
         >>> c4a = chord.Chord(['c', 'e', 'g', 'b-'])
         >>> c4a.commonName
         'dominant seventh chord'
 
         >>> c4b = chord.Chord(['c', 'e', 'g', 'a#'])
         >>> c4b.commonName
-        'German augmented sixth chord'        
+        'German augmented sixth chord'
 
         >>> c4c = chord.Chord(['c', 'e', 'f##', 'a#'])
         >>> c4c.commonName # some call it Alsacian or English
         'Swiss augmented sixth chord'
-        
+
         Dyads are called by actual name:
-        
+
         >>> dyad1 = chord.Chord('C E')
         >>> dyad1.commonName
         'Major Third'
         >>> dyad2 = chord.Chord('C F-')
         >>> dyad2.commonName
         'Diminished Fourth'
-        
+
         Changed in v5.5: special cases for checking enharmonics in some cases
         '''
         cta = self.chordTablesAddress
         if cta.cardinality == 2:
             return interval.Interval(self.pitches[0], self.pitches[1]).niceName
-        
+
         ctn = chordTables.addressToCommonNames(cta)
         forteClass = self.forteClass
         # forteClassTn = self.forteClassTn
@@ -3880,15 +3880,15 @@ class Chord(note.NotRest):
                 return ctn[1]
             else:
                 return ctn[0]
-            
+
         elif forteClass in enharmonicTests:
             out = ctn[0]
             test = enharmonicTests[forteClass]
             if not test():
                 out = 'enharmonic equivalent to ' + out
             return out
-        
-                
+
+
         if not ctn:
             return 'forte class ' + forteClass
         else:
@@ -4286,6 +4286,18 @@ class Chord(note.NotRest):
         '''
         return [d.pitch.name for d in self._notes]
 
+    @property
+    def noteIds(self):
+        '''
+        Return a list of XML note ids from each
+        :class:`~music21.note.Note` object's
+        :attr:`~music21.note.Note.id` attribute.
+
+        (Added by Werner Goebl, Martin Bonev, 7 Feb 2019)
+        
+        '''
+        return [d.id for d in self._notes]
+
     @pitchNames.setter
     def pitchNames(self, value):
         if common.isListLike(value):
@@ -4306,7 +4318,7 @@ class Chord(note.NotRest):
         Return a common name of this Chord including a pitch identifier, if possible:
 
         Most common chords will use the root as the pitch name and have it at the beginning:
-        
+
         >>> c1 = chord.Chord(['c', 'e-', 'g'])
         >>> c1.pitchedCommonName
         'C-minor triad'
@@ -4314,33 +4326,33 @@ class Chord(note.NotRest):
         >>> c2 = chord.Chord(['c', 'e', 'g'])
         >>> c2.pitchedCommonName
         'C-major triad'
-        
+
         Because the hyphen is confusing w/ music21 flat notation, flats are displayed
         as "b":
 
         >>> c2a = chord.Chord('C-2 E-2 G-2')
         >>> c2a.pitchedCommonName
-        'Cb-major triad'        
-        
+        'Cb-major triad'
+
         Other forms might have the pitch elsewhere.  Thus this is a method for display,
         not for extracting information:
-        
+
         >>> c3 = chord.Chord('A#2 D3 F3')
         >>> c3.pitchedCommonName
         'enharmonic equivalent to major triad above A#'
-        
+
         Note that in this case, the bass, not the root is used to determine the pitch name:
-        
+
         >>> c4 = chord.Chord('D3 F3 A#3')
         >>> c4.pitchedCommonName
         'enharmonic equivalent to major triad above D'
-        
+
         >>> c5 = chord.Chord([1, 2, 3, 4, 5, 10])
         >>> c5.pitchedCommonName
         'forte class 6-36B above C#'
 
-        
-        Changed in v5.5 -- octaves never included, flats are converted, 
+
+        Changed in v5.5 -- octaves never included, flats are converted,
         special tools for enharmonics.
         '''
         nameStr = self.commonName


### PR DESCRIPTION
Added the property method 'noteIds'. It exposes the individual XML IDs
of Note objects inside a Chord object. These are the XML IDs given in a
MEI file.

This method was implemented by Werner Goebl and Martin Bonev on
the 7th February 2019.

Co-authored-by: Werner Goebl <wergo@users.noreply.github.com>