### PR TITLE
Refs #633: Give precedence to longer words; Allow Alto and Bass abbrevs

### DIFF
--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -2006,7 +2006,7 @@ def fromString(instrumentString):
 
     >>> t4 = instrument.fromString('I <3 music saxofono tenore go beavers')
     >>> t4
-    <music21.instrument.TenorSaxophone 'I <3 music saxofono tenore go beavers'>
+    <music21.instrument.Saxophone 'I <3 music saxofono tenore go beavers'>
 
     Some more demos:
 
@@ -2061,6 +2061,19 @@ def fromString(instrumentString):
     >>> t11 = instrument.fromString('Cl. in B-flat')
     >>> t11.__class__ == t10.__class__
     True
+
+    Giving precedence to longer words allows both of these cases to pass:
+
+    >>> t12 = instrument.fromString('Clarinet in A')
+    >>> t12.__class__ == t10.__class__
+    True
+    >>> t12.transposition
+    <music21.interval.Interval m-3>
+
+    >>> t13 = instrument.fromString('A')
+    >>> t13
+    <music21.instrument.Alto 'A'>
+
     '''
     # pylint: disable=undefined-variable
     from music21.languageExcerpts import instrumentLookup
@@ -2090,7 +2103,7 @@ def fromString(instrumentString):
             thisInstrument = thisInstClass()
             thisBestName = thisInstrument.bestName().lower()
             if (bestInstClass is None
-                    or len(thisBestName.split()) >= len(bestName.split())
+                    or len(thisBestName.split()[0]) >= len(bestName.split()[0])
                     and not issubclass(bestInstClass, thisInstClass)):
                 # priority is also given to same length instruments which fall later
                 # on in the string (i.e. Bb Piccolo Trumpet)

--- a/music21/languageExcerpts/instrumentLookup.py
+++ b/music21/languageExcerpts/instrumentLookup.py
@@ -15,12 +15,14 @@ _DOC_IGNORE_MODULE_OR_PACKAGE = True
 
 # noinspection SpellCheckingInspection
 abbreviationToBestName = {
+    'a': 'alto',
     'a sax': 'alto saxophone',
     'ac b': 'acoustic bass',
     'ac gtr': 'acoustic guitar',
     'acc': 'accordion',
     'accdn': 'accordion',
     'arp': 'harp',
+    'b': 'bass',
     'b dr': 'bass drum',
     'bcl': 'bass clarinet',
     'b cl': 'bass clarinet',


### PR DESCRIPTION
The code comments surrounding this change suggest to me the original intent was to give precedence to longer words when parsing instrument names--or at least a subsequent word with the same number of letters (Piccolo Trumpet). As written, the check `len(bestName.split())` is pointless; it always returns 1 because it's only fed substrings already split.

This means we can support `A` and `B` in the instrument lookups without failing `Clarinet in A`.

~~Finally, and this was a head scratcher, `instrument.fromString('I <3 music saxofono tenore go beavers')` fails for me locally, and I can't figure out why it's not failing on CI or on multiprocessTest.py. Is this cached somewhere? The existing behavior was to normalize to `Tenor`, and with this patch it normalizes to `Saxophone`, hurrah, but I never saw how it could normalize to `TenorSaxophone`. Any leads?~~ Helps if you spell correctly at a shell prompt.

