### PR TITLE
Allow inspection of properties for Chord/Interval/Clef/etc.

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -1212,12 +1212,9 @@ class Chord(note.NotRest):
         False
         '''
         # no need to cache, since third, fifth, and seventh are cached
-        try:
-            third = self.third
-            fifth = self.fifth
-            seventh = self.seventh
-        except ChordException:
-            return False
+        third = self.third
+        fifth = self.fifth
+        seventh = self.seventh
 
         if third is None or fifth is None or seventh is None:
             return False
@@ -1249,13 +1246,8 @@ class Chord(note.NotRest):
         False
         '''
         # no need to cache, since third and fifth are cached
-        try:
-            third = self.third
-            fifth = self.fifth
-            # the only reason it cannot find a third or a fifth is
-            # that there is a complete 7-note diatonic scale present. or no notes
-        except ChordException:
-            return False
+        third = self.third
+        fifth = self.fifth
 
         if third is None or fifth is None:
             return False
@@ -2116,11 +2108,8 @@ class Chord(note.NotRest):
         >>> chord.Chord().isAugmentedTriad()
         False
         '''
-        try:
-            third = self.third
-            fifth = self.fifth
-        except ChordException:
-            return False
+        third = self.third
+        fifth = self.fifth
 
         if third is None or fifth is None:
             return False
@@ -2261,17 +2250,15 @@ class Chord(note.NotRest):
 
         intervalArray can be any iterable.
         '''
-        try:
-            third = self.third
-            fifth = self.fifth
-            seventh = self.seventh
-        except ChordException:
+        third = self.third
+        fifth = self.fifth
+        seventh = self.seventh
+
+        if third is None or fifth is None or seventh is None:
             return False
 
         root = self.root()
 
-        if third is None or fifth is None or seventh is None:
-            return False
         for thisPitch in self.pitches:
             thisInterval = interval.notesToInterval(root, thisPitch)
             if thisInterval.chromatic.mod12 not in intervalArray:
@@ -2300,11 +2287,8 @@ class Chord(note.NotRest):
         >>> chord.Chord().isDiminishedTriad()
         False
         '''
-        try:
-            third = self.third
-            fifth = self.fifth
-        except ChordException:
-            return False
+        third = self.third
+        fifth = self.fifth
 
         if third is None or fifth is None:
             return False
@@ -2666,10 +2650,7 @@ class Chord(note.NotRest):
         if self.chordTablesAddress[:2] != (2, 3):
             return False
 
-        try:
-            third = self.third
-        except ChordException:
-            return False
+        third = self.third
         if third is None:
             return False
 
@@ -2825,11 +2806,8 @@ class Chord(note.NotRest):
         if self.chordTablesAddress[:3] != (3, 11, -1):
             return False
 
-        try:
-            third = self.third
-            fifth = self.fifth
-        except ChordException:
-            return False
+        third = self.third
+        fifth = self.fifth
         if third is None or fifth is None:
             return False
 
@@ -2870,11 +2848,8 @@ class Chord(note.NotRest):
         if self.chordTablesAddress[:3] != (3, 11, 1):
             return False
 
-        try:
-            third = self.third
-            fifth = self.fifth
-        except ChordException:
-            return False
+        third = self.third
+        fifth = self.fifth
         if third is None or fifth is None:
             return False
 
@@ -2914,12 +2889,9 @@ class Chord(note.NotRest):
         if self.pitchClassCardinality != 4:
             return False
 
-        try:
-            third = self.third
-            fifth = self.fifth
-            seventh = self.seventh
-        except ChordException:
-            return False
+        third = self.third
+        fifth = self.fifth
+        seventh = self.seventh
 
         if third is None or fifth is None or seventh is None:
             return False
@@ -3052,11 +3024,9 @@ class Chord(note.NotRest):
         if self.pitchClassCardinality != 3:
             return False
 
-        try:
-            third = self.third
-            fifth = self.fifth
-        except ChordException:
-            return False
+        third = self.third
+        fifth = self.fifth
+
         if third is None or fifth is None:
             return False
         for thisPitch in self.pitches:
@@ -4266,7 +4236,8 @@ class Chord(note.NotRest):
     @property
     @cacheMethod
     def fifth(self) -> Optional[pitch.Pitch]:
-        '''Shortcut for getChordStep(5):
+        '''
+        Shortcut for getChordStep(5), but caches it and does not raise exceptions
 
         >>> cMaj1stInv = chord.Chord(['E3', 'C4', 'G5'])
         >>> cMaj1stInv.fifth
@@ -4277,6 +4248,10 @@ class Chord(note.NotRest):
 
         >>> chord.Chord('C4 D4').fifth is None
         True
+
+        OMIT_FROM_DOCS
+
+        >>> chord.Chord().fifth
         '''
         try:
             return self.getChordStep(5)
@@ -4300,13 +4275,13 @@ class Chord(note.NotRest):
 
         Empty chords return 'N/A'
 
-        >>> chord.Chord().forteClassTn
+        >>> chord.Chord().forteClass
         'N/A'
 
         Non-twelve-tone chords return as if all microtones and non-twelve-tone
         accidentals are removed:
 
-        >>> chord.Chord('c~4 d`4')
+        >>> chord.Chord('c~4 d`4').forteClass
         '2-2'
         '''
         try:
@@ -4345,22 +4320,8 @@ class Chord(note.NotRest):
         >>> c2 = chord.Chord(['c', 'e', 'g'])
         >>> c2.forteClassTn
         '3-11B'
-
-        Empty chords return 'N/A'
-
-        >>> chord.Chord().forteClassTn
-        'N/A'
-
-        Non-twelve-tone chords return as if all microtones and non-twelve-tone
-        accidentals are removed:
-
-        >>> chord.Chord('c~4 d`4')
-        '2-2'
         '''
-        try:
-            return self.forteClass
-        except chordTables.ChordTablesException:
-            return 'N/A'
+        return self.forteClass
 
     @property
     def forteClassTnI(self):
@@ -4378,13 +4339,13 @@ class Chord(note.NotRest):
 
         Empty chords return 'N/A'
 
-        >>> chord.Chord().forteClassTn
+        >>> chord.Chord().forteClassTnI
         'N/A'
 
         Non-twelve-tone chords return as if all microtones and non-twelve-tone
         accidentals are removed:
 
-        >>> chord.Chord('c~4 d`4')
+        >>> chord.Chord('c~4 d`4').forteClassTnI
         '2-2'
         '''
         try:
@@ -4427,6 +4388,11 @@ class Chord(note.NotRest):
         >>> c2 = chord.Chord(['c', 'c#', 'e', 'f#'])
         >>> c2.hasZRelation  # it is c, c#, e-, g
         True
+
+        OMIT_FROM_DOCS
+
+        >>> chord.Chord().hasZRelation
+        False
         '''
         try:
             post = chordTables.addressToZAddress(self.chordTablesAddress)
@@ -4454,6 +4420,11 @@ class Chord(note.NotRest):
         >>> c3 = chord.Chord(['c', 'c#', 'e-', 'g'])
         >>> c3.intervalVector
         [1, 1, 1, 1, 1, 1]
+
+        OMIT_FROM_DOCS
+
+        >>> chord.Chord().intervalVector
+        [0, 0, 0, 0, 0, 0]
         '''
         try:
             return list(chordTables.addressToIntervalVector(self.chordTablesAddress))
@@ -4630,6 +4601,9 @@ class Chord(note.NotRest):
 
         >>> chord.Chord('E#3 A3 C#4').normalOrder
         [1, 5, 9]
+
+        >>> chord.Chord().normalOrder
+        []
         '''
         cta = self.chordTablesAddress
         try:
@@ -4935,6 +4909,11 @@ class Chord(note.NotRest):
         >>> c2 = chord.Chord(['c', 'e', 'g'])
         >>> c2.primeForm
         [0, 3, 7]
+
+        OMIT_FROM_DOCS
+
+        >>> chord.Chord().primeForm
+        []
         '''
         try:
             return list(chordTables.addressToPrimeForm(self.chordTablesAddress))
@@ -5042,7 +5021,6 @@ class Chord(note.NotRest):
 
 
     @property
-    @cacheMethod
     def scaleDegrees(self):
         '''
         Returns a list of two-element tuples for each pitch in the chord where
@@ -5098,7 +5076,10 @@ class Chord(note.NotRest):
         [(1, None), (1, <accidental sharp>), (2, None),
          (3, <accidental flat>), (3, None), (4, None)]
 
-        Changed in v6.5 -- will return None if no context can be found.
+        Changed in v6.5 -- will return None if no context can be found:
+
+        >>> chord.Chord('C4 E4 G4').scaleDegrees is None
+        True
         '''
         from music21 import scale
         # roman numerals have this built in as the key attribute
@@ -5149,6 +5130,10 @@ class Chord(note.NotRest):
         <music21.pitch.Pitch B#4>
 
         Changed in v6.5 -- return None on empty chords/errors
+
+        OMIT_FROM_DOCS
+
+        >>> chord.Chord().seventh
         '''
         try:
             return self.getChordStep(7)
@@ -5170,6 +5155,10 @@ class Chord(note.NotRest):
         3
 
         Changed in v6.5 -- return None on empty chords/errors
+
+        OMIT_FROM_DOCS
+
+        >>> chord.Chord().third
         '''
         try:
             return self.getChordStep(3)
@@ -5245,6 +5234,13 @@ class Chord(note.NotRest):
         >>> c.volume.velocityIsRelative = False
         >>> c.volume  # return a new volume that is an average
         <music21.volume.Volume realized=0.76>
+
+        OMIT_FROM_DOCS
+
+        Make sure that empty chords have a volume:
+
+        >>> chord.Chord().volume
+        <music21.volume.Volume realized=0.71>
         '''
         if self._volume is not None:
             # if we already have a Volume, use that

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -176,9 +176,17 @@ class Clef(base.Music21Object):
         >>> tc = clef.TrebleClef()
         >>> tc.name
         'treble'
+
+        OMIT_FROM_DOCS
+
+        >>> clef.Clef().name
+        ''
         '''
         className = self.__class__.__name__.replace('Clef', '')
-        return className[0].lower() + className[1:]
+        if className:
+            return className[0].lower() + className[1:]
+        else:
+            return ''
 
 # ------------------------------------------------------------------------------
 

--- a/music21/common/pathTools.py
+++ b/music21/common/pathTools.py
@@ -22,6 +22,7 @@ __all__ = [
 import inspect
 import os
 import pathlib
+import unittest
 
 # ------------------------------------------------------------------------------
 
@@ -127,13 +128,14 @@ def getRootFilePath():
     which has directories such as "dist", "documentation", "music21"
 
     >>> fp = common.getRootFilePath()
-    >>> str(fp).endswith('/music21')
-    True
+    >>> #_DOCS_SHOW fp
+    PosixPath('/Users/florencePrice/git/music21')
 
     :rtype: pathlib.Path
     '''
     fpMusic21 = getSourceFilePath()
     fpParent = fpMusic21.parent
+    # Do not assume will end in music21 -- people can put this anywhere they want
     return fpParent
 
 
@@ -183,6 +185,12 @@ def cleanpath(path, *, returnPathlib=None):
         return pathlib.Path(path)
 
 
+class Test(unittest.TestCase):
+    def testGetSourcePath(self):
+        fp = getSourceFilePath()
+        self.assertIsInstance(fp, pathlib.Path)
+
+
 if __name__ == '__main__':
     import music21
-    music21.mainTest()
+    music21.mainTest(Test)

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -390,9 +390,19 @@ class Harmony(chord.Chord):
         >>> h = harmony.ChordSymbol('B-/D')
         >>> h.romanNumeral
         <music21.roman.RomanNumeral I6 in B- major>
+
+        OMIT_FROM_DOCS
+
+        Empty ChordSymbol = empty RomanNumeral:
+
+        >>> harmony.ChordSymbol().romanNumeral
+        <music21.roman.RomanNumeral>
         '''
         if self._roman is None:
             from music21 import roman
+            if not self.pitches:
+                return roman.RomanNumeral()
+
 
             storedWriteAsChord = self._writeAsChord
             self.writeAsChord = True

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -4352,6 +4352,17 @@ class Test(unittest.TestCase):
         self.assertEqual(i3.semitones, 5)
 
 
+    def testEmptyIntervalProperties(self):
+        empty = DiatonicInterval()
+        self.assertEqual(empty.cents, 0.0)
+
+        empty = Interval()
+        self.assertEqual(empty.complement, empty)
+        self.assertIsNot(empty.complement, empty)
+        self.assertEqual(empty.cents, 0.0)
+        self.assertEqual(empty.intervalClass, 0)
+
+
 # ------------------------------------------------------------------------------
 # define presented order in documentation
 _DOC_ORDER = [notesToChromatic, intervalsToDiatonic,

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -2164,7 +2164,10 @@ class DiatonicInterval(IntervalBase):
         100.0
         '''
         c = self.getChromatic()
-        return c.cents
+        if c:
+            return c.cents
+        else:
+            return 0.0
 
 
 class ChromaticInterval(IntervalBase):
@@ -3000,7 +3003,11 @@ class Interval(IntervalBase):
 
     def _reprInternal(self):
         from music21 import pitch
-        shift = self._diatonicIntervalCentShift()
+        try:
+            shift = self._diatonicIntervalCentShift()
+        except AttributeError:
+            return ''
+
         if shift != 0:
             micro = pitch.Microtone(shift)
             return self.directedName + ' ' + str(micro)
@@ -3227,8 +3234,16 @@ class Interval(IntervalBase):
         >>> dInterval = cInterval.complement
         >>> dInterval
         <music21.interval.Interval d7>
+
+        OMIT_FROM_DOCS
+
+        >>> interval.Interval().complement
+        <music21.interval.Interval>
         '''
-        return Interval(self.diatonic.mod7inversion)
+        try:
+            return Interval(self.diatonic.mod7inversion)
+        except AttributeError:
+            return Interval()
 
     @property
     def intervalClass(self):
@@ -3244,8 +3259,18 @@ class Interval(IntervalBase):
         >>> bInterval = interval.Interval('m6')
         >>> bInterval.intervalClass
         4
+
+        Empty intervals return 0:
+
+        >>> interval.Interval().intervalClass
+        0
+
+        Changed in v6.5 -- empty intervals return 0
         '''
-        return self.chromatic.intervalClass
+        try:
+            return self.chromatic.intervalClass
+        except AttributeError:
+            return 0
 
     @property
     def cents(self):
@@ -3262,8 +3287,16 @@ class Interval(IntervalBase):
         >>> microtoneInterval = interval.Interval(noteStart=n1, noteEnd=n2)
         >>> microtoneInterval.cents
         230.0
+
+        OMIT_FROM_DOCS
+
+        >>> interval.Interval().cents
+        0.0
         '''
-        return self.chromatic.cents
+        try:
+            return self.chromatic.cents
+        except AttributeError:  # chromatic might be None
+            return 0.0
 
     def _diatonicIntervalCentShift(self):
         '''

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2314,19 +2314,27 @@ class RomanNumeral(harmony.Harmony):
         >>> rn = roman.RomanNumeral('V65/V', 'e')
         >>> rn.figureAndKey
         'V65/V in e minor'
+
+        Without a key, it is the same as figure:
+
+        >>> roman.RomanNumeral('V7').figureAndKey
+        'V7'
         '''
+        if self.key is None:
+            return self.figure
+
+        mode = ''
         tonic = self.key.tonic
+
         if hasattr(tonic, 'name'):
             tonic = tonic.name
-        mode = ''
         if hasattr(self.key, 'mode'):
             mode = ' ' + self.key.mode
         elif self.key.__class__.__name__ == 'MajorScale':
             mode = ' major'
         elif self.key.__class__.__name__ == 'MinorScale':
             mode = ' minor'
-        else:
-            pass
+
         if mode == ' minor':
             tonic = tonic.lower()
         elif mode == ' major':


### PR DESCRIPTION
Fixes potential problems where retrieving a property causes an exception.

Cache a few more things.

Define what things like .forteClass are for empty Chords

remove test the common.getSourceFilePath() must end in music21 -- it does not for me! and probably others.

Document changes.

Technically backwards incompatible, but needed for a lot of Py3.8/3.9 compatibility.