### PR TITLE
Trill Fixer for OMR 

### DIFF
--- a/music21/alpha/analysis/__init__.py
+++ b/music21/alpha/analysis/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__all__ = ['aligner', 'fixer', 'hasher', 'search',
+__all__ = ['aligner', 'fixer', 'hasher', 'ornamentRecognizer', 'search',
            'testFiles']
 
 from music21.alpha.analysis import aligner

--- a/music21/alpha/analysis/aligner.py
+++ b/music21/alpha/analysis/aligner.py
@@ -828,14 +828,17 @@ class StreamAligner:
         '''
         i = self.n
         j = self.m
-        while (i != 0 or j != 0):
+        while i != 0 or j != 0:
 
             # check if possible moves are indexable
             bestOp = self.getOpFromLocation(i, j)
+            targetStreamReference = self.hashedTargetStream[i - 1].reference
+            sourceStreamReference = self.hashedSourceStream[j - 1].reference
+            opTuple = (targetStreamReference, sourceStreamReference, bestOp)
+            self.changes.insert(0, opTuple)
 
-            self.changes.insert(0, (self.hashedTargetStream[i - 1].reference,
-                                        self.hashedSourceStream[j - 1].reference,
-                                        bestOp))
+            # changes are done for this cell -- where to move next?
+
             # bestOp : 0: insertion, 1: deletion, 2: substitution; 3: nothing
             if bestOp == ChangeOps.Insertion:
                 i -= 1
@@ -850,8 +853,7 @@ class StreamAligner:
             else:  # 3: ChangeOps.NoChange
                 i -= 1
                 j -= 1
-
-        if (i != 0 and j != 0):
+        if i != 0 and j != 0:
             raise AlignmentTracebackException('Traceback of best alignment did not end properly')
 
         self.changesCount = Counter(elem[2] for elem in self.changes)

--- a/music21/alpha/analysis/fixer.py
+++ b/music21/alpha/analysis/fixer.py
@@ -9,12 +9,18 @@
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 import unittest
+from copy import deepcopy
 
 from music21.alpha.analysis import aligner
+from music21.alpha.analysis import ornamentRecognizer
+
+from music21 import duration
+from music21 import expressions
 from music21 import interval
 from music21 import note
 from music21 import pitch
 from music21 import stream
+
 
 class OMRMidiFixer:
     '''
@@ -310,8 +316,464 @@ class EnharmonicFixer(OMRMidiFixer):
             return True
         return False
 
-class Test(unittest.TestCase):
+
+class OrnamentFixer(OMRMidiFixer):
+    '''
+    Fixes missed ornaments in OMR using expanded ornaments in MIDI
+    initialized with self.changes -- a list of tuples in this form:
+    (MIDIReference, OMRReference, op)
+    MIDIReference and OMRReference are actual note/rest/chord object in some stream
+    op is a ChangeOp that relates the two references
+    '''
     pass
+
+
+def getNotesWithinDuration(startingGeneralNote, totalDuration, referenceStream=None):
+    '''
+    Returns maximal stream of deepcopies of notes, rests, and chords following
+    (and including) startingNote which occupy no more than totalDuration combined.
+
+    startingGeneralNote is a GeneralNote (could be a note, rest, or chord)
+    totalDuration is a duration
+    referenceStream is optionally a stream which the startingGeneralNote's
+        active site should be set to when provided
+    '''
+    if referenceStream:
+        startingGeneralNote.activeSite = referenceStream
+
+    notes = stream.Stream()
+
+    # even startingNote is too long
+    if startingGeneralNote.duration.quarterLength > totalDuration.quarterLength:
+        return notes
+
+    durationQlLeft = totalDuration.quarterLength - startingGeneralNote.duration.quarterLength
+    nextGeneralNote = startingGeneralNote.next('GeneralNote', activeSiteOnly=True)
+    notes.append(deepcopy(startingGeneralNote))
+
+    while nextGeneralNote and durationQlLeft >= nextGeneralNote.duration.quarterLength:
+        currentGeneralNote = nextGeneralNote
+        nextGeneralNote = currentGeneralNote.next('GeneralNote', activeSiteOnly=True)
+
+        durationQlLeft -= currentGeneralNote.duration.quarterLength
+        notes.append(deepcopy(currentGeneralNote))
+
+    return notes
+
+class TrillFixer(OrnamentFixer):
+    '''
+    Fixes missed trills in OMR using expanded ornaments in MIDI.
+    initialized with self.changes -- a list of tuples in this form:
+    (MIDIReference, OMRReference, op)
+    MIDIReference and OMRReference are actual note/rest/chord object in some stream
+    op is a ChangeOp that relates the two references
+    '''
+
+    def fix(self, show=False, inPlace=True):
+        changes = self.changes
+        sa = None
+        omrNotesLabeledTrill = []
+        midiNotesAlreadyFixedForTrill = []
+
+        if not inPlace:
+            omrStreamCopy = deepcopy(self.omrStream)
+            midiStreamCopy = deepcopy(self.midiStream)
+            sa = aligner.StreamAligner(sourceStream=omrStreamCopy, targetStream=midiStreamCopy)
+            sa.align()
+            changes = sa.changes
+
+        for midiNoteRef, omrNoteRef, change in changes:
+            # reasonable changes
+            if change is aligner.ChangeOps.NoChange or change is aligner.ChangeOps.Deletion:
+                continue
+
+            # get relevant notes
+            if omrNoteRef in omrNotesLabeledTrill:
+                continue
+            busyNotes = getNotesWithinDuration(midiNoteRef, omrNoteRef.duration)
+            busyNoteAlreadyUsed = False
+            for busyNote in busyNotes:
+                if busyNote in midiNotesAlreadyFixedForTrill:
+                    busyNoteAlreadyUsed = True
+                    break
+            if busyNoteAlreadyUsed:
+                continue
+
+            # try to recognize trill
+            simpleNs = [deepcopy(omrNoteRef)]
+            trillRecognizer = ornamentRecognizer.TrillRecognizer(busyNotes, simpleNotes=simpleNs)
+            trill = trillRecognizer.recognize()
+            trillFound = False
+            if trill:
+                trillFound = True
+            else:
+                trillRecognizer.checkNachschlag = True
+                trill = trillRecognizer.recognize()
+                if trill:
+                    trillFound = True
+
+            # mark trill
+            if trillFound:
+                if not any(isinstance(e, expressions.Ornament) for e in omrNoteRef.expressions):
+                    omrNoteRef.expressions.append(trill)
+                    midiNotesAlreadyFixedForTrill += busyNotes
+                    if show:
+                        omrNoteRef.style.color = 'blue'
+                omrNotesLabeledTrill.append(omrNoteRef)
+        if show:
+            self.omrStream.show()
+            self.midiStream.show()
+
+        if not inPlace:
+            return TrillFixer(sa.changes, sa.targetStream, sa.sourceStream)
+
+
+class Test(unittest.TestCase):
+    def testGetNotesWithinDuration(self):
+        n1 = note.Note('C')
+        n1.duration = duration.Duration('quarter')
+        m1 = stream.Stream()
+        m1.append(n1)
+
+        result = getNotesWithinDuration(n1, duration.Duration('quarter'))
+        self.assertIsInstance(result, stream.Stream)
+        self.assertListEqual([n1], list(result.notes), "starting note occupies full duration")
+
+        result = getNotesWithinDuration(n1, duration.Duration('half'))
+        self.assertListEqual([n1], list(result.notes), "starting note occupies partial duration")
+
+        result = getNotesWithinDuration(n1, duration.Duration('eighth'))
+        self.assertListEqual([], list(result.notes), "starting note too long")
+
+        m2 = stream.Measure()
+        n2 = note.Note('D')
+        n2.duration = duration.Duration('eighth')
+        n3 = note.Note('E')
+        n3.duration = duration.Duration('eighth')
+        m2.append([n1, n2, n3])
+
+        result = getNotesWithinDuration(n1, duration.Duration('quarter'))
+        self.assertListEqual([n1], list(result.notes), "starting note occupies full duration")
+
+        result = getNotesWithinDuration(n1, duration.Duration('half'))
+        self.assertListEqual([n1, n2, n3], list(result.notes), "all notes fill up full duration")
+
+        result = getNotesWithinDuration(n1, duration.Duration('whole'))
+        self.assertListEqual([n1, n2, n3], list(result.notes), "all notes fill up partial duration")
+
+        result = getNotesWithinDuration(n1, duration.Duration(1.5))
+        self.assertListEqual([n1, n2], list(result.notes), "some notes fill up full duration")
+
+        result = getNotesWithinDuration(n1, duration.Duration(1.75))
+        self.assertListEqual([n1, n2], list(result.notes), "some notes fill up partial duration")
+
+        # set active site from m2 to m1 (which runs out of notes to fill up)
+        result = getNotesWithinDuration(n1, duration.Duration('half'), referenceStream=m1)
+        self.assertListEqual([n1], list(result.notes), "partial fill up from reference stream m1")
+
+        m3 = stream.Measure()
+        m3.id = "m3"
+        r1 = note.Rest()
+        r1.duration = duration.Duration('quarter')
+        m3.append([n1, r1])  # n1 active site now with m2
+        result = getNotesWithinDuration(n1, duration.Duration('half'))
+        msg = "note and rest fill up full duration"
+        self.assertListEqual([n1, r1], list(result.notesAndRests), msg)
+
+        # set active site from m3 to m2
+        result = getNotesWithinDuration(n1, duration.Duration('half'), referenceStream=m2)
+        self.assertListEqual([n1, n2, n3], list(result.notes), "fill up from reference stream m2")
+
+    def testTrillFixer(self):
+        def createDoubleTrillMeasure():
+            '''
+            Returns a dictionary with the following keys
+
+            returnDict = {
+                "name": string,
+                "midi": measure stream,
+                "omr": measure stream,
+                "expected": measure stream,
+            }
+            '''
+            noteDuration = duration.Duration('quarter')
+
+            # GAGA Trill
+            trill1NoteDuration = duration.Duration(.25)
+            n0 = note.Note("G")
+            n0.duration = noteDuration
+            n1 = note.Note("G")
+            n1.duration = trill1NoteDuration
+            n2 = note.Note("A")
+            n2.duration = trill1NoteDuration
+            trill1 = [n1, n2, deepcopy(n1), deepcopy(n2)]  # GAGA
+
+            # CBCB Trill
+            trill2NoteDuration = duration.Duration(.0625)
+            n3 = note.Note("B3")  # omr
+            n3.duration = noteDuration
+            n4 = note.Note("B3")
+            n4.duration = trill2NoteDuration
+            n5 = note.Note("C")
+            n5.duration = trill2NoteDuration
+            trill2 = [n5, n4, deepcopy(n5), deepcopy(n4),
+                      deepcopy(n5), deepcopy(n4), deepcopy(n5), deepcopy(n4)]
+
+            midiMeasure = stream.Measure()
+            midiMeasure.append(trill1)
+            midiMeasure.append(trill2)
+
+            omrMeasure = stream.Measure()
+            omrMeasure.append([n0, n3])
+
+            expectedFixedOmrMeasure = stream.Measure()
+            n0WithTrill = deepcopy(n0)
+            n0Trill = expressions.Trill()
+            n0Trill.size = interval.Interval('m-2')
+            n0Trill.quarterLength = trill1NoteDuration.quarterLength
+            n0WithTrill.expressions.append(n0Trill)
+            n1WithTrill = deepcopy(n3)
+            n1Trill = expressions.Trill()
+            n1Trill.size = interval.Interval('M2')
+            n1Trill.quarterLength = trill2NoteDuration.quarterLength
+            n1WithTrill.expressions.append(n0Trill)
+            expectedFixedOmrMeasure.append([n0WithTrill, n1WithTrill])
+
+            returnDict = {
+                "name": "Double Trill Measure",
+                "midi": midiMeasure,
+                "omr": omrMeasure,
+                "expected": expectedFixedOmrMeasure,
+            }
+            return returnDict
+
+        def createWrongTrillMeasure():
+            '''
+            Returns a dictionary with the following keys
+
+            returnDict = {
+                "name": string,
+                "midi": measure stream,
+                "omr": measure stream,
+                "expected": measure stream,
+            }
+            '''
+            noteDuration = duration.Duration('quarter')
+
+            n0 = note.Note("C")  # omr
+            n0.duration = noteDuration
+            n1 = note.Note("C")
+            n1.duration = duration.Duration(.25)
+            n2 = note.Note("A")
+            n2.duration = duration.Duration(.25)
+
+            nontrill = [n1, n2, deepcopy(n1), deepcopy(n2)]
+
+            midiMeasure = stream.Measure()
+            midiMeasure.append(nontrill)
+            omrMeasure = stream.Measure()
+            omrMeasure.append(n0)
+
+            returnDict = {
+                "name": "Non-Trill Measure Wrong Oscillate Interval",
+                "midi": midiMeasure,
+                "omr": omrMeasure,
+                "expected": deepcopy(omrMeasure),
+            }
+            return returnDict
+
+        def createNonTrillMeasure():
+            '''
+            Returns a dictionary with the following keys
+
+            returnDict = {
+                "name": string,
+                "midi": measure stream,
+                "omr": measure stream,
+                "expected": measure stream,
+            }
+            '''
+            noteDuration = duration.Duration('quarter')
+
+            n0 = note.Note("A")  # omr
+            n0.duration = noteDuration
+            n1 = note.Note("C")
+            n1.duration = duration.Duration(.25)
+            n2 = note.Note("D")
+            n2.duration = duration.Duration(.25)
+
+            nonTrill = [n1, n2, deepcopy(n1), deepcopy(n2)]
+
+            midiMeasure = stream.Measure()
+            midiMeasure.append(nonTrill)
+            omrMeasure = stream.Measure()
+            omrMeasure.append(n0)
+
+            returnDict = {
+                "name": "Non-Trill Measure Wrong Notes",
+                "midi": midiMeasure,
+                "omr": omrMeasure,
+                "expected": deepcopy(omrMeasure),
+            }
+
+            return returnDict
+
+        def createNachschlagTrillMeasure():
+            '''
+            Returns a dictionary with the following keys
+
+            returnDict = {
+                "name": string,
+                "midi": measure stream,
+                "omr": measure stream,
+                "expected": measure stream,
+            }
+            '''
+            noteDuration = duration.Duration('quarter')
+            trillDuration = duration.Duration(.125)
+
+            n0 = note.Note("E")
+            n0.duration = noteDuration
+
+            tn1 = note.Note("E")
+            tn1.duration = trillDuration
+            tn2 = note.Note("F")
+            tn2.duration = trillDuration
+            tn3 = note.Note("D")
+            tn3.duration = trillDuration
+            firstHalfTrill = [tn1, tn2, deepcopy(tn1), deepcopy(tn2)]
+            secondHalfTrill = [deepcopy(tn1), deepcopy(tn2), deepcopy(tn1), tn3]
+            expandedTrill = firstHalfTrill + secondHalfTrill
+
+            midiMeasure = stream.Measure()
+            midiMeasure.append(expandedTrill)
+            omrMeasure = stream.Measure()
+            omrMeasure.append(n0)
+
+            nachschlagTrill = expressions.Trill()
+            nachschlagTrill.nachschlag = True
+            nachschlagTrill.quarterLength = trillDuration.quarterLength
+            expectedFixedOmrMeasure = stream.Measure()
+            noteWithTrill = deepcopy(n0)
+            noteWithTrill.expressions.append(deepcopy(nachschlagTrill))
+            expectedFixedOmrMeasure.append(noteWithTrill)
+
+            returnDict = {
+                "name": "Nachschlag Trill",
+                "midi": midiMeasure,
+                "omr": omrMeasure,
+                "expected": expectedFixedOmrMeasure,
+            }
+
+            return returnDict
+
+        def createMeasureWithTrillAlready():
+            '''
+            Returns a dictionary with the following keys
+
+            returnDict = {
+                "name": string,
+                "midi": measure stream,
+                "omr": measure stream,
+                "expected": measure stream,
+            }
+            '''
+            noteDuration = duration.Duration('quarter')
+            trillDuration = duration.Duration(.125)
+
+            noteWithTrill = note.Note("F")
+            noteWithTrill.duration = noteDuration
+            trill = expressions.Trill()
+            trill.quarterLength = trillDuration.quarterLength
+            noteWithTrill.expressions.append(trill)
+
+            tn1 = note.Note("F")
+            tn1.duration = trillDuration
+            tn2 = note.Note("G")
+            tn2.duration = trillDuration
+            expandedTrill = [tn1, tn2, deepcopy(tn1), deepcopy(tn2)]
+
+            midiMeasure = stream.Measure()
+            midiMeasure.append(expandedTrill)
+            omrMeasure = stream.Measure()
+            omrMeasure.append(noteWithTrill)
+
+            returnDict = {
+                "name": "OMR with Trill Notation",
+                "midi": midiMeasure,
+                "omr": omrMeasure,
+                "expected": deepcopy(omrMeasure),
+            }
+            return returnDict
+
+        testConditions = [createDoubleTrillMeasure(),
+                         createWrongTrillMeasure(),
+                         createNonTrillMeasure(),
+                         createNachschlagTrillMeasure(),
+                         createMeasureWithTrillAlready()]
+
+        def measuresEqual(m1, m2):
+            '''
+            Returns a tuple of (True/False, reason)
+
+            Reason is "" if True
+            '''
+            if len(m1) != len(m2):
+                msg = 'not equal length'
+                return False, msg
+            for i in range(len(m1)):
+                if len(m1[i].expressions) != len(m2[i].expressions):
+                    msg = f'Expressions {i} unequal ({m1[i].expressions} != {m2[i].expressions})'
+                    return False, msg
+                if m1[i] != m2[i]:
+                    msg = f'Elements {i} are unequal ({m1[i]} != {m2[i]})'
+                    return False, msg
+            return True, ""
+
+        for testCondition in testConditions:
+            omr = testCondition["omr"]
+            midi = testCondition["midi"]
+            expectedOmr = testCondition["expected"]
+            testingName = testCondition["name"]
+
+            # set up aligner
+            sa = aligner.StreamAligner(sourceStream=omr, targetStream=midi)
+            sa.align()
+            omrCopy = deepcopy(omr)
+            assertionCheck = "Expect no changes from creating and aligning aligner."
+            self.assertTrue(measuresEqual(omrCopy, sa.sourceStream)[0], assertionCheck)
+
+            # set up fixer
+            fixer = TrillFixer(sa.changes, sa.targetStream, sa.sourceStream)
+            assertionCheck = "Expect no changes from creating fixer."
+            self.assertTrue(measuresEqual(omrCopy, sa.sourceStream)[0], assertionCheck)
+
+            # test fixing not in place
+            notInPlaceResult = fixer.fix(inPlace=False)
+
+            assertionCheck = ". Expect no changes to aligner source stream, but unequal because "
+            isEqual, reason = measuresEqual(omrCopy, sa.sourceStream)
+            self.assertTrue(isEqual, testingName + assertionCheck + reason)
+
+            assertionCheck = ". Expect no changes to fixer omr stream, but unequal because "
+            isEqual, reason = measuresEqual(omrCopy, fixer.omrStream)
+            self.assertTrue(isEqual, testingName + assertionCheck + reason)
+
+            assertionCheck = ". Appropriate changes in new fixer, but unequal because "
+            isEqual, reason = measuresEqual(notInPlaceResult.omrStream, expectedOmr)
+            self.assertTrue(isEqual, testingName + assertionCheck + reason)
+
+            # test fixing in place
+            fixerInPlaceResult = fixer.fix()
+            self.assertIsNone(fixerInPlaceResult, testingName)
+
+            assertionCheck = ". Expect changes in fixer's omr stream, but unequal because "
+            isEqual, reason = measuresEqual(expectedOmr, fixer.omrStream)
+            self.assertTrue(isEqual, testingName + assertionCheck + reason)
+
+            assertionCheck = ". Expect changes in original omr stream, but unequal because "
+            isEqual, reason = measuresEqual(expectedOmr, omr)
+            self.assertTrue(isEqual, testingName + assertionCheck + reason)
 
 
 if __name__ == '__main__':

--- a/music21/alpha/analysis/ornamentRecognizer.py
+++ b/music21/alpha/analysis/ornamentRecognizer.py
@@ -1,0 +1,391 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+# Name:         alpha/analysis/ornamentRecognizer.py
+# Purpose:      Identifies expanded ornaments
+#
+# Authors:      Janelle Sands
+#
+# Copyright:    Copyright © 2016 Michael Scott Cuthbert and the music21 Project
+# License:      LGPL or BSD, see license.txt
+# ------------------------------------------------------------------------------
+import unittest
+from copy import deepcopy
+from typing import Union
+
+from music21 import duration
+from music21 import expressions
+from music21 import interval
+from music21 import note
+from music21 import stream
+
+
+class OrnamentRecognizer:
+    '''
+    An object to identify if a stream of notes is an expanded ornament.
+    '''
+    def __init__(self, busyNotes, simpleNotes=None):
+        self.simpleNotes = simpleNotes
+        self.busyNotes = busyNotes
+
+
+class TrillRecognizer(OrnamentRecognizer):
+    '''
+    An object to identify if a stream of ("busy") notes is an expanded trill.
+
+    By default, does not consider Nachschlag trills, but setting checkNachschlag will consider.
+
+    When optional stream of simpleNotes are provided, considers if busyNotes are
+    an expansion of a trill which would be denoted on the first note in simpleNotes.
+    '''
+    def __init__(self, busyNotes, simpleNotes=None, checkNachschlag=False):
+        super().__init__(busyNotes, simpleNotes)
+        self.checkNachschlag = checkNachschlag
+        self.acceptableInterval = 3
+        self.minimumLengthForNachschlag = 5
+
+    def calculateTrillNoteQuarterLength(self):
+        '''
+        Finds the quarter length value for each trill note
+        assuming busy notes all are an expanded trill.
+
+        Expanded trill total duration is time of all busy notes combined or
+        duration of the first note in simpleNotes when provided.
+        '''
+        numTrillNotes = len(self.busyNotes)
+        totalDurationQuarterLength = self.calculateTrillNoteTotalQuarterLength()
+        return totalDurationQuarterLength / numTrillNotes
+
+    def calculateTrillNoteTotalQuarterLength(self):
+        '''
+        Returns total length of trill assuming busy notes are all an expanded trill.
+        This is either the time of all busy notes combined or
+        duration of the first note in simpleNotes when provided.
+        '''
+        if self.simpleNotes:
+            return self.simpleNotes[0].duration.quarterLength
+        trillQl = 0
+        for n in self.busyNotes:
+            trillQl += n.duration.quarterLength
+        return trillQl
+
+    def recognize(self) -> Union[bool, expressions.Trill]:
+        '''
+        Tries to identify the busy notes as a trill.
+
+        When simple notes is provided, tries to identify busy notes
+        as the trill shortened by simple notes.
+        Currently only supports one simple note in simple notes.
+
+        Only when checkNachschlag is true, allows last few notes to break trill rules.
+
+        Trill interval size is interval between busy notes.
+
+        Returns: False if not possible or the Trill Expression
+        '''
+        busyNotes = self.busyNotes
+
+        # Enough notes to trill
+        if len(busyNotes) <= 2:
+            return False
+
+        # Oscillation pitches
+        n1 = busyNotes[0]
+        n2 = busyNotes[1]
+
+        if not n1.isNote or not n2.isNote:
+            return False
+
+        if abs(n1.pitch.midi - n2.pitch.midi) > self.acceptableInterval:
+            return False
+
+        twoNoteOscillation = True
+        i = 0
+        for i in range(len(busyNotes)):
+            noteConsidering = busyNotes[i]
+            if not noteConsidering.isNote:
+                return False
+            if i % 2 == 0 and noteConsidering.pitch != n1.pitch:
+                twoNoteOscillation = False
+                break
+            elif i % 2 != 0 and noteConsidering.pitch != n2.pitch:
+                twoNoteOscillation = False
+                break
+
+        isNachschlag = False
+        if twoNoteOscillation:
+            pass
+        elif not self.checkNachschlag:
+            return False
+        else:
+            lengthOk = len(busyNotes) >= self.minimumLengthForNachschlag
+            notTooMuchNachschlag = i >= len(busyNotes) / 2
+            if lengthOk and notTooMuchNachschlag:
+                isNachschlag = True
+            else:
+                return False
+
+        # set up trill
+        trill = expressions.Trill()
+        trill.quarterLength = self.calculateTrillNoteQuarterLength()
+        if isNachschlag:
+            trill.nachschlag = True
+
+        if not self.simpleNotes:
+            trill.size = interval.Interval(noteStart=n1, noteEnd=n2)
+            return trill
+
+        # currently ignore other notes in simpleNotes
+        simpleNote = self.simpleNotes[0]
+
+        # enharmonic invariant checker
+        if not(simpleNote.pitch.midi == n1.pitch.midi or simpleNote.pitch.midi == n2.pitch.midi):
+            return False
+
+        endNote = n2
+        startNote = n1
+        if simpleNote.pitch.midi == n2.pitch.midi:
+            endNote = n1
+            startNote = n2
+        distance = interval.Interval(noteStart=startNote, noteEnd=endNote)
+        trill.size = distance
+        return trill
+
+class TestCondition:
+    def __init__(
+        self, name, busyNotes, isTrill,
+        simpleNotes=None, trillSize=None, isNachschlag=False
+    ):
+        self.name = name
+        self.busyNotes = busyNotes
+        self.isTrill = isTrill
+        self.simpleNotes = simpleNotes
+        self.trillSize = trillSize
+        self.isNachschlag = isNachschlag
+
+class Test(unittest.TestCase):
+    def testRecognizeTrill(self):
+
+        # set up experiment
+        testConditions = []
+
+        n1Duration = duration.Duration('quarter')
+        t1NumNotes = 4
+        t1UpInterval = interval.Interval('M2')
+        t1DownInterval = interval.Interval('M-2')
+        n1Lower = note.Note("G")
+        n1Lower.duration = n1Duration
+        n1Upper = note.Note("A")
+        n1Upper.duration = n1Duration
+        t1 = expressions.Trill()
+        t1NoteDuration = calculateTrillNoteDuration(t1NumNotes, n1Duration)
+        t1.quarterLength = t1NoteDuration
+        t1Notes = t1.realize(n1Lower)[0]  # GAGA
+        t1NotesWithRest = deepcopy(t1Notes)  # GA_A
+        r1 = note.Rest()
+        r1.duration = duration.Duration(t1NoteDuration)
+        t1NotesWithRest[2] = r1
+        testConditions.append(
+            TestCondition(
+                name="even whole step trill up without simple note",
+                busyNotes=t1Notes,
+                isTrill=True,
+                trillSize=t1UpInterval)
+        )
+        testConditions.append(
+            TestCondition(
+                name="even whole step trill up from simple note",
+                busyNotes=t1Notes,
+                simpleNotes=[n1Lower],
+                isTrill=True,
+                trillSize=t1UpInterval)
+        )
+        testConditions.append(
+            TestCondition(
+                name="even whole step trill up to simple note",
+                busyNotes=t1Notes,
+                simpleNotes=[n1Upper],
+                isTrill=True,
+                trillSize=t1DownInterval)
+        )
+        testConditions.append(
+            TestCondition(
+                name="valid trill up to enharmonic simple note",
+                busyNotes=t1Notes,
+                simpleNotes=[note.Note("G##")],  # A
+                isTrill=True,
+                trillSize=t1DownInterval)
+        )
+        testConditions.append(
+            TestCondition(
+                name="valid trill but not with simple note",
+                busyNotes=t1Notes,
+                simpleNotes=[note.Note("E")],
+                isTrill=False)
+        )
+        testConditions.append(
+            TestCondition(
+                name="invalid trill has rest inside",
+                busyNotes=t1NotesWithRest,
+                isTrill=False)
+        )
+
+        n2Duration = duration.Duration('half')
+        t2NumNotes = 5
+        t2UpInterval = interval.Interval('m2')
+        t2DownInterval = interval.Interval('m-2')
+        n2Lower = note.Note("G#")
+        n2Lower.duration = n2Duration
+        n2Upper = note.Note("A")
+        n2Upper.duration = n2Duration
+        t2NoteDuration = duration.Duration(calculateTrillNoteDuration(t2NumNotes, n2Duration))
+        t2n1 = note.Note("A")  # trill2note1
+        t2n1.duration = t2NoteDuration
+        t2n2 = note.Note("G#")
+        t2n2.duration = t2NoteDuration
+        t2Notes = stream.Stream()  # A G# A G# A
+        t2Notes.append([t2n1, t2n2, deepcopy(t2n1), deepcopy(t2n2), deepcopy(t2n1)])
+        testConditions.append(
+            TestCondition(
+                name="odd half step trill down without simple note",
+                busyNotes=t2Notes,
+                isTrill=True,
+                trillSize=t2DownInterval)
+        )
+        testConditions.append(
+            TestCondition(
+                name="odd half step trill down to simple note",
+                busyNotes=t2Notes,
+                simpleNotes=[n2Lower],
+                isTrill=True,
+                trillSize=t2UpInterval)
+        )
+        testConditions.append(
+            TestCondition(
+                name="odd trill down from simple note",
+                busyNotes=t2Notes,
+                simpleNotes=[n2Upper],
+                isTrill=True,
+                trillSize=t2DownInterval)
+        )
+
+        n3Duration = duration.Duration('quarter')
+        t3NumNotes = 8
+        t3UpInterval = interval.Interval('m2')
+        t3DownInterval = interval.Interval('m-2')
+        n3 = note.Note("B")
+        n3.duration = n3Duration
+        t3NoteDuration = duration.Duration(calculateTrillNoteDuration(t3NumNotes, n3Duration))
+        t3n1 = note.Note("C5")
+        t3n1.duration = t3NoteDuration
+        t3n2 = note.Note("B")
+        t3n2.duration = t3NoteDuration
+        nachschlagN1 = note.Note("D5")
+        nachschlagN1.duration = t3NoteDuration
+        nachschlagN2 = note.Note("E5")
+        nachschlagN2.duration = t3NoteDuration
+        nachschlagN3 = note.Note("F5")
+        nachschlagN3.duration = t3NoteDuration
+        t3Notes = stream.Stream()  # CBCBCDEF
+        t3Notes.append(
+            [t3n1, t3n2, deepcopy(t3n1), deepcopy(t3n2), deepcopy(t3n1),
+            nachschlagN1, nachschlagN2, nachschlagN3]
+        )
+
+        testConditions.append(
+            TestCondition(
+                name="Nachschlag trill when not checking for nachschlag",
+                busyNotes=t3Notes,
+                isTrill=False)
+        )
+        testConditions.append(
+            TestCondition(
+                name="Nachschlag trill when checking for nachschlag",
+                busyNotes=t3Notes,
+                isNachschlag=True,
+                isTrill=True,
+                trillSize=t3DownInterval)
+        )
+        testConditions.append(
+            TestCondition(
+                name="Nachschlag trill when checking for nachschlag up to simple note",
+                busyNotes=t3Notes,
+                simpleNotes=[n3],
+                isNachschlag=True,
+                isTrill=True,
+                trillSize=t3UpInterval)
+        )
+
+        t4Duration = duration.Duration('eighth')
+        t4n1 = note.Note("A")
+        t4n1.duration = t4Duration
+        t4n2 = note.Note("G")
+        t4n2.duration = t4Duration
+        testConditions.append(
+            TestCondition(
+                name="One note not a trill",
+                busyNotes=[t4n1],
+                isTrill=False)
+        )
+        testConditions.append(
+            TestCondition(
+                name="Two notes not a trill",
+                busyNotes=[t4n1, t4n2],
+                isTrill=False)
+        )
+
+        t5NoteDuration = duration.Duration("eighth")
+        t5n1 = note.Note("A")  # trill2note1
+        t5n1.duration = t5NoteDuration
+        t5n2 = note.Note("C")
+        t5n2.duration = t5NoteDuration
+        t5Notes = stream.Stream()  # A C A C
+        t5Notes.append([t5n1, t5n2, deepcopy(t5n1), deepcopy(t5n2)])
+        testConditions.append(
+            TestCondition(
+                name="Too big of oscillating interval to be trill",
+                busyNotes=t5Notes,
+                isTrill=False)
+        )
+
+        t6NoteDuration = duration.Duration("eighth")
+        t6n1 = note.Note("F")  # trill2note1
+        t6n1.duration = t6NoteDuration
+        t6n2 = note.Note("E")
+        t6n2.duration = t6NoteDuration
+        t6n3 = note.Note("G")
+        t6n3.duration = t2NoteDuration
+        t5Notes = stream.Stream()  # F E F G
+        t5Notes.append([t6n1, t6n2, deepcopy(t6n1), t6n3])
+        testConditions.append(
+            TestCondition(
+                name="Right interval but not oscillating between same notes",
+                busyNotes=t5Notes,
+                isTrill=False)
+        )
+
+        # run test
+        for cond in testConditions:
+            trillRecognizer = TrillRecognizer(cond.busyNotes)
+            if cond.simpleNotes:
+                trillRecognizer.simpleNotes = cond.simpleNotes
+            if cond.isNachschlag:
+                trillRecognizer.checkNachschlag = True
+
+            trill = trillRecognizer.recognize()
+            if cond.isTrill:
+                self.assertIsInstance(trill, expressions.Trill, cond.name)
+                # ensure trill is correct
+                self.assertEqual(trill.nachschlag, cond.isNachschlag, cond.name)
+                if cond.trillSize:
+                    self.assertEqual(trill.size, cond.trillSize, cond.name)
+            else:
+                self.assertFalse(trill, cond.name)
+
+
+def calculateTrillNoteDuration(numTrillNotes, totalDuration):
+    return totalDuration.quarterLength / numTrillNotes
+
+
+if __name__ == '__main__':
+    import music21
+    music21.mainTest(Test)


### PR DESCRIPTION
Trill Fixer detects where a trill should be in music generated using OMR when compared against music generated from MIDI using the new Trill Recognizer. And inserts trill on appropriate omr note. 

Changes hasher to no longer split ties and only use note references in source and target stream, not root reference. This enables not in place fixing with Ornament Fixer. 