### PR TITLE
Find mid-measure and end of measure hidden rests from <forward> elements

### DIFF
--- a/music21/musicxml/testPrimitive.py
+++ b/music21/musicxml/testPrimitive.py
@@ -17808,6 +17808,76 @@ tremoloTest = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 </score-partwise>
 """
 
+hiddenRests = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name print-object="no">MusicXML Part</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>2</divisions>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+      </note>
+      <forward>
+        <duration>2</duration>
+        <voice>1</voice>
+      </forward>
+      <note>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+      </note>
+      <backup>
+        <duration>8</duration>
+      </backup>
+      <forward>
+        <duration>4</duration>
+        <voice>2</voice>
+      </forward>
+      <note>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+      </note>
+      <forward>
+        <duration>2</duration>
+        <voice>2</voice>
+      </forward>
+    </measure>
+  </part>
+</score-partwise>
+"""
 
 ALL = [
     articulations01, pitches01a, directions31a, lyricsMelisma61d, notations32a,  # 0
@@ -17824,7 +17894,7 @@ ALL = [
     mixedVoices1a, mixedVoices1b, mixedVoices2,  # 37
     colors01, triplets01, textBoxes01, otaveShifts33d,  # 40
     unicodeStrNoNonAscii, unicodeStrWithNonAscii,  # 44
-    tremoloTest  # 46
+    tremoloTest, hiddenRests  # 46
 ]
 
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -5409,7 +5409,6 @@ class MeasureParser(XMLParserBase):
         self.measureNumber = m.number
         self.numberSuffix = m.numberSuffix
 
-    
     def updateVoiceInformation(self):
         '''
         Finds all the "voice" information in <note> tags and updates the set of

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2323,7 +2323,10 @@ class MeasureParser(XMLParserBase):
         if self.useVoices is True:
             for v in self.stream.iter.voices:
                 if v:  # do not bother with empty voices
-                    v.makeRests(inPlace=True, hideRests=True)
+                    # Fill mid-measure gaps, and find end of measure gaps by ref to measure stream
+                    # https://github.com/cuthbertlab/music21/issues/444
+                    v.makeRests(refStreamOrTimeRange=self.stream, fillGaps=True,
+                                inPlace=True, hideRests=True)
                     v.coreElementsChanged()
         self.stream.coreElementsChanged()
 
@@ -5406,6 +5409,7 @@ class MeasureParser(XMLParserBase):
         self.measureNumber = m.number
         self.numberSuffix = m.numberSuffix
 
+    
     def updateVoiceInformation(self):
         '''
         Finds all the "voice" information in <note> tags and updates the set of
@@ -6463,6 +6467,20 @@ class Test(unittest.TestCase):
         self.assertIsInstance(notes[3].articulations[1], articulations.FretIndication)
         self.assertEqual(notes[3].articulations[1].number, 3)
 
+    def testHiddenRests(self):
+        from music21 import converter
+        from music21.musicxml import testPrimitive
+
+        # Voice 1: Half note, <forward> (quarter), quarter note
+        # Voice 2: <forward> (half), quarter note, <forward> (quarter)
+        s = converter.parse(testPrimitive.hiddenRests)
+        v1, v2 = s.recurse().voices
+        self.assertEqual(v1.duration.quarterLength, v2.duration.quarterLength)
+
+        restV1 = [r for r in v1.getElementsByClass(note.Rest)][0]
+        self.assertTrue(restV1.style.hideObjectOnPrint)
+        restsV2 = [r for r in v2.getElementsByClass(note.Rest)]
+        self.assertEqual([r.style.hideObjectOnPrint for r in restsV2], [True, True])
 
 if __name__ == '__main__':
     import music21

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -6481,6 +6481,7 @@ class Test(unittest.TestCase):
         restsV2 = [r for r in v2.getElementsByClass(note.Rest)]
         self.assertEqual([r.style.hideObjectOnPrint for r in restsV2], [True, True])
 
+
 if __name__ == '__main__':
     import music21
     music21.mainTest(Test)  # , runTest='testRehearsalMarks')


### PR DESCRIPTION
Resolves #444

Summary: leading hidden rests were being found because makeRests() creates them in all cases, but mid-measure and end of measure hidden rests from `<forward>` elements were not created.

fillGaps handles the midmeasure case, and using refStreamOrTimeRange to compare with the entire measure stream handles the end case.