### PR TITLE
Fixed string formatting issue in EnvironmentException when scratch directory doesn't exist

### DIFF
--- a/music21/environment.py
+++ b/music21/environment.py
@@ -557,7 +557,7 @@ class _EnvironmentCore:
 
         if not refDir.exists():
             raise EnvironmentException(
-                'user-specified scratch directory ({:s}) does not exist; '
+                'user-specified scratch directory ({!s}) does not exist; '
                 'remove preference file or reset Environment'.format(
                     refDir))
         return refDir


### PR DESCRIPTION
Thanks to David Garfinkle for the report and patch!

fixes #342 