### PR TITLE
Propagate time sig, key sig, barline in voicesToParts()

### DIFF
--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -9970,6 +9970,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 ...
                 {3.5} <music21.note.Note A>
             {8.0} <music21.stream.Measure 3 offset=8.0>
+                {0.0} <music21.bar.Barline type=final>
         <BLANKLINE>
 
         If `separateById` is True then all voices with the same id

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -10054,7 +10054,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # merge everything except Voices; this will get
             # clefs
             mActive.mergeElements(m, classFilterList=(
-                'Bar', 'TimeSignature', 'Clef', 'KeySignature'))
+                'Barline', 'TimeSignature', 'Clef', 'KeySignature'))
 
             # vIndex = 0 should not be necessary, but pylint warns on loop variables
             # that could possibly be undefined used out of the loop.
@@ -10105,6 +10105,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                     for i in range(1, partCount):
                         mEmpty = Measure()
                         mEmpty.mergeAttributes(m)
+                        # Propagate bar, meter, key elements to lower parts
+                        mEmpty.mergeElements(m, classFilterList=('Barline',
+                                            'TimeSignature', 'KeySignature'))
                         s.parts[i].insert(self.elementOffset(m), mEmpty)
         # if part has no measures but has voices, contents of each voice go into the part
         elif self.hasVoices():
@@ -12836,7 +12839,7 @@ class Score(Stream):
                         # attributes; possible other parts may have other attributes
                         mActive.mergeAttributes(m)
                         mActive.mergeElements(m, classFilterList=(
-                            'Bar', 'TimeSignature', 'Clef', 'KeySignature'))
+                            'Barline', 'TimeSignature', 'Clef', 'KeySignature'))
 
                         # if m.timeSignature is not None:
                         #     mActive.timeSignature = m.timeSignature
@@ -12855,7 +12858,7 @@ class Score(Stream):
                         if setStems and hasattr(e, 'stemDirection'):
                             e.stemDirection = 'up' if pIndex % 2 == 0 else 'down'
                         v.insert(e.getOffsetBySite(m), e)
-                    # insert voice in new  measure
+                    # insert voice in new measure
                     # environLocal.printDebug(['inserting voice', v, v.id, 'into measure', mActive])
                     mActive.insert(0, v)
                     # mActive.show('t')

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -5412,9 +5412,12 @@ class Test(unittest.TestCase):
         s.append((m1, m2))
 
         partScore = s.voicesToParts()
-        for element in (k, ts, b1, b2):
-            self.assertIn(element, partScore.parts[0].flat)
-            self.assertIn(element, partScore.parts[1].flat)
+        for part in partScore.parts:
+            flattenedPart = part.flat
+            self.assertIn(k, flattenedPart)
+            self.assertIn(ts, flattenedPart)
+            self.assertIsNotNone(part.getElementsByClass("Measure")[0].rightBarline)
+            self.assertIsNotNone(part.getElementsByClass("Measure")[1].rightBarline)
 
     def testMergeElements(self):
         from music21 import stream

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -5391,6 +5391,31 @@ class Test(unittest.TestCase):
 
         # s1.show()
 
+    def testVoicesToPartsNonNoteElementPropagation(self):
+        k = key.Key('E')
+        ts = meter.TimeSignature('2/4')
+        b1 = bar.Barline('regular')
+        b2 = bar.Barline('final')
+
+        s = Score()
+        m1 = Measure()  # No voices
+        m1.append((k, ts, note.Note(type='half')))
+        m1.rightBarline = b1
+        m2 = Measure()  # Has voices
+        v1 = Voice()
+        v2 = Voice()
+        v1.append(note.Note(type='half'))
+        v2.append(note.Note(type='half'))
+        m2.insert(0, v1)
+        m2.insert(0, v2)
+        m2.rightBarline = b2
+        s.append((m1, m2))
+
+        partScore = s.voicesToParts()
+        for element in (k, ts, b1, b2):
+            self.assertIn(element, partScore.parts[0].flat)
+            self.assertIn(element, partScore.parts[1].flat)
+
     def testMergeElements(self):
         from music21 import stream
         s1 = stream.Stream()


### PR DESCRIPTION
Fixes #575 

Before: time sig and key sig were only propagated to lower parts by `voicesToParts()` if the source measure for those elements had voices. Barlines also weren't propagated even in measures with voices due to a typo.

Now: time sig and key sig and barlines all propagate whether the source measure had voices or not.

Current behavior for clef is maintained: don't propagate, and let `bestClef()` run at the end.