### PR TITLE
Check if zero before taking log; prefer math.log2()

### DIFF
--- a/music21/audioSearch/__init__.py
+++ b/music21/audioSearch/__init__.py
@@ -202,7 +202,7 @@ def prepareThresholds(useScale=None):
     scPitchesRemainder = []
 
     for p in scPitches:
-        pLog2 = math.log(p.frequency, 2)
+        pLog2 = math.log2(p.frequency)
         scPitchesRemainder.append(math.modf(pLog2)[0])
     scPitchesRemainder[-1] += 1
 
@@ -271,7 +271,7 @@ def normalizeInputFrequency(inputPitchFrequency, thresholds=None, pitches=None):
     if thresholds is None:
         (thresholds, pitches) = prepareThresholds()
 
-    inputPitchLog2 = math.log(inputPitchFrequency, 2)
+    inputPitchLog2 = math.log2(inputPitchFrequency)
     (remainder, octave) = math.modf(inputPitchLog2)
     octave = int(octave)
 
@@ -785,7 +785,7 @@ def quarterLengthEstimation(durationList, mostRepeatedQuarterLength=1.0):
     if mostRepeatedQuarterLength == 0:
         mostRepeatedQuarterLength = 1.0
 
-    binPosition = 0 - math.log(mostRepeatedQuarterLength, 2)
+    binPosition = 0 - math.log2(mostRepeatedQuarterLength)
     qle = qle * math.pow(2, binPosition)  # it normalizes the length to a quarter note
 
     # environLocal.printDebug('QUARTER ESTIMATION')

--- a/music21/graph/axis.py
+++ b/music21/graph/axis.py
@@ -1161,13 +1161,13 @@ class QuarterLengthAxis(PositionAxis):
     def remapQuarterLength(self, x):
         '''
         Remap a quarter length as its log2.  Essentially it's
-        just math.log(x, 2), but x=0 is replaced with self.graceNoteQL.
+        just math.log2(x), but x=0 is replaced with self.graceNoteQL.
         '''
         if x == 0:  # grace note
             x = self.graceNoteQL
 
         try:
-            return math.log(float(x), 2)
+            return math.log2(float(x))
         except ValueError:  # pragma: no cover
             raise GraphException('cannot take log of x value: %s' % x)
 

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -2345,7 +2345,7 @@ def hdStringToNote(contents):
                 thisObject.duration.dots = contents.count('.')
         else:
             dT = int(durationType) + 0.0
-            (unused_remainder, exponents) = math.modf(math.log(dT, 2))
+            (unused_remainder, exponents) = math.modf(math.log2(dT))
             baseValue = 2 ** exponents
             thisObject.duration.type = duration.typeFromNumDict[int(baseValue)]
             newTup = duration.Tuplet()

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -789,7 +789,7 @@ def timeSignatureToMidiEvents(ts, includeDeltaTime=True):
     n = ts.numerator
     # need log base 2 to solve for exponent of 2
     # 1 is 0, 2 is 1, 4 is 2, 16 is 4, etc
-    d = int(math.log(ts.denominator, 2))
+    d = int(math.log2(ts.denominator))
     metroClick = 24  # clock signals per click, clicks are 24 per quarter
     subCount = 8  # number of 32 notes in a quarter note
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3192,7 +3192,10 @@ class MeasureParser(XMLParserBase):
                 try:
                     d.components = durRaw.components
                 except duration.DurationException:  # TODO: Test
-                    qLenRounded = 2.0 ** round(math.log2(qLen))
+                    if qLen:
+                        qLenRounded = 2.0 ** round(math.log2(qLen))
+                    else:
+                        qLenRounded = 0.0
                     environLocal.printDebug(
                         ['mxToDuration',
                          'rounding duration to {0} as type is not'.format(qLenRounded)

--- a/music21/omr/correctors.py
+++ b/music21/omr/correctors.py
@@ -839,11 +839,10 @@ class MeasureHash:
         >>> hasher.hashQuarterLength(2.0)
         90
         '''
-        duration1to127 = int(math.log(ql * 256, 2) * 10)
-        if duration1to127 >= 127:
-            duration1to127 = 127
-        elif duration1to127 == 0:
-            duration1to127 = 1
+        duration1to127 = 1
+        if ql:
+            duration1to127 = int(math.log2(ql * 256) * 10)
+            duration1to127 = max(min(duration1to127, 127), 1)
         return duration1to127
 
     def setSequenceMatcher(self, hashes=None):

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -404,7 +404,7 @@ def _convertHarmonicToCents(value: Union[int, float]) -> int:
     '''
     if value < 0:  # subharmonics
         value = 1 / (abs(value))
-    return round(1200 * math.log(value, 2))
+    return round(1200 * math.log2(value))
 
 # -----------------------------------------------------------------------------
 

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -918,8 +918,9 @@ def translateNoteWithDurationToBytes(n, includeTieByte=True):
     takes a note.Note object and translates it to a three-byte representation.
 
     currently returns the chr() for the note's midi number. or chr(127) for rests
-    followed by the log of the quarter length (fitted to 1-127, see formula below)
-    followed by 's', 'c', or 'e' if includeTieByte is True and there is a tie
+    followed by the log of the quarter length (fitted to 1-127, see
+    :func:`~music21.search.base.translateDurationToBytes`)
+    followed by 's', 'c', or 'e' if includeTieByte is True and there is a tie.
 
 
     >>> n = note.Note('C4')
@@ -942,13 +943,7 @@ def translateNoteWithDurationToBytes(n, includeTieByte=True):
 
     '''
     firstByte = translateNoteToByte(n)
-    duration1to127 = int(math.log(n.duration.quarterLength * 256, 2) * 10)
-    if duration1to127 >= 127:
-        duration1to127 = 127
-    elif duration1to127 == 0:
-        duration1to127 = 1
-    secondByte = chr(duration1to127)
-
+    secondByte = translateDurationToBytes(n)
     thirdByte = translateNoteTieToByte(n)
     if includeTieByte is True:
         return firstByte + secondByte + thirdByte
@@ -1007,11 +1002,10 @@ def translateDurationToBytes(n):
     2.828...
 
     '''
-    duration1to127 = int(math.log2(n.duration.quarterLength * 256) * 10)
-    if duration1to127 >= 127:
-        duration1to127 = 127
-    elif duration1to127 == 0:
-        duration1to127 = 1
+    duration1to127 = 1
+    if n.duration.quarterLength:
+        duration1to127 = int(math.log2(n.duration.quarterLength * 256) * 10)
+        duration1to127 = max(min(duration1to127, 127), 1)
     secondByte = chr(duration1to127)
     return secondByte
 


### PR DESCRIPTION
Fixed #608 

• `search.base.translateDurationToBytes()` checks for zero before taking `math.log2()`

• `search.base.translateNoteWithDurationToBytes()` calls the above function rather than performing the same calculation with duplicative code

•  similar changes in `omr.correctors.hashQuarterLength()` and `musicxml.xmlToM21.xmlToDuration()`

• `math.log(2, x)` changed to `math.log2(x)` where possible, since as of Python 3.3 `log2` is considered more reliable