### PR TITLE
Update Humdrum links in FAQ

### DIFF
--- a/documentation/source/about/faq.rst
+++ b/documentation/source/about/faq.rst
@@ -180,7 +180,7 @@ And this Humdrum about which you speak?
 
     Information on Humdrum can be found here at the following links:
 
-    * http://music-cog.ohio-state.edu/Humdrum
-    * http://kern.humdrum.net
+    * http://www.humdrum.org
+    * http://kern.humdrum.org
 
 


### PR DESCRIPTION
The Humdrum links in the FAQ were outdated. The Ohio State link no longer leads to Humdrum info, and the .net yielded a spam site.