### PR TITLE
spineParser.py: fix testShowSousa()

### DIFF
--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -2894,6 +2894,7 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
 
     def testShowSousa(self):
         hf1 = HumdrumDataCollection(testFiles.sousaStars)
+        hf1.parse()
         hf1.stream.show()
 
 


### PR DESCRIPTION
In testShowSousa(), parse() must be called first to generate a stream. Noted while running the test suite:

ERROR: testShowSousa (music21.humdrum.spineParser.TestExternal)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/disciple/pkgsrc/wip_dhg/py-music21/work/music21-5.7.0/music21/humdrum/spineParser.py", line 2897, in testShowSousa
    hf1.stream.show()
AttributeError: 'NoneType' object has no attribute 'show'