### PR TITLE
Add error messages for invalid chord roots and abbreviations

### DIFF
--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1806,7 +1806,7 @@ class ChordSymbol(Harmony):
                 st = prelimFigure.replace(m1.group(), '')
             else:
                 raise ValueError(f'Chord {prelimFigure} does not begin '
-                                  'with a valid root note')
+                                 + 'with a valid root note.')
 
         if root:
             self.root(pitch.Pitch(root))
@@ -1854,9 +1854,9 @@ class ChordSymbol(Harmony):
             try:
                 justInts = int(justInts)
             except ValueError:
-                raise ValueError(f'Invalid chord abbreviation "{st}"; see '
-                                  'music21.harmony.CHORD_TYPES for valid '
-                                  'abbreviations or specify all alternations')
+                raise ValueError(f'Invalid chord abbreviation {st!r}; see '
+                                 + 'music21.harmony.CHORD_TYPES for valid '
+                                 + 'abbreviations or specify all alterations.')
             if justInts > 20:   # MSC: what is this doing?
                 skipNext = False
                 i = 0
@@ -2542,16 +2542,21 @@ class Test(unittest.TestCase):
         from music21 import harmony
         with self.assertRaises(ValueError) as context:
             harmony.ChordSymbol('H-7')
-            self.assertEqual(str(context.exception), (
-                'Chord H-7 does not begin with a valid root note'))
+        
+        self.assertEqual(
+            str(context.exception),
+            'Chord H-7 does not begin with a valid root note.'
+        )
 
         with self.assertRaises(ValueError) as context:
-            harmony.ChordSymbol('Gmajor7')
-            self.assertEqual(str(context.exception), (
-                'Invalid chord abbreviation "major7"; see '
-                'music21.harmony.CHORD_TYPES for valid '
-                'abbreviations or specify all alternations'
-            ))
+            harmony.ChordSymbol('Gaug7')
+
+        self.assertEqual(
+            str(context.exception),
+            "Invalid chord abbreviation 'aug7'; see "
+            + 'music21.harmony.CHORD_TYPES for valid '
+            + 'abbreviations or specify all alterations.'
+        )
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1737,8 +1737,8 @@ class ChordSymbol(Harmony):
         if '#' in sH and sH[sH.index('#') + 1].isdigit():
             sH = sH[0:sH.index('#')]
         if ('b' in sH and sH.index('b') < len(sH) - 1
-            and sH[sH.index('b') + 1].isdigit() 
-            and 'ob9' not in sH and 'øb9' not in sH):
+                and sH[sH.index('b') + 1].isdigit()
+                and 'ob9' not in sH and 'øb9' not in sH):
             sH = sH[0:sH.index('b')]
         for chordKind in CHORD_TYPES:
             for charString in getAbbreviationListGivenChordType(chordKind):
@@ -2542,18 +2542,18 @@ class Test(unittest.TestCase):
         from music21 import harmony
         with self.assertRaises(ValueError) as context:
             harmony.ChordSymbol('H-7')
-        
+
         self.assertEqual(
             str(context.exception),
             'Chord H-7 does not begin with a valid root note.'
         )
 
         with self.assertRaises(ValueError) as context:
-            harmony.ChordSymbol('Gaug7')
+            harmony.ChordSymbol('Garg7')
 
         self.assertEqual(
             str(context.exception),
-            "Invalid chord abbreviation 'aug7'; see "
+            "Invalid chord abbreviation 'arg7'; see "
             + 'music21.harmony.CHORD_TYPES for valid '
             + 'abbreviations or specify all alterations.'
         )

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -113,9 +113,6 @@ CHORD_TYPES = collections.OrderedDict([
     ('Tristan', ['1,#4,#6,#9', ['tristan']]),  # Y
 ])
 
-VALID_ABBRS = [abbr for chord, (notes, abbrs) 
-                    in CHORD_TYPES.items() for abbr in abbrs]
-
 # these are different names used by MusicXML and others,
 # and the authoritative name that they resolve to
 CHORD_ALIASES = {'dominant': 'dominant-seventh',
@@ -1739,8 +1736,8 @@ class ChordSymbol(Harmony):
             sH = sH[0:sH.index('omit')]
         if '#' in sH and sH[sH.index('#') + 1].isdigit():
             sH = sH[0:sH.index('#')]
-        if ('b' in sH and sH.index('b') < len(sH) - 1 and 
-            sH[sH.index('b') + 1].isdigit() 
+        if ('b' in sH and sH.index('b') < len(sH) - 1
+            and sH[sH.index('b') + 1].isdigit() 
             and 'ob9' not in sH and 'øb9' not in sH):
             sH = sH[0:sH.index('b')]
         for chordKind in CHORD_TYPES:
@@ -1808,8 +1805,8 @@ class ChordSymbol(Harmony):
                 # remove the root and bass from the string and any additions/omissions/alterations/
                 st = prelimFigure.replace(m1.group(), '')
             else:
-                raise ValueError(f"Chord {prelimFigure} does not begin "
-                    f"with a valid root note")
+                raise ValueError(f'Chord {prelimFigure} does not begin '
+                                  'with a valid root note')
 
         if root:
             self.root(pitch.Pitch(root))
@@ -1857,8 +1854,9 @@ class ChordSymbol(Harmony):
             try:
                 justInts = int(justInts)
             except ValueError:
-                raise ValueError(f"Invalid chord abbreviation '{st}'; must be one of "
-                    f"{VALID_ABBRS} or specify all alterations")
+                raise ValueError(f'Invalid chord abbreviation "{st}"; see '
+                                  'music21.harmony.CHORD_TYPES for valid '
+                                  'abbreviations or specify all alternations')
             if justInts > 20:   # MSC: what is this doing?
                 skipNext = False
                 i = 0
@@ -2539,6 +2537,21 @@ class Test(unittest.TestCase):
 
         nc._updatePitches()
         self.assertEqual(0, len(nc.pitches))
+
+    def testInvalidRoots(self):
+        from music21 import harmony
+        with self.assertRaises(ValueError) as context:
+            harmony.ChordSymbol('H-7')
+            self.assertEqual(str(context.exception), (
+                'Chord H-7 does not begin with a valid root note'))
+
+        with self.assertRaises(ValueError) as context:
+            harmony.ChordSymbol('Gmajor7')
+            self.assertEqual(str(context.exception), (
+                'Invalid chord abbreviation "major7"; see '
+                'music21.harmony.CHORD_TYPES for valid '
+                'abbreviations or specify all alternations'
+            ))
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -113,6 +113,9 @@ CHORD_TYPES = collections.OrderedDict([
     ('Tristan', ['1,#4,#6,#9', ['tristan']]),  # Y
 ])
 
+VALID_ABBRS = [abbr for chord, (notes, abbrs) 
+                    in CHORD_TYPES.items() for abbr in abbrs]
+
 # these are different names used by MusicXML and others,
 # and the authoritative name that they resolve to
 CHORD_ALIASES = {'dominant': 'dominant-seventh',
@@ -1736,8 +1739,9 @@ class ChordSymbol(Harmony):
             sH = sH[0:sH.index('omit')]
         if '#' in sH and sH[sH.index('#') + 1].isdigit():
             sH = sH[0:sH.index('#')]
-        if 'b' in sH and sH[sH.index('b') + 1].isdigit() and 'ob9' not in sH and 'øb9' not in sH:
-            # yuck, special exception
+        if ('b' in sH and sH.index('b') < len(sH) - 1 and 
+            sH[sH.index('b') + 1].isdigit() 
+            and 'ob9' not in sH and 'øb9' not in sH):
             sH = sH[0:sH.index('b')]
         for chordKind in CHORD_TYPES:
             for charString in getAbbreviationListGivenChordType(chordKind):
@@ -1804,8 +1808,8 @@ class ChordSymbol(Harmony):
                 # remove the root and bass from the string and any additions/omissions/alterations/
                 st = prelimFigure.replace(m1.group(), '')
             else:
-                raise ValueError  # This means that the given argument wasn't
-                # a proper chord name.
+                raise ValueError(f"Chord {prelimFigure} does not begin "
+                    f"with a valid root note")
 
         if root:
             self.root(pitch.Pitch(root))
@@ -1853,7 +1857,8 @@ class ChordSymbol(Harmony):
             try:
                 justInts = int(justInts)
             except ValueError:
-                raise ValueError  # Not a properly formatted chord, ignore it
+                raise ValueError(f"Invalid chord abbreviation '{st}'; must be one of "
+                    f"{VALID_ABBRS} or specify all alterations")
             if justInts > 20:   # MSC: what is this doing?
                 skipNext = False
                 i = 0


### PR DESCRIPTION
Hey all, I noticed that error messages aren't helpful in cases where an invalid string is passed to ChordSymbol so I added a couple in this PR. It took me some debugging to figure out why ChordSymbol('Bb') was not working because the error I was getting was not informative -- so it took a while for me to realize that music21 expects - for flats in this case.

Do let me know your thoughts