### PR TITLE
Help Mac users find and run the Configuration Assistant

### DIFF
--- a/documentation/source/installing/installMac.rst
+++ b/documentation/source/installing/installMac.rst
@@ -88,10 +88,22 @@ Exit python by typing `quit()`.
 Starting the Configuration Assistant
 -----------------------------------------------------
 
-Double click on the installer.command file to start.
-This file should open a Terminal window and begin running the Configuration Assistant.
-As this is a program downloaded from the Internet, the System will likely warn you about
-running it. Go ahead and click "Open".
+If you downloaded the `music21` project from Github, the project folder will
+contain a script that runs a configuration assistant. Double click on the
+installer.command file to start. This should open a Terminal window and run
+the Configuration Assistant. As this is a program downloaded from the Internet,
+the System will likely warn you about running it. Go ahead and click "Open".
+
+More likely, if you only installed the `music21` package with `pip` (for
+instance, by running `sudo pip3 install music21`), you may run the Configuration
+Assistant from a Python shell after importing `music21`, like this::
+
+    import music21
+    music21.configure.run()
+
+Otherwise, you may launch the assistant from a command prompt::
+
+    python3 -m music21.configure
 
 After waiting a few moments to load modules, the Configuration Assistant begins.
 

--- a/documentation/source/installing/installWindows.rst
+++ b/documentation/source/installing/installWindows.rst
@@ -67,12 +67,12 @@ and then restarting from scratch).
 
 You should then configure `music21` to find your helper programs
 such as MuseScore or Finale.  In IDLE
-type:
+type::
 
     import music21
     music21.configure.run()
 
-or in the command prompt, type:
+or in the command prompt, type::
 
     python3 -m music21.configure
 


### PR DESCRIPTION
Fixed #526 Fixed #354 (duplicates)

Mac users were having trouble finding `installer.command` because `pip` doesn't install it, and the Mac install instructions don't mention any other way to find and run the configuration assistant.

Also fixed the lack of line break in the Windows installation instructions by treating it as a quoted code block.