### PR TITLE
Typo in Krumhansl-Schmuckler algorithm

### DIFF
--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -523,7 +523,7 @@ class StreamForms:
        'midiPitchHistogram': formMidiPitchHistogram,
        'midiIntervalHistogram': formMidiIntervalHistogram,
        'contourList': formContourList,
-       'analyzedKey': lambda unused, f: f.analyze(method='key'),
+       'analyzedKey': lambda unused, f: f.analyze(method='KrumhanslSchmuckler'),
        'tonalCertainty': lambda unused, foundKey: foundKey.tonalCertainty(),
        'metadata': lambda unused, p: p.metadata,
        'secondsMap': formSecondsMap,

--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -62,11 +62,10 @@ class QualityFeature(featuresModule.FeatureExtractor):
     '''
     Extends the jSymbolic QualityFeature to automatically find mode
 
-    Set to 0 if the key signature indicates that
-    a recording is major, set to 1 if it indicates
-    that it is minor.  A Music21
-    addition: if no key mode is found in the piece, analyze the piece to
-    discover what mode it is most likely in.
+    Set to 0 if the key signature indicates that the score is major,
+    set to 1 if it indicates that it is minor. Music21 addition:
+    if no key mode is found in the piece, analyze the piece using
+    predetermined key profiles to discover what mode it is most likely in.
 
 
     Example: Handel, Rinaldo Aria (musicxml) is explicitly encoded as being in Major:
@@ -104,11 +103,11 @@ class QualityFeature(featuresModule.FeatureExtractor):
 
         self.name = 'Quality'
         self.description = '''
-            Set to 0 if the Key or KeySignature indicates that
-            a recording is major, set to 1 if it indicates
-            that it is minor.
-            Music21 addition: if no key mode is found in the piece, analyze the piece to
-            discover what mode it is most likely in.
+            Set to 0 if the Key or KeySignature indicates that a score
+            is major; set to 1 if it indicates that it is minor.
+            Music21 addition: if no key mode is found in the piece, analyze
+            the piece using predetermined key profiles to discover what mode
+            it is most likely in.
             '''
         self.isSequential = True
         self.dimensions = 1
@@ -165,7 +164,7 @@ class TonalCertainty(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, *arguments, **keywords)
 
         self.name = 'Tonal Certainty'
-        self.description = ('A floating point magnitude value that suggest tonal ' +
+        self.description = ('A floating point magnitude value that suggests tonal ' +
                         'certainty based on automatic key analysis.')
         self.dimensions = 1
         self.discrete = False


### PR DESCRIPTION
The tone profile for C# had a typo in it. This commit fixes the error.