### PR TITLE
Quote Command for Windows for Showing PNGs

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -898,6 +898,10 @@ class ConverterMusicXML(SubConverter):
         if common.runningUnderIPython():
             musescoreRun += ' -r ' + str(defaults.ipythonImageDpi)
 
+        platform = common.getPlatform()
+        if platform == 'win':
+            musescoreRun = '"' + musescoreRun + '"'
+
         storedStrErr = sys.stderr
         fileLikeOpen = io.StringIO()
         sys.stderr = fileLikeOpen


### PR DESCRIPTION
Hi,

showing a PNG didn't work for me on Windows.
Minimal example:

```python
import music21 as m21
n = m21.note.Note('c')
n.show('ipython.musicxml.png')
```

Before, that caused the error at the end of this message. In the subconverter, I just put the command in quotes before passing it to `os.system`. For me, it is now working fine. The same solution was used in this old commit 9ea4e43c5e5c6ed7aefdeb25b738d22e490158fc (see the `launch` method).

Possibly related issue: #348.

Best,

Frank

---


Error before:
```
---------------------------------------------------------------------------
SubConverterFileIOException               Traceback (most recent call last)
<ipython-input-28-b03574fb841c> in <module>()
      5 # %load_ext music21.ipython21
      6 n = m21.note.Note('c')
----> 7 n.show('ipython.musicxml.png')

~\AppData\Local\Continuum\Anaconda3\envs\FMP\lib\site-packages\music21\base.py in show(self, fmt, app, **keywords)
   2628                                  app=app,
   2629                                  subformats=subformats,
-> 2630                                  **keywords)
   2631 
   2632     # -------------------------------------------------------------------------

~\AppData\Local\Continuum\Anaconda3\envs\FMP\lib\site-packages\music21\converter\subConverters.py in show(self, obj, fmt, app, subformats, **keywords)
    358             for s in scores:
    359                 fp = helperSubConverter.write(s, helperFormat,
--> 360                                               subformats=helperSubformats, **keywords)
    361 
    362                 if helperSubformats[0] == 'png':

~\AppData\Local\Continuum\Anaconda3\envs\FMP\lib\site-packages\music21\converter\subConverters.py in write(self, obj, fmt, fp, subformats, **keywords)
    940                 and ('png' in subformats or 'pdf' in subformats)
    941                 and not str(environLocal['musescoreDirectPNGPath']).startswith('/skip')):
--> 942             fp = self.runThroughMusescore(fp, subformats, **keywords)
    943 
    944         return fp

~\AppData\Local\Continuum\Anaconda3\envs\FMP\lib\site-packages\music21\converter\subConverters.py in runThroughMusescore(self, fp, subformats, **keywords)
    897 
    898         if subformatExtension == 'png':
--> 899             return self.findPNGfpFromXMLfp(fpOut)
    900         else:
    901             return fpOut

~\AppData\Local\Continuum\Anaconda3\envs\FMP\lib\site-packages\music21\converter\subConverters.py in findPNGfpFromXMLfp(self, xmlFilePath)
    805         else:
    806             raise SubConverterFileIOException(
--> 807                 'png file of xml not found. Or file >999 pages?')
    808         return pngfp
    809 

SubConverterFileIOException: png file of xml not found. Or file >999 pages?
```