### PR TITLE
Allow element to lack duration when coinciding with last measure's end offset

### DIFF
--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -2031,7 +2031,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         This method is useful for putting things such as
         right bar lines or courtesy clefs that should always
         be at the end of a Stream no matter what else is appended
-        to it
+        to it.
 
         As sorting is done only by priority and class,
         it cannot avoid setting isSorted to False.

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -566,7 +566,6 @@ def makeMeasures(
             mEnd = postMeasureInfo['mEnd']
             m = postMeasureInfo['measure']
 
-            # also allow zero duration element at last measure's end offset
             if mStart <= start < mEnd:
                 match = True
                 # environLocal.printDebug([

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -567,16 +567,19 @@ def makeMeasures(
             m = postMeasureInfo['measure']
 
             # also allow zero duration element at last measure's end offset
-            if mStart <= start < mEnd or mEnd == oMax == start == end:
+            if mStart <= start < mEnd:
                 match = True
                 # environLocal.printDebug([
                 #    'found measure match', i, mStart, mEnd, start, end, e])
                 break
 
         if not match:
-            raise stream.StreamException(
-                'cannot place element %s with start/end %s/%s '
-                'within any measures' % (e, start, end))
+            if start == end == oMax:
+                post.storeAtEnd(e)
+            else:
+                raise stream.StreamException(
+                    'cannot place element %s with start/end %s/%s '
+                    'within any measures' % (e, start, end))
 
         # find offset in the temporal context of this measure
         # i is the index of the measure that this element starts at

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -566,7 +566,8 @@ def makeMeasures(
             mEnd = postMeasureInfo['mEnd']
             m = postMeasureInfo['measure']
 
-            if mStart <= start < mEnd:
+            # also allow zero duration element at last measure's end offset
+            if mStart <= start < mEnd or (i == postLen - 1 and start == end == mEnd):
                 match = True
                 # environLocal.printDebug([
                 #    'found measure match', i, mStart, mEnd, start, end, e])

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -567,7 +567,7 @@ def makeMeasures(
             m = postMeasureInfo['measure']
 
             # also allow zero duration element at last measure's end offset
-            if mStart <= start < mEnd or (i == postLen - 1 and start == end == mEnd):
+            if mStart <= start < mEnd or mEnd == oMax == start == end:
                 match = True
                 # environLocal.printDebug([
                 #    'found measure match', i, mStart, mEnd, start, end, e])

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -1972,6 +1972,16 @@ class Test(unittest.TestCase):
                  barred4.getElementsByClass('Measure')]
         self.assertEqual(match, ['None', 'None', 'None', 'None'])
 
+    def testMakeMeasuresLastElementNoDuration(self):
+        from music21 import expressions
+
+        s = Stream()
+        s.append(meter.TimeSignature('3/4'))
+        obj = expressions.TextExpression('FREEZE')
+        s.insert(3, obj)
+        s.makeMeasures(inPlace=True)
+        self.assertEqual(len(s.measure(1).getElementsByClass('Expression')), 1)
+
     def testRemove(self):
         '''Test removing components from a Stream.
         '''


### PR DESCRIPTION
Fixes #534 Fixes #515 (duplicates)

**Before**:  `makeMeasures()` would choke on a duration-less element coinciding with the end offset of the final measure.

**Now**: `makeMeasures()` places a duration-less element coinciding with the end offset of the final measure <s>in that final measure</s> at the end of the stream.