### PR TITLE
Constructed m21 instrument from MIDI instrument name or sequence track name

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1632,7 +1632,7 @@ class ScoreExporter(XMLExporterBase):
     def setScoreHeader(self):
         '''
         Sets the group score-header in <score-partwise>.  Note that score-header is not
-        a separate tag, but just a way of crouping things from the tag.
+        a separate tag, but just a way of grouping things from the tag.
 
         runs `setTitles()`, `setIdentification()`, `setDefaults()`, changes textBoxes
         to `<credit>` and does the major task of setting up the part-list with `setPartList()`


### PR DESCRIPTION
Fixed #588 

**Before**: `MetaEvent.INSTRUMENT_NAME` and `MetaEvent.SEQUENCE_TRACK_NAME` were ignored when parsing midi files into streams.

**Now**:  Instrument instances are constructed.