### PR TITLE
Support multi-digit endings in xml export; bump MuseScore version paths

### DIFF
--- a/music21/environment.py
+++ b/music21/environment.py
@@ -395,7 +395,7 @@ class _EnvironmentCore:
             for name, value in [
                 ('lilypondPath', 'lilypond'),
                 ('musescoreDirectPNGPath',
-                    common.cleanpath(r'%PROGRAMFILES(x86)%\MuseScore 3\MuseScore.exe')),
+                    common.cleanpath(r'%PROGRAMFILES(x86)%\MuseScore 3.5\MuseScore.exe')),
             ]:
                 self.__setitem__(name, value)  # use for key checking
         elif platform == 'nix':
@@ -405,13 +405,13 @@ class _EnvironmentCore:
             for name, value in [
                 ('lilypondPath',
                             '/Applications/Lilypond.app/Contents/Resources/bin/lilypond'),
-                ('musicxmlPath', '/Applications/MuseScore 3.app/Contents/MacOS/mscore'),
+                ('musicxmlPath', '/Applications/MuseScore 3.5.app/Contents/MacOS/mscore'),
                 ('graphicsPath', '/Applications/Preview.app'),
                 ('vectorPath', '/Applications/Preview.app'),
                 ('pdfPath', '/Applications/Preview.app'),
                 ('midiPath', '/Applications/Utilities/QuickTime Player 7.app'),
                 ('musescoreDirectPNGPath',
-                            '/Applications/MuseScore 3.app/Contents/MacOS/mscore'),
+                            '/Applications/MuseScore 3.5.app/Contents/MacOS/mscore'),
             ]:
                 self.__setitem__(name, value)  # use for key checking
 
@@ -1468,8 +1468,8 @@ class Test(unittest.TestCase):
   <preference name="manualCoreCorpusPath" />
   <preference name="midiPath" value="/Applications/Utilities/QuickTime Player 7.app" />
   <preference name="musescoreDirectPNGPath"
-      value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
-  <preference name="musicxmlPath" value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
+      value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
+  <preference name="musicxmlPath" value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
   <preference name="pdfPath" value="/Applications/Preview.app" />
   <preference name="showFormat" value="musicxml" />
   <preference name="vectorPath" value="/Applications/Preview.app" />
@@ -1521,8 +1521,8 @@ class Test(unittest.TestCase):
   <preference name="manualCoreCorpusPath" />
   <preference name="midiPath" value="/Applications/Utilities/QuickTime Player 7.app" />
   <preference name="musescoreDirectPNGPath"
-      value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
-  <preference name="musicxmlPath" value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
+      value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
+  <preference name="musicxmlPath" value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
   <preference name="pdfPath" value="/Applications/Preview.app" />
   <preference name="showFormat" value="musicxml" />
   <preference name="vectorPath" value="/Applications/Preview.app" />
@@ -1574,8 +1574,8 @@ class Test(unittest.TestCase):
   <preference name="manualCoreCorpusPath" />
   <preference name="midiPath" value="w" />
   <preference name="musescoreDirectPNGPath"
-      value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
-  <preference name="musicxmlPath" value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
+      value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
+  <preference name="musicxmlPath" value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
   <preference name="pdfPath" value="/Applications/Preview.app" />
   <preference name="showFormat" value="musicxml" />
   <preference name="vectorPath" value="/Applications/Preview.app" />

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5428,10 +5428,10 @@ class MeasureExporter(XMLExporterBase):
             else:
                 endingType = 'stop'
             numberList = self.rbSpanners[0].getNumberList()
-            number = str(numberList[0])
-            for n in numberList[1:]:
-                number += ',' + str(n)  # comma-separated ending numbers
-            mxEnding.set('number', number)
+            numberStr = str(numberList[0])
+            for num in numberList[1:]:
+                numberStr += ',' + str(num)  # comma-separated ending numbers
+            mxEnding.set('number', numberStr)
             mxEnding.set('type', endingType)
             mxBarline.append(mxEnding)  # make sure it is after fermata but before repeat.
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5427,7 +5427,11 @@ class MeasureExporter(XMLExporterBase):
                 endingType = 'start'
             else:
                 endingType = 'stop'
-            mxEnding.set('number', str(self.rbSpanners[0].getNumberList()[0]))
+            numberList = self.rbSpanners[0].getNumberList()
+            number = str(numberList[0])
+            for n in numberList[1:]:
+                number += ',' + str(n)  # comma-separated ending numbers
+            mxEnding.set('number', number)
             mxEnding.set('type', endingType)
             mxBarline.append(mxEnding)  # make sure it is after fermata but before repeat.
 
@@ -6192,6 +6196,21 @@ class Test(unittest.TestCase):
         mxScoreInstrument = tree.findall('.//score-instrument')[0]
         mxMidiInstrument = tree.findall('.//midi-instrument')[0]
         self.assertEqual(mxScoreInstrument.get('id'), mxMidiInstrument.get('id'))
+
+    def testMultiDigitEndingsWrite(self):
+        from music21 import converter
+        from music21.musicxml import testPrimitive
+
+        # Relevant barlines:
+        # Measure 2, left barline: <ending number="1,2" type="start"/>
+        # Measure 2, right barline: <ending number="1,2" type="stop"/>
+        # Measure 3, left barline: <ending number="3" type="start"/>
+        # Measure 3, right barline: <ending number="3" type="stop"/>
+        s = converter.parse(testPrimitive.multiDigitEnding)
+        x = self.getET(s)
+        endings = x.findall('.//ending')
+        self.assertSequenceEqual([e.get('number') for e in endings],
+                                ['1,2', '1,2', '3', '3'])
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover


### PR DESCRIPTION
- Now with support for multi-digit endings from m21 -> xml (before I only did xml -> m21)

- Tried .write('musicxml.png') for the first time and needed to download MuseScore, which now downloads as MuseScore 3.5.app, so updated the default paths.