### PR TITLE
Change the name of the default scratch directory.

### DIFF
--- a/music21/environment.py
+++ b/music21/environment.py
@@ -484,7 +484,7 @@ class _EnvironmentCore:
     def getDefaultRootTempDir(self):
         # noinspection SpellCheckingInspection
         '''
-        returns whatever tempfile.gettempdir() returns plus 'music21'.
+        returns whatever tempfile.gettempdir() returns plus 'music21-$UID'.
 
         Creates the subdirectory if it doesn't exist:
 
@@ -496,11 +496,11 @@ class _EnvironmentCore:
 
         >>> import os
         >>> e = environment.Environment()
-        >>> e.getDefaultRootTempDir() == pathlib.Path(t) / 'music21'
+        >>> e.getDefaultRootTempDir() == pathlib.Path(t) / 'music21-$UID'
         True
         '''
         # this returns the root temp dir; this does not create a new dir
-        dstDir = pathlib.Path(tempfile.gettempdir()) / 'music21'
+        dstDir = pathlib.Path(tempfile.gettempdir()) / 'music21-{}'.format(os.getuid())
         # if this path already exists, we have nothing more to do
         if dstDir.exists():
             return dstDir


### PR DESCRIPTION
Hi,

I find in the multi-user environment such as a server, all users share the same scratch directory (/tmp/music21 for Linux) by default will cause permission problems because the default permission of a newly created directory doesn't allow "write" from others.

I know music21 provides a way which let users custom their scratch directory. But I think this problem can be avoided by just making few changes.

Hence, I change the name of the default scratch directory to music21-$UID to avoid different users sharing the same directory.
For example, the directory /tmp/music21-1000 will be created for the user with UID of 1000.

I test and make sure that this way works. Hope you guys agree with me and accept this code.

Thanks,
Chih-Pin