### PR TITLE
reduceChords.py: fix removeVerticalDissonances()

### DIFF
--- a/music21/analysis/reduceChords.py
+++ b/music21/analysis/reduceChords.py
@@ -652,7 +652,7 @@ class ChordReducer:
             # print(verticality, intervalClassSet, allowableChords, forbiddenChords)
             if allowableChords and intervalClassSet in allowableChords:
                 isConsonant = True
-            if verticality.isConsonant:
+            if verticality.toChord().isConsonant():
                 isConsonant = True
             if forbiddenChords and intervalClassSet in forbiddenChords:
                 isConsonant = False


### PR DESCRIPTION
This code uses the Verticality class from tree/verticality.py, not the
Verticality class from voiceLeading.py; the object supplied here has to
have the toChord() method called first to prepare it for this usage.
Also, isConsonant() is a method, not an attribute.

Noted while running the test suite:

======================================================================
ERROR: testTrecentoMadrigal (music21.analysis.reduceChords.TestExternal)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/disciple/pkgsrc/wip_dhg/py-music21/work/music21-5.7.0/music21/analysis/reduceChords.py", line 729, in testTrecentoMadrigal
    maximumNumberOfChords=3,
  File "/home/disciple/pkgsrc/wip_dhg/py-music21/work/music21-5.7.0/music21/analysis/reduceChords.py", line 107, in run
    forbiddenChords=forbiddenChords)
  File "/home/disciple/pkgsrc/wip_dhg/py-music21/work/music21-5.7.0/music21/analysis/reduceChords.py", line 654, in removeVerticalDissonances
    if verticality.isConsonant():
AttributeError: 'Verticality' object has no attribute 'isConsonant'