### PR TITLE
Fixing example to match following comment about double parens.

### DIFF
--- a/documentation/source/usersGuide/usersGuide_02_notes.ipynb
+++ b/documentation/source/usersGuide/usersGuide_02_notes.ipynb
@@ -1379,7 +1379,7 @@
    },
    "outputs": [],
    "source": [
-    "r = note.Rest(type='whole')"
+    "r = note.Rest()"
    ]
   },
   {


### PR DESCRIPTION
Noticed that there's a comment in this chapter about ensuring you have the double parentheses, but the example actually doesn't have double parens because it's got a parameter. This parameter is the default, so the example stays the same if it's excluded, and then it matches the comment.