### PR TITLE
WIP: Bugfixes in figure parsing for chord symbols

### DIFF
--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -1031,10 +1031,18 @@ class Test(unittest.TestCase):
         self.assertEqual(cs.bass(), pitch.Pitch('B-2'))
         self.assertEqual(cs.pitches[0], pitch.Pitch('B-2'))
 
+        # common.cleanedFlatNotation() shouldn't be called by
+        # the following calls, which what is being tested here:
+
         cs = harmony.ChordSymbol('b-3')
         self.assertEqual(cs.root(), pitch.Pitch('b-3'))
         self.assertEqual(cs.pitches[0], pitch.Pitch('B-3'))
         self.assertEqual(cs.pitches[1], pitch.Pitch('D4'))
+
+        cs = harmony.ChordSymbol('bb3')
+        self.assertEqual(cs.root(), pitch.Pitch('b2'))
+        self.assertEqual(cs.pitches[0], pitch.Pitch('B2'))
+        self.assertEqual(cs.pitches[1], pitch.Pitch('D3'))
 
     def xtestTranslateB(self):
         '''

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -1031,6 +1031,11 @@ class Test(unittest.TestCase):
         self.assertEqual(cs.bass(), pitch.Pitch('B-2'))
         self.assertEqual(cs.pitches[0], pitch.Pitch('B-2'))
 
+        cs = harmony.ChordSymbol('b-3')
+        self.assertEqual(cs.root(), pitch.Pitch('b-3'))
+        self.assertEqual(cs.pitches[0], pitch.Pitch('B-3'))
+        self.assertEqual(cs.pitches[1], pitch.Pitch('D4'))
+
     def xtestTranslateB(self):
         '''
         Dylan -- this could be too slow to make it a test!

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -1031,20 +1031,6 @@ class Test(unittest.TestCase):
         self.assertEqual(cs.bass(), pitch.Pitch('B-2'))
         self.assertEqual(cs.pitches[0], pitch.Pitch('B-2'))
 
-        # common.cleanedFlatNotation() shouldn't be called by
-        # the following calls, which what is being tested here:
-
-        cs = harmony.ChordSymbol('b-3')
-        self.assertEqual(cs.root(), pitch.Pitch('b-3'))
-        self.assertEqual(cs.pitches[0], pitch.Pitch('B-3'))
-        self.assertEqual(cs.pitches[1], pitch.Pitch('D4'))
-
-        cs = harmony.ChordSymbol('bb3')
-        self.assertEqual(cs.root(), pitch.Pitch('b3'))
-        self.assertEqual(cs.pitches[0], pitch.Pitch('B3'))
-        self.assertEqual(cs.pitches[1], pitch.Pitch('D#4'))
-
-
     def xtestTranslateB(self):
         '''
         Dylan -- this could be too slow to make it a test!

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -3698,7 +3698,7 @@ class Chord(note.NotRest):
             returnObj = self
         else:
             returnObj = copy.deepcopy(self)
-        returnObj._notes.sort(key=lambda x: (x.pitch.diatonicNoteNum, x.pitch.ps))
+        sortDiatonicAscending(returnObj._notes)
         return returnObj
 
     def sortFrequencyAscending(self):
@@ -4770,6 +4770,26 @@ class Chord(note.NotRest):
 
     # --------------------------------------------------------------------------
 
+def sort_pitches(notes_or_pitches, key_pitch):
+    """
+    Sort the list of notes or pitches according to the key defined on the
+    pitches.
+    :param notes_or_pitches: a list of either notes or pitches
+    :param key_pitch: a key on the pitches for sorting the list
+    :return:
+    """
+    def _pitch(e):
+        if isinstance(e, note.Note):
+            return e.pitch
+        if isinstance(e, pitch.Pitch):
+            return e
+        raise ValueError
+
+    notes_or_pitches.sort(key = lambda e:key_pitch(_pitch(e)))
+
+def sortDiatonicAscending(notes_or_pitches):
+    sort_pitches(notes_or_pitches,
+                 key_pitch= lambda p: (p.diatonicNoteNum, p.ps))
 
 
 def fromForteClass(notation):

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4770,12 +4770,12 @@ class Chord(note.NotRest):
 
     # --------------------------------------------------------------------------
 
-def sort_pitches(notes_or_pitches, key_pitch):
+def sortPitches(notesOrPitches, keyPitch):
     """
     Sort the list of notes or pitches according to the key defined on the
     pitches.
-    :param notes_or_pitches: a list of either notes or pitches
-    :param key_pitch: a key on the pitches for sorting the list
+    :param notesOrPitches: a list of either notes or pitches
+    :param keyPitch: a key on the pitches for sorting the list
     :return:
     """
     def _pitch(e):
@@ -4785,11 +4785,15 @@ def sort_pitches(notes_or_pitches, key_pitch):
             return e
         raise ValueError
 
-    notes_or_pitches.sort(key = lambda e:key_pitch(_pitch(e)))
+    notesOrPitches.sort(key = lambda e:keyPitch(_pitch(e)))
 
-def sortDiatonicAscending(notes_or_pitches):
-    sort_pitches(notes_or_pitches,
-                 key_pitch= lambda p: (p.diatonicNoteNum, p.ps))
+def sortDiatonicAscending(notesOrPitches):
+    """
+    The notes or pitches are sorted by Scale degree and then by Offset (so F##
+    sorts below G-).
+    Notes that are the identical pitch retain their order
+    """
+    sortPitches(notesOrPitches, keyPitch= lambda p: (p.diatonicNoteNum, p.ps))
 
 
 def fromForteClass(notation):

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1740,7 +1740,9 @@ class ChordSymbol(Harmony):
                 degree = degree.replace('A', '') #A is for 'Altered'
                 if hD.degree == int(degree):
                     # transpose by semitones (positive for up, negative for down)
-                    p.transpose(hD.interval, inPlace=True),
+                    pAltered = p.transpose(hD.interval)
+                    pitches.remove(p)
+                    pitches.append(pAltered)
                     pitchFound = True
 
 #                         for degreeString in self._degreesList:

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1841,7 +1841,6 @@ class ChordSymbol(Harmony):
             # get the match on st, should match since st is a substring of
             # prelimFigure
             m3 = re.search(r'/[A-Ga-g][#-]*', st)
-            assert m3
             remaining = st[:m3.start()] + st[m3.end():]
 
         st = self._getKindFromShortHand(remaining)

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1783,7 +1783,7 @@ class ChordSymbol(Harmony):
         for hD in chordStepModifications:
             if hD.modType == 'add':
                 typeAdd(hD)
-            elif hD.modType == 'subtract' or hD.modType == 'omit':
+            elif hD.modType in ('subtract', 'omit'):
                 typeSubtract(hD)
             elif hD.modType == 'alter':
                 typeAlter(hD)

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1358,17 +1358,19 @@ def _getAlteration(alteration):
     ('alter', 5, 2)
 
     """
-    if alteration != '':
-        if 'b' in alteration:
-            semiToneAlter = -1 * alteration.count('b')
-        else:
-            semiToneAlter = alteration.count('#')
-        mt = re.search('^alter|add|subtract|omit', alteration)
-        type = mt.group() if mt else 'add'
-        md = re.search(r'[1-9]+', alteration)
-        if md:
-            degree = int(md.group())
-            return type, degree, semiToneAlter
+    if not alteration:
+        return None
+
+    if 'b' in alteration:
+        semiToneAlter = -1 * alteration.count('b')
+    else:
+        semiToneAlter = alteration.count('#')
+    mt = re.search('^alter|add|subtract|omit', alteration)
+    type = mt.group() if mt else 'add'
+    md = re.search(r'[1-9]+', alteration)
+    if md:
+        degree = int(md.group())
+        return type, degree, semiToneAlter
 
 # --------------------------------------------------------------------------
 realizerScaleCache = {}

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1768,13 +1768,13 @@ class ChordSymbol(Harmony):
         return tuple(pitches)
 
     def _getKindFromShortHand(self, sH):
-        all_abbr = [a for type in CHORD_TYPES.values() for a in type[1]]
+        allAbbr = [a for type in CHORD_TYPES.values() for a in type[1]]
         # check all abbr that contain a # or b in their name (initially it
-        # was checking only ob9
-        with_sharp = [a for a in all_abbr if '#' in a]
-        with_sharp = [a for a in with_sharp if a in sH]
-        with_flat = [a for a in all_abbr if 'b' in a]
-        with_flat = [a for a in with_flat if a in sH]
+        # was checking only ob9)
+        withSharp = [a for a in allAbbr if '#' in a]
+        withSharp = [a for a in withSharp if a in sH]
+        withFlat = [a for a in allAbbr if 'b' in a]
+        withFlat = [a for a in withFlat if a in sH]
         originalsH = sH
         if 'add' in sH:
             sH = sH[0:sH.index('add')]
@@ -1784,9 +1784,9 @@ class ChordSymbol(Harmony):
             sH = sH[0:sH.index('subtract')]
         if 'alter' in sH:
             sH = sH[0:sH.index('alter')]
-        if '#' in sH and sH[sH.index('#') + 1].isdigit() and not with_sharp:
+        if '#' in sH and sH[sH.index('#') + 1].isdigit() and not withSharp:
             sH = sH[0:sH.index('#')]
-        if 'b' in sH and sH[sH.index('b') + 1].isdigit() and not with_flat:
+        if 'b' in sH and sH[sH.index('b') + 1].isdigit() and not withFlat:
             sH = sH[0:sH.index('b')]
         for chordKind in CHORD_TYPES:
             for charString in getAbbreviationListGivenChordType(chordKind):

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1776,13 +1776,13 @@ class ChordSymbol(Harmony):
         type, and returns the remaining shorthand, with the chord kind
         abbreviation removed.
 
-        >>> cs = ChordSymbol(root='C')
+        >>> cs = harmony.ChordSymbol(root='C')
         >>> cs._getKindFromShortHand('7')
         ''
         >>> cs.chordKind
         'dominant-seventh'
 
-        >>> cs = ChordSymbol(root='C')
+        >>> cs = harmony.ChordSymbol(root='C')
         >>> cs._getKindFromShortHand('7sus4')
         ''
         >>> cs.chordKind
@@ -1791,7 +1791,7 @@ class ChordSymbol(Harmony):
         When the shorthand contains additional information, it is returned
         after setting the chord kind:
 
-        >>> cs = ChordSymbol(root='C')
+        >>> cs = harmony.ChordSymbol(root='C')
         >>> cs._getKindFromShortHand('7add4subtract3')
         'add4subtract3'
         >>> cs.chordKind
@@ -1800,7 +1800,7 @@ class ChordSymbol(Harmony):
         When the shorthand does not contain any valid chord kind
         abbreviation, it is returned as is, and the chordKind remains unset:
 
-        >>> cs = ChordSymbol(root='C')
+        >>> cs = harmony.ChordSymbol(root='C')
         >>> cs._getKindFromShortHand('maj69')
         'maj69'
         >>> cs.chordKind

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1611,6 +1611,32 @@ class ChordSymbol(Harmony):
         """
         Assigns the highest octave to the bass that ensures it remains lower
         than the root.
+
+        >>> cs = harmony.ChordSymbol()
+        >>> cs.root('A3')
+        >>> cs.bass('E')
+        >>> cs._assignOctaveForBass()
+        3
+        >>> cs.bass()
+        <music21.pitch.Pitch E3>
+
+        >>> cs = harmony.ChordSymbol()
+        >>> cs.root('C3')
+        >>> cs.bass('E')
+        >>> cs._assignOctaveForBass()
+        2
+        >>> cs.bass()
+        <music21.pitch.Pitch E2>
+
+        >>> cs = harmony.ChordSymbol()
+        >>> cs.root('E-3')
+        >>> cs.bass('E')
+        >>> cs._assignOctaveForBass()
+        2
+        >>> cs.bass()
+        <music21.pitch.Pitch E2>
+
+
         """
         root = self._overrides['root']
         bass = self._overrides['bass']

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1705,7 +1705,7 @@ class ChordSymbol(Harmony):
                 degree = degree.replace('A', '') #A is for 'Altered'
                 if hD.degree == int(degree):
                     # transpose by semitones (positive for up, negative for down)
-                    p = p.transpose(hD.interval)
+                    p.transpose(hD.interval, inPlace=True),
                     pitchFound = True
 
 #                         for degreeString in self._degreesList:

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2036,8 +2036,6 @@ class ChordSymbol(Harmony):
         # set overrides to be pitches in the harmony
         self.bass(self.bass())
         self.root(self.root())
-        assert self.root() in pitches
-        assert self.bass() in pitches
 
     ### PUBLIC METHODS ###
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1917,7 +1917,7 @@ class ChordSymbol(Harmony):
         ['C3', 'E-3', 'G3']
 
         >>> [str(p) for p in harmony.ChordSymbol(root='C', bass='B', kind='major-ninth').pitches]
-        ['B2', 'C3', 'D3', 'E3', 'G3']
+        ['B1', 'D2', 'C3', 'E3', 'G3']
 
         >>> [str(p) for p in harmony.ChordSymbol(root='D', bass='F', kind='minor-seventh').pitches]
         ['F3', 'A3', 'C4', 'D4']

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2094,6 +2094,11 @@ class ChordSymbol(Harmony):
             if not self.inversionIsValid(inversionNum):
                 #there is a bass, yet no normal inversion was found....must be added note
                 ignoreInversion = True
+            elif inversionNum >= len(pitches):
+                # For some reason we don't have enough pitches to make the 
+                # inversion -- can happen in some weird cases, but still that
+                # shouldn't fail.
+                ignoreInversion = True
             elif not pitches[inversionNum].pitchClass == self._overrides[
                 'bass'].pitchClass:
                 # the bass found by the inversion doesn't not correspond to
@@ -3041,13 +3046,23 @@ class Test(unittest.TestCase):
 
         self.assertEqual(1, cs1.inversion())
         self.assertEqual(1, cs2.inversion())
-        
+
         # self.assertEqual(cs1.pitches, pitches)
         # self.assertEqual(cs2.pitches, pitches)
 
         # self.assertEqual(cs1.root(), cs2.root())
         # self.assertEqual(cs1.bass(), cs2.bass())
 
+    def testChordWithoutKind(self):
+        """
+        This verifies that the chord creation doesn't fail with an index out
+        of range exception when no chord kind is specified.
+        """
+        cs = ChordSymbol(root='C', bass='E')
+
+        self.assertEqual(1, cs.inversion())
+        self.assertEqual('C3', str(cs.root()))
+        self.assertEqual('E2', str(cs.bass()))
 
 
     def testAddSubtractAlterations(self):

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1504,8 +1504,8 @@ class ChordSymbol(Harmony):
     (<music21.pitch.Pitch A-2>, <music21.pitch.Pitch C-3>, <music21.pitch.Pitch E-3>)
 
     >>> harmony.ChordSymbol('F-dim7').pitches
-    (<music21.pitch.Pitch F-2>, <music21.pitch.Pitch A--2>, \
-<music21.pitch.Pitch C--3>, <music21.pitch.Pitch E---3>)
+    (<music21.pitch.Pitch F-2>, <music21.pitch.Pitch A--2>,
+    <music21.pitch.Pitch C--3>, <music21.pitch.Pitch E---3>)
 
     Thanks to David Bolton for catching the bugs tested below:
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1975,6 +1975,13 @@ class ChordSymbol(Harmony):
         if self._overrides['root'].name != self._overrides['bass'].name:
 
             inversionNum = self.inversion()
+            # Special case for first inversion of suspended chords...
+            suspended = ['suspended-second','suspended-fourth',
+                         'suspended-fourth-seventh']
+            if self.chordKind in suspended:
+                if interval.notesToInterval(self._overrides['root'],
+                                            self._overrides['bass']).generic.simpleDirected == 4:
+                    inv = 1
 
             if not self.inversionIsValid(inversionNum):
                 #there is a bass, yet no normal inversion was found....must be added note

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2038,7 +2038,6 @@ class ChordSymbol(Harmony):
         self.root(self.root())
         assert self.root() in pitches
         assert self.bass() in pitches
-        self._overrides = {}
 
     ### PUBLIC METHODS ###
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1768,6 +1768,43 @@ class ChordSymbol(Harmony):
         return tuple(pitches)
 
     def _getKindFromShortHand(self, sH):
+        """
+        Tries to identify a chord kind abbreviation in the given shorthand,
+        and if successful, sets self.chordKind to the corresponding chord
+        type, and returns the remaining shorthand, with the chord kind
+        abbreviation removed.
+
+        >>> cs = ChordSymbol(root='C')
+        >>> cs._getKindFromShortHand('7')
+        ''
+        >>> cs.chordKind
+        'dominant-seventh'
+
+        >>> cs = ChordSymbol(root='C')
+        >>> cs._getKindFromShortHand('7sus4')
+        ''
+        >>> cs.chordKind
+        'suspended-fourth-seventh'
+
+        When the shorthand contains additional information, it is returned
+        after setting the chord kind:
+
+        >>> cs = ChordSymbol(root='C')
+        >>> cs._getKindFromShortHand('7add4subtract3')
+        'add4subtract3'
+        >>> cs.chordKind
+        'dominant-seventh'
+
+        When the shorthand does not contain any valid chord kind
+        abbreviation, it is returned as is, and the chordKind remains unset:
+
+        >>> cs = ChordSymbol(root='C')
+        >>> cs._getKindFromShortHand('maj69')
+        'maj69'
+        >>> cs.chordKind
+        ''
+
+        """
         allAbbr = [a for type in CHORD_TYPES.values() for a in type[1]]
         # check all abbr that contain a # or b in their name (initially it
         # was checking only ob9)

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -171,6 +171,8 @@ class Harmony(chord.Chord):
     is True, but can be set to False to initialize faster if pitches are not needed.
     '''
     _styleClass = style.TextStyle
+    _alterRe = re.compile('((?:alter|add|omit|subtract)[b#]*[1-9]+)')
+    _addRe = re.compile('([b#]+[^b#]+)')
 
     ### INITIALIZER ###
 
@@ -1933,11 +1935,9 @@ class ChordSymbol(Harmony):
 
         st = st.replace(',', '')
         if 'add' in st or 'alter'in st or 'omit' in st or 'subtract' in st:
-            splitter = re.compile('((?:alter|add|omit|subtract)[b#]*[1-9]+)')
-            alterations = splitter.split(st)
+            alterations = self._alterRe.split(st)
         elif 'b' in st or '#' in st:
-            splitter = re.compile('([b#]+[^b#]+)')
-            alterations = splitter.split(st)
+            alterations = self._addRe.split(st)
         else:
             alterations = [st]
         indexes = []

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1504,7 +1504,8 @@ class ChordSymbol(Harmony):
     (<music21.pitch.Pitch A-2>, <music21.pitch.Pitch C-3>, <music21.pitch.Pitch E-3>)
 
     >>> harmony.ChordSymbol('F-dim7').pitches
-    (<music21.pitch.Pitch F-2>, <music21.pitch.Pitch A--2>, <music21.pitch.Pitch C--3>, <music21.pitch.Pitch E---3>)
+    (<music21.pitch.Pitch F-2>, <music21.pitch.Pitch A--2>, \
+<music21.pitch.Pitch C--3>, <music21.pitch.Pitch E---3>)
 
     Thanks to David Bolton for catching the bugs tested below:
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2981,6 +2981,40 @@ class Test(unittest.TestCase):
 
         self.runTestOnChord(xmlString, figure, pitches)
 
+    def testInversion(self):
+        from xml.etree.ElementTree import fromstring as EL
+        from music21 import musicxml, pitch
+
+        xmlString = """
+        <harmony>
+          <root>
+            <root-step>C</root-step>
+          </root>
+          <kind>major</kind>
+          <inversion>1</inversion>
+        </harmony>
+        """
+
+        # pitches = ('E3','G3','C4')
+        # pitches = tuple(pitch.Pitch(p) for p in pitches)
+
+        MP = musicxml.xmlToM21.MeasureParser()
+        mxHarmony = EL(xmlString)
+
+        cs1 = MP.xmlToChordSymbol(mxHarmony)
+        cs2 = ChordSymbol('C/E')
+
+        self.assertEqual(1, cs1.inversion())
+        self.assertEqual(1, cs2.inversion())
+        
+        # self.assertEqual(cs1.pitches, pitches)
+        # self.assertEqual(cs2.pitches, pitches)
+
+        # self.assertEqual(cs1.root(), cs2.root())
+        # self.assertEqual(cs1.bass(), cs2.bass())
+
+
+
     def testAddSubtractAlterations(self):
         ch1 = ChordSymbol('F7 add 4 subtract 3')
         ch2 = ChordSymbol('F7sus4')

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2723,21 +2723,6 @@ class Test(unittest.TestCase):
         self.assertEqual(pitches, cs2.pitches)
         self.assertEqual(pitches, cs3.pitches)
 
-    def testBug(self):
-        """
-    (<music21.pitch.Pitch F-2>, <music21.pitch.Pitch A--2>, <music21.pitch.Pitch C--3>, <music21.pitch.Pitch E---3>)
-Got:
-    (<music21.pitch.Pitch F-2>, <music21.pitch.Pitch A--2>, <music21.pitch.Pitch C--3>, <music21.pitch.Pitch E---3>)
-
-        :return:
-        """
-        s = corpus.parse('leadsheet/fosterBrownHair')
-        initialSymbols = s.flat.getElementsByClass(ChordSymbol)[0:5]
-        l = [[str(c.name) for c in c.pitches] for c in initialSymbols]
-
-        print(l)
-
-
     def testAddSubtractAlterations(self):
         ch1 = ChordSymbol('F7 add 4 subtract 3')
         ch2 = ChordSymbol('F7sus4')

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2625,6 +2625,12 @@ class Test(unittest.TestCase):
         self.assertEqual(kind1, kind2)
         self.assertEqual(kind1, kind3)
 
+        self.assertEqual(cs1.root(), cs2.root())
+        self.assertEqual(cs1.root(), cs3.root())
+
+        self.assertEqual(cs1.bass(), cs2.bass())
+        self.assertEqual(cs1.bass(), cs3.bass())
+
     def testChordStepFromFigure(self):
         xmlString = """
           <harmony>

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1653,7 +1653,7 @@ class ChordSymbol(Harmony):
         # in case of inversion, the root should be updated, so make sure it's
         # still accurate
         if not rootPitch is pitches[0]:
-            print('hey')
+            raise ValueError('List of pitches does not start with the root')
 
         def typeAdd(hD):
             '''

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2574,13 +2574,43 @@ class Test(unittest.TestCase):
         b = d.bass()
         self.assertEqual(b.nameWithOctave, 'E-3')
 
-    def testChordStepFromFigure(self):
+    def runTestOnChord(self, xmlString, figure, pitches):
+        """
+        Run a series of tests on the given chord.
+
+        :param xmlString: an XML harmony object
+        :param figure: the equivalent figure representation
+        :param pitches: the list of pitches of the chord
+        """
         from xml.etree.ElementTree import fromstring as EL
         from music21 import musicxml, pitch
 
-        pitches = ('G2', 'B2', 'F3', 'A-3', 'A#3', 'C#4', 'E-4')
         pitches = tuple(pitch.Pitch(p) for p in pitches)
 
+        MP = musicxml.xmlToM21.MeasureParser()
+        mxHarmony = EL(xmlString)
+
+        cs1 = MP.xmlToChordSymbol(mxHarmony)
+        cs2 = ChordSymbol(cs1.figure)
+        cs3 = ChordSymbol(figure)
+
+        self.assertEqual(pitches, cs1.pitches)
+        self.assertEqual(pitches, cs2.pitches)
+        self.assertEqual(pitches, cs3.pitches)
+
+        kind1 = cs1.chordKind
+        kind2 = cs2.chordKind
+        kind3 = cs3.chordKind
+        if kind1 in CHORD_ALIASES:
+            kind1 = CHORD_ALIASES[kind1]
+        if kind2 in CHORD_ALIASES:
+            kind2 = CHORD_ALIASES[kind2]
+        if kind3 in CHORD_ALIASES:
+            kind3 = CHORD_ALIASES[kind3]
+        self.assertEqual(kind1, kind2)
+        self.assertEqual(kind1, kind3)
+
+    def testChordStepFromFigure(self):
         xmlString = """
           <harmony>
             <root>
@@ -2614,22 +2644,18 @@ class Test(unittest.TestCase):
             </degree>
           </harmony>
         """
+        figure = 'G7 subtract 5 add b9 add #9 add #11 add b13'
+        pitches = ('G2', 'B2', 'F3', 'A-3', 'A#3', 'C#4', 'E-4')
+        self.runTestOnChord(xmlString, figure, pitches)
 
-        MP = musicxml.xmlToM21.MeasureParser()
-        mxHarmony = EL(xmlString)
+        figure = 'G7 subtract5 addb9 add#9 add#11 addb13'
+        self.runTestOnChord(xmlString, figure, pitches)
 
-        cs1 = MP.xmlToChordSymbol(mxHarmony)
-        cs2 = ChordSymbol(cs1.figure)
-        cs3 = ChordSymbol('G7 subtract 5 add b9 add #9 add #11 add b13')
-
-        self.assertEqual(pitches, cs1.pitches)
-        self.assertEqual(pitches, cs2.pitches)
-        self.assertEqual(pitches, cs3.pitches)
+        figure = 'G7subtract5addb9add#9add#11addb13'
+        self.runTestOnChord(xmlString, figure, pitches)
 
         #########
 
-        pitches = ('C3', 'E3', 'G3', 'B-3', 'D-4')
-        pitches = tuple(pitch.Pitch(p) for p in pitches)
 
         xmlString = """
             <harmony>
@@ -2644,19 +2670,13 @@ class Test(unittest.TestCase):
             </degree>
           </harmony>
         """
+        figure = 'C7 b9'
+        pitches = ('C3', 'E3', 'G3', 'B-3', 'D-4')
 
-        MP = musicxml.xmlToM21.MeasureParser()
-        mxHarmony = EL(xmlString)
+        self.runTestOnChord(xmlString, figure, pitches)
 
-        cs1 = MP.xmlToChordSymbol(mxHarmony)
-        cs2 = ChordSymbol(cs1.figure)
-        cs3 = ChordSymbol('C7 b9')
-        cs4 = ChordSymbol('C7 add b9')
-
-        self.assertEqual(pitches, cs1.pitches)
-        self.assertEqual(pitches, cs2.pitches)
-        self.assertEqual(pitches, cs3.pitches)
-        self.assertEqual(pitches, cs4.pitches)
+        figure = 'C7 add b9'
+        self.runTestOnChord(xmlString, figure, pitches)
 
         # Test alter
         cs = ChordSymbol('A7 alter #5')
@@ -2665,9 +2685,6 @@ class Test(unittest.TestCase):
                          '<music21.pitch.Pitch G3>)', str(cs.pitches))
 
         #########
-
-        pitches = ('A2','C#3','E#3','G3','B#3','D#4')
-        pitches = tuple(pitch.Pitch(p) for p in pitches)
 
         xmlString = """
           <harmony>
@@ -2692,26 +2709,12 @@ class Test(unittest.TestCase):
               </degree>
             </harmony>
         """
+        figure = 'A7 alter #5 add #9 add #11'
+        pitches = ('A2','C#3','E#3','G3','B#3','D#4')
 
-        MP = musicxml.xmlToM21.MeasureParser()
-        mxHarmony = EL(xmlString)
-
-        cs1 = MP.xmlToChordSymbol(mxHarmony)
-        cs2 = ChordSymbol(cs1.figure)
-        cs3 = ChordSymbol('A7 alter #5 add #9 add #11')
-
-        self.assertEqual(pitches, cs1.pitches)
-        self.assertEqual(pitches, cs2.pitches)
-        self.assertEqual(pitches, cs3.pitches)
+        self.runTestOnChord(xmlString, figure, pitches)
 
     def testChordWithBass(self):
-
-
-        from xml.etree.ElementTree import fromstring as EL
-        from music21 import musicxml, pitch
-
-        pitches = ('G2', 'A2', 'C#3', 'E3')
-        pitches = tuple(pitch.Pitch(p) for p in pitches)
 
         xmlString = """
           <harmony>
@@ -2725,24 +2728,13 @@ class Test(unittest.TestCase):
             </bass>
           </harmony>
           """
+        figure = 'A7/G'
+        pitches = ('G2', 'A2', 'C#3', 'E3')
 
-        MP = musicxml.xmlToM21.MeasureParser()
-        mxHarmony = EL(xmlString)
+        self.runTestOnChord(xmlString, figure, pitches)
 
-        cs1 = MP.xmlToChordSymbol(mxHarmony)
-        cs2 = ChordSymbol(cs1.figure)
-        cs3 = ChordSymbol('A7/G')
-
-        self.assertEqual(pitches, cs1.pitches)
-        self.assertEqual(pitches, cs2.pitches)
-        self.assertEqual(pitches, cs3.pitches)
 
     def testChordFlatSharpInFigure(self):
-        from xml.etree.ElementTree import fromstring as EL
-        from music21 import musicxml, pitch
-
-        pitches = ('G2', 'A2', 'B2', 'D#3', 'F3')
-        pitches = tuple(pitch.Pitch(p) for p in pitches)
 
         xmlString = """
           <harmony>
@@ -2752,19 +2744,13 @@ class Test(unittest.TestCase):
             <kind text="9+">augmented-dominant-ninth</kind>
           </harmony>
         """
+        pitches = ('G2', 'A2', 'B2', 'D#3', 'F3')
+        figure = 'G+9'
+        self.runTestOnChord(xmlString, figure, pitches)
 
-        MP = musicxml.xmlToM21.MeasureParser()
-        mxHarmony = EL(xmlString)
+        figure = 'G9#5'
+        self.runTestOnChord(xmlString, figure, pitches)
 
-        cs1 = MP.xmlToChordSymbol(mxHarmony)
-        cs2 = ChordSymbol(cs1.figure)
-        cs3 = ChordSymbol('G+9')
-        cs4 = ChordSymbol('G9#5')
-
-        self.assertEqual(pitches, cs1.pitches)
-        self.assertEqual(pitches, cs2.pitches)
-        self.assertEqual(pitches, cs3.pitches)
-        self.assertEqual(pitches, cs4.pitches)
 
         pitches = ('A2', 'C3', 'E3', 'G#3')
         pitches = tuple(pitch.Pitch(p) for p in pitches)
@@ -2778,11 +2764,6 @@ class Test(unittest.TestCase):
         since the matched root and bass where globally removed from figure,
         and not only where matched.
         """
-        from xml.etree.ElementTree import fromstring as EL
-        from music21 import musicxml, pitch
-
-        pitches = ('E-2', 'E3', 'G#3', 'B3', 'D4')
-        pitches = tuple(pitch.Pitch(p) for p in pitches)
 
         xmlString = """
           <harmony>
@@ -2796,87 +2777,55 @@ class Test(unittest.TestCase):
             </bass>
           </harmony>
         """
+        figure = 'E7/E-'
+        pitches = ('E-2', 'E3', 'G#3', 'B3', 'D4')
+        self.runTestOnChord(xmlString, figure, pitches)
 
-        MP = musicxml.xmlToM21.MeasureParser()
-        mxHarmony = EL(xmlString)
-
-        cs1 = MP.xmlToChordSymbol(mxHarmony)
-        cs2 = ChordSymbol(cs1.figure)
-        cs3 = ChordSymbol('E7/E-')
-
-        self.assertEqual(pitches, cs1.pitches)
-        self.assertEqual(pitches, cs2.pitches)
-        self.assertEqual(pitches, cs3.pitches)
 
     def testChordStepBass(self):
         """
         This tests a bug where the chord modification (add 2) was placed at a
         wrong octave, resulting in a D bass instead of the proper E.
         """
-        from xml.etree.ElementTree import fromstring as EL
-        from music21 import musicxml, pitch
-
-        pitches = ('E3', 'G3', 'C4', 'D4')
-        pitches = tuple(pitch.Pitch(p) for p in pitches)
 
         xmlString = """
-      <harmony default-y="40" font-size="15">
-        <root>
-          <root-step>C</root-step>
-        </root>
-        <kind halign="center">major</kind>
-        <bass>
-          <bass-step>E</bass-step>
-        </bass>
-        <degree>
-          <degree-value>2</degree-value>
-          <degree-alter>0</degree-alter>
-          <degree-type text="add">add</degree-type>
-        </degree>
-      </harmony>
+          <harmony>
+            <root>
+              <root-step>C</root-step>
+            </root>
+            <kind>major</kind>
+            <bass>
+              <bass-step>E</bass-step>
+            </bass>
+            <degree>
+              <degree-value>2</degree-value>
+              <degree-alter>0</degree-alter>
+              <degree-type text="add">add</degree-type>
+            </degree>
+          </harmony>
            """
+        figure = 'C/E add 2'
+        pitches = ('E3', 'G3', 'C4', 'D4')
 
-        MP = musicxml.xmlToM21.MeasureParser()
-        mxHarmony = EL(xmlString)
-
-        cs1 = MP.xmlToChordSymbol(mxHarmony)
-        cs2 = ChordSymbol(cs1.figure)
-        cs3 = ChordSymbol('C/E add 2')
-
-        self.assertEqual(pitches, cs1.pitches)
-        self.assertEqual(pitches, cs2.pitches)
-        self.assertEqual(pitches, cs3.pitches)
+        self.runTestOnChord(xmlString, figure, pitches)
 
     def testNinth(self):
         """
         This tests a bug in _adjustOctaves.
         """
-        from xml.etree.ElementTree import fromstring as EL
-        from music21 import musicxml, pitch
-
-        pitches = ('D2', 'F2', 'A2', 'C3', 'E3')
-        pitches = tuple(pitch.Pitch(p) for p in pitches)
 
         xmlString = """
-        <harmony default-y="40" font-size="15">
+        <harmony >
             <root>
               <root-step>D</root-step>
             </root>
-            <kind halign="center" text="min9">minor-ninth</kind>
+            <kind text="min9">minor-ninth</kind>
         </harmony>
            """
+        pitches = ('D2', 'F2', 'A2', 'C3', 'E3')
+        figure = 'Dm9'
 
-        MP = musicxml.xmlToM21.MeasureParser()
-        mxHarmony = EL(xmlString)
-
-        cs1 = MP.xmlToChordSymbol(mxHarmony)
-        cs2 = ChordSymbol(cs1.figure)
-        cs3 = ChordSymbol('Dm9')
-
-        self.assertEqual(pitches, cs1.pitches)
-        self.assertEqual(pitches, cs2.pitches)
-        self.assertEqual(pitches, cs3.pitches)
-
+        self.runTestOnChord(xmlString, figure, pitches)
 
     def testAddSubtractAlterations(self):
         ch1 = ChordSymbol('F7 add 4 subtract 3')

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2012,9 +2012,9 @@ class ChordSymbol(Harmony):
 
             #if after bumping up the octaves, there are still pitches below bass pitch
             #bump up their octaves
-            #bassPitch = pitches[inversionNum]
+            bassPitch = pitches[inversionNum]
 
-            #self.bass(bassPitch)
+            self.bass(bassPitch)
             for p in pitches:
                 if p.diatonicNoteNum < self._overrides['bass'].diatonicNoteNum:
                     p.octave = p.octave + 1
@@ -2035,9 +2035,11 @@ class ChordSymbol(Harmony):
         self.pitches = tuple(pitches)
 
         # set overrides to be pitches in the harmony
-        self._overrides = {}
         self.bass(self.bass())
         self.root(self.root())
+        assert self.root() in pitches
+        assert self.bass() in pitches
+        self._overrides = {}
 
     ### PUBLIC METHODS ###
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1605,7 +1605,7 @@ class ChordSymbol(Harmony):
 
     def _assignOctaveForBass(self):
         """
-        Assigns the highest octave to the bass that ensure it remains lower
+        Assigns the highest octave to the bass that ensures it remains lower
         than the root.
         """
         root = self._overrides['root']
@@ -1615,7 +1615,8 @@ class ChordSymbol(Harmony):
         if bass.ps > root.ps:
             bass.octave -= 1
 
-        assert bass.ps < root.ps
+        if bass.ps == root.ps:
+            raise ValueError('bass and root should be different')
 
         return bass.octave
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1326,7 +1326,36 @@ def removeChordSymbols(chordType):
     '''
     del CHORD_TYPES[chordType]
 
-def _get_alteration(alteration):
+def _getAlteration(alteration):
+    """
+    Parses the string-encoded alteration and returns a tuple containing the
+    alteration type (add, subtract/omit, alter), the degree of the chord,
+    and the number representing the chromatic alteration of this degree. add
+    is considered by default if not explicitly mentioned. If list is emtpy,
+    returns None.
+
+    >>> harmony._getAlteration('add4')
+    ('add', 4, 0)
+
+    >>> harmony._getAlteration('subtract3')
+    ('subtract', 3, -1)
+
+    >>> harmony._getAlteration('addb9')
+    ('add', 9, -1)
+
+    >>> harmony._getAlteration('add#9')
+    ('add', 9, 1)
+
+    >>> harmony._getAlteration('b9')
+    ('add', 9, -1)
+
+    >>> harmony._getAlteration('alter#5')
+    ('alter', 5, 1)
+
+    >>> harmony._getAlteration('alter##5')
+    ('alter', 5, 2)
+
+    """
     if alteration != '':
         if 'b' in alteration:
             semiToneAlter = -1 * alteration.count('b')
@@ -1893,7 +1922,7 @@ class ChordSymbol(Harmony):
             altCopy.append(item)
         alterations = altCopy
         for alteration in alterations:
-            alteration = _get_alteration(alteration)
+            alteration = _getAlteration(alteration)
             if alteration:
                 modType, alteration, alterBy = alteration
                 self.addChordStepModification(

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -15,6 +15,7 @@ An object representation of harmony, a subclass of chord, as encountered as chor
 roman numerals, or other chord representations with a defined root.
 '''
 import collections
+import copy
 import re
 import unittest
 
@@ -1979,9 +1980,13 @@ class ChordSymbol(Harmony):
             suspended = ['suspended-second','suspended-fourth',
                          'suspended-fourth-seventh']
             if self.chordKind in suspended:
-                if interval.notesToInterval(self._overrides['root'],
-                                            self._overrides['bass']).generic.simpleDirected == 4:
-                    inv = 1
+                tempRoot = copy.deepcopy(self._overrides['root'])
+                tempRoot.octave = 3
+                tempBass = copy.deepcopy(self._overrides['bass'])
+                tempBass.octave = 3
+                if interval.notesToInterval(tempRoot,
+                                            tempBass).generic.simpleDirected == 4:
+                    inversionNum = 1
 
             if not self.inversionIsValid(inversionNum):
                 #there is a bass, yet no normal inversion was found....must be added note

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4495,6 +4495,7 @@ class MeasureExporter(XMLExporterBase):
     def chordSymbolToXml(self, cs):
         '''
         Convert a ChordSymbol object to an mxHarmony object.
+        
         >>> cs = harmony.ChordSymbol()
         >>> cs.root('E-')
         >>> cs.bass('B-')

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4495,7 +4495,6 @@ class MeasureExporter(XMLExporterBase):
     def chordSymbolToXml(self, cs):
         '''
         Convert a ChordSymbol object to an mxHarmony object.
-
         >>> cs = harmony.ChordSymbol()
         >>> cs.root('E-')
         >>> cs.bass('B-')
@@ -4576,7 +4575,7 @@ class MeasureExporter(XMLExporterBase):
           <kind>suspended-fourth</kind>
           <degree>
             <degree-value>9</degree-value>
-            <degree-alter />
+            <degree-alter>0</degree-alter>
             <degree-type>add</degree-type>
           </degree>
         </harmony>
@@ -6040,7 +6039,6 @@ class Test(unittest.TestCase):
         #p.getElementsByClass('Measure')[1].insert(0.0, sl3)
         self.assertEqual(self.getXml(p).count(u'<slur '), 6)
 
-
     def testExportNC(self):
         from music21 import harmony
 
@@ -6083,6 +6081,10 @@ class Test(unittest.TestCase):
                                                  u'text="N.C.">none</kind>'))
         self.assertEqual(1, self.getXml(s).count(u'<kind '
                                                  u'text="No Chord">none</kind>'))
+
+
+
+
 
 
 class TestExternal(unittest.TestCase): # pragma: no cover

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4495,7 +4495,7 @@ class MeasureExporter(XMLExporterBase):
     def chordSymbolToXml(self, cs):
         '''
         Convert a ChordSymbol object to an mxHarmony object.
-        
+
         >>> cs = harmony.ChordSymbol()
         >>> cs.root('E-')
         >>> cs.bass('B-')

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -6491,6 +6491,49 @@ class Test(unittest.TestCase):
                               offsets):
             self.assertEqual(ch.offset, offset)
 
+    def testEmptyDegreeAlter(self):
+        from xml.etree.ElementTree import fromstring as EL
+
+        MP = MeasureParser()
+
+        xmlString = """
+        <harmony>
+          <root>
+            <root-step>F</root-step>
+          </root>
+          <kind>suspended-fourth</kind>
+          <degree>
+            <degree-value>9</degree-value>
+            <degree-alter>0</degree-alter>
+            <degree-type>add</degree-type>
+          </degree>
+        </harmony>
+        """
+        mxHarmony = EL(xmlString)
+
+        cs1 = MP.xmlToChordSymbol(mxHarmony)
+
+        xmlString = """
+        <harmony>
+          <root>
+            <root-step>F</root-step>
+          </root>
+          <kind>suspended-fourth</kind>
+          <degree>
+            <degree-value>9</degree-value>
+            <degree-alter />
+            <degree-type>add</degree-type>
+          </degree>
+        </harmony>
+        """
+        mxHarmony = EL(xmlString)
+        cs2 = MP.xmlToChordSymbol(mxHarmony)
+
+        cs3 = harmony.ChordSymbol('F sus add 9')
+
+        self.assertEqual(cs1.pitches, cs3.pitches)
+        self.assertEqual(cs2.pitches, cs3.pitches)
+
 if __name__ == '__main__':
     import music21
     music21.mainTest(Test) #, runTest='testRehearsalMarks')


### PR DESCRIPTION
I fixed a couple of bugs I encountered while parsing a large dataset of lead sheets.

Basically, I want to ensure that given a ChordSymbol ch, music21 can always create a ChordSymbol given the figure ch.figure, and that the resulting chord symbol is always equivalent to the first.

I have included tests for the several cases I encountered, without any reference to the original dataset.