### PR TITLE
MANIFEST.in: specify the correct path to prune .mypy_cache

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 global-include *.p.gz *.py *.txt *.xml *.krn *.mxl *.musicxml *.pdf *.html *.ipynb *.css *.js *.png *.tiff *.jpg *.xls *.mid *.abc *.json *.md *.rst *.zip *.rntxt *.command *.scl *nwc *.nwctxt *.wav *.mei LICENSE
 global-exclude *ipynb_checkpoints* *-checkpoint.ipynb
 prune dist
-prune .mypy_cache
+prune music21/.mypy_cache
 prune obsolete
 prune documentation


### PR DESCRIPTION
Source distributions and subsequent downstream packaging results were including .mypy_cache contents.