### PR TITLE
Set literal name parsed from SEQUENCE_TRACK_NAME or INSTRUMENT_NAME on instrument.partName or .instrumentName

### DIFF
--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -689,6 +689,8 @@ def midiEventsToInstrument(eventList):
     '''
     Convert a single MIDI event into a music21 Instrument object.
     '''
+    from music21 import midi as midiModule
+
     if not common.isListLike(eventList):
         event = eventList
     else:  # get the second event; first is delta time
@@ -706,9 +708,12 @@ def midiEventsToInstrument(eventList):
             i = instrument.instrumentFromMidiProgram(event.data)
     except (instrument.InstrumentException, UnicodeDecodeError):  # pragma: no cover
         i = instrument.Instrument()
-    # Set partName with literal value from parsing
+    # Set partName or instrumentName with literal value from parsing
     if decoded:
-        i.partName = decoded
+        if event.type == midiModule.MetaEvents.SEQUENCE_TRACK_NAME:
+            i.partName = decoded
+        elif event.type == midiModule.MetaEvents.INSTRUMENT_NAME:
+            i.instrumentName = decoded
     return i
 
 

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -703,6 +703,7 @@ def midiEventsToInstrument(eventList):
             # MuseScore writes MIDI files with null-terminated
             # instrument names.  Thus stop before the byte-0x0
             decoded = event.data.decode('utf-8').split('\x00')[0]
+            decoded = decoded.strip()
             i = instrument.fromString(decoded)
         else:
             i = instrument.instrumentFromMidiProgram(event.data)
@@ -3275,6 +3276,15 @@ class Test(unittest.TestCase):
         event.data = bytes('Flute', 'utf-8')
         i = midiEventsToInstrument(event)
         self.assertIsInstance(i, instrument.Flute)
+
+    def testLousyInstrumentName(self):
+        from music21 import midi as midiModule
+
+        event = midiModule.MidiEvent()
+        event.data = bytes('     ', 'utf-8')
+        event.type = midiModule.MetaEvents.INSTRUMENT_NAME
+        i = midiEventsToInstrument(event)
+        self.assertIsNone(i.instrumentName)
 
 
 # ------------------------------------------------------------------------------

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -695,6 +695,7 @@ def midiEventsToInstrument(eventList):
         event = eventList[1]
 
     from music21 import instrument
+    decoded: str = ''
     try:
         if isinstance(event.data, bytes):
             # MuseScore writes MIDI files with null-terminated
@@ -705,6 +706,9 @@ def midiEventsToInstrument(eventList):
             i = instrument.instrumentFromMidiProgram(event.data)
     except (instrument.InstrumentException, UnicodeDecodeError):  # pragma: no cover
         i = instrument.Instrument()
+    # Set partName with literal value from parsing
+    if decoded:
+        i.partName = decoded
     return i
 
 
@@ -3217,6 +3221,12 @@ class Test(unittest.TestCase):
         instruments = out.parts[0].getElementsByClass('Instrument')
         self.assertIsInstance(instruments[0], instrument.Oboe)
         self.assertEqual(instruments[0].quarterLength, 0)
+
+        # Unrecognized instrument "Inst 1"
+        dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
+        fp = dirLib / 'test11.mid'
+        s2 = converter.parse(fp)
+        self.assertEqual(s2.parts[0].partName, 'Inst 1')
 
     def testImportZeroDurationNote(self):
         '''


### PR DESCRIPTION
Refs #684 

**Before**: `instrument.partName` was not set on instruments created from parsing MIDI. If the instruments could successfully be normalized to m21 instruments, `.partName` on the `Part` would come out okay because of the way the property drills down to the instrument types. If a default instrument was created from a string like "Marcato" that doesn't normalize, the information was lost (there was no specific instrument for the property to drill down to).

**Now**: We store the text from SEQUENCE_TRACK_NAME or INSTRUMENT_NAME meta messages on `instrument.partName` so it will flow upstream to `Part.partName` and thus to an xml export, whether the text successfully normalizes to a specific instrument or not.