### PR TITLE
Let stripTies() recurse when deleting and searching

### DIFF
--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -1279,12 +1279,13 @@ class MelodicIntervalDiversity(DiscreteAnalysis):
         # if this has parts, need to move through each at a time
         if sStream.hasPartLikeStreams():
             procList = [s for s in sStream.getElementsByClass('Stream')]
-        else:  # assume a single list of notes
+        else:  # assume a single list of notes, or sStream is a part
             procList = [sStream]
 
         for p in procList:
             # get only Notes for now, skipping rests and chords
-            noteStream = p.stripTies(inPlace=False).getElementsByClass('Note').stream()
+            # flatten to reach notes contained in measures
+            noteStream = p.flat.stripTies(inPlace=False).getElementsByClass('Note').stream()
             # noteStream.show()
             for i, n in enumerate(noteStream):
                 if i <= len(noteStream) - 2:

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -367,7 +367,7 @@ class StreamForms:
             # was causing millions of deepcopy calls
             # so I made it inPlace, but for some reason
             # code errored with 'p =' not present
-            # also, this part has measures...so should retainContains be True?
+            # also, this part has measures...so should retainContainers be True?
             p = p.stripTies(retainContainers=False, inPlace=True)
             # noNone means that we will see all connections, even w/ a gap
             post = p.findConsecutiveNotes(skipRests=True,

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -314,7 +314,9 @@ class StreamForms:
 
         Currently: runs stripTies.
         '''
-        streamObj = streamObj.stripTies(inPlace=True, retainContainers=True)
+        # this causes lots of deepcopies, but an inPlace operation loses
+        # accuracy on feature extractors
+        streamObj = streamObj.stripTies(retainContainers=True)
         return streamObj
 
     def __getitem__(self, key):

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -314,9 +314,7 @@ class StreamForms:
 
         Currently: runs stripTies.
         '''
-        # this causes lots of deepcopies, but an inPlace operation loses
-        # accuracy on feature extractors
-        streamObj = streamObj.stripTies(retainContainers=True)
+        streamObj = streamObj.stripTies(inPlace=True, retainContainers=True)
         return streamObj
 
     def __getitem__(self, key):
@@ -368,7 +366,7 @@ class StreamForms:
             # so I made it inPlace, but for some reason
             # code errored with 'p =' not present
             # also, this part has measures...so should retainContainers be True?
-            p = p.stripTies(retainContainers=False, inPlace=True)
+            # p = p.stripTies(retainContainers=False, inPlace=True)
             # noNone means that we will see all connections, even w/ a gap
             post = p.findConsecutiveNotes(skipRests=True,
                                           skipChords=True, skipGaps=True, noNone=True)
@@ -467,10 +465,10 @@ class StreamForms:
             # edit June 2012:
             # was causing lots of deepcopy calls, so I made
             # it inPlace=True, but errors when 'p =' no present
-            # also, this part has measures...so should retainContains be True?
+            # also, this part has measures...so should retainContainers be True?
 
             # REMOVE? Prepared is stripped!!!
-            p = p.stripTies(retainContainers=False, inPlace=True)  # will be flat
+            # p = p.stripTies(retainContainers=False, inPlace=True)  # will be flat
             # noNone means that we will see all connections, even w/ a gap
             post = p.findConsecutiveNotes(skipRests=True,
                                           skipChords=False,
@@ -708,7 +706,7 @@ class DataInstance:
             return self.formsByPart
         elif key in ['voices']:
             # return a list of Forms for voices
-            return self.formsByVoices
+            return self.formsByVoice
         # try to create by calling the attribute
         # will raise an attribute error if there is a problem
         return self.forms[key]

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -316,7 +316,7 @@ class StreamForms:
         '''
         # this causes lots of deepcopies, but an inPlace operation loses
         # accuracy on feature extractors
-        streamObj = streamObj.stripTies(retainContainers=True)
+        streamObj = streamObj.stripTies()
         return streamObj
 
     def __getitem__(self, key):

--- a/music21/features/jSymbolic.py
+++ b/music21/features/jSymbolic.py
@@ -1765,7 +1765,7 @@ class StrengthOfStrongestRhythmicPulseFeature(featuresModule.FeatureExtractor):
     ...     p.insert(0, tempo.MetronomeMark('Langsam', 70))
     >>> fe = features.jSymbolic.StrengthOfStrongestRhythmicPulseFeature(sch)
     >>> fe.extract().vector[0]
-    0.853...
+    0.857...
     '''
     id = 'R4'
 
@@ -1792,7 +1792,7 @@ class StrengthOfSecondStrongestRhythmicPulseFeature(
     ...     p.insert(0, tempo.MetronomeMark('Langsam', 70))
     >>> fe = features.jSymbolic.StrengthOfSecondStrongestRhythmicPulseFeature(sch)
     >>> fe.extract().vector[0]
-    0.12...
+    0.119...
     '''
     id = 'R5'
 
@@ -1828,7 +1828,7 @@ class StrengthRatioOfTwoStrongestRhythmicPulsesFeature(
     ...     p.insert(0, tempo.MetronomeMark('Langsam', 70))
     >>> fe = features.jSymbolic.StrengthRatioOfTwoStrongestRhythmicPulsesFeature(sch)
     >>> fe.extract().vector[0]
-    7.0
+    7.2
 
     '''
     id = 'R6'
@@ -1864,7 +1864,7 @@ class CombinedStrengthOfTwoStrongestRhythmicPulsesFeature(
     ...     p.insert(0, tempo.MetronomeMark('Langsam', 70))
     >>> fe = features.jSymbolic.CombinedStrengthOfTwoStrongestRhythmicPulsesFeature(sch)
     >>> fe.extract().vector[0]
-    0.975...
+    0.976...
     '''
     id = 'R7'
 

--- a/music21/features/jSymbolic.py
+++ b/music21/features/jSymbolic.py
@@ -1765,7 +1765,7 @@ class StrengthOfStrongestRhythmicPulseFeature(featuresModule.FeatureExtractor):
     ...     p.insert(0, tempo.MetronomeMark('Langsam', 70))
     >>> fe = features.jSymbolic.StrengthOfStrongestRhythmicPulseFeature(sch)
     >>> fe.extract().vector[0]
-    0.857...
+    0.853...
     '''
     id = 'R4'
 
@@ -1792,7 +1792,7 @@ class StrengthOfSecondStrongestRhythmicPulseFeature(
     ...     p.insert(0, tempo.MetronomeMark('Langsam', 70))
     >>> fe = features.jSymbolic.StrengthOfSecondStrongestRhythmicPulseFeature(sch)
     >>> fe.extract().vector[0]
-    0.119...
+    0.12...
     '''
     id = 'R5'
 
@@ -1828,7 +1828,7 @@ class StrengthRatioOfTwoStrongestRhythmicPulsesFeature(
     ...     p.insert(0, tempo.MetronomeMark('Langsam', 70))
     >>> fe = features.jSymbolic.StrengthRatioOfTwoStrongestRhythmicPulsesFeature(sch)
     >>> fe.extract().vector[0]
-    7.2
+    7.0
 
     '''
     id = 'R6'
@@ -1864,7 +1864,7 @@ class CombinedStrengthOfTwoStrongestRhythmicPulsesFeature(
     ...     p.insert(0, tempo.MetronomeMark('Langsam', 70))
     >>> fe = features.jSymbolic.CombinedStrengthOfTwoStrongestRhythmicPulsesFeature(sch)
     >>> fe.extract().vector[0]
-    0.976...
+    0.975...
     '''
     id = 'R7'
 

--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -81,14 +81,14 @@ class QualityFeature(featuresModule.FeatureExtractor):
 
     now we will try it with the last movement of Schoenberg's opus 19 which has
     no mode explicitly encoded in the musicxml but which our analysis routines
-    believe (having very little to go on) fits the profile of e-minor best.
+    believe (having very little to go on) fits the profile of F major best.
 
 
     >>> schoenberg19mvmt6 = corpus.parse('schoenberg/opus19', 6)
     >>> fe2 = features.native.QualityFeature(schoenberg19mvmt6)
     >>> f2 = fe2.extract()
     >>> f2.vector
-    [1]
+    [0]
 
 
     OMIT_FROM_DOCS
@@ -445,7 +445,7 @@ class MostCommonSetClassSimultaneityPrevalence(featuresModule.FeatureExtractor):
     >>> s2 = corpus.parse('schoenberg/opus19', 6)
     >>> fe2 = features.native.MostCommonSetClassSimultaneityPrevalence(s2)
     >>> fe2.extract().vector
-    [0.25]
+    [0.228...]
     '''
     id = 'CS4'
 
@@ -605,7 +605,7 @@ class TriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
     >>> s2 = corpus.parse('schoenberg/opus19', 2)
     >>> fe2 = features.native.TriadSimultaneityPrevalence(s2)
     >>> fe2.extract().vector
-    [0.021739...]
+    [0.022727...]
     '''
     id = 'CS9'
 

--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -445,7 +445,7 @@ class MostCommonSetClassSimultaneityPrevalence(featuresModule.FeatureExtractor):
     >>> s2 = corpus.parse('schoenberg/opus19', 6)
     >>> fe2 = features.native.MostCommonSetClassSimultaneityPrevalence(s2)
     >>> fe2.extract().vector
-    [0.222...]
+    [0.25]
     '''
     id = 'CS4'
 
@@ -605,7 +605,7 @@ class TriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
     >>> s2 = corpus.parse('schoenberg/opus19', 2)
     >>> fe2 = features.native.TriadSimultaneityPrevalence(s2)
     >>> fe2.extract().vector
-    [0.022727...]
+    [0.021739...]
     '''
     id = 'CS9'
 

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -802,7 +802,7 @@ class GraphColorGridLegend(Graph):
         >>> fig = matplotlib.pyplot.figure()
         >>> subplot = colorLegend.makeOneRowOfGraph(fig, 0, 'Scriabin Mapping', rowData)
         >>> subplot
-        <matplotlib...AxesSubplot object at 0x111e13828>
+        <AxesSubplot:>
         '''
         # environLocal.printDebug(['rowLabel', rowLabel, i])
 

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1973,8 +1973,7 @@ def streamHierarchyToMidiTracks(
 
     # strip all ties inPlace
     for subs in substreamList:
-        subs.stripTies(inPlace=True, matchByPitch=False,
-                        retainContainers=True)
+        subs.stripTies(inPlace=True, matchByPitch=False)
 
     packetStorage = packetStorageFromSubstreamList(substreamList, addStartDelay=addStartDelay)
     updatePacketStorageWithChannelInfo(packetStorage, channelByInstrument)

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -6185,7 +6185,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
     def stripTies(self,
                   inPlace=False,
                   matchByPitch=False,
-                  retainContainers=False):
+                  retainContainers=True):
         '''
         Find all notes that are tied; remove all tied notes,
         then make the first of the tied notes have a duration
@@ -6198,16 +6198,16 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         Stream subclasses are retained.
 
         `inPlace` controls whether the input stream is modified or whether a deep copy
-        is made. Independently of what stream is operated upon, `retainContainers=False`
-        provides the option to have returned a flat Stream of Notes where Measures
-        and other structures have been stripped. This keyword only controls the return
-        object, not the input stream, which may have been edited `inPlace`.
+        is made. `retainContainers=False` returns a flattened stream where Measures
+        and other structures have been stripped.
 
-        If `retainContainers=True`, which is enforced for all streams with part-like
-        substreams without regard to the keyword supplied by the user, the Stream
-        operated upon is returned, which may have been edited `inPlace` or deep copied.
-        `retainContainers=False` is the default keyword accepted by the method, but to
-        reiterate, it will only have an effect if the stream has no part-like substreams.
+        N.B.: `retainContainers=False` will have no effect on streams with part-like
+        substreams, such as a :class:`~music21.stream.Score`.
+
+        Changed in v.6 -- `retainContainers` defaults to True.
+        Changed in v.6 -- `retainContainers=False` now only flattens the return
+        stream, rather than also calling `.notesAndRests`.
+        TODO: retainContainers TO BE DEPRECATED in v.7 (just call `.flat`)
 
         Presently, this only works if tied notes are sequential in the same voice; ultimately
         this will need to look at .to and .from attributes (if they exist)
@@ -6390,7 +6390,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         if retainContainers:
             return returnObj
         else:
-            return returnObj.flat.notesAndRests.stream()
+            return returnObj.flat
 
     def extendTies(self, ignoreRests=False, pitchAttr='nameWithOctave'):
         '''

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -8931,7 +8931,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         for v in vGroups:
             for e in v:
                 # Filter out all but notes and rests
-                if not isinstance(e, note.GeneralNote):
+                if 'GeneralNote' not in e.classes:
                     continue
                 if (lastWasNone is False
                         and skipGaps is False

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -978,6 +978,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(intS1), 2)
 
     def testStripTiesBuiltA(self):
+        from music21 import tie
+
         s1 = Stream()
         n1 = note.Note('D#2')
         n1.quarterLength = 6
@@ -992,6 +994,16 @@ class Test(unittest.TestCase):
         sUntied = s1.stripTies()
         self.assertEqual(len(sUntied.notes), 1)
         self.assertEqual(sUntied.notes[0].quarterLength, 6)
+
+        s2 = Stream()
+        n2 = note.Note('A4')
+        n2.quarterLength = 12
+        s2.append(n2)
+        s2 = s2.makeMeasures()
+        s2.makeTies(inPlace=True)
+        s2.flat.notes[1].tie = tie.Tie('start')  # two start ties -> continuation
+        s2Untied = s2.stripTies()
+        self.assertEqual(len(s2Untied.notes), 1)
 
         n = note.Note()
         n.quarterLength = 3

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -952,6 +952,12 @@ class Test(unittest.TestCase):
         self.assertIs(l14[0], n1)
         self.assertIs(l14[1], n2)
 
+        s7 = Stream()
+        s7.append(clef.Clef())  # Stream without Notes
+        s7.append(key.Key('B'))
+        l15 = s7.findConsecutiveNotes()
+        self.assertSequenceEqual(l15, [])
+
     def testMelodicIntervals(self):
         c4 = note.Note('C4')
         d5 = note.Note('D5')

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -1040,6 +1040,30 @@ class Test(unittest.TestCase):
         # lesser notes
         self.assertEqual(len(p4Notes.notesAndRests), 10)
 
+    def testStripTiesNonMeasureContainers(self):
+        '''
+        Testing that ties are stripped from containers that are not Measures.
+        https://github.com/cuthbertLab/music21/issues/266
+        '''
+
+        from music21 import tie
+
+        s = Stream()
+        v = Voice()
+        s.append(v)
+
+        n = note.Note('C4', quarterLength=1.0)
+        n.tie = tie.Tie('start')
+        n2 = note.Note('C4', quarterLength=1.0)
+        n2.tie = tie.Tie('continue')
+        n3 = note.Note('C4', quarterLength=1.0)
+        n3.tie = tie.Tie('stop')
+        n4 = note.Note('C4', quarterLength=1.0)
+        v.append([n, n2, n3, n4])
+
+        s.stripTies(inPlace=True, retainContainers=True)
+        self.assertEqual(len(s.flat.notesAndRests), 2)
+
     def testGetElementsByOffsetZeroLength(self):
         '''
         Testing multiple zero-length elements with mustBeginInSpan:
@@ -1089,7 +1113,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(sPost.parts[2].flat.notesAndRests), 3)
         self.assertEqual(len(sPost.parts[3].flat.notesAndRests), 10)
 
-        # make sure original is unchchanged
+        # make sure original is unchanged
         self.assertEqual(len(s.parts[0].flat.notesAndRests), 16)
         self.assertEqual(len(s.parts[1].flat.notesAndRests), 16)
         self.assertEqual(len(s.parts[2].flat.notesAndRests), 16)

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -1063,7 +1063,6 @@ class Test(unittest.TestCase):
         Testing that ties are stripped from containers that are not Measures.
         https://github.com/cuthbertLab/music21/issues/266
         '''
-
         from music21 import tie
 
         s = Stream()
@@ -1088,7 +1087,6 @@ class Test(unittest.TestCase):
         but not consecutive in a flattened parent stream.
         https://github.com/cuthbertLab/music21/issues/568
         '''
-
         from music21 import tie
 
         s = Score()
@@ -1096,25 +1094,18 @@ class Test(unittest.TestCase):
         v1 = Voice()
         v2 = Voice()
 
-        n1 = note.Note('A4')
-        n1.quarterLength = 2.0
-        n1.tie = tie.Tie('start')
-        n2 = note.Note('A4')
-        n2.quarterLength = 2.0
-        n2.tie = tie.Tie('stop')
-        n3 = note.Rest()
-        n3.quarterLength = 1
-        n4 = note.Note()
-        n4 = note.Note('D4')
-        n4.quarterLength = 1.0
-        n4.tie = tie.Tie('start')  # Tie begins in v2 before tie in v1 stops
-        n5 = note.Note()
-        n5 = note.Note('D4')
-        n5.quarterLength = 2.0
-        n5.tie = tie.Tie('stop')
+        v1n1 = note.Note(quarterLength=2)
+        v1n1.tie = tie.Tie('start')
+        v1n2 = note.Note(quarterLength=2)
+        v1n2.tie = tie.Tie('stop')
+        v2n1 = note.Rest(quarterLength=1)
+        v2n2 = note.Note(quarterLength=1)
+        v2n2.tie = tie.Tie('start')  # Tie begins in v2 before tie in v1 stops
+        v2n3 = note.Note(quarterLength=2)
+        v2n3.tie = tie.Tie('stop')
 
-        v1.append([n1, n2])
-        v2.append([n3, n4, n5])
+        v1.append([v1n1, v1n2])
+        v2.append([v2n1, v2n2, v2n3])
         p.append(v1)
         p.insert(0, v2)
         s.append(p)

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -992,8 +992,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s1.flat.notes), 2)
 
         sUntied = s1.stripTies()
-        self.assertEqual(len(sUntied.notes), 1)
-        self.assertEqual(sUntied.notes[0].quarterLength, 6)
+        self.assertEqual(len(sUntied.flat.notes), 1)
+        self.assertEqual(sUntied.flat.notes[0].quarterLength, 6)
 
         s2 = Stream()
         n2 = note.Note('A4')
@@ -1003,7 +1003,7 @@ class Test(unittest.TestCase):
         s2.makeTies(inPlace=True)
         s2.flat.notes[1].tie = tie.Tie('start')  # two start ties -> continuation
         s2Untied = s2.stripTies()
-        self.assertEqual(len(s2Untied.notes), 1)
+        self.assertEqual(len(s2Untied.flat.notes), 1)
 
         n = note.Note()
         n.quarterLength = 3
@@ -1024,8 +1024,8 @@ class Test(unittest.TestCase):
         # we now have 65 notes, as ties have been created
         self.assertEqual(len(b.flat.notes), 65)
 
-        c = b.stripTies()  # gets flat, removes measures
-        self.assertEqual(len(c.notes), 40)
+        c = b.stripTies()
+        self.assertEqual(len(c.flat.notes), 40)
 
     def testStripTiesImportedA(self):
         from music21 import converter
@@ -1223,7 +1223,7 @@ class Test(unittest.TestCase):
             m.append(c)
             p.append(m)
         p2 = p.stripTies(matchByPitch=True)
-        chordsOut = list(p2.getElementsByClass('Chord'))
+        chordsOut = list(p2.flat.getElementsByClass('Chord'))
         self.assertEqual(len(chordsOut), 5)
         self.assertEqual(chordsOut[0].pitches, ch0.pitches)
         self.assertEqual(chordsOut[0].duration.quarterLength, 2.0)
@@ -1420,27 +1420,25 @@ class Test(unittest.TestCase):
 
         # after stripping ties, we have a stream with fewer notes
         altoPostTie = a.parts[1].stripTies()
-        # we can get the length of this directly b/c we just of a stream of
-        # notes, no Measures
-        self.assertEqual(len(altoPostTie.notesAndRests), countedAltoNotes - 2)
+        self.assertEqual(len(altoPostTie.flat.notesAndRests), countedAltoNotes - 2)
 
         # we can still get measure numbers:
-        mNo = altoPostTie.notesAndRests[3].getContextByClass(stream.Measure).number
+        mNo = altoPostTie.flat.notesAndRests[3].getContextByClass(stream.Measure).number
         self.assertEqual(mNo, 1)
-        mNo = altoPostTie.notesAndRests[8].getContextByClass(stream.Measure).number
+        mNo = altoPostTie.flat.notesAndRests[8].getContextByClass(stream.Measure).number
         self.assertEqual(mNo, 2)
-        mNo = altoPostTie.notesAndRests[15].getContextByClass(stream.Measure).number
+        mNo = altoPostTie.flat.notesAndRests[15].getContextByClass(stream.Measure).number
         self.assertEqual(mNo, 4)
 
         # can we get an offset Measure map by looking for measures
         post = altoPostTie.measureOffsetMap(stream.Measure)
-        # nothing: no Measures:
-        self.assertEqual(list(post.keys()), [])
+        # yes, retainContainers defaults to True
+        self.assertEqual(list(post.keys()), correctMeasureOffsetMap)
 
         # but, we can get an offset Measure map by looking at Notes
-        post = altoPostTie.measureOffsetMap(note.Note)
-        # nothing: no Measures:
-        self.assertEqual(sorted(list(post.keys())), correctMeasureOffsetMap)
+        # commenting out because no longer relevant
+        # post = altoPostTie.measureOffsetMap(note.Note)
+        # self.assertEqual(sorted(list(post.keys())), correctMeasureOffsetMap)
 
         # fom music21 import graph
         # gaph.plotStream(altoPostTie, 'scatter', values=['pitchclass', 'offset'])


### PR DESCRIPTION
Fixes #266 fixes #514 

Summary: when `stripTies(retainContainers=True)` deletes notes, it only searches `Measure` containers. Notes in other containers or no containers will stick around and end up as duplicates.

Fix: use `Stream.remove(recurse=True)` rather than popping notes from `Measure` containers.

Update: fixes #568 

Summary: `stripTies()` depends on tied notes being consecutive in the flattened parent container, which when voices are involved, may not obtain, and will yield unexpected results.

Fix: make recursive calls to `stripTies()` for each voice, modeling on how this is currently done for part-like substreams.

Update: Fixes #491 by filtering non-`GeneralNote` objects from `findConsecutiveNotes()` output.