### PR TITLE
Prevent multiple periods in the filepath from opus.write()

### DIFF
--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -13400,6 +13400,9 @@ class Opus(Stream):
         #_DOCS_SHOW >>> o.write()
         #_DOCS_SHOW PosixPath('/some/temp/path-2.xml')
         '''
+        if not self.scores:
+            return None
+
         if fmt is not None and 'lily' in fmt:
             return Stream.write(self, fmt, fp, **keywords)
         elif common.runningUnderIPython():
@@ -13407,10 +13410,10 @@ class Opus(Stream):
 
         if fp is None:
             if fmt is None:
-                suffix = environLocal['writeFormat']
+                suffix = '.' + environLocal['writeFormat']
             else:
                 unused_format, suffix = common.findFormat(fmt)
-            fp = environLocal.getTempFile(returnPathlib=False) + '.' + suffix
+            fp = environLocal.getTempFile(returnPathlib=False) + suffix
         if isinstance(fp, str):
             fp = pathlib.Path(fp)
 
@@ -13424,7 +13427,7 @@ class Opus(Stream):
             placesConsumed = math.ceil(math.log10(i + 1))
             zeroesNeeded = placesRequired - placesConsumed
             zeroes = '0' * zeroesNeeded
-            scoreName = fpStem + '-' + zeroes + str(i + 1) + '.' + fpSuffix
+            scoreName = fpStem + '-' + zeroes + str(i + 1) + fpSuffix
             fpToUse = fpParent / scoreName
             fpReturned = s.write(fmt=fmt, fp=fpToUse, **keywords)
             environLocal.printDebug(f'Component {s} written to {fpReturned}')

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -8154,6 +8154,9 @@ class Test(unittest.TestCase):
         out = o.write(fp=environLocal.getTempFile())
         self.assertTrue(str(out).endswith('-2.xml'))
 
+        out = o.write(fmt='midi')
+        self.assertTrue(str(out).endswith('-2.mid'))
+
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
When writing a test for the line I hadn't covered yet, sure enough there was a bug. Multiple periods were being created in a couple places.

Also short-circuited on lack of `.scores` so that we don't raise an ugly `MathDomainError`.