### PR TITLE
Fixes #502: Strip ties from chords only when all members have a stop tie

### DIFF
--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -6266,9 +6266,18 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             updateEndMatch based on nList, iLast, matchByPitch, etc.
             '''
             # ties tell us when they are ended
+            # unless n is a chord, which only tells if SOME member has a tie
+            # https://github.com/cuthbertLab/music21/issues/502
             if (hasattr(n, 'tie')
+                    and 'Chord' not in n.classes
                     and n.tie is not None
                     and n.tie.type == 'stop'):
+                return True
+            # but capture case where all chord members have a stop tie
+            elif (hasattr(n, 'tie')
+                    and 'Chord' in n.classes
+                    and None not in [p.tie for p in n.notes]
+                    and {p.tie.type for p in n.notes} == {'stop'}):
                 return True
             # if we cannot find a stop tie, see if last note was connected
             # and this and the last note are the same pitch; this assumes

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -1120,6 +1120,41 @@ class Test(unittest.TestCase):
         self.assertEqual(voice2Note.quarterLength, 3)
         self.assertIsNone(voice2Note.tie)
 
+    def testStripTiesChordMembersSomeTied(self):
+        '''
+        Testing ties NOT stripped where only some chord members are tied.
+        https://github.com/cuthbertLab/music21/issues/502
+        '''
+        from music21 import tie
+
+        s = Stream()
+        n1 = note.Note('C5', quarterLength=0.5)
+        n2 = note.Note('Bb4', quarterLength=0.5)
+        n3 = note.Note('C3', quarterLength=0.5)
+        n3.tie = tie.Tie('start')
+        n4 = note.Note('C3', quarterLength=0.5)
+        n4.tie = tie.Tie('stop')
+
+        c1 = chord.Chord([n1, n3])
+        c2 = chord.Chord([n2, n4])
+        s.append([c1, c2])
+        stripped = s.stripTies()
+
+        self.assertIsNotNone(stripped.notes[0].tie)
+
+    def testStripTiesChordMembersAllTied(self):
+        '''
+        Testing ties stripped where all chord members are tied.
+        '''
+
+        s = Stream()
+        c = chord.Chord(['C3', 'C5'])
+        s.append(meter.TimeSignature('1/8'))
+        s.append(c)
+        s.makeNotation(inPlace=True)  # makes ties
+        stripped = s.stripTies()
+        self.assertEqual(len(stripped.flat.notes), 1)
+
     def testGetElementsByOffsetZeroLength(self):
         '''
         Testing multiple zero-length elements with mustBeginInSpan:


### PR DESCRIPTION
Fixes #502 fixes #430 (duplicates)

**Before**: `stripTies()` would accept at face value a tie type of stop from a `Chord` object, even though not all of its members might participate in a tie. This would leave downstream effects in `chordify()` where verticalities would go missing.

**Now**: `stripTies()` only treats a `Chord` as the end of a tie if every member has a tie type of stop. That is, unless `matchByPitch` is used.

--

(PS -- LMK if you think linking back to the issue tracker is overkill -- seems useful in the event there is either a discussion there or evidence of something happening in the wild, but would certainly defer on this style point!)