### PR TITLE
CHANGING:  .notes returns new StreamIterator

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (6, 0, 2, 'a2')
+__version_info__ = (6, 0, 3, 'a3')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'6.0.2a2'
+'6.0.3a3'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -196,7 +196,7 @@ class PlotStreamMixin(prebase.ProtoM21Object):
             sIter = self.streamObj.iter
 
         if self.classFilterList:
-            sIter.getElementsByClass(self.classFilterList)
+            sIter = sIter.getElementsByClass(self.classFilterList)
 
         self.data = []
 

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -195,9 +195,13 @@ class StreamSearcher:
                 thisStreamIterator = self.streamSearch.iter
 
             if self.filterNotesAndRests:
-                thisStreamIterator = thisStreamIterator.addFilter(filters.ClassFilter('GeneralNote'))
+                thisStreamIterator = thisStreamIterator.addFilter(
+                    filters.ClassFilter('GeneralNote')
+                )
             elif self.filterNotes:
-                thisStreamIterator = thisStreamIterator.addFilter(filters.ClassFilter(['Note', 'Chord']))
+                thisStreamIterator = thisStreamIterator.addFilter(
+                    filters.ClassFilter(['Note', 'Chord'])
+                )
 
         self.activeIterator = thisStreamIterator
 

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -195,9 +195,9 @@ class StreamSearcher:
                 thisStreamIterator = self.streamSearch.iter
 
             if self.filterNotesAndRests:
-                thisStreamIterator.addFilter(filters.ClassFilter('GeneralNote'))
+                thisStreamIterator = thisStreamIterator.addFilter(filters.ClassFilter('GeneralNote'))
             elif self.filterNotes:
-                thisStreamIterator.addFilter(filters.ClassFilter(['Note', 'Chord']))
+                thisStreamIterator = thisStreamIterator.addFilter(filters.ClassFilter(['Note', 'Chord']))
 
         self.activeIterator = thisStreamIterator
 

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -2754,7 +2754,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         '''
         sIterator = self.iter
         if classFilter is not None:
-            sIterator.addFilter(filters.ClassFilter(classFilter))
+            sIterator = sIterator.addFilter(filters.ClassFilter(classFilter))
         for el in sIterator:
             el.groups.append(group)
 
@@ -2935,7 +2935,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         '''
         sIterator = self.iter.addFilter(filters.IdFilter(elementId))
         if classFilter is not None:
-            sIterator.getElementsByClass(classFilter)
+            sIterator = sIterator.getElementsByClass(classFilter)
         for e in sIterator:
             return e
         return None
@@ -3187,7 +3187,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             mustBeginInSpan=mustBeginInSpan,
             includeElementsThatEndAtStart=includeElementsThatEndAtStart)
         if classList is not None:
-            sIterator.getElementsByClass(classList)
+            sIterator = sIterator.getElementsByClass(classList)
         return sIterator
 
     def getElementAtOrBefore(self, offset, classList=None):
@@ -3283,7 +3283,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         sIterator = self.iter
         if classList:
-            sIterator.getElementsByClass(classList)
+            sIterator = sIterator.getElementsByClass(classList)
 
         # need both _elements and _endElements
         for e in sIterator:
@@ -3371,7 +3371,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         sIterator = self.iter
         if classList:
-            sIterator.getElementsByClass(classList)
+            sIterator = sIterator.getElementsByClass(classList)
 
         for e in sIterator:
             span = opFrac(offset - self.elementOffset(e))
@@ -7101,7 +7101,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                                         includeSelf=includeSelf
                                         )
         if classFilter != ():
-            ri.addFilter(filters.ClassFilter(classFilter))
+            ri = ri.addFilter(filters.ClassFilter(classFilter))
         return ri
 
     def containerInHierarchy(self, el, *, setActiveSite=True):
@@ -7961,7 +7961,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             sIterator = post.__iter__()
 
         if classFilterList:
-            sIterator.addFilter(filters.ClassFilter(classFilterList))
+            sIterator = sIterator.addFilter(filters.ClassFilter(classFilterList))
 
         for e in sIterator:
             if e.isStream:
@@ -10361,6 +10361,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         # --------------------
 
+        # noinspection PyShadowingNames
         def appendLyricsFromNote(n, returnLists, numNonesToAppend):
             if not n.lyrics:
                 for k in returnLists:
@@ -10402,7 +10403,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                         returnLists[k] = []
                     returnLists[k].append(sublists[k])
             elif 'NotRest' in eClasses:  # elif 'Stream' not in eClasses and hasattr(e, 'lyrics'):
-                n = e
+                # noinspection PyTypeChecker
+                n: 'music21.note.NotRest' = e
                 if skipTies is True:
                     if n.tie is None or n.tie.type == 'start':
                         appendLyricsFromNote(n, returnLists, numNotes)

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -427,7 +427,6 @@ class StreamIterator(prebase.ProtoM21Object):
         )
         return out
 
-
     # ---------------------------------------------------------------
     # start and stop
     def updateActiveInformation(self):

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -15,7 +15,7 @@ this class contains iterators and filters for walking through streams
 StreamIterators are explicitly allowed to access private methods on streams.
 '''
 import copy
-from typing import TypeVar, Optional, List, Union, Callable, Generator
+from typing import TypeVar, Optional, List, Union, Callable
 import unittest
 import warnings
 
@@ -421,16 +421,15 @@ class StreamIterator(prebase.ProtoM21Object):
         '''
         out: _SIter = type(self)(
             self.srcStream,
-            filterList = copy.copy(self.filters),
-            restoreActiveSites = self.restoreActiveSites,
-            activeInformation = copy.copy(self.activeInformation),
+            filterList=copy.copy(self.filters),
+            restoreActiveSites=self.restoreActiveSites,
+            activeInformation=copy.copy(self.activeInformation),
         )
         return out
 
 
     # ---------------------------------------------------------------
     # start and stop
-
     def updateActiveInformation(self):
         '''
         Updates the (shared) activeInformation dictionary


### PR DESCRIPTION
Filter adding properties and methods such as `.notes` or `.getElementsByClass()` now return a new StreamIterator

Fixes #536

Backwards incompatible change (won't be noticed by most users but might catch power users