### PR TITLE
WIP -- handle out of measure bounds `<direction>` tags (and avoid creating gaps)

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6271,6 +6271,22 @@ class Test(unittest.TestCase):
         for direction in tree.findall('.//direction'):
             self.assertIsNone(direction.find('offset'))
 
+    def testDirectionFractionalOffset(self):
+        '''
+        Streams might contain elements that map to <direction> tags
+        with an .offset parsed from an <offset> subelement.
+        Without special handling, on export they can cause <forward> tags, i.e. rests.
+        '''
+        from music21 import converter, tempo
+
+        s = converter.parse('tinynotation: 2/4 d2 d2')
+        mm = tempo.MetronomeMark(number=144)
+        s.measure(1).insert(2.25, mm)
+
+        tree = self.getET(s)
+        # Assert no gaps in stream
+        self.assertSequenceEqual(tree.findall('.//forward'), [])
+
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1516,7 +1516,7 @@ class PartParser(XMLParserBase):
             if printObject == 'no':
                 part.style.printPartName = False
 
-        # This will later be put in the default instrument object also also...
+        # This will later be put in the default instrument object also...
 
         # TODO: partNameDisplay
         seta(part, mxScorePart, 'part-abbreviation', transform=_clean)


### PR DESCRIPTION
Fixes an issue where `<direction>` tags with `<offset>` subelements yielding unique offsets in the measure would create gaps when exporting to xml:

```
>>> s = corpus.parse('weber')
>>> s.parts[0].measure(1).show('t')
...
{0.0} <music21.meter.TimeSignature 3/4>
{0.0} <music21.note.Rest rest>
{2.0} <music21.note.Rest rest>
{3.1064} <music21.tempo.MetronomeMark larghetto Quarter=60.0>
>>> s.show()
```

Output:
![before](https://user-images.githubusercontent.com/38668450/101988468-c63b3880-3c67-11eb-8589-4a1668a61ca5.png)

Now:
![after](https://user-images.githubusercontent.com/38668450/101988474-d3f0be00-3c67-11eb-870b-1d3f8f4daa03.png)

Source musicxml from the corpus file (preceding the initial rest; divisions=1024):
```
      <direction placement="above">
        <direction-type>
          <words default-y="40" font-size="8.4" relative-x="-74">Adagio ma non troppo</words>
        </direction-type>
        <sound tempo="72"/>
      </direction>
      <direction placement="above">
        <direction-type>
          <metronome default-y="42" font-family="Petrucci" font-size="10.8" halign="left">
            <beat-unit>quarter</beat-unit>
            <per-minute>60</per-minute>
          </metronome>
        </direction-type>
        <offset>3181</offset>
        <sound tempo="60"/>
      </direction>
```

~WIP for now; needs tests.~ done ( at least for MetronomeMark)