### PR TITLE
Let makeAccidentals() recurse

### DIFF
--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -8783,7 +8783,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         {0.0} <music21.note.Note B>
         {2.0} <music21.chord.Chord A B->
         {3.0} <music21.note.Note D>
-        
+
         (Technical note: All elements of class NotRest are being found
         right now.  This will eventually change to also filter out
         Unpitched objects, so that all elements returned by

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -5865,18 +5865,15 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         # need to move through notes in order
         # recurse to capture notes in substreams: https://github.com/cuthbertLab/music21/issues/577
-        noteStream = returnObj.recurse().notesAndRests
+        noteIterator = returnObj.recurse().notesAndRests
 
         # environLocal.printDebug(['alteredPitches', alteredPitches])
         # environLocal.printDebug(['pitchPast', pitchPast])
 
-        # # get chords, notes, and rests
-        # for i in range(len(noteStream)):
-        #     e = noteStream[i]
         if tiePitchSet is None:
             tiePitchSet = set()
 
-        for e in noteStream:
+        for e in noteIterator:
             if isinstance(e, note.Note):
                 if e.pitch.nameWithOctave in tiePitchSet:
                     lastNoteWasTied = True
@@ -8786,6 +8783,11 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         {0.0} <music21.note.Note B>
         {2.0} <music21.chord.Chord A B->
         {3.0} <music21.note.Note D>
+        
+        (Technical note: All elements of class NotRest are being found
+        right now.  This will eventually change to also filter out
+        Unpitched objects, so that all elements returned by
+        `.notes` have a `.pitches` attribute.
         '''
         if 'notes' not in self._cache or self._cache['notes'] is None:
             noteIterator = self.getElementsByClass('NotRest')

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -5864,8 +5864,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         #   alteredPitches])
 
         # need to move through notes in order
-        # NOTE: this may or may have sub-streams that are not being examined
-        noteStream = returnObj.notesAndRests
+        # recurse to capture notes in substreams: https://github.com/cuthbertLab/music21/issues/577
+        noteStream = returnObj.recurse().notesAndRests
 
         # environLocal.printDebug(['alteredPitches', alteredPitches])
         # environLocal.printDebug(['pitchPast', pitchPast])
@@ -6058,7 +6058,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 pass
 
         # note: this needs to be after makeBeams, as placing this before
-        # makeBeams was causing the duration's tuplet to loose its type setting
+        # makeBeams was causing the duration's tuplet to lose its type setting
         # check for tuplet brackets one measure at a time
         # this means that they will never extend beyond one measure
         for m in measureStream:

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -231,7 +231,7 @@ def makeMeasures(
 
     Here is a simple example of makeMeasures:
 
-    A single measure of 4/4 is created by from a Stream
+    A single measure of 4/4 is created from a Stream
     containing only three quarter notes:
 
     >>> from music21 import articulations

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -5993,12 +5993,20 @@ class Test(unittest.TestCase):
         p = stream.Part()
         p.append([m1, m2])
         # p.show()
-        # test result of xml output to make sure a natural has been hadded
+        # test result of xml output to make sure a natural has been added
         GEX = m21ToXml.GeneralObjectExporter()
         raw = GEX.parse(p).decode('utf-8')
         self.assertGreater(raw.find('<accidental>natural</accidental>'), 0)
-        # make sure original is not chagned
+        # make sure original is not changed
         self.assertFalse(p.haveAccidentalsBeenMade())
+
+    def testHaveAccidentalsBeenMadeInVoices(self):
+        s = Score()
+        s.insert(key.Key('Gb'))
+        s.insert(0, note.Note('D-5'))
+        s.insert(0, note.Note('D-4'))
+        post = s.makeNotation()  # makes voices, makes measures, makes accidentals
+        self.assertTrue(post.haveAccidentalsBeenMade())
 
     def testHaveBeamsBeenMadeA(self):
         from music21 import stream

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -6006,6 +6006,7 @@ class Test(unittest.TestCase):
         s.insert(0, note.Note('D-5'))
         s.insert(0, note.Note('D-4'))
         post = s.makeNotation()  # makes voices, makes measures, makes accidentals
+        self.assertEqual(len(post.recurse().getElementsByClass('Voice')), 2)
         self.assertTrue(post.haveAccidentalsBeenMade())
 
     def testHaveBeamsBeenMadeA(self):


### PR DESCRIPTION
Fixes #577. Easy patch, so I just forged on.


Before: calling `makeAccidentals()` on a Measure with substreams would have no effect. Such calls are made by `makeNotation()` and xml export.

Now: just let `makeAccidentals()` recurse over the input Stream.

Question: is there a valid use case for not recursing over substreams when making accidentals?  If so, this needs a couple quick lines of documentation in `makeAccidentals()`, possibly a keyword `recurse=`, and a decision about whether the default should be True or False in v.6 and whether it should move to True in v.7, etc.

I'm having trouble imagining the use case for NOT wanting accidentals made on substreams, so I didn't create a keyword arg. If a user doesn't want the new behavior, well, `makeAccidentals()` wasn't doing anything to substreams before, so such a user could just call `makeAccidentals()` directly on the desired substreams, if any.

`makeNotation()` now does what it advertises in more cases, so I didn't see a specific reason to update the docs, but happy to if you think wise.
