### PR TITLE
solved issue with float/int conversion

### DIFF
--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -124,7 +124,7 @@ class WindowedAnalysis:
         >>> len(wa._windowedStream)
         36
         >>> a, b = wa.analyze(1)
-        >>> len(a) , len(b)
+        >>> len(a), len(b)
         (36, 36)
 
         >>> a, b = wa.analyze(4)

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -130,6 +130,7 @@ class WindowedAnalysis:
         >>> a, b = wa.analyze(4)
         >>> len(a), len(b)
         (33, 33)
+
         >>> a, b = wa.analyze(1, windowType='noOverlap')
         >>> len(a), len(b)
         (37, 37)
@@ -138,9 +139,6 @@ class WindowedAnalysis:
         >>> len(a), len(b)
         (10, 10)
 
-        >>> a, b = wa.analyze(4)
-        >>> len(a), len(b)
-        (33, 33)
         >>> a, b = wa.analyze(1, windowType='adjacentAverage')
         >>> len(a), len(b)
         (36, 36)

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -158,6 +158,8 @@ class WindowedAnalysis:
             windowCount = int(windowCountFloat)
             if windowCountFloat != windowCount:
                 warnings.warn('maxWindowCount is not divisible by windowSize, possibly undefined behavior')
+        elif windowType == 'adjacentAverage':
+            windowCount = maxWindowCount
         else:
             raise Music21Exception(f'Unknown windowType: {windowType}')
 

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -137,7 +137,10 @@ class WindowedAnalysis:
         if windowType == 'overlap':
             windowCount = maxWindowCount - windowSize + 1
         elif windowType == 'noOverlap':
-            windowCount = (maxWindowCount / windowSize) + 1
+            windowCountFloat = maxWindowCount / windowSize + 1
+            windowCount = int(windowCountFloat)
+            if int(windowCountFloat) != windowCount:
+                raise Warning(f"maxWindowCount is not divisible by windowSize, possibly undefined behavior")
         elif windowType == 'adjacentAverage':
             windowCount = maxWindowCount
         else:

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -145,7 +145,7 @@ class WindowedAnalysis:
 
         >>> a, b = wa.analyze(5, windowType='adjacentAverage')
         >>> len(a), len(b)
-        (36, 36)
+        (32, 32)
 
         '''
         maxWindowCount = len(self._windowedStream)

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -143,7 +143,7 @@ class WindowedAnalysis:
         >>> len(a), len(b)
         (36, 36)
 
-        >>> a, b = wa.analyze(4, windowType='adjacentAverage')
+        >>> a, b = wa.analyze(5, windowType='adjacentAverage')
         >>> len(a), len(b)
         (36, 36)
 

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -138,6 +138,17 @@ class WindowedAnalysis:
         >>> len(a), len(b)
         (10, 10)
 
+        >>> a, b = wa.analyze(4)
+        >>> len(a), len(b)
+        (33, 33)
+        >>> a, b = wa.analyze(1, windowType='adjacentAverage')
+        >>> len(a), len(b)
+        (36, 36)
+
+        >>> a, b = wa.analyze(4, windowType='adjacentAverage')
+        >>> len(a), len(b)
+        (33, 33)
+
         '''
         maxWindowCount = len(self._windowedStream)
         # assuming that this is sorted

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -20,6 +20,8 @@ The :class:`music21.analysis.discrete.KrumhanslSchmuckler` (for algorithmic key 
 and :class:`music21.analysis.discrete.Ambitus` (for pitch range analysis) classes provide examples.
 '''
 import unittest
+import warnings
+
 
 from music21 import exceptions21
 
@@ -31,6 +33,7 @@ from music21.analysis.discrete import DiscreteAnalysisException
 
 
 from music21 import environment
+
 _MOD = 'analysis.windowed'
 environLocal = environment.Environment(_MOD)
 
@@ -129,6 +132,13 @@ class WindowedAnalysis:
         >>> a, b = wa.analyze(4)
         >>> len(a), len(b)
         (33, 33)
+        >>> a, b = wa.analyze(1,windowType='noOverlap')
+        >>> len(a), len(b)
+        (36, 36)
+
+        >>> a, b = wa.analyze(4,windowType='noOverlap')
+        >>> len(a), len(b)
+        (10, 10)
 
         '''
         maxWindowCount = len(self._windowedStream)
@@ -140,7 +150,7 @@ class WindowedAnalysis:
             windowCountFloat = maxWindowCount / windowSize + 1
             windowCount = int(windowCountFloat)
             if windowCountFloat != windowCount:
-                raise Warning(f"maxWindowCount is not divisible by windowSize, possibly undefined behavior")
+                warnings.warn('maxWindowCount is not divisible by windowSize, possibly undefined behavior')
         else:
             raise Music21Exception(f'Unknown windowType: {windowType}')
 

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -145,7 +145,7 @@ class WindowedAnalysis:
 
         >>> a, b = wa.analyze(4, windowType='adjacentAverage')
         >>> len(a), len(b)
-        (33, 33)
+        (36, 36)
 
         '''
         maxWindowCount = len(self._windowedStream)

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -143,10 +143,6 @@ class WindowedAnalysis:
         >>> len(a), len(b)
         (36, 36)
 
-        >>> a, b = wa.analyze(5, windowType='adjacentAverage')
-        >>> len(a), len(b)
-        (32, 32)
-
         '''
         maxWindowCount = len(self._windowedStream)
         # assuming that this is sorted

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -22,7 +22,6 @@ and :class:`music21.analysis.discrete.Ambitus` (for pitch range analysis) classe
 import unittest
 import warnings
 
-
 from music21 import exceptions21
 
 from music21 import common
@@ -33,7 +32,6 @@ from music21.analysis.discrete import DiscreteAnalysisException
 
 
 from music21 import environment
-
 _MOD = 'analysis.windowed'
 environLocal = environment.Environment(_MOD)
 
@@ -126,17 +124,17 @@ class WindowedAnalysis:
         >>> len(wa._windowedStream)
         36
         >>> a, b = wa.analyze(1)
-        >>> len(a), len(b)
+        >>> len(a) , len(b)
         (36, 36)
 
         >>> a, b = wa.analyze(4)
         >>> len(a), len(b)
         (33, 33)
-        >>> a, b = wa.analyze(1,windowType='noOverlap')
+        >>> a, b = wa.analyze(1, windowType='noOverlap')
         >>> len(a), len(b)
-        (36, 36)
+        (37, 37)
 
-        >>> a, b = wa.analyze(4,windowType='noOverlap')
+        >>> a, b = wa.analyze(4, windowType='noOverlap')
         >>> len(a), len(b)
         (10, 10)
 

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -139,10 +139,8 @@ class WindowedAnalysis:
         elif windowType == 'noOverlap':
             windowCountFloat = maxWindowCount / windowSize + 1
             windowCount = int(windowCountFloat)
-            if int(windowCountFloat) != windowCount:
+            if windowCountFloat != windowCount:
                 raise Warning(f"maxWindowCount is not divisible by windowSize, possibly undefined behavior")
-        elif windowType == 'adjacentAverage':
-            windowCount = maxWindowCount
         else:
             raise Music21Exception(f'Unknown windowType: {windowType}')
 


### PR DESCRIPTION
The issue is(I assume due to changes of how python3 handels division), that windowCount in the 'noOverlap' case will be a float (even in the case where maxWindowCount / windowSize is divisible). This will then create an issue in line 149,       
`  data = [0] * windowCount`
`  File "/usr/local/lib/python3.7/site-packages/music21/analysis/windowed.py", line 146, in analyze
    data = [0] * windowCount
TypeError: can't multiply sequence by non-int of type 'float'`

This Pr solves this by casting(I assume this way is most consistent with prior versions of python), also adds a warning, since i belive user should eb made aware