### PR TITLE
Corrected octaves on pitches derived in IntervalNetwork.nextPitch()

### DIFF
--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -396,7 +396,7 @@ class IntervalNetwork:
                  octaveDuplicating=False,
                  deterministic=True,
                  pitchSimplification='maxAccidental'):
-        # store each edge with and index that is incremented when added
+        # store each edge with an index that is incremented when added
         # these values have no fixed meaning but are only for reference
         self.edgeIdCount = 0
         self.nodeIdCount = 0
@@ -1211,11 +1211,12 @@ class IntervalNetwork:
         # environLocal.printDebug(['nextPitch()', 'got node Id', nodeId,
         #  'direction', direction, 'self.nodes[nodeId].degree', self.nodes[nodeId].degree,
         #  'pitchOrigin', pitchOrigin])
-
+        usedNeighbor = False
         # if no match, get the neighbor
         if (nodeId is None and getNeighbor in (
                 True, DIRECTION_ASCENDING, DIRECTION_DESCENDING, DIRECTION_BI
         )):
+            usedNeighbor = True
             lowId, highId = self.getNeighborNodeIds(pitchReference=pitchReference,
                                                     nodeName=nodeName,
                                                     pitchTarget=pitchOrigin,
@@ -1252,6 +1253,21 @@ class IntervalNetwork:
         # transfer octave from origin to new pitch derived from node
         # note: this assumes octave equivalence and may be a problem
         p.octave = pitchOrigin.octave
+
+        # correct for derived pitch crossing octave boundary
+        # https://github.com/cuthbertLab/music21/issues/319
+        alterSemitones = 0
+        degree = self.nodeIdToDegree(nodeId)
+        if alteredDegrees and degree in alteredDegrees:
+            alterSemitones = alteredDegrees[degree]['interval'].semitones
+        if (usedNeighbor and getNeighbor == DIRECTION_DESCENDING) or (
+                not usedNeighbor and direction == DIRECTION_ASCENDING):
+            while p.transpose(alterSemitones) > pitchOrigin:
+                p.octave -= 1
+        else:
+            while p.transpose(alterSemitones) < pitchOrigin:
+                p.octave += 1
+
         # pitchObj = p
         n = self.nodes[nodeId]
         # pCollect = p  # usually p, unless altered
@@ -3443,7 +3459,7 @@ class Test(unittest.TestCase):
             'E-4'
         )
 
-        # if we get the descending neighbor, we move from  c to d
+        # if we get the descending neighbor, we move from c to d
         self.assertEqual(str(net.nextPitch('c4', 1, 'c#4', 'ascending',
                                            getNeighbor='descending')), 'D4')
 
@@ -3451,13 +3467,16 @@ class Test(unittest.TestCase):
         self.assertEqual(str(net.nextPitch('c4', 1, 'a-', 'ascending',
                                            getNeighbor='ascending')), 'B4')
 
-        # if on a- and get ascending neighbor, move from g to a
+        # if on a- and get descending neighbor, move from g to a
         self.assertEqual(str(net.nextPitch('c4', 1, 'a-', 'ascending',
                                            getNeighbor='descending')), 'A4')
 
-        # if on b, ascending neighbor, move form c to b-
-        self.assertEqual(str(net.nextPitch('c4', 1, 'b', 'descending',
+        # if on b, ascending neighbor, move from c to b-
+        self.assertEqual(str(net.nextPitch('c4', 1, 'b3', 'descending',
                                            getNeighbor='ascending')), 'B-3')
+
+        # if on c-4, use mode derivation instead of neighbor, move from b4 to c4
+        self.assertEqual(str(net.nextPitch('c4', 1, 'c-4', 'ascending')), 'C4')
 
         self.assertEqual(net.getNeighborNodeIds(
             pitchReference='c4', nodeName=1, pitchTarget='c#'),
@@ -3484,7 +3503,7 @@ class Test(unittest.TestCase):
                 pitchTarget='b-', direction='descending'),
             (7, 'terminusLow'))
 
-        # if on b, descending neighbor, move form b- to a-
+        # if on b, descending neighbor, move from b- to a-
         self.assertEqual(
             str(net.nextPitch(
                 'c4', 1, 'b4', 'descending',


### PR DESCRIPTION
Fixed #319 

**Before:** next pitches derived from a node in `IntervalNetwork.nextPitch()` would have their octave copied from the node in question, which comes out wrong if stepping to the next pitch crosses an octave boundary.

**Now:** increment or decrement octaves as necessary until upper neighbors are above `pitchOrigin` or lower neighbors are below it. Only one octave adjustment should be necessary in most cases, but I didn't see a reason to rule out compound intervals -- lmk if those aren't supported/necessary to worry about here -- that's what the `while` is there for.