### PR TITLE
Add ipython SVG support + fix no show images

### DIFF
--- a/music21/environment.py
+++ b/music21/environment.py
@@ -366,6 +366,8 @@ class _EnvironmentCore:
         self._ref['showFormat'] = 'musicxml'
         self._ref['writeFormat'] = 'musicxml'
         self._ref['ipythonShowFormat'] = 'ipython.musicxml.png'
+        self._ref['ipythonSVGScale'] = 0.28
+        self._ref['ipythonSVGColor'] = None
 
         self._ref['autoDownload'] = 'ask'
         self._ref['debug'] = 0
@@ -969,6 +971,8 @@ class Environment:
         'debug'
         'directoryScratch'
         'graphicsPath'
+        'ipythonSVGColor'
+        'ipythonSVGScale'
         'ipythonShowFormat'
         'lilypondBackend'
         'lilypondFormat'
@@ -1028,6 +1032,8 @@ class Environment:
         'debug'
         'directoryScratch'
         'graphicsPath'
+        'ipythonSVGColor'
+        'ipythonSVGScale'
         'ipythonShowFormat'
         'lilypondBackend'
         'lilypondFormat'
@@ -1203,6 +1209,8 @@ class UserSettings:
     'debug'
     'directoryScratch'
     'graphicsPath'
+    'ipythonSVGColor'
+    'ipythonSVGScale'
     'ipythonShowFormat'
     'lilypondBackend'
     'lilypondFormat'
@@ -1448,6 +1456,8 @@ class Test(unittest.TestCase):
   <preference name="debug" value="0" />
   <preference name="directoryScratch" />
   <preference name="graphicsPath" value="/Applications/Preview.app" />
+  <preference name="ipythonSVGColor" />
+  <preference name="ipythonSVGScale" value="0.28" />
   <preference name="ipythonShowFormat" value="ipython.musicxml.png" />
   <preference name="lilypondBackend" value="ps" />
   <preference name="lilypondFormat" value="pdf" />
@@ -1490,6 +1500,8 @@ class Test(unittest.TestCase):
   <preference name="debug" value="0" />
   <preference name="directoryScratch" />
   <preference name="graphicsPath" value="/Applications/Preview.app" />
+  <preference name="ipythonSVGColor" />
+  <preference name="ipythonSVGScale" value="0.28" />
   <preference name="ipythonShowFormat" value="ipython.musicxml.png" />
   <preference name="lilypondBackend" value="ps" />
   <preference name="lilypondFormat" value="pdf" />
@@ -1550,6 +1562,8 @@ class Test(unittest.TestCase):
   <preference name="debug" value="0" />
   <preference name="directoryScratch" />
   <preference name="graphicsPath" value="/Applications/Preview.app" />
+  <preference name="ipythonSVGColor" />
+  <preference name="ipythonSVGScale" value="0.28" />
   <preference name="ipythonShowFormat" value="ipython.musicxml.png" />
   <preference name="lilypondBackend" value="ps" />
   <preference name="lilypondFormat" value="pdf" />


### PR DESCRIPTION
This PR adds SVG support in Jupyter and fixes an issue where images would not display when generated from Musescore due to a SubConverterFileIOException.

The fix required switching to subprocess module and supplying environment variable QT_QPA_PLATFORM being set to "offscreen".

SVG support in ipython requires the latest version of musescore which is in alpha currently. This is because there was a bug in the SVG rendering was was resolved in recently merged PR for https://github.com/musescore/MuseScore/pull/5970.

The following is possible with SVG support:

![image](https://user-images.githubusercontent.com/6608130/82161096-e782a480-9891-11ea-8d2b-c2223be55845.png)

The images can be scaled to any size to assist in readability.

With SVG color support one can use Jupyter dark theme like so:

![image](https://user-images.githubusercontent.com/6608130/82161175-6d065480-9892-11ea-9a2d-2bf60cb5dc83.png)

