### PR TITLE
Improve readability of parsing PITCH_BEND and POLYPHONIC_KEY_PRESSURE messages

### DIFF
--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -829,12 +829,20 @@ class MidiEvent:
                 self.parameter1 = byte1  # this is the controller id
                 self.parameter2 = byte2  # this is the controller value
             return midiBytes[3:]
-        else:
-            # NOTE_ON and NOTE_OFF
+        elif self.type == ChannelVoiceMessages.PITCH_BEND:
+            self.parameter1 = byte1  # least significant byte
+            self.parameter2 = byte2  # most significant byte
+            return midiBytes[3:]
+        elif self.type in (ChannelVoiceMessages.NOTE_ON, ChannelVoiceMessages.NOTE_OFF):
             # next two bytes:  pitch, velocity
             self.pitch = byte1
             self.velocity = byte2
             return midiBytes[3:]
+        elif self.type == ChannelVoiceMessages.POLYPHONIC_KEY_PRESSURE:
+            self.pitch = byte1
+            self.data = byte2
+            return midiBytes[3:]
+        raise TypeError(f'expected ChannelVoiceMessage, got {self.type}')  # pragma: no cover
 
     def read(self, midiBytes):
         r'''


### PR DESCRIPTION
Noticed while debugging that the `else` case was capturing more than NOTE_ON and NOTE_OFF. So I looked up what was being captured and wrote cases for them. Needs a test file; none of the .midi files in the repo have PITCH_BEND messages, for instance.