### PR TITLE
Augmented sixths

### DIFF
--- a/music21/features/outputFormats.py
+++ b/music21/features/outputFormats.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from music21 import exceptions21
 from music21 import environment
 

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -1921,6 +1921,10 @@ class RomanNumeral(harmony.Harmony):
                 useScale = key.Key(useScale.tonic, 'minor')
                 self.impliedScale = useScale
                 self.useImpliedScale = True
+                # Set secondary key to minor, if any
+                if self.secondaryRomanNumeralKey is not None:
+                    self.secondaryRomanNumeralKey = key.Key(
+                        self.secondaryRomanNumeralKey.tonic, 'minor')
             rm = self._augmentedSixthRegex.match(workingFigure)
             romanNumeralAlone = rm.group(1)
             if romanNumeralAlone in ('It', 'Ger'):
@@ -2966,6 +2970,10 @@ class Test(unittest.TestCase):
 
         rn = romanNumeralFromChord(c, k)
         self.assertEqual(rn.figure, 'I#853')
+
+    def testSecondaryAugmentedSixth(self):
+        rn = RomanNumeral('Ger65/IV', 'C')
+        self.assertEqual([p.name for p in rn.pitches], ['D-', 'F', 'A-', 'B'])
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -1903,6 +1903,11 @@ class RomanNumeral(harmony.Harmony):
         >>> workingFig, outScale = rn._parseRNAloneAmidstAug6('Ger65', useScale)
         >>> rn.scaleDegreeWithAlteration
         (4, <accidental sharp>)
+
+        >>> rn = roman.RomanNumeral()
+        >>> workingFig, outScale = rn._parseRNAloneAmidstAug6('It6', scale.MajorScale('C'))
+        >>> outScale
+        <music21.key.Key of c minor>
         '''
         if (not self._romanNumeralAloneRegex.match(workingFigure)
                 and not self._augmentedSixthRegex.match(workingFigure)):
@@ -1910,7 +1915,9 @@ class RomanNumeral(harmony.Harmony):
                 workingFigure))
 
         if self._augmentedSixthRegex.match(workingFigure):
-            if useScale.mode == 'major':
+            # NB -- could be Key or Scale
+            if (('Key' in useScale.classes and useScale.mode == 'major')
+                    or ('DiatonicScale' in useScale.classes and useScale.type == 'major')):
                 useScale = key.Key(useScale.tonic, 'minor')
                 self.impliedScale = useScale
                 self.useImpliedScale = True

--- a/music21/test/testPerformance.py
+++ b/music21/test/testPerformance.py
@@ -199,6 +199,8 @@ class Test(unittest.TestCase):
 
         for p in s.parts:
             for m in p.getElementsByClass('Measure'):
+                if m.number == 0:
+                    continue
                 post = m.getContextByClass('Clef')
                 assert post is not None
                 post = m.getContextByClass('TimeSignature')
@@ -224,6 +226,8 @@ class Test(unittest.TestCase):
 
         for p in s.parts:
             for m in p.getElementsByClass('Measure'):
+                if m.number == 0:
+                    continue
                 post = m.previous('Clef')
                 assert post is not None
                 post = m.previous('TimeSignature')
@@ -371,7 +375,7 @@ class Test(unittest.TestCase):
             testMethod()
             t.stop()
             dur = t()
-            items = best.items()
+            items = list(best.items())
             items.sort()
             items.reverse()
             environLocal.printDebug(['\n\ntiming tolerance for:',


### PR DESCRIPTION
Fixes #585
**Before:** `RomanNumeral` objects without keys would pass a `Scale` object to `_parseRNAloneAmidstAug6()`, which only contemplated `Key` objects for `useScale`, even though elsewhere `useScale` is a scale or key.
**Now:** check the appropriate attribute on scales vs. keys to get to `'major'`.

Fixes #609 
**Before:** augmented sixths must be built from minor scales, but this mode correction was never set in the context of secondary Roman numeral keys.
**Now:** set `RomanNumeral.secondaryRomanNumeralKey` to the parallel minor key when building augmented sixths.

Also! Was poking around in the test directory and ran findNonUTF8.py and testPerformance.py and found some small fixes.