### PR TITLE
Start of a cleanup for ABC parsing

### DIFF
--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -59,7 +59,7 @@ import io
 import pathlib
 import re
 import unittest
-from typing import Union
+from typing import Union, Optional, List, Tuple, Any
 
 from music21 import common
 from music21 import environment
@@ -135,19 +135,17 @@ class ABCToken(prebase.ProtoM21Object):
     adjustments to all tokens, then calls :meth:`~music21.abcFormat.ABCToken.parse` on all tokens.
 
     The source ABC string itself is stored in self.src
-
     '''
-
     def __init__(self, src=''):
-        self.src = src  # store source character sequence
+        self.src: str = src  # store source character sequence
 
     def _reprInternal(self):
         return repr(self.src)
 
-    def stripComment(self, strSrc):
+    @staticmethod
+    def stripComment(strSrc):
         '''
         removes ABC-style comments from a string:
-
 
         >>> ao = abcFormat.ABCToken()
         >>> ao.stripComment('asdf')
@@ -158,6 +156,13 @@ class ABCToken(prebase.ProtoM21Object):
         'asdf  '
         >>> ao.stripComment('[ceg]% this chord appears 50% more often than other chords do')
         '[ceg]'
+
+        This is a static method, so it can also be called on the class itself:
+
+        >>> abcFormat.ABCToken.stripComment('b1 % a b-flat actually')
+        'b1 '
+
+        Changed: v6.2 -- made a staticmethod
         '''
         if '%' in strSrc:
             return strSrc.split('%')[0]
@@ -181,14 +186,35 @@ class ABCToken(prebase.ProtoM21Object):
 
 
 class ABCMetadata(ABCToken):
+    '''
+    Defines a token of metadata in ABC.
+
+    >>> md = abcFormat.ABCMetadata('I:linebreak')
+    >>> md.src
+    'I:linebreak'
+
+    Has two attributes, `tag` and `data` which are strings or None.
+    Initially both are set to None:
+
+    >>> print(md.tag)
+    None
+
+    After calling `preParse()`, these are separated:
+
+    >>> md.preParse()
+    >>> md.tag
+    'I'
+    >>> md.data
+    'linebreak'
+    '''
     # given a logical unit, create an object
     # may be a chord, notes, metadata, bars
     def __init__(self, src=''):
         super().__init__(src)
-        self.tag = None
-        self.data = None
+        self.tag: Optional[str] = None
+        self.data: Optional[str] = None
 
-    def preParse(self):
+    def preParse(self) -> None:
         '''
         Called before contextual adjustments and needs
         to have access to data.  Divides a token into
@@ -209,16 +235,17 @@ class ABCMetadata(ABCToken):
     def parse(self):
         pass
 
-    def isDefaultNoteLength(self):
-        '''Returns True if the tag is "L", False otherwise.
+    def isDefaultNoteLength(self) -> bool:
+        '''
+        Returns True if the tag is "L", False otherwise.
         '''
         if self.tag == 'L':
             return True
         return False
 
-    def isReferenceNumber(self):
-        '''Returns True if the tag is "X", False otherwise.
-
+    def isReferenceNumber(self) -> bool:
+        '''
+        Returns True if the tag is "X", False otherwise.
 
         >>> x = abcFormat.ABCMetadata('X:5')
         >>> x.preParse()
@@ -231,7 +258,7 @@ class ABCMetadata(ABCToken):
             return True
         return False
 
-    def isMeter(self):
+    def isMeter(self) -> bool:
         '''
         Returns True if the tag is "M" for meter, False otherwise.
         '''
@@ -239,7 +266,7 @@ class ABCMetadata(ABCToken):
             return True
         return False
 
-    def isTitle(self):
+    def isTitle(self) -> bool:
         '''
         Returns True if the tag is "T" for title, False otherwise.
         '''
@@ -247,7 +274,7 @@ class ABCMetadata(ABCToken):
             return True
         return False
 
-    def isComposer(self):
+    def isComposer(self) -> bool:
         '''
         Returns True if the tag is "C" for composer, False otherwise.
         '''
@@ -255,7 +282,7 @@ class ABCMetadata(ABCToken):
             return True
         return False
 
-    def isOrigin(self):
+    def isOrigin(self) -> bool:
         '''
         Returns True if the tag is "O" for origin, False otherwise.
         This value is set in the Metadata `localOfComposition` of field.
@@ -264,7 +291,7 @@ class ABCMetadata(ABCToken):
             return True
         return False
 
-    def isVoice(self):
+    def isVoice(self) -> bool:
         '''
         Returns True if the tag is "V", False otherwise.
         '''
@@ -272,8 +299,9 @@ class ABCMetadata(ABCToken):
             return True
         return False
 
-    def isKey(self):
-        '''Returns True if the tag is "K", False otherwise.
+    def isKey(self) -> bool:
+        '''
+        Returns True if the tag is "K", False otherwise.
         Note that in some cases a Key will encode clef information.
 
         (example from corpus: josquin/laDeplorationDeLaMorteDeJohannesOckeghem.abc)
@@ -282,19 +310,20 @@ class ABCMetadata(ABCToken):
             return True
         return False
 
-    def isTempo(self):
-        '''Returns True if the tag is "Q" for tempo, False otherwise.
+    def isTempo(self) -> bool:
+        '''
+        Returns True if the tag is "Q" for tempo, False otherwise.
         '''
         if self.tag == 'Q':
             return True
         return False
 
     def getTimeSignatureParameters(self):
-        '''If there is a time signature representation available,
+        '''
+        If there is a time signature representation available,
         get a numerator, denominator and an abbreviation symbol.
         To get a music21 :class:`~music21.meter.TimeSignature` object, use
         the :meth:`~music21.abcFormat.ABCMetadata.getTimeSignatureObject` method.
-
 
         >>> am = abcFormat.ABCMetadata('M:2/2')
         >>> am.preParse()
@@ -317,10 +346,9 @@ class ABCMetadata(ABCToken):
         >>> am.preParse()
         >>> am.getTimeSignatureParameters()
         (4, 4, 'normal')
-
         '''
         if not self.isMeter():
-            raise ABCTokenException('no time signature associated with this meta-data')
+            raise ABCTokenException('no time signature associated with this metadata')
 
         if self.data.lower() == 'none':
             return None
@@ -342,18 +370,23 @@ class ABCMetadata(ABCToken):
     def getTimeSignatureObject(self):
         '''
         Return a music21 :class:`~music21.meter.TimeSignature`
-        object for this metadata tag.
-
+        object for this metadata tag, if isMeter is True, otherwise raise exception.
 
         >>> am = abcFormat.ABCMetadata('M:2/2')
         >>> am.preParse()
         >>> ts = am.getTimeSignatureObject()
         >>> ts
         <music21.meter.TimeSignature 2/2>
+
+        >>> am = abcFormat.ABCMetadata('Q:40')
+        >>> am.getTimeSignatureObject()
+        Traceback (most recent call last):
+        music21.abcFormat.ABCTokenException: no time signature associated with
+            this non-metrical metadata.
         '''
         if not self.isMeter():
             raise ABCTokenException(
-                'no time signature associated with this non-metrical meta-data')
+                'no time signature associated with this non-metrical metadata.')
         from music21 import meter
         parameters = self.getTimeSignatureParameters()
         if parameters is None:
@@ -426,7 +459,7 @@ class ABCMetadata(ABCToken):
         from music21 import key
 
         if not self.isKey():
-            raise ABCTokenException('no key signature associated with this meta-data')
+            raise ABCTokenException('no key signature associated with this metadata.')
 
         # abc uses b for flat in key spec only
         keyNameMatch = ['c', 'g', 'd', 'a', 'e', 'b', 'f#', 'g#', 'a#',
@@ -517,7 +550,7 @@ class ABCMetadata(ABCToken):
         <music21.key.Key of g minor>
         '''
         if not self.isKey():
-            raise ABCTokenException('no key signature associated with this meta-data')
+            raise ABCTokenException('no key signature associated with this metadata')
         from music21 import key
         # return values of getKeySignatureParameters are sharps, mode
         # need to unpack list w/ *
@@ -528,14 +561,13 @@ class ABCMetadata(ABCToken):
         else:
             return ks.asKey(mode)
 
-    def getClefObject(self):
+    def getClefObject(self) -> Tuple[Optional['music21.clef.Clef'], Optional[int]]:
         '''
         Extract any clef parameters stored in the key metadata token.
         Assume that a clef definition suggests a transposition.
         Return both the Clef and the transposition.
 
         Returns a two-element tuple of clefObj and transposition in semitones
-
 
         >>> am = abcFormat.ABCMetadata('K:Eb Lydian bass')
         >>> am.preParse()
@@ -544,7 +576,7 @@ class ABCMetadata(ABCToken):
         '''
         if not self.isKey():
             raise ABCTokenException(
-                'no key signature associated with this meta-data; needed for getting Clef Object')
+                'no key signature associated with this metadata; needed for getting Clef Object')
 
         # placing this import in method for now; key.py may import this module
         clefObj = None
@@ -561,10 +593,9 @@ class ABCMetadata(ABCToken):
         # if not defined, returns None, None
         return clefObj, t
 
-    def getMetronomeMarkObject(self):
+    def getMetronomeMarkObject(self) -> Optional['music21.tempo.MetronomeMark']:
         '''
         Extract any tempo parameters stored in a tempo metadata token.
-
 
         >>> am = abcFormat.ABCMetadata('Q: "Allegro" 1/4=120')
         >>> am.preParse()
@@ -593,7 +624,7 @@ class ABCMetadata(ABCToken):
 
         '''
         if not self.isTempo():
-            raise ABCTokenException('no tempo associated with this meta-data')
+            raise ABCTokenException('no tempo associated with this metadata')
         mmObj = None
         from music21 import tempo
         # see if there is a text expression in quotes
@@ -644,10 +675,9 @@ class ABCMetadata(ABCToken):
         # returns None if not defined
         return mmObj
 
-    def getDefaultQuarterLength(self):
+    def getDefaultQuarterLength(self) -> float:
         r'''
         If there is a quarter length representation available, return it as a floating point value
-
 
         >>> am = abcFormat.ABCMetadata('L:1/2')
         >>> am.preParse()
@@ -718,7 +748,7 @@ class ABCMetadata(ABCToken):
                 return 0.5  # otherwise it is an eighth note
         else:  # pragma: no cover
             raise ABCTokenException(
-                'no quarter length associated with this meta-data: %s' % self.data)
+                'no quarter length associated with this metadata: %s' % self.data)
 
 
 class ABCBar(ABCToken):
@@ -1279,7 +1309,11 @@ class ABCNote(ABCToken):
         else:
             return [], strSrc
 
-    def getPitchName(self, strSrc, forceKeySignature=None):
+    def getPitchName(
+        self,
+        strSrc: str,
+        forceKeySignature=None
+    ) -> Tuple[Optional[str], Union[bool, None]]:
         '''
         Given a note or rest string without a chord symbol,
         return a music21 pitch string or None (if a rest),
@@ -1309,10 +1343,13 @@ class ABCNote(ABCToken):
         ('G-7', True)
         >>> an.getPitchName('=c')
         ('Cn5', True)
+
+        If pitch is a rest (z) then the Pitch name is None:
+
         >>> an.getPitchName('z4')
         (None, None)
 
-        Grace note
+        Grace note:
 
         >>> an.getPitchName('{c}')
         ('C5', None)
@@ -1324,6 +1361,9 @@ class ABCNote(ABCToken):
         >>> an.activeKeySignature = key.KeySignature(3)
         >>> an.getPitchName('c')
         ('C#5', False)
+
+
+        Illegal pitch names raise an ABCHandlerException
 
         >>> an.getPitchName('x')
         Traceback (most recent call last):
@@ -1418,17 +1458,21 @@ class ABCNote(ABCToken):
 
         # making upper here, but this is not relevant
         if carriedAccString:
-            pStr = '%s%s%s' % (name.upper(), carriedAccString, octave)
+            pStr = f'{name.upper()}{carriedAccString}{octave}'
         else:
-            pStr = '%s%s%s' % (name.upper(), accString, octave)
+            pStr = f'{name.upper()}{accString}{octave}'
 
-        # store in global cache
-        _pitchTranslationCache[(strSrc,
-                                self.carriedAccidental,
-                                str(activeKeySignature))] = pStr, accidentalDisplayStatus
-        return pStr, accidentalDisplayStatus
+        # store in global cache for faster speed
+        _cacheKey = (
+            strSrc,
+            self.carriedAccidental,
+            str(activeKeySignature)
+        )
 
-    def getQuarterLength(self, strSrc, forceDefaultQuarterLength=None):
+        _pitchTranslationCache[_cacheKey] = (pStr, accidentalDisplayStatus)
+        return (pStr, accidentalDisplayStatus)
+
+    def getQuarterLength(self, strSrc, forceDefaultQuarterLength=None) -> float:
         '''
         Called with parse(), after context processing, to calculate duration
 
@@ -1487,7 +1531,7 @@ class ABCNote(ABCToken):
 
         numStr = []
         for c in strSrc:
-            if c.isdigit() or c in '/':
+            if c.isdigit() or c == '/':
                 numStr.append(c)
         numStr = ''.join(numStr)
         numStr = numStr.strip()
@@ -1552,8 +1596,11 @@ class ABCNote(ABCToken):
 
         return ql
 
-    def parse(self, forceDefaultQuarterLength=None,
-                    forceKeySignature=None):
+    def parse(
+        self,
+        forceDefaultQuarterLength=None,
+        forceKeySignature=None
+    ) -> None:
         # environLocal.printDebug(['parse', self.src])
         self.chordSymbols, nonChordSymStr = self._splitChordSymbols(self.src)
         # get pitch name form remaining string
@@ -1638,24 +1685,41 @@ class ABCChord(ABCNote):
 
 # ------------------------------------------------------------------------------
 class ABCHandler:
-    # divide elements of a character stream into objects and handle
-    # store in a list, and pass global information to components
-    # Optionally, specify the (major, minor, patch) version of ABC to process--
-    # e.g., (1.2.0). If not set, default ABC 1.3 parsing is performed.
-    def __init__(self, abcVersion=None):
+    '''
+    An ABCHandler is able to divide elements of a character stream into objects and handle
+    store in a list, and passes global information to components
+
+    Optionally, specify the (major, minor, patch) version of ABC to process--
+    e.g., (1.2.0). If not set, default ABC 1.3 parsing is performed.
+
+    If lineBreaksDefinePhrases is True then new lines within music elements
+    define new phrases.  This is useful for parsing extra information from
+    the Essen Folksong repertory
+
+    New in v6.2 -- lineBreaksDefinePhrases -- does not yet do anything
+    '''
+    def __init__(self, abcVersion=None, lineBreaksDefinePhrases=False):
         # tokens are ABC objects import n a linear stream
         self.abcVersion = abcVersion
         self.abcDirectives = {}
         self.tokens = []
         self.activeParens = []
         self.activeSpanners = []
+        self.lineBreaksDefinePhrases = lineBreaksDefinePhrases
+        self.pos = -1
+        self.skipAhead = 0
+        self.isFirstComment = True
+        self.strSrc = ''
+        self.srcLen = len(self.strSrc)  # just documenting this.
+        self.currentCollectStr = ''
 
     @staticmethod
-    def _getLinearContext(strSrc, i):
+    def _getLinearContext(source, i: int) -> Tuple[Any, Any, Any, Any]:
         '''
-        Find the local context of a string or list of objects
+        Find the local context of a string or iterable of objects
         beginning at a particular index.
-        Returns charPrev, charThis, charNext, charNextNext.
+
+        Returns a tuple of charPrev, charThis, charNext, charNextNext.
 
         Staticmethod
 
@@ -1669,7 +1733,7 @@ class ABCHandler:
         >>> abcFormat.ABCHandler._getLinearContext('12345', 4)
         ('4', '5', None, None)
 
-        >>> ah._getLinearContext([32, None, 8, 11, 53], 4)
+        >>> abcFormat.ABCHandler._getLinearContext([32, None, 8, 11, 53], 4)
         (11, 53, None, None)
         >>> ah._getLinearContext([32, None, 8, 11, 53], 2)
         (None, 8, 11, 53)
@@ -1677,61 +1741,59 @@ class ABCHandler:
         (None, 32, None, 8)
         '''
         # Note: this is performance critical method
-
-        lastIndex = len(strSrc) - 1
+        lastIndex = len(source) - 1
         if i > lastIndex:
-            raise ABCHandlerException('bad index value: %d max is %d' % (i, lastIndex))
+            raise ABCHandlerException(f'bad index value {i}, max is {lastIndex}')
 
-        # find local area of string
+        # find local area of iterable
+        cPrev = None
         if i > 0:
-            cPrev = strSrc[i - 1]
-        else:
-            cPrev = None
-        # set this characters
-        c = strSrc[i]
+            cPrev = source[i - 1]
+
+        # set current characters or items
+        c = source[i]
 
         cNext = None
-        if i < len(strSrc) - 1:
-            cNext = strSrc[i + 1]
+        if i < len(source) - 1:
+            cNext = source[i + 1]
 
-        # get 2 chars forward
+        # get 2 entries forward
         cNextNext = None
-        if i < len(strSrc) - 2:
-            cNextNext = strSrc[i + 2]
+        if i < len(source) - 2:
+            cNextNext = source[i + 2]
 
         return cPrev, c, cNext, cNextNext
         # return cPrevNotSpace, cPrev, c, cNext, cNextNotSpace, cNextNext
 
     @staticmethod
-    def _getNextLineBreak(strSrc, i):
-        '''
+    def _getNextLineBreak(strSrc: str, i: int) -> Optional[int]:
+        r'''
         Return index of next line break after character i.
 
         Staticmethod
 
         >>> ah = abcFormat.ABCHandler()
-        >>> strSrc = 'de  we\\n wer bfg\\n'
-        >>> ah._getNextLineBreak(strSrc, 0)
+        >>> inputString = 'de  we\n wer bfg\n'
+        >>> ah._getNextLineBreak(inputString, 0)
         6
-        >>> strSrc[0:6]
+        >>> inputString[0:6]
         'de  we'
 
         from last line break
 
-        >>> abcFormat.ABCHandler._getNextLineBreak(strSrc, 6)
+        >>> abcFormat.ABCHandler._getNextLineBreak(inputString, 6)
         15
-        >>> strSrc[ah._getNextLineBreak(strSrc, 0):]
-        '\\n wer bfg\\n'
+        >>> inputString[ah._getNextLineBreak(inputString, 0):]
+        '\n wer bfg\n'
         '''
         lastIndex = len(strSrc) - 1
-        j = i + 1  # start with next
-        while True:
-            if j > lastIndex or strSrc[j] == '\n':
-                return j  # will increment to next char on loop
-            j += 1
+        for j in range(i + 1, lastIndex + 1):
+            if strSrc[j] == '\n':
+                return j
+        return lastIndex + 1
 
     @staticmethod
-    def barlineTokenFilter(token):
+    def barlineTokenFilter(token: str) -> List[ABCBar]:
         '''
         Some single barline tokens are better replaced
         with two tokens. This method, given a token,
@@ -1748,6 +1810,11 @@ class ABCHandler:
 
         >>> abcFormat.ABCHandler.barlineTokenFilter(':|1')
         [<music21.abcFormat.ABCBar ':|'>, <music21.abcFormat.ABCBar '[1'>]
+
+        If nothing matches, the original token is returned as an ABCBar object:
+
+        >>> abcFormat.ABCHandler.barlineTokenFilter('hi')
+        [<music21.abcFormat.ABCBar 'hi'>]
         '''
         post = []
         if token == '::':
@@ -1777,7 +1844,7 @@ class ABCHandler:
     # --------------------------------------------------------------------------
     # token processing
 
-    def _accidentalPropagation(self):
+    def _accidentalPropagation(self) -> str:
         '''
         Determine how accidentals should 'carry through the measure.'
 
@@ -1795,13 +1862,134 @@ class ABCHandler:
             return self.abcDirectives['propagate-accidentals']
         return 'pitch'  # Default per abc 2.1 standard
 
-    def tokenize(self, strSrc):
+    def parseCommentForVersionInformation(self, commentLine: str):
+        '''
+        If this is the first comment then searches for a version
+        match and set it as .abcVersion
+
+        If not isFirstComment then does nothing:
+
+        >>> ah = abcFormat.ABCHandler()
+        >>> ah.abcVersion is None
+        True
+        >>> ah.isFirstComment
+        True
+
+        >>> ah.parseCommentForVersionInformation('%abc-2.3.2')
+        >>> ah.abcVersion
+        (2, 3, 2)
+        >>> ah.isFirstComment
+        False
+
+        Now will do nothing since isFirstComment is False
+
+        >>> ah.parseCommentForVersionInformation('%abc-4.9.7')
+        >>> ah.abcVersion
+        (2, 3, 2)
+        '''
+        if not self.isFirstComment:
+            return
+        self.isFirstComment = False
+        verMats = reAbcVersion.match(commentLine)
+        if verMats:
+            abcMajor = int(verMats.group(2))
+            abcMinor = int(verMats.group(3))
+            if verMats.group(4):
+                abcPatch = int(verMats.group(4))
+            else:
+                abcPatch = 0
+            verTuple = (abcMajor, abcMinor, abcPatch)
+            self.abcVersion = verTuple
+
+    def processComment(self):
+        r'''
+        Processes the comment at self.pos in self.strSrc, setting self.skipAhead,
+        possibly self.abcVersion, and self.abcDirectives for the directiveKey.
+
+        TODO: store the comment in the stream also.
+
+        >>> from textwrap import dedent
+        >>> ah = abcFormat.ABCHandler()
+        >>> data = dedent("""
+        ...    Hello % this is a comment
+        ...    Bye
+        ...    """)
+        >>> ah.strSrc = data
+        >>> ah.pos = 6
+        >>> ah.processComment()
+        >>> ah.skipAhead
+        19
+        >>> len(' this is a comment\n')
+        19
+        '''
+        self.skipAhead = self._getNextLineBreak(
+            self.strSrc, self.pos
+        ) - (self.pos + 1)
+        commentLine = self.strSrc[self.pos:self.pos + self.skipAhead + 1]
+        self.parseCommentForVersionInformation(commentLine)
+        directiveMatches = reDirective.match(commentLine)
+        if directiveMatches:
+            directiveKey = directiveMatches.group(1)
+            directiveValue = directiveMatches.group(2)
+            self.abcDirectives[directiveKey] = directiveValue
+        # environLocal.printDebug(['got comment:', repr(self.strSrc[i:j + 1])])
+
+    @staticmethod
+    def startsMetadata(c: str, cNext: Optional[str], cNextNext: Optional[str]) -> bool:
+        '''
+        Returns True if this context describes the start of a metadata section, like
+
+        A:something
+
+        Metadata: capital letter, with next char as ':' and some following character
+
+        >>> ah = abcFormat.ABCHandler
+        >>> ah.startsMetadata('A', ':', 's')
+        True
+
+        lowercase w: is a special case for lyric defs
+
+        >>> ah.startsMetadata('w', ':', 's')
+        True
+
+        Following char must be ":"
+
+        >>> ah.startsMetadata('A', ' ', 's')
+        False
+
+        Pipe after colon indicates not metadata (bar info).
+        For example need to not misinterpret repeat bars as metadata
+
+        e.g. dAG FED:|2 dAG FGA|
+
+        this is incorrect, but we can avoid it by
+        looking for a leading pipe and returning False
+
+        >>> ah.startsMetadata('A', ':', '|')
+        False
+
+        >>> ah.startsMetadata('A', ':', None)
+        False
+        '''
+        if cNext != ':':
+            return False
+        elif cNextNext is None:
+            return False
+        elif cNextNext == '|':
+            return False
+        elif c == 'w':
+            return True  # special case, w:...
+        elif c.isalpha() and c.isupper():
+            return True
+        return False
+
+
+    def tokenize(self, strSrc: str) -> None:
         '''
         Walk the abc string, creating ABC objects along the way.
 
         This may be called separately from process(), in the case
         that pre/post parse processing is not needed.
-
 
         >>> abch = abcFormat.ABCHandler()
         >>> abch.tokens
@@ -1830,10 +2018,11 @@ class ABCHandler:
         >>> abch.tokens
         [<music21.abcFormat.ABCTuplet '(6::2'>, <music21.abcFormat.ABCNote 'f'>]
         '''
-        currentIndex = -1
-        collect = []
-        lastIndex = len(strSrc) - 1
-        skipAhead = 0
+        self.srcLen = len(strSrc)
+        self.strSrc = strSrc
+        self.pos = -1
+        self.currentCollectStr = ''
+        self.skipAhead = 0
         # noinspection SpellCheckingInspection
         accidentalsAndDecorations = '.~^=_HLMOPSTuv'
         accidentals = '^=_'
@@ -1842,64 +2031,34 @@ class ABCHandler:
         accidentalized = {}
         accidental = None
         abcPitch = None  # ABC substring defining any pitch within the current token
-        isFirstComment = True
+        self.isFirstComment = True
 
-        while currentIndex < lastIndex:
-            currentIndex += 1
-            currentIndex += skipAhead
-            skipAhead = 0
-            if currentIndex > lastIndex:
+        while self.pos < self.srcLen - 1:
+            self.pos += 1
+            self.pos += self.skipAhead
+            self.skipAhead = 0
+            if self.pos > self.srcLen + 1:
                 break
 
-            q = self._getLinearContext(strSrc, currentIndex)
+            q = self._getLinearContext(self.strSrc, self.pos)
             unused_cPrev, c, cNext, cNextNext = q
             # cPrevNotSpace, cPrev, c, cNext, cNextNotSpace, cNextNext = q
 
             # comment lines, also encoding defs
             if c == '%':
-                skipAhead = self._getNextLineBreak(strSrc, currentIndex) - (currentIndex + 1)
-                commentLine = strSrc[currentIndex:currentIndex + skipAhead + 1]
-                if isFirstComment:
-                    isFirstComment = False
-                    verMats = reAbcVersion.match(commentLine)
-                    if verMats:
-                        abcMajor = int(verMats.group(2))
-                        abcMinor = int(verMats.group(3))
-                        if verMats.group(4):
-                            abcPatch = int(verMats.group(4))
-                        else:
-                            abcPatch = 0
-                        verTuple = (abcMajor, abcMinor, abcPatch)
-                        self.abcVersion = verTuple
-                dirMats = reDirective.match(commentLine)
-                if dirMats:
-                    var = dirMats.group(1)
-                    val = dirMats.group(2)
-                    self.abcDirectives[var] = val
-                # environLocal.printDebug(['got comment:', repr(strSrc[i:j + 1])])
+                self.processComment()
                 continue
 
-            # metadata: capital letter, with next char as ':'
-            # or w: (lyric defs)
-            # some meta data might have bar symbols, for example
-            # need to not misinterpret repeat bars as meta
-            # e.g. dAG FED:|2 dAG FGA| this is incorrect, but can avoid by
-            # looking for a leading pipe
-
-            if (((c.isalpha() and c.isupper()) or c in 'w')
-                    and cNext is not None
-                    and cNext == ':'
-                    and cNextNext is not None
-                    and cNextNext not in '|'):
+            if self.startsMetadata(c, cNext, cNextNext):
                 # collect until end of line; add one to get line break
-                j = self._getNextLineBreak(strSrc, currentIndex)
-                skipAhead = j - (currentIndex + 1)
-                collect = strSrc[currentIndex:j].strip()
-                # environLocal.printDebug(['got metadata:', repr(''.join(collect))])
-                # print('Skipped %d, collected %r, currentIndex %d, new index %d' % (
-                #    skipAhead, collect, currentIndex, j))
+                j = self._getNextLineBreak(self.strSrc, self.pos)
+                self.skipAhead = j - (self.pos + 1)
+                self.currentCollectStr = self.strSrc[self.pos:j].strip()
+                # environLocal.printDebug(['got metadata:', repr(self.currentCollectStr)])
+                # print('Skipped %d, collected %r, pos %d, new index %d' % (
+                #    self.skipAhead, self.currentCollectStr, self.pos, j))
 
-                self.tokens.append(ABCMetadata(collect))
+                self.tokens.append(ABCMetadata(self.currentCollectStr))
                 continue
 
             # get bars: if not a space and not alphanumeric
@@ -1911,69 +2070,70 @@ class ABCHandler:
                     barTokenArchetype = ABC_BARS[barIndex][0]
                     if len(barTokenArchetype) == 3:
                         if cNextNext is not None and (c + cNext + cNextNext == barTokenArchetype):
-                            skipAhead = 2
+                            self.skipAhead = 2
                             matchBars = True
                             break
                     elif cNext is not None and (len(barTokenArchetype) == 2):
                         if c + cNext == barTokenArchetype:
-                            skipAhead = 1
+                            self.skipAhead = 1
                             matchBars = True
                             break
                     elif len(barTokenArchetype) == 1:
                         if c == barTokenArchetype:
-                            skipAhead = 0
+                            self.skipAhead = 0
                             matchBars = True
                             break
                 if matchBars is True:
                     accidentalized = {}
                     accidental = None
-                    j = currentIndex + skipAhead + 1
-                    collect = strSrc[currentIndex:j]
+                    j = self.pos + self.skipAhead + 1
+                    self.currentCollectStr = self.strSrc[self.pos:j]
                     # filter and replace with 2 tokens if necessary
-                    for tokenSub in self.barlineTokenFilter(collect):
+                    for tokenSub in self.barlineTokenFilter(self.currentCollectStr):
                         self.tokens.append(tokenSub)
-                    # environLocal.printDebug(['got bars:', repr(collect)])
-                    # if collect == '::':
+                    # environLocal.printDebug(['got bars:', repr(self.currentCollectStr)])
+                    # if self.currentCollectStr == '::':
                     #     # create a start and and an end
                     #     self.tokens.append(ABCBar(':|'))
                     #     self.tokens.append(ABCBar('|:'))
                     # else:
-                    #     self.tokens.append(ABCBar(collect))
+                    #     self.tokens.append(ABCBar(self.currentCollectStr))
                     continue
 
             # get tuplet indicators: (2, (3, (p:q:r or (3::
             if c == '(' and cNext is not None and cNext.isdigit():
-                skipAhead = 1
-                j = currentIndex + skipAhead + 1  # always two characters
-                unused1, possibleColon, qChar, unused2 = self._getLinearContext(strSrc, j)
+                self.skipAhead = 1
+                j = self.pos + self.skipAhead + 1  # always two characters
+                unused1, possibleColon, qChar, unused2 = self._getLinearContext(self.strSrc, j)
                 if possibleColon == ':':
                     j += 1
-                    skipAhead += 1
+                    self.skipAhead += 1
                     if qChar is not None and qChar.isdigit():
                         j += 1
-                        skipAhead += 1
-                    unused1, possibleColon, rChar, unused2 = self._getLinearContext(strSrc, j)
+                        self.skipAhead += 1
+                    unused1, possibleColon, rChar, unused2 = self._getLinearContext(self.strSrc, j)
                     if possibleColon == ':':
                         j += 1  # include the r characters
-                        skipAhead += 1
+                        self.skipAhead += 1
                         if rChar is not None and rChar.isdigit():
                             j += 1
-                            skipAhead += 1
+                            self.skipAhead += 1
 
-                collect = strSrc[currentIndex:j]
-                # environLocal.printDebug(['got tuplet start:', repr(collect)])
-                self.tokens.append(ABCTuplet(collect))
+                self.currentCollectStr = self.strSrc[self.pos:j]
+                # environLocal.printDebug(['got tuplet start:', repr(self.currentCollectStr)])
+                self.tokens.append(ABCTuplet(self.currentCollectStr))
                 continue
 
             # get broken rhythm modifiers: < or >, >>, up to <<<
             if c in '<>':
-                j = currentIndex + 1
-                while j < lastIndex and strSrc[j] in '<>':
+                j = self.pos + 1
+                while j < self.srcLen - 1 and self.strSrc[j] in '<>':
                     j += 1
-                collect = strSrc[currentIndex:j]
-                # environLocal.printDebug(['got bidrectional rhythm mod:', repr(collect)])
-                self.tokens.append(ABCBrokenRhythmMarker(collect))
-                skipAhead = j - (currentIndex + 1)
+                self.currentCollectStr = self.strSrc[self.pos:j]
+                # environLocal.printDebug(
+                #     ['got bidrectional rhythm mod:', repr(self.currentCollectStr)])
+                self.tokens.append(ABCBrokenRhythmMarker(self.currentCollectStr))
+                self.skipAhead = j - (self.pos + 1)
                 continue
 
             # get dynamics. skip over the open paren to avoid confusion.
@@ -1984,18 +2144,18 @@ class ABCHandler:
                                '!diminuendo(!': ABCDimStart,
                                '!diminuendo)!': ABCParenStop,
                                }
-                j = currentIndex + 1
-                while j < currentIndex + 20:  # a reasonable upper bound
-                    if strSrc[j] == '!':
-                        if strSrc[currentIndex:j + 1] in exclaimDict:
-                            exclaimClass = exclaimDict[strSrc[currentIndex:j + 1]]
+                j = self.pos + 1
+                while j < self.pos + 20 and j < self.srcLen:  # a reasonable upper bound
+                    if self.strSrc[j] == '!':
+                        if self.strSrc[self.pos:j + 1] in exclaimDict:
+                            exclaimClass = exclaimDict[self.strSrc[self.pos:j + 1]]
                             exclaimObject = exclaimClass(c)
                             self.tokens.append(exclaimObject)
-                            skipAhead = j - currentIndex  # not + 1
+                            self.skipAhead = j - self.pos  # not + 1
                             break
                         # NB: We're currently skipping over all other '!' expressions
                         else:
-                            skipAhead = j - currentIndex  # not + 1
+                            self.skipAhead = j - self.pos  # not + 1
                             break
                     j += 1
                 # not found, continue...
@@ -2019,32 +2179,32 @@ class ABCHandler:
             # get chord symbols / guitar chords; collected and joined with
             # chord or notes
             if c == '"':
-                j = currentIndex + 1
-                while j < lastIndex and strSrc[j] not in '"':
+                j = self.pos + 1
+                while j < self.srcLen - 1 and self.strSrc[j] != '"':
                     j += 1
                 j += 1  # need character that caused break
                 # there may be more than one chord symbol: need to accumulate
-                activeChordSymbol += strSrc[currentIndex:j]
+                activeChordSymbol += self.strSrc[self.pos:j]
                 # environLocal.printDebug(['got chord symbol:', repr(activeChordSymbol)])
-                skipAhead = j - (currentIndex + 1)
+                self.skipAhead = j - (self.pos + 1)
                 continue
 
             # get chords
             if c == '[':
-                j = currentIndex + 1
-                while j < lastIndex and strSrc[j] not in ']':
+                j = self.pos + 1
+                while j < self.srcLen - 1 and self.strSrc[j] != ']':
                     j += 1
                 j += 1  # need character that caused break
                 # prepend chord symbol
                 if activeChordSymbol != '':
-                    collect = activeChordSymbol + strSrc[currentIndex:j]
+                    self.currentCollectStr = activeChordSymbol + self.strSrc[self.pos:j]
                     activeChordSymbol = ''  # reset
                 else:
-                    collect = strSrc[currentIndex:j]
+                    self.currentCollectStr = self.strSrc[self.pos:j]
 
-                # environLocal.printDebug(['got chord:', repr(collect)])
-                self.tokens.append(ABCChord(collect))
-                skipAhead = j - (currentIndex + 1)
+                # environLocal.printDebug(['got chord:', repr(self.currentCollectStr)])
+                self.tokens.append(ABCChord(self.currentCollectStr))
+                self.skipAhead = j - (self.pos + 1)
                 # TODO: Chords need to be aware of accidentals too.
                 # Also what happens to prefixes and suffixes attached to chords,
                 # like ties.
@@ -2111,50 +2271,50 @@ class ABCHandler:
                     abcPitch = c
                 if c in accidentals:
                     accidental = c
-                j = currentIndex + 1
+                j = self.pos + 1
 
-                while j <= lastIndex:
+                while j <= self.srcLen - 1:
                     # if we have not found pitch alpha
                     # decorations and/or accidentals may precede note names
-                    if not foundPitchAlpha and strSrc[j] in accidentalsAndDecorations:
+                    if not foundPitchAlpha and self.strSrc[j] in accidentalsAndDecorations:
                         j += 1
-                        if strSrc[j] in accidentals:
-                            accidental += strSrc[j]
+                        if self.strSrc[j] in accidentals:
+                            accidental += self.strSrc[j]
                         continue
                     # only allow one pitch alpha to be a continue condition
-                    elif (not foundPitchAlpha and strSrc[j].isalpha()
+                    elif (not foundPitchAlpha and self.strSrc[j].isalpha()
                           # noinspection SpellCheckingInspection
-                          and strSrc[j] not in '~wuvhHLTSN'):
+                          and self.strSrc[j] not in '~wuvhHLTSN'):
                         foundPitchAlpha = True
-                        abcPitch = strSrc[j]
+                        abcPitch = self.strSrc[j]
                         j += 1
                         continue
                     # continue conditions after alpha:
                     # , register modification (, ') or number, rhythm indication
                     # number, /,
-                    elif strSrc[j].isdigit() or strSrc[j] in ',/,\'':
-                        if strSrc[j] in ',\'':  # Register (octave) modification
-                            abcPitch += strSrc[j]
+                    elif self.strSrc[j].isdigit() or self.strSrc[j] in ',/,\'':
+                        if self.strSrc[j] in ',\'':  # Register (octave) modification
+                            abcPitch += self.strSrc[j]
                         j += 1
                         continue
                     else:  # space, all else: break
                         break
                 # prepend chord symbol
                 if activeChordSymbol != '':
-                    collect = activeChordSymbol + strSrc[currentIndex:j]
+                    self.currentCollectStr = activeChordSymbol + self.strSrc[self.pos:j]
                     activeChordSymbol = ''  # reset
                 else:
-                    collect = strSrc[currentIndex:j]
-                # environLocal.printDebug(['got note event:', repr(collect)])
+                    self.currentCollectStr = self.strSrc[self.pos:j]
+                # environLocal.printDebug(['got note event:', repr(self.currentCollectStr)])
 
                 # NOTE: skipping a number of articulations and other markers
-                # not yet supported
+                # that are not yet supported
                 # some collections here are not yet supported; others may be
                 # the result of errors in encoded files
                 # v is up bow; might be: "^Segno"v which also should be dropped
                 # H is fermata
                 # . dot may be staccato, but should be attached to pitch
-                if collect in ('w', 'u', 'v', 'v.', 'h', 'H', 'vk',
+                if self.currentCollectStr in ('w', 'u', 'v', 'v.', 'h', 'H', 'vk',
                                'uk', 'U', '~',
                                '.', '=', 'V', 'v.', 'S', 's',
                                'i', 'I', 'ui', 'u.', 'Q', 'Hy', 'Hx',
@@ -2164,17 +2324,22 @@ class ABCHandler:
                     pass
                 # these are bad chords, or other problematic notations like
                 # "D.C."x
-                elif (collect.startswith('"')
-                      and (collect[-1] in ('u', 'v', 'k', 'K', 'Q', '.',
-                                           'y', 'T', 'w', 'h', 'x')
-                           or collect.endswith('v.'))):
+                elif (self.currentCollectStr.startswith('"')
+                      and (self.currentCollectStr[-1] in (
+                            'u', 'v', 'k', 'K', 'Q', '.',
+                            'y', 'T', 'w', 'h', 'x')
+                           or self.currentCollectStr.endswith('v.'))):
                     pass
-                elif collect.startswith('x') or collect.startswith('H') or collect.startswith('Z'):
+                elif (self.currentCollectStr.startswith('x')
+                      or self.currentCollectStr.startswith('H')
+                      or self.currentCollectStr.startswith('Z')):
                     pass
                 # not sure what =20 refers to
-                elif len(collect) > 1 and collect.startswith('=') and collect[1].isdigit():
+                elif (len(self.currentCollectStr) > 1
+                      and self.currentCollectStr.startswith('=')
+                      and self.currentCollectStr[1].isdigit()):
                     pass
-                # only let valid collect strings be parsed
+                # only let valid self.currentCollectStr strings be parsed
                 elif abcPitch:
                     pitchClass = abcPitch[0].upper()
                     carriedAccidental = None
@@ -2191,11 +2356,12 @@ class ABCHandler:
                             carriedAccidental = accidentalized[pitchClass]
                         elif propagation == 'octave' and abcPitch in accidentalized:
                             carriedAccidental = accidentalized[abcPitch]
-                    self.tokens.append(ABCNote(collect, carriedAccidental=carriedAccidental))
+                    abcNote = ABCNote(self.currentCollectStr, carriedAccidental=carriedAccidental)
+                    self.tokens.append(abcNote)
                 else:
-                    self.tokens.append(ABCNote(collect))
+                    self.tokens.append(ABCNote(self.currentCollectStr))
 
-                skipAhead = j - (currentIndex + 1)
+                self.skipAhead = j - (self.pos + 1)
                 continue
             # look for white space: can be used to determine beam groups
             # no action: normal continuation of 1 char
@@ -2337,7 +2503,8 @@ class ABCHandler:
                 if lastDefaultQL is None:
                     raise ABCHandlerException(
                         'no active default note length provided for note processing. '
-                        + 'tPrev: %s, t: %s, tNext: %s' % (tPrev, t, tNext))
+                        + f'tPrev: {tPrev}, t: {t}, tNext: {tNext}'
+                    )
                 t.activeDefaultQuarterLength = lastDefaultQL
                 t.activeKeySignature = lastKeySignature
                 t.applicableSpanners = self.activeSpanners[:]  # fast copy of a list
@@ -2380,7 +2547,7 @@ class ABCHandler:
             # environLocal.printDebug(['tokenProcess: calling parse()', t])
             t.parse()
 
-    def process(self, strSrc):
+    def process(self, strSrc: str) -> None:
         self.tokens = []
         self.tokenize(strSrc)
         self.tokenProcess()
@@ -2693,7 +2860,10 @@ class ABCHandler:
         return post
 
     @staticmethod
-    def _buildMeasureBoundaryIndices(positionList, lastValidIndex):
+    def _buildMeasureBoundaryIndices(
+        positionList: List[int],
+        lastValidIndex: int
+    ) -> List[List[int]]:
         '''
         Staticmethod
 
@@ -2742,7 +2912,7 @@ class ABCHandler:
         # environLocal.printDebug(['splitByMeasure(); pairs pre filter', pairs])
         return pairs
 
-    def splitByMeasure(self):
+    def splitByMeasure(self) -> List['ABCHandlerBar']:
         '''
         Divide a token list by Measures, also
         defining start and end bars of each Measure.
@@ -2851,7 +3021,7 @@ class ABCHandler:
         #         print('\t', t)
         return post
 
-    def tokensToBarIndices(self):
+    def tokensToBarIndices(self) -> List[int]:
         '''
         Return a list of indices indicating which tokens in self.tokens are
         bar lines or the last piece of metadata before a note or chord.
@@ -2879,7 +3049,7 @@ class ABCHandler:
 
         return barIndices
 
-    def hasNotes(self):
+    def hasNotes(self) -> bool:
         '''
         If tokens are processed, return True if ABCNote or
         ABCChord classes are defined
@@ -2909,7 +3079,7 @@ class ABCHandler:
         else:
             return False
 
-    def getTitle(self):
+    def getTitle(self) -> Optional[str]:
         '''
         Get the first title tag. Used for testing.
 
@@ -2967,7 +3137,7 @@ class ABCHandlerBar(ABCHandler):
         return ah
 
 
-def mergeLeadingMetaData(barHandlers):
+def mergeLeadingMetaData(barHandlers: List[ABCHandlerBar]) -> List[ABCHandlerBar]:
     '''
     Given a list of ABCHandlerBar objects, return a list of ABCHandlerBar
     objects where leading metadata is merged, if possible,
@@ -3014,10 +3184,11 @@ def mergeLeadingMetaData(barHandlers):
 class ABCFile(prebase.ProtoM21Object):
     '''
     ABC File or String access
-    # Optionally, specify the (major, minor, patch) version of ABC to process--
-    # e.g., (1.2.0). If not set, default ABC 1.3 parsing is performed.
-    '''
 
+    The abcVersion attribution optionally specifies the (major, minor, patch)
+    version of ABC to process-- e.g., (1.2.0).
+    If not set, default ABC 1.3 parsing is performed.
+    '''
     def __init__(self, abcVersion=None):
         self.abcVersion = abcVersion
         self.file = None
@@ -3058,20 +3229,52 @@ class ABCFile(prebase.ProtoM21Object):
         '''
         return self.readstr(self.file.read(), number)
 
-    def extractReferenceNumber(self, strSrc, number):
+    @staticmethod
+    def extractReferenceNumber(strSrc: str, number: int) -> str:
         '''
-        Extract a single reference number from many defined in a file.
-        This permits loading a single work from a collection/opus
+        Extract the string data relating to a single reference number
+        from a file that defines multiple songs or pieces.
+
+        This method permits loading a single work from a collection/opus
         without parsing the entire file.
+
+        Here is sample data that is not correct ABC but demonstrates the basic concept:
+
+        >>> fileData = """
+        ...   X:1
+        ...   Hello
+        ...   X:2
+        ...   Aloha
+        ...   X:3
+        ...   Goodbye
+        ...   """
+
+        >>> file2 = abcFormat.ABCFile.extractReferenceNumber(fileData, 2)
+        >>> print(file2)
+        X:2
+        Aloha
+
+        If the number does not exist, raises an ABCFileException:
+
+        >>> abcFormat.ABCFile.extractReferenceNumber(fileData, 99)
+        Traceback (most recent call last):
+        music21.abcFormat.ABCFileException: cannot find requested
+            reference number in source file: 99
+
+
+        If the same number is defined twice in one file (should not be) only
+        the first data is returned.
+
+        Changed in v6.2: now a static method.
         '''
         collect = []
         gather = False
         for line in strSrc.split('\n'):
             # must be a single line definition
             # rstrip because of '\r\n' carriage returns
-            if line.strip().startswith('X:') and line.replace(' ', '').rstrip() == 'X:%s' % number:
+            if line.strip().startswith('X:') and line.replace(' ', '').rstrip() == f'X:{number}':
                 gather = True
-            elif line.strip().startswith('X:') and gather is False:
+            elif line.strip().startswith('X:') and not gather:
                 # some numbers are like X:0490 but we may request them as 490...
                 try:
                     forcedNum = int(line.replace(' ', '').rstrip().replace('X:', ''))
@@ -3081,19 +3284,20 @@ class ABCFile(prebase.ProtoM21Object):
                     pass
             # if already gathering and find another ref number definition
             # stop gathering
-            elif gather is True and line.strip().startswith('X:'):
+            elif gather and line.strip().startswith('X:'):
                 break
-            if gather is True:
+
+            if gather:
                 collect.append(line)
 
         if not collect:
             raise ABCFileException(
-                'cannot find requested reference number in source file: %s' % number)
+                f'cannot find requested reference number in source file: {number}')
 
         post = '\n'.join(collect)
         return post
 
-    def readstr(self, strSrc, number=None):
+    def readstr(self, strSrc: str, number: Optional[int] = None) -> ABCHandler:
         '''
         Read a string and process all Tokens.
         Returns a ABCHandler instance.

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -2037,7 +2037,7 @@ class ABCHandler:
             self.pos += 1
             self.pos += self.skipAhead
             self.skipAhead = 0
-            if self.pos > self.srcLen + 1:
+            if self.pos > self.srcLen - 1:
                 break
 
             q = self._getLinearContext(self.strSrc, self.pos)
@@ -2325,9 +2325,8 @@ class ABCHandler:
                 # these are bad chords, or other problematic notations like
                 # "D.C."x
                 elif (self.currentCollectStr.startswith('"')
-                      and (self.currentCollectStr[-1] in (
-                            'u', 'v', 'k', 'K', 'Q', '.',
-                            'y', 'T', 'w', 'h', 'x')
+                      and (self.currentCollectStr[-1] in ('u', 'v', 'k', 'K', 'Q', '.',
+                                                          'y', 'T', 'w', 'h', 'x',)
                            or self.currentCollectStr.endswith('v.'))):
                     pass
                 elif (self.currentCollectStr.startswith('x')

--- a/music21/corpus/virtual.py
+++ b/music21/corpus/virtual.py
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 '''
 The virtual.py module is a library of references to remotely stored music data files,
-as well as meta-data necessary to download and, if available, access an already downloaded file.
+as well as metadata necessary to download and, if available, access an already downloaded file.
 
 This is probably not the best way to handle this -- instead it should be a link to
 a directory or listing of files and repositories, each handled as a different Corpus.

--- a/music21/editorial.py
+++ b/music21/editorial.py
@@ -11,7 +11,7 @@
 # License:      BSD, see license.txt
 # -----------------------------------------------------------------------------
 '''
-Editorial objects store comments and other meta-data associated with specific
+Editorial objects store comments and other metadata associated with specific
 :class:`~music21.base.Music21Object` elements such as Notes.
 
 Some of the aspects of :class:`~music21.editorial.Editorial` objects
@@ -32,10 +32,10 @@ the object, call `.hasEditorialInformation`
 >>> n = note.Note('C#4')
 >>> n.hasEditorialInformation
 False
+
 >>> n.editorial.unedited = True
 >>> n.hasEditorialInformation
 True
-
 '''
 import unittest
 from music21 import exceptions21
@@ -85,7 +85,6 @@ class Editorial(prebase.ProtoM21Object, dict):
         :width: 103
 
     '''
-
     _DOC_ATTR = {
         'comments': '''
             a list of :class:`~music21.editorial.Comment` objects that represent any comments
@@ -166,7 +165,6 @@ class Comment(prebase.ProtoM21Object, style.StyleMixin):
     >>> c.style.color
     'red'
     '''
-
     def __init__(self, text=None):
         super().__init__()
         self.text = text
@@ -206,6 +204,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             name = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(name) and not isinstance(name, types.FunctionType):
                 try:  # see if obj can be made w/ args
                     obj = name()

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Name:         metadata.py
-# Purpose:      music21 classes for representing score and work meta-data
+# Purpose:      music21 classes for representing score and work metadata
 #
 # Authors:      Christopher Ariza
 #               Michael Scott Cuthbert

--- a/music21/metadata/bundles.py
+++ b/music21/metadata/bundles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Name:         bundles.py
-# Purpose:      music21 classes for representing score and work meta-data
+# Purpose:      music21 classes for representing score and work metadata
 #
 # Authors:      Christopher Ariza
 #               Michael Scott Cuthbert

--- a/music21/metadata/caching.py
+++ b/music21/metadata/caching.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Name:         caching.py
-# Purpose:      music21 classes for representing score and work meta-data
+# Purpose:      music21 classes for representing score and work metadata
 #
 # Authors:      Christopher Ariza
 #               Michael Scott Cuthbert

--- a/music21/metadata/primitives.py
+++ b/music21/metadata/primitives.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Name:         primitives.py
-# Purpose:      music21 classes for representing score and work meta-data
+# Purpose:      music21 classes for representing score and work metadata
 #
 # Authors:      Christopher Ariza
 #               Michael Scott Cuthbert


### PR DESCRIPTION
I wanted to add one tiny feature to ABC, but the tokenize method is way too complex as it is.  A start to cleanup methods by making current parsing positions be attributes on the ABCHandler class.

Next step will be to move ABCHandler to two classes:  ABCStringParser and ABCTokenParser.  But will merge in small PRs that make incremental improvements.