### PR TITLE
Refactor getTempFile() and catch PermissionError when unable to write to scratch directory

### DIFF
--- a/documentation/source/usersGuide/usersGuide_24_environment.ipynb
+++ b/documentation/source/usersGuide/usersGuide_24_environment.ipynb
@@ -13,12 +13,12 @@
     "Environment configuration is particularly useful for setting default\n",
     "third-party applications (necessary for handling Music21 output in different\n",
     "media formats such as MusicXML, Lilypond, and graphics files) and for setting a\n",
-    "default scratch directory (for writing output without providing explitic file\n",
+    "default scratch directory (for writing output without providing explicit file\n",
     "paths).\n",
     "\n",
     "Environment configuration can be handled with two objects. The\n",
     ":class:`~music21.environment.Environment` object provides lower-level access\n",
-    "and control, as well as a numerous utiity methods for music21 modules. The\n",
+    "and control, as well as numerous utility methods for music21 modules. The\n",
     ":class:`~music21.environment.UserSettings` object is a convenience class for\n",
     "users to quickly set and check settings, and is reccommended for general usage.\n",
     "For complete information on the Environment and UserSettings objects, see\n",
@@ -28,7 +28,7 @@
     "## Creating and Configuring the UserSettings Object\n",
     "\n",
     "Environment configuration files are not created by default. To create an\n",
-    "environment configuration file, import environment from Music21 and create an\n",
+    "environment configuration file, import environment from Music21 and create a\n",
     ":class:`~music21.environment.UserSettings` object. Then, call the\n",
     ":meth:`~music21.environment.UserSettings.create` method to create an XML\n",
     "environment file."
@@ -52,7 +52,7 @@
    "metadata": {},
    "source": [
     "After creating an environment file, the resulting XML preference file can be\n",
-    "edited directly by the user or using the UserSettings object.  The keys tell you what can be changed:"
+    "edited directly by the user by using the UserSettings object.  The keys tell you what can be changed:"
    ]
   },
   {
@@ -215,8 +215,8 @@
     "### `parseURL()` and `parse()` Functions and 'autoDownload'\n",
     "\n",
     "The :func:`~music21.converter.parseURL` function, as well as the\n",
-    ":func:`~music21.corpus.parse` function, offer the ability to download a files\n",
-    "directly directly from the internet.\n",
+    ":func:`~music21.corpus.parse` function, offer the ability to download files\n",
+    "directly from the internet.\n",
     "\n",
     "Users may configure the 'autoDownload' key to determine whether downloading is\n",
     "attempted automatically without prompting the user ('allow'), whether the user\n",

--- a/documentation/source/usersGuide/usersGuide_54_extendingConverter.ipynb
+++ b/documentation/source/usersGuide/usersGuide_54_extendingConverter.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For this example, rather than importing \\* from music21, we'll just import the modules we need.  If you're developing a new SubConverter class just for yourself you can import everything, but if you're thinking that you'd like to contribute your module back to music21 someday, it is important not to import \\* since that will create circular imports"
+    "For this example, rather than importing \\* from music21, we'll just import the modules we need.  If you're developing a new SubConverter class just for yourself you can import everything, but if you're thinking that you'd like to contribute your module back to music21 someday, it is important not to import \\* since that will create circular imports."
    ]
   },
   {

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -1628,7 +1628,8 @@ class Test(unittest.TestCase):
 
     @unittest.skipUnless(
         os.access(Environment().getDefaultRootTempDir(), stat.S_IRWXU),
-            'test will programmatically set read/write/exec permissions on this dir')
+        'test will programmatically set read/write/exec permissions on this dir'
+    )
     def testGetTempFile(self):
         import getpass
         import stat

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -628,7 +628,7 @@ class _EnvironmentCore:
             if not newDir.exists():
                 try:
                     newDir.mkdir()
-                except (OSError, PermissionError):  # pragma: no cover
+                except OSError:  # pragma: no cover
                     # Give up and use /tmp
                     newDir = rootDir.parent
 


### PR DESCRIPTION
Came up while discussing #660:

First commit refactors `getTempFile()`. Second commit attempts to address #660 by writing to a user-specific dir only when needed (when catching `PermissionError`). Second commit has lower utility if #660 or #680 is merged, but `PermissionError`s could still theoretically arise, even if those PRs make it less likely to arise accidentally.