### PR TITLE
Allow dotted tuplet notes when looking for duration candidates

### DIFF
--- a/music21/braille/basic.py
+++ b/music21/braille/basic.py
@@ -602,7 +602,7 @@ def noteToBraille(music21Note, showOctave=True, upperFirstInFingering=True):
     ⠸⠶⠄⠐⠹
     >>> for x in C4._brailleEnglish:
     ...     print(x)
-    Tuplet of 7/4ths ⠸⠶⠄
+    Septuplet ⠸⠶⠄
     Octave 4 ⠐
     C quarter ⠹
     '''

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -51,7 +51,6 @@ import unittest
 import copy
 
 from collections import namedtuple
-from fractions import Fraction
 
 from music21 import prebase
 
@@ -70,7 +69,7 @@ environLocal = environment.Environment(_MOD)
 DENOM_LIMIT = defaults.limitOffsetDenominator
 
 POSSIBLE_DOTS_IN_TUPLETS = [0, 1]
-DOT_LENGTH_MULTIPLAYER = Fraction(3, 2)
+DOT_LENGTH_MULTIPLAYER = fractions.Fraction(3, 2)
 
 _inf = float('inf')
 

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -456,11 +456,10 @@ def quarterLengthToTuplet(qLen,
             qLenBase = opFrac(typeValue / float(i))
             # try multiples of the tuplet division, from 1 to max-1
             for m in range(1, i):
-                for number_of_dots in POSSIBLE_DOTS_IN_TUPLETS:
-                    dot_multiplayer = fractions.Fraction(common.dotMultiplier(number_of_dots))
-                    qLenCandidate = qLenBase * m * dot_multiplayer
+                for numberOfDots in POSSIBLE_DOTS_IN_TUPLETS:
+                    qLenCandidate = qLenBase * m * fractions.Fraction(common.dotMultiplier(numberOfDots))
                     if qLenCandidate == qLen:
-                        tupletDuration = durationTupleFromTypeDots(typeKey, number_of_dots)
+                        tupletDuration = durationTupleFromTypeDots(typeKey, numberOfDots)
                         newTuplet = Tuplet(numberNotesActual=i,
                                            numberNotesNormal=m,
                                            durationActual=tupletDuration,

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -2500,7 +2500,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
         >>> d = duration.Duration(quarterLength=0.571428)
         >>> d.fullName
-        'Quarter Tuplet of 7/4ths (4/7 QL)'
+        'Quarter Septuplet (4/7 QL)'
 
         >>> d = duration.Duration(quarterLength=0)
         >>> d.fullName

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -69,7 +69,6 @@ environLocal = environment.Environment(_MOD)
 DENOM_LIMIT = defaults.limitOffsetDenominator
 
 POSSIBLE_DOTS_IN_TUPLETS = [0, 1, 2]
-DOT_LENGTH_MULTIPLAYER = fractions.Fraction(3, 2)
 
 _inf = float('inf')
 

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -68,7 +68,7 @@ environLocal = environment.Environment(_MOD)
 
 DENOM_LIMIT = defaults.limitOffsetDenominator
 
-POSSIBLE_DOTS_IN_TUPLETS = [0, 1]
+POSSIBLE_DOTS_IN_TUPLETS = [0, 1, 2]
 DOT_LENGTH_MULTIPLAYER = fractions.Fraction(3, 2)
 
 _inf = float('inf')
@@ -458,7 +458,7 @@ def quarterLengthToTuplet(qLen,
             # try multiples of the tuplet division, from 1 to max-1
             for m in range(1, i):
                 for number_of_dots in POSSIBLE_DOTS_IN_TUPLETS:
-                    dot_multiplayer = DOT_LENGTH_MULTIPLAYER ** number_of_dots
+                    dot_multiplayer = fractions.Fraction(common.dotMultiplier(number_of_dots))
                     qLenCandidate = qLenBase * m * dot_multiplayer
                     if qLenCandidate == qLen:
                         tupletDuration = durationTupleFromTypeDots(typeKey, number_of_dots)
@@ -1317,6 +1317,8 @@ class Tuplet(prebase.ProtoM21Object):
             return 'Quintuplet'
         elif numActual == 6 and numNormal == 4:
             return 'Sextuplet'
+        elif numActual == 7 and numNormal == 4:
+            return 'Septuplet'
         ordStr = common.ordinalAbbreviation(numNormal, plural=True)
         return 'Tuplet of %s/%s%s' % (numActual, numNormal, ordStr)
 
@@ -3546,6 +3548,63 @@ class Test(unittest.TestCase):
         self.assertEqual(repr(d.quarterLength), 'Fraction(1, 3)')
         self.assertEqual(str(unitSpec(d)), "(Fraction(1, 3), 'eighth', 0, 3, 2, 'eighth')")
 
+    def testTupletDurations(self):
+        """
+        Test tuplet durations are assigned with proper duration
+
+        This test was written while adding support for dotted tuplet notes
+        """
+        # Before the fix, the duration was "Quarter Tuplet of 5/3rds (3/5 QL)"
+        self.assertEqual(
+            'Eighth Triplet (1/3 QL)',
+            Duration(fractions.Fraction(1 / 3)).fullName
+        )
+        self.assertEqual(
+            'Quarter Triplet (2/3 QL)',
+            Duration(fractions.Fraction(2 / 3)).fullName
+        )
+
+        self.assertEqual(
+            '16th Quintuplet (1/5 QL)',
+            Duration(fractions.Fraction(1 / 5)).fullName
+        )
+        self.assertEqual(
+            'Eighth Quintuplet (2/5 QL)',
+            Duration(fractions.Fraction(2 / 5)).fullName
+        )
+        self.assertEqual(
+            'Dotted Eighth Quintuplet (3/5 QL)',
+            Duration(fractions.Fraction(3 / 5)).fullName
+        )
+        self.assertEqual(
+            'Double Dotted Eighth Quintuplet (7/10 QL)',
+            Duration(fractions.Fraction(3.5 / 5)).fullName
+        )
+        self.assertEqual(
+            'Quarter Quintuplet (4/5 QL)',
+            Duration(fractions.Fraction(4 / 5)).fullName
+        )
+
+        self.assertEqual(
+            '16th Septuplet (1/7 QL)',
+            Duration(fractions.Fraction(1 / 7)).fullName
+        )
+        self.assertEqual(
+            'Eighth Septuplet (2/7 QL)',
+            Duration(fractions.Fraction(2 / 7)).fullName
+        )
+        self.assertEqual(
+            'Dotted Eighth Septuplet (3/7 QL)',
+            Duration(fractions.Fraction(3 / 7)).fullName
+        )
+        self.assertEqual(
+            'Quarter Septuplet (4/7 QL)',
+            Duration(fractions.Fraction(4 / 7)).fullName
+        )
+        self.assertEqual(
+            'Dotted Quarter Septuplet (6/7 QL)',
+            Duration(fractions.Fraction(6 / 7)).fullName
+        )
 
 # -------------------------------------------------------------------------------
 # define presented order in documentation

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -68,7 +68,7 @@ environLocal = environment.Environment(_MOD)
 
 DENOM_LIMIT = defaults.limitOffsetDenominator
 
-POSSIBLE_DOTS_IN_TUPLETS = [0, 1, 2]
+POSSIBLE_DOTS_IN_TUPLETS = [0, 1]
 
 _inf = float('inf')
 
@@ -3574,10 +3574,6 @@ class Test(unittest.TestCase):
         self.assertEqual(
             'Dotted Eighth Quintuplet (3/5 QL)',
             Duration(fractions.Fraction(3 / 5)).fullName
-        )
-        self.assertEqual(
-            'Double Dotted Eighth Quintuplet (7/10 QL)',
-            Duration(fractions.Fraction(3.5 / 5)).fullName
         )
         self.assertEqual(
             'Quarter Quintuplet (4/5 QL)',

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -8009,15 +8009,6 @@ class Test(unittest.TestCase):
     #     cLast = m10.notes[-1]
     #     self.assertEqual(cLast.expressions, [])
 
-    def testDottedTupletNotes(self):
-        """Test that quarterLen of dotted tuplet notes is assigned with proper duration"""
-        m = Measure()
-
-        m.append(note.Note(quarterLength=0.6))
-
-        # Before the fix, the duration was "Quarter Tuplet of 5/3rds (3/5 QL)"
-        self.assertEqual('Dotted Eighth Quintuplet (3/5 QL)', m[0].duration.fullName)
-
 # -----------------------------------------------------------------------------
 
 if __name__ == '__main__':

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -8009,6 +8009,15 @@ class Test(unittest.TestCase):
     #     cLast = m10.notes[-1]
     #     self.assertEqual(cLast.expressions, [])
 
+    def testDottedTupletNotes(self):
+        """Test that quarterLen of dotted tuplet notes is assigned with proper duration"""
+        m = Measure()
+
+        m.append(note.Note(quarterLength=0.6))
+
+        # Before the fix, the duration was "Quarter Tuplet of 5/3rds (3/5 QL)"
+        self.assertEqual('Dotted Eighth Quintuplet (3/5 QL)', m[0].duration.fullName)
+
 # -----------------------------------------------------------------------------
 
 if __name__ == '__main__':


### PR DESCRIPTION
Before this change music21 did not support dotted notes within tuplets when constructing notes based on their quarterLength. This change allow up to 1 dot when looking for the best represation candidate.

One unittest was added to demonstrate that the original issue was indeed fixed. I'd be happy to make any changes to get these changes into music21.

Thanks!