### PR TITLE
Cleanup pre 6.3

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -22,6 +22,7 @@
       <option name="ignoredNames">
         <list>
           <option value="type" />
+          <option value="format" />
         </list>
       </option>
     </inspection_tool>

--- a/dist/dist.py
+++ b/dist/dist.py
@@ -65,8 +65,8 @@ while it is running.  This takes a while and runs single core, so allocate time.
             pypi
 
         [pypi]
-        username:yourusername
-        password:yourpassword
+        username:your_username
+        password:your_password
 
 16. Delete the two .tar.gz files in dist...
 
@@ -287,8 +287,6 @@ class Distributor:
                           ]:
             environLocal.warn('making %s' % buildType)
 
-            # setup.writeManifestTemplate(self.fpPackageDir)
-            # setup.runDisutils(type)
             savePath = os.getcwd()
             os.chdir(self.fpPackageDir)
             os.system('%s setup.py %s' % (PY, buildType))

--- a/documentation/docbuild/documenters.py
+++ b/documentation/docbuild/documenters.py
@@ -87,7 +87,7 @@ class ObjectDocumenter(Documenter):
 
     # PUBLIC PROPERTIES #
 
-    def referentPackagesystemPath(self):
+    def referentPackageSystemPath(self):
         raise NotImplementedError
 
     def rstAutodocDirectiveFormat(self):
@@ -97,7 +97,7 @@ class ObjectDocumenter(Documenter):
     def rstCrossReferenceString(self):
         return ':{0}:`~{1}`'.format(
             self.sphinxCrossReferenceRole,
-            self.referentPackagesystemPath,
+            self.referentPackageSystemPath,
             )
 
     def sphinxCrossReferenceRole(self):
@@ -131,6 +131,7 @@ class FunctionDocumenter(ObjectDocumenter):
     # INITIALIZER #
 
     def __init__(self, referent=None):
+        # noinspection PyTypeChecker
         if not isinstance(referent, types.FunctionType):
             raise Music21Exception('referent must be a function')
         super().__init__(referent)
@@ -145,17 +146,17 @@ class FunctionDocumenter(ObjectDocumenter):
     def __repr__(self):
         return '<{0}: {1}>'.format(
             self._packageSystemPath,
-            self.referentPackagesystemPath,
+            self.referentPackageSystemPath,
             )
 
     # PUBLIC PROPERTIES #
 
     @property
-    def referentPackagesystemPath(self):
+    def referentPackageSystemPath(self):
         '''
         >>> function = common.opFrac
         >>> documenter = FunctionDocumenter(function)
-        >>> documenter.referentPackagesystemPath
+        >>> documenter.referentPackageSystemPath
         'music21.common.numberTools.opFrac'
         '''
         path = '.'.join((
@@ -173,10 +174,10 @@ class FunctionDocumenter(ObjectDocumenter):
         ['.. autofunction:: music21.common.numberTools.opFrac', '']
         '''
         result = []
-        referentPackagesystemPath = self.referentPackagesystemPath.replace(
+        referentPackageSystemPath = self.referentPackageSystemPath.replace(
             '.__init__', '')
         result.append('.. autofunction:: {0}'.format(
-            referentPackagesystemPath,
+            referentPackageSystemPath,
             ))
         result.append('')
         return result
@@ -232,7 +233,7 @@ class MemberDocumenter(ObjectDocumenter):
     # PUBLIC PROPERTIES #
 
     @property
-    def referentPackagesystemPath(self):
+    def referentPackageSystemPath(self):
         path = '.'.join((
             self.definingClass.__module__,
             self.definingClass.__name__,
@@ -240,8 +241,9 @@ class MemberDocumenter(ObjectDocumenter):
             ))
         return path.replace('.__init__', '')
 
+    @property
     def rstAutodocDirectiveFormat(self):
-        pass
+        return []
 
     def sphinxCrossReferenceRole(self):
         pass
@@ -278,7 +280,7 @@ class MethodDocumenter(MemberDocumenter):
     def rstAutodocDirectiveFormat(self):
         result = []
         result.append('.. automethod:: {0}'.format(
-            self.referentPackagesystemPath,
+            self.referentPackageSystemPath,
             ))
         result.append('')
         return result
@@ -314,7 +316,7 @@ class AttributeDocumenter(MemberDocumenter):
     def rstAutodocDirectiveFormat(self):
         result = []
         result.append('.. autoattribute:: {0}'.format(
-            self.referentPackagesystemPath,
+            self.referentPackageSystemPath,
             ))
         result.append('')
         return result
@@ -486,7 +488,7 @@ class ClassDocumenter(ObjectDocumenter):
             documenterClass = AttributeDocumenter
             localMemberList = self._readonlyProperties
             inheritedMembersMapping = self._inheritedReadonlyPropertiesMapping
-        else:  # do not support writeonlyProperties
+        else:  # do not support write-only properties
             return
 
         documenter = documenterClass(
@@ -641,7 +643,7 @@ class ClassDocumenter(ObjectDocumenter):
         >>> klass = stream.Measure
         >>> documenter = ClassDocumenter(klass)
         >>> mapping = documenter.inheritedDocAttrMapping
-        >>> sortBy = lambda x: x.referentPackagesystemPath
+        >>> sortBy = lambda x: x.referentPackageSystemPath
         >>> for classDocumenter in sorted(mapping, key=sortBy):
         ...     classDocumenter
         ...
@@ -677,13 +679,13 @@ class ClassDocumenter(ObjectDocumenter):
         >>> klass = stream.Measure
         >>> documenter = ClassDocumenter(klass)
         >>> mapping = documenter.inheritedReadonlyPropertiesMapping
-        >>> sortBy = lambda x: x.referentPackagesystemPath
+        >>> sortBy = lambda x: x.referentPackageSystemPath
         >>> for classDocumenter in sorted(mapping, key=sortBy):
         ...     print('{0}:'.format(
-        ...         classDocumenter.referentPackagesystemPath))
+        ...         classDocumenter.referentPackageSystemPath))
         ...     for attributeDocumenter in mapping[classDocumenter][:10]:
         ...         print('- {0}'.format(
-        ...             attributeDocumenter.referentPackagesystemPath))
+        ...             attributeDocumenter.referentPackageSystemPath))
         ...
         music21.base.Music21Object:
         - music21.base.Music21Object.classSet
@@ -717,13 +719,13 @@ class ClassDocumenter(ObjectDocumenter):
         >>> klass = stream.Measure
         >>> documenter = ClassDocumenter(klass)
         >>> mapping = documenter.inheritedMethodsMapping
-        >>> sortBy = lambda x: x.referentPackagesystemPath
+        >>> sortBy = lambda x: x.referentPackageSystemPath
         >>> for classDocumenter in sorted(mapping, key=sortBy):
         ...     print('{0}:'.format(
-        ...         classDocumenter.referentPackagesystemPath))
+        ...         classDocumenter.referentPackageSystemPath))
         ...     for attributeDocumenter in mapping[classDocumenter][:10]:
         ...         print('- {0}'.format(
-        ...             attributeDocumenter.referentPackagesystemPath))
+        ...             attributeDocumenter.referentPackageSystemPath))
         ...
         music21.base.Music21Object:
         - music21.base.Music21Object.containerHierarchy
@@ -771,11 +773,11 @@ class ClassDocumenter(ObjectDocumenter):
         >>> klass = stream.Measure
         >>> documenter = ClassDocumenter(klass)
         >>> mapping = documenter.inheritedReadwritePropertiesMapping
-        >>> sortBy = lambda x: x.referentPackagesystemPath
+        >>> sortBy = lambda x: x.referentPackageSystemPath
         >>> for classDocumenter in sorted(mapping, key=sortBy):
-        ...     print('{0}:'.format(classDocumenter.referentPackagesystemPath))
+        ...     print('{0}:'.format(classDocumenter.referentPackageSystemPath))
         ...     for attributeDocumenter in mapping[classDocumenter][:10]:
-        ...         print('- {0}'.format(attributeDocumenter.referentPackagesystemPath))
+        ...         print('- {0}'.format(attributeDocumenter.referentPackageSystemPath))
         ...
         music21.base.Music21Object:
         - music21.base.Music21Object.activeSite
@@ -893,7 +895,7 @@ class ClassDocumenter(ObjectDocumenter):
         return self._readwriteProperties
 
     @property
-    def referentPackagesystemPath(self):
+    def referentPackageSystemPath(self):
         path = '.'.join((
             self.referent.__module__,
             self.referent.__name__,
@@ -903,10 +905,10 @@ class ClassDocumenter(ObjectDocumenter):
     @property
     def rstAutodocDirectiveFormat(self):
         result = []
-        referentPackagesystemPath = self.referentPackagesystemPath.replace(
+        referentPackageSystemPath = self.referentPackageSystemPath.replace(
             '.__init__', '')
         result.append('.. autoclass:: {0}'.format(
-            referentPackagesystemPath,
+            referentPackageSystemPath,
             ))
         result.append('')
         return result
@@ -947,7 +949,7 @@ class ClassDocumenter(ObjectDocumenter):
         if self.docAttr:
             for attrName, attrDescription in sorted(self.docAttr.items()):
                 path = '{0}.{1}'.format(
-                    self.referentPackagesystemPath.split('.')[-1],
+                    self.referentPackageSystemPath.split('.')[-1],
                     attrName,
                     )
                 directive = '.. attribute:: {0}'.format(path)
@@ -980,7 +982,7 @@ class ClassDocumenter(ObjectDocumenter):
                 formatString = '   - :attr:`~{0}.{1}`'
                 for attrName in attrNames:
                     result.append(formatString.format(
-                        baseDocumenter.referentPackagesystemPath,
+                        baseDocumenter.referentPackageSystemPath,
                         attrName,
                         ))
                 result.append('')
@@ -1117,8 +1119,8 @@ class ClassDocumenter(ObjectDocumenter):
 
         >>> from music21 import scale
         >>> klass = scale.MajorScale
-        >>> documenter = ClassDocumenter(klass)
-        >>> for line in documenter.rstMethodsFormat:
+        >>> classDocumenter = ClassDocumenter(klass)
+        >>> for line in classDocumenter.rstMethodsFormat:
         ...     line
         '.. rubric:: :class:`~music21.scale.MajorScale` methods'
         ''
@@ -1179,8 +1181,8 @@ class ClassDocumenter(ObjectDocumenter):
 
         >>> from music21 import note
         >>> klass = note.Note
-        >>> documenter = ClassDocumenter(klass)
-        >>> for line in documenter.rstReadonlyPropertiesFormat:
+        >>> classDocumenter = ClassDocumenter(klass)
+        >>> for line in classDocumenter.rstReadonlyPropertiesFormat:
         ...     line
         '.. rubric:: :class:`~music21.note.Note` read-only properties'
         ''
@@ -1223,8 +1225,8 @@ class ClassDocumenter(ObjectDocumenter):
 
         >>> from music21 import scale
         >>> klass = scale.MajorScale
-        >>> documenter = ClassDocumenter(klass)
-        >>> for line in documenter.rstReadwritePropertiesFormat:
+        >>> classDocumenter = ClassDocumenter(klass)
+        >>> for line in classDocumenter.rstReadwritePropertiesFormat:
         ...     line
         '.. rubric:: :class:`~music21.scale.MajorScale` read/write properties'
         ''
@@ -1323,9 +1325,9 @@ class ModuleDocumenter(ObjectDocumenter):
     def run(self):
         result = []
         result.extend(self.rstPageReferenceFormat)
-        referentPackagesystemPath = self.referentPackagesystemPath.replace(
+        referentPackageSystemPath = self.referentPackageSystemPath.replace(
             '.__init__', '')
-        result.extend(self.makeHeading(referentPackagesystemPath, 1))
+        result.extend(self.makeHeading(referentPackageSystemPath, 1))
         result.extend(self.rstEditingWarningFormat)
         result.extend(self.rstAutodocDirectiveFormat)
         for classDocumenter in self.classDocumenters:
@@ -1339,7 +1341,7 @@ class ModuleDocumenter(ObjectDocumenter):
     def __repr__(self):
         return '<{0}: {1}>'.format(
             self._packageSystemPath,
-            self.referentPackagesystemPath,
+            self.referentPackageSystemPath,
             )
 
     # PRIVATE METHODS #
@@ -1350,6 +1352,7 @@ class ModuleDocumenter(ObjectDocumenter):
             if name.startswith('_'):
                 continue
             named = getattr(self.referent, name)
+            # noinspection PyTypeChecker
             if isinstance(named, type):
                 if set(inspect.getmro(named)).intersection(
                     self._ignored_classes):
@@ -1375,9 +1378,9 @@ class ModuleDocumenter(ObjectDocumenter):
 
         >>> from music21 import serial
         >>> module = serial
-        >>> documenter = ModuleDocumenter(module)
-        >>> for classDocumenter in documenter.classDocumenters:
-        ...     print(classDocumenter.referentPackagesystemPath)
+        >>> modDocumenter = ModuleDocumenter(module)
+        >>> for classDocumenter in modDocumenter.classDocumenters:
+        ...     print(classDocumenter.referentPackageSystemPath)
         ...
         music21.serial.HistoricalTwelveToneRow
         music21.serial.ToneRow
@@ -1396,7 +1399,7 @@ class ModuleDocumenter(ObjectDocumenter):
                 del(classDocumenters[referent])
         for documenter in sorted(
                 classDocumenters.values(),
-                key=lambda x: x.referentPackagesystemPath):
+                key=lambda x: x.referentPackageSystemPath):
             result.append(documenter)
         return result
 
@@ -1409,9 +1412,9 @@ class ModuleDocumenter(ObjectDocumenter):
 
         >>> from music21 import serial
         >>> module = serial
-        >>> documenter = ModuleDocumenter(module)
-        >>> for functionDocumenter in documenter.functionDocumenters:
-        ...     print(functionDocumenter.referentPackagesystemPath)
+        >>> modDocumenter = ModuleDocumenter(module)
+        >>> for functionDocumenter in modDocumenter.functionDocumenters:
+        ...     print(functionDocumenter.referentPackageSystemPath)
         ...
         music21.serial.getHistoricalRowByName
         music21.serial.pcToToneRow
@@ -1428,7 +1431,7 @@ class ModuleDocumenter(ObjectDocumenter):
                 result.append(functionDocumenters[referent])
                 del(functionDocumenters[referent])
         for documenter in sorted(functionDocumenters.values(),
-            key=lambda x: x.referentPackagesystemPath):
+            key=lambda x: x.referentPackageSystemPath):
             result.append(documenter)
         return result
 
@@ -1441,7 +1444,7 @@ class ModuleDocumenter(ObjectDocumenter):
         return self._memberOrder
 
     @property
-    def referentPackagesystemPath(self):
+    def referentPackageSystemPath(self):
         if isinstance(self.referent.__name__, tuple):
             path = self.referent.__name__[0],
         else:
@@ -1452,7 +1455,7 @@ class ModuleDocumenter(ObjectDocumenter):
     def rstAutodocDirectiveFormat(self):
         result = []
         result.append('.. automodule:: {0}'.format(
-            self.referentPackagesystemPath,
+            self.referentPackageSystemPath,
             ))
         result.append('')
         return result
@@ -1481,9 +1484,9 @@ class ModuleDocumenter(ObjectDocumenter):
         'moduleStreamMakeNotation'
 
         '''
-        referentPackagesystemPath = self.referentPackagesystemPath.replace(
+        referentPackageSystemPath = self.referentPackageSystemPath.replace(
             '.__init__', '')
-        parts = referentPackagesystemPath.split('.')[1:]
+        parts = referentPackageSystemPath.split('.')[1:]
         for i, part in enumerate(parts):
             if not part[0].isupper():
                 parts[i] = part[0].upper() + part[1:]

--- a/documentation/docbuild/iterators.py
+++ b/documentation/docbuild/iterators.py
@@ -246,6 +246,7 @@ class FunctionIterator(Iterator):
 
     def __iter__(self):
         for x in CodebaseIterator(verbose=self.verbose):
+            # noinspection PyTypeChecker
             if isinstance(x, types.FunctionType):
                 yield x
 

--- a/music21/analysis/correlate.py
+++ b/music21/analysis/correlate.py
@@ -200,6 +200,8 @@ class Test(unittest.TestCase):
             if match:
                 continue
             name = getattr(sys.modules[self.__module__], part)
+
+            # noinspection PyTypeChecker
             if callable(name) and not isinstance(name, types.FunctionType):
                 try:  # see if obj can be made w/ args
                     obj = name()

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -22,10 +22,10 @@ The :class:`music21.analysis.discrete.KrumhanslSchmuckler`
 :class:`music21.analysis.discrete.Ambitus` (for pitch range analysis) provide examples.
 '''
 # TODO: make an analysis.base for the Discrete and analyzeStream aspects, then create
-# range and key modules in analysis
+#     range and key modules in analysis
 
 import unittest
-from typing import Union, List, Any, Tuple
+from typing import Union, List, Any, Tuple, Iterable
 
 from collections import OrderedDict
 from music21 import exceptions21
@@ -72,7 +72,7 @@ class DiscreteAnalysis:
         # store alternative solutions, which may be sorted or not
         self.alternativeSolutions = []
 
-    def _rgbToHex(self, rgb):
+    def _rgbToHex(self, rgb: Iterable[Union[float, int]]) -> str:
         '''
         Utility conversion method
 
@@ -84,7 +84,7 @@ class DiscreteAnalysis:
         rgb = round(rgb[0]), round(rgb[1]), round(rgb[2])
         return '#%02x%02x%02x' % rgb
 
-    def _hexToRgb(self, value):
+    def _hexToRgb(self, value: str) -> List[int]:
         '''
         Utility conversion method for six-digit hex values to RGB lists.
 
@@ -293,6 +293,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
                 dst[validKey.name] = self._rgbToHex(rgbStep)
 
     def _getSharpFlatCount(self, subStream) -> Tuple[int, int]:
+        # noinspection PyShadowingNames
         '''
         Determine count of sharps and flats in a Stream
 
@@ -514,6 +515,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
         return 'Keys'
 
     def solutionToColor(self, solution):
+        # noinspection PyShadowingNames
         '''
         Given a two-element tuple of (tonicPitch, modality) return the proper color
 
@@ -833,7 +835,7 @@ class AardenEssen(KeyWeightKeyAnalysis):
 
 class SimpleWeights(KeyWeightKeyAnalysis):
     '''
-    Implementation of Craig Sapp's simple weights for Krumhansl-Schmuckler
+    Implementation of simple weights by Craig Sapp for Krumhansl-Schmuckler
     key determination algorithm.
 
     Values from from http://extra.humdrum.org/man/keycor/, which describes
@@ -978,6 +980,7 @@ class Ambitus(DiscreteAnalysis):
         self._generateColors()
 
     def _generateColors(self, numColors=None):
+        # noinspection PyShadowingNames
         '''
         Provide uniformly distributed colors across the entire range.
 
@@ -1063,30 +1066,30 @@ class Ambitus(DiscreteAnalysis):
 
         return pitchesFound[minPitchIndex], pitchesFound[maxPitchIndex]
 
-    def getPitchRanges(self, subStream):
+    def getPitchRanges(self, subStream) -> Tuple[int, int]:
         '''
         For a given subStream, return the smallest .ps difference
         between any two pitches and the largest difference
         between any two pitches. This is used to get the
         smallest and largest ambitus possible in a given work.
 
-
-        >>> p = analysis.discrete.Ambitus()
+        >>> ambitusAnalyzer = analysis.discrete.Ambitus()
         >>> s = stream.Stream()
         >>> c = chord.Chord(['a2', 'b4', 'c8'])
         >>> s.append(c)
-        >>> [int(thisPitch.ps) for thisPitch in p.getPitchSpan(s)]
+        >>> [int(thisPitch.ps) for thisPitch in ambitusAnalyzer.getPitchSpan(s)]
         [45, 108]
-        >>> p.getPitchRanges(s)
+        >>> ambitusAnalyzer.getPitchRanges(s)
         (26, 63)
 
         >>> s = corpus.parse('bach/bwv66.6')
-        >>> p.getPitchRanges(s)
+        >>> ambitusAnalyzer.getPitchRanges(s)
         (0, 34)
 
+        An empty stream has pitch range (0, 0)
 
         >>> s = stream.Stream()
-        >>> p.getPitchRanges(s)
+        >>> ambitusAnalyzer.getPitchRanges(s)
         (0, 0)
         '''
         ssfn = subStream.flat.notes

--- a/music21/analysis/elements.py
+++ b/music21/analysis/elements.py
@@ -12,7 +12,7 @@ import collections
 
 _MOD = 'analysis.elements'
 
-def attributeCount(streamOrStreamIter, attrName='quarterLength'):
+def attributeCount(streamOrStreamIter, attrName='quarterLength') -> collections.Counter:
     '''
     Return a collections.Counter of attribute usage for elements in a stream
     or StreamIterator

--- a/music21/base.py
+++ b/music21/base.py
@@ -3610,7 +3610,7 @@ class Music21Object(prebase.ProtoM21Object):
     seconds = property(_getSeconds, _setSeconds, doc='''
         Get or set the duration of this object in seconds, assuming
         that this object has a :class:`~music21.tempo.MetronomeMark`
-        or :class:`~music21.tempo.MetricModulation` 
+        or :class:`~music21.tempo.MetricModulation`
         (or any :class:`~music21.tempo.TempoIndication`) in its past context.
 
         >>> s = stream.Stream()
@@ -3622,53 +3622,53 @@ class Music21Object(prebase.ProtoM21Object):
         >>> s.insert(4, tempo.MetronomeMark(number=30))
         >>> [n.seconds for n in s.notes]
         [1.0, 1.5, 0.5, 0.75, 2.0, 3.0]
-        
+
         Setting the number of seconds on a music21 object changes its duration:
-        
+
         >>> lastNote = s.notes[-1]
         >>> lastNote.duration.fullName
         'Dotted Quarter'
         >>> lastNote.seconds = 4.0
         >>> lastNote.duration.fullName
         'Half'
-        
+
         Any object of length 0 has zero-second length:
-        
+
         >>> tc = clef.TrebleClef()
         >>> tc.seconds
         0.0
-        
+
         If an object has positive duration but no tempo indication in its context,
         then the special number 'nan' for "not-a-number" is returned:
-        
+
         >>> r = note.Rest(type='whole')
         >>> r.seconds
         nan
-        
+
         Check for 'nan' with the `math.isnan()` routine:
-        
+
         >>> import math
         >>> math.isnan(r.seconds)
         True
-        
+
         Setting seconds for an element without a tempo-indication in its sites raises
         a Music21ObjectException:
-        
+
         >>> r.seconds = 2.0
         Traceback (most recent call last):
         music21.base.Music21ObjectException: this object does not have a TempoIndication in Sites
 
         Note that if an object is in multiple Sites with multiple Metronome marks,
-        the activeSite (or the hierarchy of the activeSite) 
+        the activeSite (or the hierarchy of the activeSite)
         determines its seconds for getting or setting:
-        
+
         >>> r = note.Rest(type='whole')
         >>> m1 = stream.Measure()
         >>> m1.insert(0, tempo.MetronomeMark(number=60))
         >>> m1.append(r)
         >>> r.seconds
         4.0
-        
+
         >>> m2 = stream.Measure()
         >>> m2.insert(0, tempo.MetronomeMark(number=120))
         >>> m2.append(r)
@@ -3684,8 +3684,8 @@ class Music21Object(prebase.ProtoM21Object):
         >>> r.seconds = 1.0
         >>> r.duration.type
         'half'
-                
-        Changed in v6.3 -- 
+
+        Changed in v6.3 -- return nan instead of raising an exception.
         ''')
 
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -5206,6 +5206,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             name = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(name) and not isinstance(name, types.FunctionType):
                 try:  # see if obj can be made w/ args
                     obj = name()

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -878,6 +878,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             name = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(name) and not isinstance(name, types.FunctionType):
                 try:  # see if obj can be made w/ args
                     obj = name()

--- a/music21/common/fileTools.py
+++ b/music21/common/fileTools.py
@@ -154,8 +154,8 @@ def restorePathClassesAfterUnpickling():
     else:
         pathlib.WindowsPath = _storedPathlibClasses['windowsPath']
 
-# -----------------------------------------------------------------------------
 
+# -----------------------------------------------------------------------------
 if __name__ == '__main__':
     import music21
     music21.mainTest()

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -46,7 +46,7 @@ import unittest
 import urllib
 import zipfile
 
-from typing import Union
+from typing import Union, Tuple
 
 __all__ = [
     'subConverters', 'ArchiveManagerException', 'PickleFilterException',
@@ -298,7 +298,7 @@ class PickleFilter:
         if pickleFp.exists():
             os.remove(pickleFp)
 
-    def status(self):
+    def status(self) -> Tuple[pathlib.Path, bool, pathlib.Path]:
         '''
         Given a file path specified with __init__, look for an up to date pickled
         version of this file path. If it exists, return its fp, otherwise return the
@@ -388,6 +388,7 @@ def registerSubconverter(newSubConverter):
 
 
 def unregisterSubconverter(removeSubconverter):
+    # noinspection PyShadowingNames
     '''
     Remove a Subconverter from the list of registered subconverters.
 
@@ -498,6 +499,7 @@ class Converter:
         self.stream.fileFormat = useFormat
 
     def getFormatFromFileExtension(self, fp):
+        # noinspection PyShadowingNames
         '''
         gets the format from a file extension.
 
@@ -804,6 +806,7 @@ class Converter:
         defaultSubconverters = []
         for i in sorted(subConverters.__dict__):
             name = getattr(subConverters, i)
+            # noinspection PyTypeChecker
             if (callable(name)
                     and not isinstance(name, types.FunctionType)
                     and hasattr(name, '__mro__')   # Typing imports break this.
@@ -1159,7 +1162,8 @@ def parse(value: Union[bundles.MetadataEntry, bytes, str, pathlib.Path],
         return parseData(value, number=number, format=m21Format, **keywords)
 
 
-def freeze(streamObj, fmt=None, fp=None, fastButUnsafe=False, zipType='zlib'):
+def freeze(streamObj, fmt=None, fp=None, fastButUnsafe=False, zipType='zlib') -> pathlib.Path:
+    # noinspection PyShadowingNames
     '''Given a StreamObject and a file path, serialize and store the Stream to a file.
 
     This function is based on the :class:`~music21.converter.StreamFreezer` object.
@@ -1170,7 +1174,6 @@ def freeze(streamObj, fmt=None, fp=None, fastButUnsafe=False, zipType='zlib'):
     If no file path is given, a temporary file is used.
 
     The file path is returned.
-
 
     >>> c = converter.parse('tinynotation: 4/4 c4 d e f')
     >>> c.show('text')
@@ -1184,7 +1187,7 @@ def freeze(streamObj, fmt=None, fp=None, fastButUnsafe=False, zipType='zlib'):
         {4.0} <music21.bar.Barline type=final>
     >>> fp = converter.freeze(c, fmt='pickle')
     >>> #_DOCS_SHOW fp
-    '/tmp/music21/sjiwoe.pgz'
+    PosixPath('/tmp/music21/sjiwoe.pgz')
 
     The file can then be "thawed" back into a Stream using the
     :func:`~music21.converter.thaw` method.
@@ -1350,6 +1353,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             obj = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(obj) and not isinstance(obj, types.FunctionType):
                 i = copy.copy(obj)
                 j = copy.deepcopy(obj)

--- a/music21/corpus/manager.py
+++ b/music21/corpus/manager.py
@@ -323,6 +323,8 @@ def cacheMetadataBundleFromDisk(corpusObject):
         metadataBundle = metadata.bundles.MetadataBundle(corpusName)
         metadataBundle.read()
         metadataBundle.validate()
+        # _metadataBundles needs TypedDict.
+        # noinspection PyTypeChecker
         _metadataBundles[corpusName] = metadataBundle
 
 

--- a/music21/editorial.py
+++ b/music21/editorial.py
@@ -203,6 +203,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             name = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(name) and not isinstance(name, types.FunctionType):
                 try:  # see if obj can be made w/ args
                     obj = name()

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -75,7 +75,7 @@ import time
 import unittest
 import zlib
 
-from typing import Union
+from typing import Union, List
 
 from music21 import base
 from music21 import common
@@ -143,8 +143,6 @@ class StreamFreezer(StreamFreezeThawBase):
 
     Use the :func:`~music21.converter.unfreeze` to read from a
     serialized file
-
-    >>> from music21 import freezeThaw
 
     >>> s = stream.Stream()
     >>> s.repeatAppend(note.Note('C4'), 8)
@@ -215,7 +213,6 @@ class StreamFreezer(StreamFreezeThawBase):
         self.streamIds = streamIds
 
         self.subStreamFreezers = {}  # this will keep track of sub freezers for spanners
-        #
 
         if streamObj is not None and fastButUnsafe is False:
             # deepcopy necessary because we mangle sites in the objects
@@ -259,8 +256,6 @@ class StreamFreezer(StreamFreezeThawBase):
         the Stream is deepcopied before this method is called. The
         attribute `fastButUnsafe = True` setting of StreamFreezer ignores the destructive
         effects of these processes and skips the deepcopy.
-
-        >>> from music21 import freezeThaw
 
         >>> a = stream.Stream()
         >>> n = note.Note()
@@ -470,8 +465,8 @@ class StreamFreezer(StreamFreezeThawBase):
                 self.setupStoredElementOffsetTuples(e)
             e.sites.remove(streamObj)
             e.activeSite = None
-#                e._preFreezeId = id(e)
-#                elementDict[id(e)] = s.elementOffset(e)
+            # e._preFreezeId = id(e)
+            # elementDict[id(e)] = s.elementOffset(e)
         for e in streamObj._endElements:
             elementTuple = (e, 'end')
             storedElementOffsetTuples.append(elementTuple)
@@ -487,12 +482,15 @@ class StreamFreezer(StreamFreezeThawBase):
         streamObj._endElements = []
         streamObj.coreElementsChanged()
 
-    def findActiveStreamIdsInHierarchy(self,
-                                       hierarchyObject=None,
-                                       getSpanners=True,
-                                       getVariants=True):
+    def findActiveStreamIdsInHierarchy(
+        self,
+        hierarchyObject=None,
+        getSpanners=True,
+        getVariants=True
+    ) -> List[int]:
         '''
-        Return a list of all Stream ids anywhere in the hierarchy.
+        Return a list of all Stream ids anywhere in the hierarchy.  By id,
+        we mean `id(s)` not `s.id` -- so they are memory locations and unique.
 
         Stores them in .streamIds.
 
@@ -604,9 +602,8 @@ class StreamFreezer(StreamFreezeThawBase):
     # --------------------------------------------------------------------------
 
     def parseWriteFmt(self, fmt):
-        '''Parse a passed-in write format
-
-        >>> from music21 import freezeThaw
+        '''
+        Parse a passed-in write format
 
         >>> sf = freezeThaw.StreamFreezer()
         >>> sf.parseWriteFmt(None)
@@ -659,10 +656,10 @@ class StreamFreezer(StreamFreezeThawBase):
         environLocal.printDebug(['writing fp', str(fp)])
 
         if fmt == 'pickle':
-            # a negative protocol value will get the highest protocol;
-            # this is generally desirable
+            # previously used highest protocol, but now protocols are changing too
+            # fast, and might not be compatible for sharing.
             # packStream() returns a storage dictionary
-            pickleString = pickle.dumps(storage, protocol=pickle.HIGHEST_PROTOCOL)
+            pickleString = pickle.dumps(storage)
             if zipType == 'zlib':
                 pickleString = zlib.compress(pickleString)
 
@@ -711,8 +708,6 @@ class StreamThawer(StreamFreezeThawBase):
     In general user :func:`~music21.converter.parse` to read from a
     serialized file.
 
-    >>> from music21 import freezeThaw
-
     >>> s = stream.Stream()
     >>> s.repeatAppend(note.Note('C4'), 8)
     >>> temp = [s[n].transpose(n, inPlace=True) for n in range(len(s))]
@@ -745,9 +740,6 @@ class StreamThawer(StreamFreezeThawBase):
         After rebuilding this Stream from pickled storage, prepare this as a normal `Stream`.
 
         If streamObj is None, runs it on the embedded stream
-
-        >>> from music21 import freezeThaw
-
 
         >>> a = stream.Stream()
         >>> n = note.Note()
@@ -928,6 +920,7 @@ class StreamThawer(StreamFreezeThawBase):
 
         fmt = self.parseOpenFmt(fileData)
         if fmt == 'pickle':
+            common.restorePathClassesAfterUnpickling()
             # environLocal.printDebug(['opening fp', fp])
             f = open(fp, 'rb')
             if zipType is None:
@@ -938,11 +931,14 @@ class StreamThawer(StreamFreezeThawBase):
                 try:
                     storage = pickle.loads(uncompressed)
                 except AttributeError as e:
+                    common.restoreWindowsAfterUnpickling()
                     raise FreezeThawException(
                         f'Problem in decoding: {e}'
                     ) from e
             else:
+                common.restorePathClassesAfterUnpickling()
                 raise FreezeThawException(f'Unknown zipType {zipType}')
+            common.restorePathClassesAfterUnpickling()
             f.close()
         elif fmt == 'jsonpickle':
             import jsonpickle
@@ -1158,7 +1154,6 @@ class Test(unittest.TestCase):
             n = note.Note(pitchName)
             n.duration.type = durType
             m.append(n)
-#            stream2.append(n)
         stream2.append(m)
         # c.show('t')
         variant.addVariant(c.parts[0], 6.0, stream2,

--- a/music21/graph/__init__.py
+++ b/music21/graph/__init__.py
@@ -154,6 +154,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             name = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(name) and not isinstance(name, types.FunctionType):
                 try:  # see if obj can be made w/ args
                     obj = name()

--- a/music21/graph/findPlot.py
+++ b/music21/graph/findPlot.py
@@ -60,6 +60,7 @@ def getPlotClasses():
     allPlot = []
     for i in sorted(plot.__dict__):
         name = getattr(plot, i)
+        # noinspection PyTypeChecker
         if (callable(name)
                 and not isinstance(name, types.FunctionType)
                 and plot.PlotStreamMixin in name.__mro__
@@ -82,6 +83,7 @@ def getAxisClasses():
     allAxis = []
     for i in sorted(axis.__dict__):
         name = getattr(axis, i)
+        # noinspection PyTypeChecker
         if (callable(name)
                 and not isinstance(name, types.FunctionType)
                 and axis.Axis in name.__mro__):

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -86,9 +86,9 @@ class PlotStreamMixin(prebase.ProtoM21Object):
         The representation of the Plot shows the stream repr
         in addition to the class name.
 
-        >>> s = stream.Stream()
-        >>> s.id = 'empty'
-        >>> plot = graph.plot.ScatterPitchClassQuarterLength(s)
+        >>> st = stream.Stream()
+        >>> st.id = 'empty'
+        >>> plot = graph.plot.ScatterPitchClassQuarterLength(st)
         >>> plot
         <music21.graph.plot.ScatterPitchClassQuarterLength for <music21.stream.Stream empty>>
 
@@ -1599,6 +1599,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             name = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(name) and not isinstance(name, types.FunctionType):
                 try:  # see if obj can be made w/ args
                     obj = name()

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -2138,6 +2138,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             name = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(name) and not isinstance(name, types.FunctionType):
                 try:  # see if obj can be made w/ args
                     obj = name()

--- a/music21/metadata/caching.py
+++ b/music21/metadata/caching.py
@@ -348,7 +348,7 @@ class JobProcessor:
             worker.start()
         if jobs:
             for job in jobs:
-                job_queue.put(pickle.dumps(job, protocol=pickle.HIGHEST_PROTOCOL))
+                job_queue.put(pickle.dumps(job))  # do not use highest protocol to generate.
             for unused_jobCounter in range(len(jobs)):
                 job = pickle.loads(result_queue.get())
                 results = job.getResults()

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -726,10 +726,10 @@ class MidiEvent:
         Demonstration.  First let's create a helper function and a MidiEvent:
 
         >>> to_bytes = midi.intsToHexBytes
-        >>> midiBytes = to_bytes([0x90, 60, 120])
-        >>> midiBytes
+        >>> midBytes = to_bytes([0x90, 60, 120])
+        >>> midBytes
         b'\x90<x'
-        >>> midiBytes += b'hello'
+        >>> midBytes += b'hello'
         >>> mt = midi.MidiTrack(1)
         >>> me1 = midi.MidiEvent(mt)
         >>> me1
@@ -738,7 +738,7 @@ class MidiEvent:
 
         Now show how the midiBytes changes the event:
 
-        >>> remainder = me1.parseChannelVoiceMessage(midiBytes)
+        >>> remainder = me1.parseChannelVoiceMessage(midBytes)
         >>> me1
         <MidiEvent NOTE_ON, t=0, track=1, channel=1, pitch=60, velocity=120>
 
@@ -1604,7 +1604,7 @@ class MidiFile(prebase.ProtoM21Object):
         ws = self.writestr()
         self.file.write(ws)
 
-    def writestr(self):
+    def writestr(self) -> bytes:
         '''
         Generate the MIDI data header and convert the list of
         MidiTrack objects in self.tracks into MIDI data and return it as bytes.
@@ -1616,7 +1616,7 @@ class MidiFile(prebase.ProtoM21Object):
             midiBytes = midiBytes + trk.getBytes()
         return midiBytes
 
-    def writeMThdStr(self):
+    def writeMThdStr(self) -> bytes:
         '''
         Convert the information in self.ticksPerQuarterNote
         into MIDI data header and return it as bytes.

--- a/music21/midi/percussion.py
+++ b/music21/midi/percussion.py
@@ -217,6 +217,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             name = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(name) and not isinstance(name, types.FunctionType):
                 try:  # see if obj can be made w/o any args
                     obj = name()

--- a/music21/note.py
+++ b/music21/note.py
@@ -1652,6 +1652,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             name = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(name) and not isinstance(name, types.FunctionType):
                 try:  # see if obj can be made w/ args
                     obj = name()

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         clercqTemperley.py
-# Purpose:      Demonstration of using music21 to parse Clercq-Temperley's
-#               popular music flavor of RomanText
+# Purpose:      Routines to parse the popular music
+#               Roman Numeral encoding system used by Clercq-Temperley
 #
 # Authors:      Beth Hadley
 #               Michael Scott Cuthbert
@@ -103,6 +103,7 @@ class CTSongException(exceptions21.Music21Exception):
 
 
 class CTSong(prebase.ProtoM21Object):
+    # noinspection PyShadowingNames
     r"""
     This parser is an object-oriented approach to parsing clercqTemperley text files into music.
 
@@ -404,6 +405,7 @@ class CTSong(prebase.ProtoM21Object):
 
     @property
     def rules(self):
+        # noinspection PyShadowingNames
         '''
         Get the rules of a CTSong. the Rules is an OrderedDict of
         objects of type CTRule. If only a text file
@@ -501,6 +503,7 @@ class CTSong(prebase.ProtoM21Object):
         return self._homeKeySig
 
     def toScore(self, labelRomanNumerals=True, labelSubsectionsOnScore=True):
+        # noinspection PyShadowingNames
         '''
         creates Score object out of a from CTSong...also creates CTRule objects in the process,
         filling their .streamFromCTSong attribute with the corresponding smaller inner stream.

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -1111,6 +1111,7 @@ class Test(unittest.TestCase):
             if match:
                 continue
             obj = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(obj) and not isinstance(obj, types.FunctionType):
                 i = copy.copy(obj)
                 j = copy.deepcopy(obj)

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -1419,33 +1419,34 @@ class Test(unittest.TestCase):
             if match:
                 continue
             obj = getattr(sys.modules[self.__module__], part)
+            # noinspection PyTypeChecker
             if callable(obj) and not isinstance(obj, types.FunctionType):
                 i = copy.copy(obj)
                 j = copy.deepcopy(obj)
 
-#    def testRows(self):
-#        from music21 import interval
-#
-#        self.assertEqual(len(vienneseRows), 71)
-#
-#        totalRows = 0
-#        cRows = 0
-#        for thisRow in vienneseRows:
-#            thisRow = thisRow()
-#            self.assertIsInstance(thisRow, TwelveToneRow)
-#
-#            if thisRow.composer == 'Berg':
-#                continue
-#            post = thisRow.title
-#
-#            totalRows += 1
-#            if thisRow[0].pitchClass == 0:
-#                cRows += 1
-
-#             if interval.notesToInterval(thisRow[0],
-#                                    thisRow[6]).intervalClass == 6:
-#              # between element 1 and element 7 is there a TriTone?
-#              rowsWithTTRelations += 1
+   # def testRows(self):
+   #     from music21 import interval
+   #
+   #     self.assertEqual(len(vienneseRows), 71)
+   #
+   #     totalRows = 0
+   #     cRows = 0
+   #     for thisRow in vienneseRows:
+   #         thisRow = thisRow()
+   #         self.assertIsInstance(thisRow, TwelveToneRow)
+   #
+   #         if thisRow.composer == 'Berg':
+   #             continue
+   #         post = thisRow.title
+   #
+   #         totalRows += 1
+   #         if thisRow[0].pitchClass == 0:
+   #             cRows += 1
+   #
+   #          if interval.notesToInterval(thisRow[0],
+   #                                 thisRow[6]).intervalClass == 6:
+   #           # between element 1 and element 7 is there a TriTone?
+   #           rowsWithTTRelations += 1
 
 
 # ------------------------------------------------------------------------------

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -1424,29 +1424,29 @@ class Test(unittest.TestCase):
                 i = copy.copy(obj)
                 j = copy.deepcopy(obj)
 
-   # def testRows(self):
-   #     from music21 import interval
-   #
-   #     self.assertEqual(len(vienneseRows), 71)
-   #
-   #     totalRows = 0
-   #     cRows = 0
-   #     for thisRow in vienneseRows:
-   #         thisRow = thisRow()
-   #         self.assertIsInstance(thisRow, TwelveToneRow)
-   #
-   #         if thisRow.composer == 'Berg':
-   #             continue
-   #         post = thisRow.title
-   #
-   #         totalRows += 1
-   #         if thisRow[0].pitchClass == 0:
-   #             cRows += 1
-   #
-   #          if interval.notesToInterval(thisRow[0],
-   #                                 thisRow[6]).intervalClass == 6:
-   #           # between element 1 and element 7 is there a TriTone?
-   #           rowsWithTTRelations += 1
+    # def testRows(self):
+    #     from music21 import interval
+    #
+    #     self.assertEqual(len(vienneseRows), 71)
+    #
+    #     totalRows = 0
+    #     cRows = 0
+    #     for thisRow in vienneseRows:
+    #         thisRow = thisRow()
+    #         self.assertIsInstance(thisRow, TwelveToneRow)
+    #
+    #         if thisRow.composer == 'Berg':
+    #             continue
+    #         post = thisRow.title
+    #
+    #         totalRows += 1
+    #         if thisRow[0].pitchClass == 0:
+    #             cRows += 1
+    #
+    #          if interval.notesToInterval(thisRow[0],
+    #                                 thisRow[6]).intervalClass == 6:
+    #           # between element 1 and element 7 is there a TriTone?
+    #           rowsWithTTRelations += 1
 
 
 # ------------------------------------------------------------------------------

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -2565,14 +2565,14 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             else:
                 off = common.strTrimFloat(offGet)
             if addEndTimes is False:
-                return in_indent + '{' + off + '} ' + repr(element)
+                return in_indent + '{' + off + '} ' + repr(in_element)
             else:
-                ql = offGet + element.duration.quarterLength
+                ql = offGet + in_element.duration.quarterLength
                 if useMixedNumerals:
                     qlStr = common.mixedNumeral(ql)
                 else:
                     qlStr = common.strTrimFloat(ql)
-                return in_indent + '{' + off + ' - ' + qlStr + '} ' + repr(element)
+                return in_indent + '{' + off + ' - ' + qlStr + '} ' + repr(in_element)
 
         msg = []
         insertSpaces = 4
@@ -4179,7 +4179,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         if self.hasMeasures():
             self.getElementsByClass('Measure')[-1].rightBarline = value
         elif hasattr(self, 'rightBarline'):
-            self.rightBarline = value
+            self.rightBarline = value  # pylint: disable=attribute-defined-outside-init
         # do nothing for other streams
 
     finalBarline = property(_getFinalBarline, _setFinalBarline, doc='''
@@ -4207,17 +4207,17 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         [<music21.bar.Barline type=final>,
          <music21.bar.Barline type=final>,
          <music21.bar.Barline type=final>,
-         <music21.bar.Barline type=final>]         
-                
+         <music21.bar.Barline type=final>]
+
         >>> s.finalBarline = 'none'
         >>> s.finalBarline
         [<music21.bar.Barline type=none>,
          <music21.bar.Barline type=none>,
          <music21.bar.Barline type=none>,
-         <music21.bar.Barline type=none>]         
-         
+         <music21.bar.Barline type=none>]
 
-        Getting or setting a final barline on a Measure (or another Stream 
+
+        Getting or setting a final barline on a Measure (or another Stream
         with a rightBarline attribute) is the same as getting or setting the rightBarline.
 
         >>> m = stream.Measure()
@@ -4228,17 +4228,17 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         <music21.bar.Barline type=final>
         >>> m.rightBarline
         <music21.bar.Barline type=final>
-        
+
         Getting on a generic Stream, Voice, or Opus always returns a barline of None,
         and setting on a generic Stream, Voice, or Opus always returns None:
-        
+
         >>> s = stream.Stream()
         >>> s.finalBarline is None
         True
         >>> s.finalBarline = 'final'
         >>> s.finalBarline is None
         True
-        
+
         Changed in v6.3 -- does not raise an exception if queried or set on a measure-less stream.
         Previously raised a StreamException
         ''')
@@ -7489,14 +7489,14 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> sFlat.replace(t, tFast)
         >>> sFlat.seconds
         16.363...
-        
+
         Setting seconds on streams is not supported.  Ideally it would instead
         scale all elements to fit, but this is a long way off.
-        
-        If a stream does not have a tempo-indication in it then the property 
-        returns 0.0 if an empty Stream (or self.highestTime is 0.0) or 'nan' 
+
+        If a stream does not have a tempo-indication in it then the property
+        returns 0.0 if an empty Stream (or self.highestTime is 0.0) or 'nan'
         if there are non-zero duration objects in the stream:
-        
+
         >>> s = stream.Stream()
         >>> s.seconds
         0.0
@@ -7509,7 +7509,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> import math
         >>> math.isnan(s.seconds)
         True
-        
+
         Changed in v6.3 -- return nan rather than raising an exception.  Do not
         attempt to change seconds on a stream, as it did not do what you would expect.
         ''')

--- a/music21/test/testPerformance.py
+++ b/music21/test/testPerformance.py
@@ -182,7 +182,7 @@ class Test(unittest.TestCase):
             p.transpose('p5', inPlace=True)
 
     def runParseABC(self):
-        '''Creating loading a large multiwork abc file
+        '''Creating loading a large multiple work abc file (han1)
         '''
         dummy = corpus.parse('essenFolksong/han1')
 

--- a/music21/test/timeGraphImportStar.py
+++ b/music21/test/timeGraphImportStar.py
@@ -162,7 +162,6 @@
 #                 # on MacOS, fd returns an int, like 3, when this is called
 #                 # in some context (specifically, programmatically in a
 #                 # TestExternal class. the fp is still valid and works
-#                 # TODO: this did not work on MacOS 10.6.8 w/ py 2.7
 #                     pass
 #                 else:
 #                     fd.close()

--- a/music21/test/timeGraphs.py
+++ b/music21/test/timeGraphs.py
@@ -611,7 +611,6 @@
 #                 # on MacOS, fd returns an int, like 3, when this is called
 #                 # in some context (specifically, programmatically in a
 #                 # TestExternal class. the fp is still valid and works
-#                 # TODO: this did not work on MacOS 10.6.8 w/ py 2.7
 #                     pass
 #                 else:
 #                     fd.close()

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -851,7 +851,7 @@ def mergePartAsOssia(mainPart, ossiaPart, ossiaName,
 def addVariant(
     s: stream.Stream,
     startOffset: Union[int, float],
-    sVariant: 'Variant',
+    sVariant: Union[stream.Stream, 'Variant'],
     variantName=None,
     variantGroups=None,
     replacementDuration=None


### PR DESCRIPTION
Deals with issues seen in #636 by making all properties (found so far) return sensible values rather than crashing on retrieval.  Fixes mock and other issues in Python 3.8.  

Also should fix corpus loading and converter.freeze()/converter.thaw() incompatibility across Mac and PC.

Pre 6.3 release