### PR TITLE
meter.py: fix testBasic() test case

### DIFF
--- a/music21/meter.py
+++ b/music21/meter.py
@@ -4438,8 +4438,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         a = stream.Stream()
         for meterStrDenominator in [1, 2, 4, 8, 16, 32]:
             for meterStrNumerator in [2, 3, 4, 5, 6, 7, 9, 11, 12, 13]:
-                ts = music21.meter.TimeSignature('%s/%s' % (meterStrNumerator,
-                                                            meterStrDenominator))
+                ts = TimeSignature('%s/%s' % (meterStrNumerator,
+                                              meterStrDenominator))
                 m = stream.Measure()
                 m.timeSignature = ts
                 a.insert(m.timeSignature.barDuration.quarterLength, m)


### PR DESCRIPTION
Fix a reference so that the test case executes. (Or, to put it another way,
make this reference to TimeSignature() consistent with the rest of the test
cases here.)

Noted while running the test suite:

======================================================================
ERROR: testBasic (music21.meter.TestExternal)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/disciple/pkgsrc/wip_dhg/py-music21/work/music21-5.7.0/music21/meter.py", line 4444, in testBasic
    ts = music21.meter.TimeSignature('%s/%s' % (meterStrNumerator,
NameError: name 'music21' is not defined