### PR TITLE
Add minimal package requirements to setup.py

### DIFF
--- a/requirements-minimum.txt
+++ b/requirements-minimum.txt
@@ -1,3 +1,4 @@
 chardet
-more_itertools
+joblib
+more-itertools
 webcolors

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,14 @@ DESCRIPTION_LONG = """A Toolkit for Computer-Aided Musical Analysis.
                         The development of music21 is supported by the
                         generosity of the Seaver Institute and the NEH."""
 
+INSTALL_REQUIRES = [
+    "chardet",
+    "joblib",
+    "more-itertools",
+    "webcolors",
+]
+
+
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',
@@ -68,9 +76,7 @@ if __name__ == '__main__':
         classifiers=classifiers,
         download_url='https://github.com/cuthbertLab/music21/releases/download/v%s/music21-%s.tar.gz' % (m21version, m21version),
         packages=setuptools.find_packages(exclude=['ez_setup']),
+        install_requires=INSTALL_REQUIRES,
         include_package_data=True,
         zip_safe=False,
     )
-
-# -----------------------------------------------------------------------------
-# eof


### PR DESCRIPTION
As part of the steps to make this package more developer friendly, I wanted to list the minimal requirements this package needs. By listing these in the `setup.py` we make sure that following a `pip install music21` the package can be used immediately by users.

**How did I determine the minimal dependencies?**

1. Checkout the `music21` project as-is from this repo to a local folder
2. Start a fresh `pipenv` (basically a type of a `virtualenv`) that has nothing installed in it.
3. Run `from music21 import *` and make sure we get no errors: For each `ModuleNotFoundError: No module named '<module-name>'` exception I got, I installed the package. Repeating this step until `from music21 import *` is working with no exceptions.

So the list of minimal dependencies we got via this process is: `chardet`, `joblib`, `more-itertools` and `webcolors`.

@mscuthbert let me know if there is anything you would like me to change. The `setup.py` change is more important than the `requirements-minimum.txt` file as all the dependencies from the `setup.py` are automatically installed when a user is running `pip install music21`.

