### PR TITLE
Alternative (faster) implementation of DiatonicScale.getLeadingTone()

### DIFF
--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -2503,12 +2503,15 @@ class DiatonicScale(ConcreteScale):
         <music21.pitch.Pitch B-4>
         '''
         # NOTE: must be adjust for modes that do not have a proper leading tone
-        interval1to7 = interval.notesToInterval(self.tonic, self.pitchFromDegree(7))
-        if interval1to7.name != 'M7':
-            # if not a major seventh from the tonic, get a pitch a M7 above
-            return interval.transposePitch(self.pitchFromDegree(1), 'M7')
-        else:
-            return self.pitchFromDegree(7)
+        seventhDegree = self.pitchFromDegree(7)
+        distanceInSemitones = seventhDegree.midi - self.tonic.midi
+        if distanceInSemitones != 11:
+            # if not a major seventh, raise/lower the seventh degree
+            alterationInSemitones = 11 - distanceInSemitones
+            seventhDegree.accidental = pitch.Accidental(
+                seventhDegree.alter + alterationInSemitones
+            )
+        return seventhDegree
 
     def getParallelMinor(self):
         '''


### PR DESCRIPTION
Here is the new implementation of `DiatonicScale.getLeadingTone()` as discussed in #699.

Based on the last comment by @mscuthbert (each step appears exactly once in DiatonicScales), it should be safe to omit the `mod 12` in the condition.

Credit for faster check on 11 semitones (rather than `M7` Intervals) goes to @jacobtylerwalls.