### PR TITLE
Enforce nonzero duration on non-grace notes when quantized

### DIFF
--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2987,7 +2987,7 @@ class Test(unittest.TestCase):
         dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
         # a file with three tracks and one conductor track
         fp = dirLib / 'test11.mid'
-        s = converter.parse(fp, forceSource=True)
+        s = converter.parse(fp)
         self.assertEqual(len(s.parts), 3)
         # metronome marks end up only on the top-most staff
         self.assertEqual(len(s.parts[0].getElementsByClass('MetronomeMark')), 4)
@@ -3227,7 +3227,7 @@ class Test(unittest.TestCase):
 
         dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
         fp = dirLib / 'test16.mid'
-        s = converter.parse(fp, forceSource=True)
+        s = converter.parse(fp)
         self.assertEqual(len(s.parts[0].voices), 2)
         els = s.parts[0].flat.getElementsByOffset(0.5)
         self.assertSequenceEqual([e.duration.quarterLength for e in els], [0, 1])

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -352,8 +352,8 @@ def midiEventsToNote(eventList, ticksPerQuarter=None, inputM21=None):
         ticksToDuration(tOff - tOn, ticksPerQuarter, n.duration)
     else:
         # environLocal.printDebug(['cannot translate found midi event with zero duration:', eOn, n])
-        # for now, substitute 0
-        n.quarterLength = 0
+        # for now, substitute grace note
+        n.getGrace(inPlace=True)
 
     return n
 
@@ -521,7 +521,7 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
             v = volume.Volume(velocity=eOn.velocity)
             v.velocityIsRelative = False  # velocity is absolute coming from
             volumes.append(v)
-    # assume it is  a flat list
+    # assume it is a flat list
     else:
         onEvents = eventList[:(len(eventList) // 2)]
         offEvents = eventList[(len(eventList) // 2):]
@@ -545,8 +545,8 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
     else:
         # environLocal.printDebug(['cannot translate found midi event with zero duration:',
         #                         eventList, c])
-        # for now, substitute 0
-        c.quarterLength = 0
+        # for now, get grace
+        c.getGrace(inPlace=True)
     return c
 
 
@@ -1669,7 +1669,7 @@ def midiTrackToStream(mt,
     # composite = []
     chordSub = None
     i = 0
-    iGathered = []  # store a lost of indexes of gathered values put into chords
+    iGathered = []  # store a list of indexes of gathered values put into chords
     voicesRequired = False
     if len(notes) > 1:
         # environLocal.printDebug(['\n', 'midiTrackToStream(): notes', notes])
@@ -2987,7 +2987,7 @@ class Test(unittest.TestCase):
         dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
         # a file with three tracks and one conductor track
         fp = dirLib / 'test11.mid'
-        s = converter.parse(fp)
+        s = converter.parse(fp, forceSource=True)
         self.assertEqual(len(s.parts), 3)
         # metronome marks end up only on the top-most staff
         self.assertEqual(len(s.parts[0].getElementsByClass('MetronomeMark')), 4)
@@ -3221,13 +3221,13 @@ class Test(unittest.TestCase):
         '''
         Musescore places zero duration notes in multiple voice scenarios
         to represent double stemmed notes. Avoid false positives for extra voices.
-        # https://github.com/cuthbertLab/music21/issues/600
+        https://github.com/cuthbertLab/music21/issues/600
         '''
         from music21 import converter
 
         dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
         fp = dirLib / 'test16.mid'
-        s = converter.parse(fp)
+        s = converter.parse(fp, forceSource=True)
         self.assertEqual(len(s.parts[0].voices), 2)
         els = s.parts[0].flat.getElementsByOffset(0.5)
         self.assertSequenceEqual([e.duration.quarterLength for e in els], [0, 1])

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -8195,6 +8195,10 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                             ql = 0
                         unused_error, qlNew, signedError = bestMatch(
                             float(ql), quarterLengthDivisors)
+                        # Enforce nonzero duration for non-grace notes
+                        if qlNew == 0 and not e.duration.isGrace:
+                            qlNew = 1 / max(quarterLengthDivisors)
+                            signedError = ql - qlNew
                         e.duration.quarterLength = qlNew
                         if (hasattr(e, 'editorial')
                                 and signedError != 0):

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -3637,6 +3637,19 @@ class Test(unittest.TestCase):
 
                     [8, 6])  # snap to 0.125 and 0.1666666
 
+    def testQuantizeMinimumDuration(self):
+        '''
+        Notes of nonzero duration should retain a nonzero
+        duration after quantizing.
+        '''
+        from music21 import converter
+
+        dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
+        fp = dirLib / 'test15.mid'  # 3 16ths, 2 32nds
+        s = converter.parse(fp, quarterLengthDivisors=[2])
+        self.assertEqual(s.flat.notes[-1].duration.quarterLength, 0.5)
+        self.assertEqual(s.flat.notes[-1].editorial.quarterLengthQuantizationError, .125 - .5)
+
     def testAnalyze(self):
         from music21 import corpus
 


### PR DESCRIPTION
Fixes #629 

**Before:** `Stream.quantize(processDurations=True)` would allow durations of 0 on non-grace notes. By contrast, sequencers and notation programs such as Logic Pro and Finale enforce a minimum nonzero duration when quantizing MIDI:

> For example, a note with a short note value, such as a 32nd note, can only be displayed at its original length if Quantize is set to 32 or shorter. If Quantize is set to 8, the 32nd note is displayed as an eighth note (the shortest note value displayed at that Quantize setting). 
https://support.apple.com/guide/logicpro/quantize-lgcp8535c422/mac


**After:** Unless a note's duration `isGrace`, `Stream.quantize(processDurations=True)` uses the largest value of `quarterLengthDivisors` to derive and set a nonzero duration.
