### PR TITLE
Don't assign durations to instruments during MIDI parsing

### DIFF
--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3216,6 +3216,7 @@ class Test(unittest.TestCase):
         out = midiFileToStream(mf)
         instruments = out.parts[0].getElementsByClass('Instrument')
         self.assertIsInstance(instruments[0], instrument.Oboe)
+        self.assertEqual(instruments[0].quarterLength, 0)
 
     def testImportZeroDurationNote(self):
         '''

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -8303,7 +8303,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                         unused_error, qlNew, signedError = bestMatch(
                             float(ql), quarterLengthDivisors)
                         # Enforce nonzero duration for non-grace notes
-                        if qlNew == 0 and not e.duration.isGrace:
+                        if qlNew == 0 and 'GeneralNote' in e.classes and not e.duration.isGrace:
                             qlNew = 1 / max(quarterLengthDivisors)
                             signedError = ql - qlNew
                         e.duration.quarterLength = qlNew


### PR DESCRIPTION
Regression in #641. Was causing leading rests at the beginning of a part to be broken up into smaller chunks.
Noticed while poking at #684.