### PR TITLE
Conductor track

### DIFF
--- a/.idea/dictionaries/music21.xml
+++ b/.idea/dictionaries/music21.xml
@@ -751,7 +751,7 @@
       <w>slendro</w>
       <w>slurlongphrasewithbrackets</w>
       <w>smooshed</w>
-      <w>smtpe</w>
+      <w>smpte</w>
       <w>smts</w>
       <w>smufl</w>
       <w>solfeg</w>

--- a/documentation/source/usersGuide/usersGuide_13_music21object2.ipynb
+++ b/documentation/source/usersGuide/usersGuide_13_music21object2.ipynb
@@ -60,7 +60,7 @@
    "source": [
     "### Derivations\n",
     "\n",
-    "We will talk about derivations more in a future chapter, butwe alluded to them in the Example in chapter 10, so let's say a few words about this advanced feature. A :class:`~music21.derivation.Derivation` object is a pointer to an object that this object is derived from in some way.  They've gone their separate ways to an extent, but may want to talk to each other later.  A `Music21Object` starts out with no useful Derivation:"
+    "We will talk about derivations more in a future chapter, but we alluded to them in the Example in chapter 10, so let's say a few words about this advanced feature. A :class:`~music21.derivation.Derivation` object is a pointer to an object that this object is derived from in some way.  They've gone their separate ways to an extent, but may want to talk to each other later.  A `Music21Object` starts out with no useful Derivation:"
    ]
   },
   {
@@ -732,7 +732,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you might expect, the `.measureNumber` routine uses `.getContextByClass('Measure')` internally. What is also interesting is that `.getContextByClass` is smart enough to search out derivation chains to find what it is looking for.  For instance, this flat stream has only notes, no time signatures.  But it can still find each note's time signature ane measure number context."
+    "As you might expect, the `.measureNumber` routine uses `.getContextByClass('Measure')` internally. What is also interesting is that `.getContextByClass` is smart enough to search out derivation chains to find what it is looking for.  For instance, this flat stream has only notes, no time signatures.  But it can still find each note's time signature and measure number context."
    ]
   },
   {

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -1674,6 +1674,15 @@ class Bass(Vocalist):
         self.instrumentAbbreviation = 'B'
         self.instrumentSound = 'voice.bass'
 
+# -----------------------------------------------------
+
+
+class Conductor(Instrument):
+    '''Presently used only for tracking the MIDI track containing tempo,
+    key signature, and related metadata.'''
+    def __init__(self):
+        super().__init__(instrumentName='Conductor')
+
 # -----------------------------------------------------------------------------
 
 

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -947,8 +947,6 @@ class MidiEvent:
         '''
         if self.type in ChannelVoiceMessages:
             # environLocal.printDebug(['writing channelVoiceMessages', self.type])
-            if self.channel is None:
-                return b'\x00'
             bytes0 = bytes([self.channel - 1 + self.type.value])
             # for writing note-on/note-off
             if self.type not in (ChannelVoiceMessages.PROGRAM_CHANGE,

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -947,6 +947,8 @@ class MidiEvent:
         '''
         if self.type in ChannelVoiceMessages:
             # environLocal.printDebug(['writing channelVoiceMessages', self.type])
+            if self.channel is None:
+                return b'\x00'
             bytes0 = bytes([self.channel - 1 + self.type.value])
             # for writing note-on/note-off
             if self.type not in (ChannelVoiceMessages.PROGRAM_CHANGE,

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -1680,7 +1680,7 @@ class Test(unittest.TestCase):
     def testBasicImport(self):
         dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
         fp = dirLib / 'test01.mid'
-        environLocal.printDebug(fp)
+        environLocal.printDebug([fp])
         mf = MidiFile()
         mf.open(fp)
         mf.read()

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -154,7 +154,7 @@ def getNumber(midiStr, length):
 
 def getVariableLengthNumber(midiBytes):
     r'''
-    Given a string or bytes of data, strip off a the first character, or all high-byte characters
+    Given a string or bytes of data, strip off the first character, or all high-byte characters
     terminating with one whose ord() function is < 0x80.  Thus a variable number of bytes
     might be read.
 
@@ -162,7 +162,7 @@ def getVariableLengthNumber(midiBytes):
     return the remaining string.
 
     This is necessary as DeltaTime times are given with variable size,
-    and thus may be if different numbers of characters are used.
+    and thus may be of different numbers if characters are used.
 
     >>> midi.getVariableLengthNumber(b'A-u')
     (65, b'-u')
@@ -401,7 +401,7 @@ class MetaEvents(_ContainsEnum):
     MIDI_PORT = 0x21
     END_OF_TRACK = 0x2F
     SET_TEMPO = 0x51
-    SMTPE_OFFSET = 0x54
+    SMPTE_OFFSET = 0x54
     TIME_SIGNATURE = 0x58
     KEY_SIGNATURE = 0x59
     SEQUENCER_SPECIFIC_META_EVENT = 0x7F

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2113,26 +2113,16 @@ def midiTracksToStreams(
                               quantizePost,
                               inputM21=conductorTrack, **keywords)
     # environLocal.printDebug(['show() conductorTrack elements'])
-    # if we have time sig/key sig elements, add to each part
+    # if we have time sig/key sig/tempo elements, add to each part
 
-    # TODO: this would be faster if we iterated in the other order.
-    for p in s.getElementsByClass('Stream'):
-        for e in conductorTrack.getElementsByClass(
-                ('TimeSignature', 'KeySignature')):
+    for e in conductorTrack.getElementsByClass(
+            ('TimeSignature', 'KeySignature', 'MetronomeMark')):
+        for p in s.getElementsByClass('Stream'):
             # create a deepcopy of the element so a flat does not cause
             # multiple references of the same
             eventCopy = copy.deepcopy(e)
             p.insert(conductorTrack.elementOffset(e), eventCopy)
 
-    # if there is a conductor track, add tempo only to the top-most part
-    # MSC: WHY?
-
-    p = s.getElementsByClass('Stream')[0]
-    for e in conductorTrack.getElementsByClass('MetronomeMark'):
-        # create a deepcopy of the element so a flat does not cause
-        # multiple references of the same
-        eventCopy = copy.deepcopy(e)
-        p.insert(conductorTrack.elementOffset(e), eventCopy)
     return s
 
 
@@ -3046,10 +3036,10 @@ class Test(unittest.TestCase):
         fp = dirLib / 'test11.mid'
         s = converter.parse(fp)
         self.assertEqual(len(s.parts), 3)
-        # metronome marks end up only on the top-most staff
+        # metronome marks end up on every staff
         self.assertEqual(len(s.parts[0].getElementsByClass('MetronomeMark')), 4)
-        self.assertEqual(len(s.parts[1].getElementsByClass('MetronomeMark')), 0)
-        self.assertEqual(len(s.parts[2].getElementsByClass('MetronomeMark')), 0)
+        self.assertEqual(len(s.parts[1].getElementsByClass('MetronomeMark')), 4)
+        self.assertEqual(len(s.parts[2].getElementsByClass('MetronomeMark')), 4)
 
     def testMidiExportConductorA(self):
         '''Export conductor data to MIDI conductor track.'''

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -26,6 +26,8 @@ from music21 import exceptions21
 from music21 import environment
 from music21 import stream
 
+from music21.instrument import Conductor
+
 _MOD = 'midi.translate'
 environLocal = environment.Environment(_MOD)
 
@@ -177,7 +179,7 @@ def getStartEvents(mt=None, channel=1, instrumentObj=None):
     '''
     from music21 import midi as midiModule
     events = []
-    if instrumentObj == 'conductor':
+    if isinstance(instrumentObj, Conductor):
         return events
     elif instrumentObj is None or instrumentObj.bestName() is None:
         partName = ''
@@ -1955,7 +1957,7 @@ def packetStorageFromSubstreamList(
             instObj = instrumentStream[0]
         elif trackId == 0 and not subs.notesAndRests:
             # Conductor track
-            instObj = 'conductor'
+            instObj = Conductor()
         else:
             instObj = None
 
@@ -1980,13 +1982,13 @@ def updatePacketStorageWithChannelInfo(
     for unused_trackId, bundle in packetStorage.items():
         # get instrument
         instObj = bundle['initInstrument']
-        if instObj == 'conductor':
-            initCh = None
-        elif instObj is None:
+        if instObj is None:
             try:
                 initCh = channelByInstrument[None]
             except KeyError:  # pragma: no cover
                 initCh = 1  # fallback, should not happen.
+        elif 'Conductor' in instObj.classes:
+            initCh = None
         else:  # use midi program
             initCh = channelByInstrument[instObj.midiProgram]
         bundle['initChannel'] = initCh  # set for bundle too

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1877,6 +1877,9 @@ def channelInstrumentData(s: stream.Stream,
     the first a dictionary mapping MIDI program numbers to channel numbers,
     and the second, a list of unassigned channels that can be used for dynamic
     allocation.
+
+    Substreams without notes or rests (e.g. representing a conductor track)
+    will not consume a channel.
     '''
     # temporary channel allocation
     if acceptableChannelList is not None:
@@ -1892,8 +1895,7 @@ def channelInstrumentData(s: stream.Stream,
     substreamList = []
     if s.hasPartLikeStreams():
         for obj in s.getElementsByClass('Stream'):
-            # _prepareStreamForMidi() supplies defaults for these
-            if obj.getElementsByClass(('MetronomeMark', 'TimeSignature')):
+            if not obj.flat.notesAndRests:
                 # Conductor track: don't consume a channel
                 continue
             else:

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2143,9 +2143,9 @@ def streamToMidiFile(
     >>> n.quarterLength = 0.5
     >>> s.repeatAppend(n, 4)
     >>> mf = midi.translate.streamToMidiFile(s)
-    >>> len(mf.tracks)  # Includes conductor track
-    2
-    >>> len(mf.tracks[1].events)  # First music track
+    >>> mf.tracks[0].index  # Track 0: conductor track
+    0
+    >>> len(mf.tracks[1].events)  # Track 1: music track
     22
 
     From here, you can call mf.writestr() to get the actual file info.
@@ -2163,10 +2163,7 @@ def streamToMidiFile(
     s = inputM21
     midiTracks = streamHierarchyToMidiTracks(s, addStartDelay=addStartDelay)
 
-    # update track indices
     # may need to update channel information
-    for i in range(len(midiTracks)):
-        midiTracks[i].index = i + 1
 
     mf = midiModule.MidiFile()
     mf.tracks = midiTracks

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1797,7 +1797,7 @@ def midiTrackToStream(mt,
     return s
 
 
-def _prepareStreamForMidi(s):
+def _prepareStreamForMidi(s) -> stream.Stream:
     '''
     Given a score, prepare it for MIDI processing:
     1. Expand repeats.
@@ -2022,17 +2022,14 @@ def streamHierarchyToMidiTracks(
     # TODO: may need to shift all time values to accommodate
     # Streams that do not start at same time
 
-    # store streams in uniform list
+    # store streams in uniform list: _prepareStreamForMidi() ensures there are substreams
     substreamList = []
-    if s.hasPartLikeStreams():
-        for obj in s.getElementsByClass('Stream'):
-            if obj.getElementsByClass(('MetronomeMark', 'TimeSignature')):
-                # Ensure conductor track is first
-                substreamList.insert(0, obj)
-            else:
-                substreamList.append(obj)
-    else:
-        substreamList.append(s)  # add single
+    for obj in s.getElementsByClass('Stream'):
+        if obj.getElementsByClass(('MetronomeMark', 'TimeSignature')):
+            # Ensure conductor track is first
+            substreamList.insert(0, obj)
+        else:
+            substreamList.append(obj)
 
     # strip all ties inPlace
     for subs in substreamList:

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -309,7 +309,7 @@ class AbstractScale(Scale):
         if pitchList[-1].name == pitchList[0].name:  # the completion of the scale has been given.
             # print('hi %s ' % pitchList)
             # this scale is only octave duplicating if the top note is exactly
-            # 1 octave above the bottom; if it spans more thane one active,
+            # 1 octave above the bottom; if it spans more than one octave,
             # all notes must be identical in each octave
             # if abs(pitchList[-1].ps - pitchList[0].ps) == 12:
             span = interval.notesToInterval(pitchList[0], pitchList[-1])

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -3323,9 +3323,9 @@ class Test(unittest.TestCase):
         # post = s.midiTracks  # get a lost
         post = midiTranslate.streamHierarchyToMidiTracks(s)
 
-        self.assertEqual(len(post[0].events), 30)
+        self.assertEqual(len(post[1].events), 30)
         # must be an even number
-        self.assertEqual(len(post[0].events) % 2, 0)
+        self.assertEqual(len(post[1].events) % 2, 0)
 
         mf = midiTranslate.streamToMidiFile(s)
         match = [

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -3309,9 +3309,9 @@ class Test(unittest.TestCase):
 
         def procCompare(mf_inner, match_inner):
             triples = []
-            for i in range(0, len(mf_inner.tracks[0].events), 2):
-                delta = mf_inner.tracks[0].events[i]  # delta
-                e = mf_inner.tracks[0].events[i + 1]  # events
+            for i in range(0, len(mf_inner.tracks[1].events), 2):
+                delta = mf_inner.tracks[1].events[i]  # delta
+                e = mf_inner.tracks[1].events[i + 1]  # events
                 triples.append((delta.time, e.type, e.pitch))
 
             self.assertEqual(triples, match_inner)

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -434,8 +434,7 @@ def realizeVolume(srcStream,
     This is a top-down routine, as opposed to bottom-up values available with
     context searches on Volume. This thus offers a performance benefit.
 
-    This is always done in place; for the option of non-in place processing,
-    see Stream.realizeVolume().
+    This is always done in place.
 
     If setAbsoluteVelocity is True, the realized values will overwrite all
     existing velocity values, and the Volume objects velocityIsRelative


### PR DESCRIPTION
Fixed #152 Fixed #569

**Before:** music21 produced multitrack MIDI files in format 1 (multi-track) without a conductor track. This isn't standard practice and could lead to the failure to propagate tempo, meter, and key to subsequent tracks when loaded into sequencers or notation programs.

**Now:** every produced MIDI file begins with a conductor track (Track 0) before the first music track (Track 1).

**Update:** On MIDI _import_, A `MetronomeMark` in the conductor track will now propagate to every m21 part, to fix a bug but more importantly so that `.seconds` will be correct on notes in subsequent parts.

I would appreciate some testers beating this up before merge. I'm not a MIDI expert.