### PR TITLE
Loosen minimum webcolors version to 1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ jsonpickle
 matplotlib
 more_itertools
 numpy
-webcolors>=1.11
+webcolors>=1.5


### PR DESCRIPTION
Minimum version for `webcolors` was set to the latest release 1.11 in f178932728ed54462755bc837b2cef8e59b75c6c, but this was because a function was finally deprecated and its replacement `name_to_hex()` has been working since at least 1.5.

Loosening the minimum version to 1.5 would help folks install on conda-forge, where the latest version of `webcolors` available is 1.9.

Test suite passes when rolling `webcolors` back to 1.5.