### PR TITLE
Make adjustMinorVIandVIIByQuality() private; unsharpen root in figure when sharpening root

### DIFF
--- a/music21/roman.py
+++ b/music21/roman.py
@@ -1150,6 +1150,11 @@ class RomanNumeral(harmony.Harmony):
     >>> [str(p) for p in minoriiiB.pitches]
     ['G4', 'B-4', 'D5']
 
+    `caseMatters=False` will prevent `sixthMinor` or `seventhMinor` from having effect.
+    >>> vii = roman.RomanNumeral('viio', 'a', caseMatters=False, seventhMinor=roman.Minor67Default.QUALITY)
+    >>> [str(p) for p in vii.pitches]
+    ['G5', 'B-5', 'D-6']
+
     Can also take a scale object, here we build a first-inversion chord
     on the raised-three degree of D-flat major, that is, F#-major (late
     Schubert would be proud.)

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2039,15 +2039,14 @@ class RomanNumeral(harmony.Harmony):
 
         return workingFigure, useScale
 
-    def _adjustMinorVIandVIIByQuality(self, workingFigure, useScale):
+    def adjustMinorVIandVIIByQuality(self, useScale):
         '''
-        fix minor vi and vii to always be #vi and #vii if `.caseMatters`.
+        Fix minor vi and vii to always be #vi and #vii if `.caseMatters`.
 
         >>> rn = roman.RomanNumeral()
         >>> rn.scaleDegree = 6
         >>> rn.impliedQuality = 'minor'
-        >>> rn._adjustMinorVIandVIIByQuality('', key.Key('c'))
-        ''
+        >>> rn.adjustMinorVIandVIIByQuality(key.Key('c'))
         >>> rn.frontAlterationTransposeInterval
         <music21.interval.Interval A1>
 
@@ -2058,12 +2057,25 @@ class RomanNumeral(harmony.Harmony):
         >>> rn = roman.RomanNumeral()
         >>> rn.scaleDegree = 6
         >>> rn.impliedQuality = 'major'
-        >>> rn._adjustMinorVIandVIIByQuality('', key.Key('c'))
-        ''
+        >>> rn.adjustMinorVIandVIIByQuality(key.Key('c'))
         >>> rn.frontAlterationTransposeInterval is None
         True
         >>> rn.frontAlterationAccidental is None
         True
+
+        Changed in v.6.2: hook to private function with new signature for backwards compatibility
+        '''
+        unused_workingFigure = self._adjustMinorVIandVIIByQuality('', useScale)
+
+    def _adjustMinorVIandVIIByQuality(self, workingFigure, useScale) -> str:
+        '''
+        Fix minor vi and vii to always be #vi and #vii if `.caseMatters`.
+
+        Made private in v.6.2 when `workingFigure` was added to the signature
+        and returned.
+
+        Altering `workingFigure` became necessary to handle these chromatic figures:
+        https://github.com/cuthbertLab/music21/issues/437
 
         >>> rn = roman.RomanNumeral('viio#6', 'a')
         >>> ' '.join([p.name for p in rn.pitches])

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -918,7 +918,11 @@ def romanNumeralFromChord(chordObj,
 
 class Minor67Default(enum.Enum):
     '''
-    Showing how sixthMinor affects the interpretation of `vi`
+    Enumeration that can be passed into :class:`~music21.roman.RomanNumeral`'s
+    keyword arguments `sixthMinor` and `seventhMinor` to define how Roman numerals
+    on the sixth and seventh scale degrees are parsed in minor.
+
+    Showing how `sixthMinor` affects the interpretation of `vi`:
 
     >>> vi = lambda sixChord, quality: ' '.join(p.name for p in roman.RomanNumeral(
     ...                                   sixChord, 'c',
@@ -2089,19 +2093,24 @@ class RomanNumeral(harmony.Harmony):
         >>> rn = roman.RomanNumeral('viio#853', 'a')
         >>> ' '.join([p.name for p in rn.pitches])
         'G# B D'
+        >>> rn = roman.RomanNumeral('viio##853', 'a')
+        >>> ' '.join([p.name for p in rn.pitches])
+        'G# B D G##'
         '''
-        def sharpen(workingFigure):
+        def sharpen(wFig):
             changeFrontAlteration(interval.Interval('A1'), 1)
-            # Unsharpen the root for inverted figures to avoid double-sharpening
-            if '#2' in workingFigure:
-                workingFigure = workingFigure.replace('#2', '2')
-            elif '#4' in workingFigure:
-                workingFigure = workingFigure.replace('#4', '4')
-            elif '#6' in workingFigure:
-                workingFigure = workingFigure.replace('#6', '6')
+            # If root is in the figure, unsharpen to avoid double-sharpening
+            if '##' in wFig:
+                wFig = wFig.replace('##8', '#8')
+            elif '#2' in wFig:
+                wFig = wFig.replace('#2', '2')
+            elif '#4' in wFig:
+                wFig = wFig.replace('#4', '4')
+            elif '#6' in wFig:
+                wFig = wFig.replace('#6', '6')
             else:
-                workingFigure = workingFigure.replace('#8', '')
-            return workingFigure
+                wFig = wFig.replace('#8', '')
+            return wFig
 
         # def flatten():
         #    changeFrontAlteration(interval.Interval('-A1'), -1)

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2063,7 +2063,7 @@ class RomanNumeral(harmony.Harmony):
         >>> rn.frontAlterationAccidental is None
         True
 
-        Changed in v.6.2: hook to private function with new signature for backwards compatibility
+        Changed in v.6.4: public function became hook to private function having the actual guts
         '''
         unused_workingFigure = self._adjustMinorVIandVIIByQuality('', useScale)
 
@@ -2071,7 +2071,7 @@ class RomanNumeral(harmony.Harmony):
         '''
         Fix minor vi and vii to always be #vi and #vii if `.caseMatters`.
 
-        Made private in v.6.2 when `workingFigure` was added to the signature
+        Made private in v.6.4 when `workingFigure` was added to the signature
         and returned.
 
         Altering `workingFigure` became necessary to handle these chromatic figures:

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -1151,7 +1151,8 @@ class RomanNumeral(harmony.Harmony):
     ['G4', 'B-4', 'D5']
 
     `caseMatters=False` will prevent `sixthMinor` or `seventhMinor` from having effect.
-    >>> vii = roman.RomanNumeral('viio', 'a', caseMatters=False, seventhMinor=roman.Minor67Default.QUALITY)
+    >>> vii = roman.RomanNumeral('viio', 'a', caseMatters=False,
+    ...                           seventhMinor=roman.Minor67Default.QUALITY)
     >>> [str(p) for p in vii.pitches]
     ['G5', 'B-5', 'D-6']
 


### PR DESCRIPTION
Fixes #437

The subroutine `sharpen()` was not unsharpening roots from figures representing inversions when sharpening the root. This led to the need to pass in and return `workingFigure`, which led me to question whether this method serves any purpose being public, save for its useful documentation about `Minor67Default`, since this is extremely low-level work. So I moved the documentation to `Minor67Default` and made the method private for consistency with its neighbors, and provided a backwards compatible public stub.

