### PR TITLE
parse <sound> and <staff> associated with <direction-type><words>

### DIFF
--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -319,7 +319,7 @@ class TextExpression(Expression):
     classSortOrder = -30
     _styleClass = style.TextStyle
 
-    def __init__(self, content=None):
+    def __init__(self, content=None, staffKey=None, mxSound=None):
         super().__init__()
         # numerous properties are inherited from TextFormat
         # the text string to be displayed; not that line breaks
@@ -333,6 +333,10 @@ class TextExpression(Expression):
 
         # this does not do anything if default y is defined
         self.positionPlacement = None
+        # staff number of this TextExpression
+        self.staffKey = staffKey
+        # musicXML <sound> element that is in <direction>, if it exists
+        self.mxSound = mxSound
 
     def _reprInternal(self):
         if len(self._content) >= 13:

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4502,6 +4502,7 @@ class MeasureParser(XMLParserBase):
         # TODO: percussion
         # TODO: other-direction
         tag = mxDir.tag
+        mxSound = mxDirection.find('sound')
         if tag == 'dynamics':  # fp, mf, etc., each as a tag
             # in rare cases there may be more than one dynamic in the same
             # direction, so we iterate
@@ -4558,7 +4559,7 @@ class MeasureParser(XMLParserBase):
             self.setEditorial(mxDirection, rm)
 
         elif tag == 'words':
-            textExpression = self.xmlToTextExpression(mxDir)
+            textExpression = self.xmlToTextExpression(mxDir, staffKey, mxSound)
             # environLocal.printDebug(['got TextExpression object', repr(te)])
             # offset here is a combination of the current position
             # (offsetMeasureNote) and and the direction's offset


### PR DESCRIPTION
Partially fixes #159 

Issue: parser does not parse `<sound>` and `<staff>` in imported `<direction><direction-type><words>` elements. This fixes the issue by passing `staffKey` and the `<sound>` Element itself to `TextExpression`. The exporter then places these Elements inside `<direction>`.