### PR TITLE
Hide metronome marks on subsequent staffs from MIDI

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -16,7 +16,7 @@ Each subconverter should inherit from the base SubConverter object and have at l
 parseData method that sets self.stream.
 '''
 # ------------------------------------------------------------------------------
-# Converters are associated classes; they are not subclasses, but most define a pareData() method,
+# Converters are associated classes; they are not subclasses, but most define a parseData() method,
 # a parseFile() method, and a .stream attribute or property.
 import base64
 import io
@@ -201,9 +201,9 @@ class SubConverter:
         '''
         Given a default format or subformats, give the file extension it should have:
 
-        >>> c = converter.subConverters.ConverterLilypond()
-
-        This is currently basically completely unused!
+        >>> c = converter.subConverters.ConverterMidi()
+        >>> c.getExtensionForSubformats()
+        '.mid'
         '''
         extensions = self.registerOutputExtensions
         if not extensions:
@@ -220,7 +220,7 @@ class SubConverter:
 
     def getTemporaryFile(self, subformats=None) -> pathlib.Path:
         '''
-        This is never called with subformats and should probably be deleted!
+        Return a temporary file with an extension appropriate for the format.
 
         >>> c = corpus.parse('bwv66.6')
         >>> lpConverter = converter.subConverters.ConverterLilypond()

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2322,6 +2322,7 @@ def midiTracksToStreams(
             eventCopy = copy.deepcopy(e)
             if 'TempoIndication' in eventCopy.classes and i != 0:
                 eventCopy.style.hideObjectOnPrint = True
+                eventCopy.numberImplicit = True
 
             p.insert(conductorPart.elementOffset(e), eventCopy)
 
@@ -3238,14 +3239,23 @@ class Test(unittest.TestCase):
         from music21 import converter
 
         dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
-        # a file with three tracks and one conductor track
+        # a file with three tracks and one conductor track with four tempo marks
         fp = dirLib / 'test11.mid'
         s = converter.parse(fp)
         self.assertEqual(len(s.parts), 3)
-        # metronome marks end up on every staff
-        self.assertEqual(len(s.parts[0].getElementsByClass('MetronomeMark')), 4)
-        self.assertEqual(len(s.parts[1].getElementsByClass('MetronomeMark')), 4)
-        self.assertEqual(len(s.parts[2].getElementsByClass('MetronomeMark')), 4)
+        # metronome marks propagate to every staff, but are hidden on subsequent staffs
+        self.assertEqual(
+            [mm.numberImplicit for mm in s.parts[0].getElementsByClass('MetronomeMark')],
+            [False, False, False, False]
+        )
+        self.assertEqual(
+            [mm.numberImplicit for mm in s.parts[1].getElementsByClass('MetronomeMark')],
+            [True, True, True, True]
+        )
+        self.assertEqual(
+            [mm.numberImplicit for mm in s.parts[2].getElementsByClass('MetronomeMark')],
+            [True, True, True, True]
+        )
 
     def testMidiExportConductorA(self):
         '''Export conductor data to MIDI conductor track.'''


### PR DESCRIPTION
Refs #684
`.numberImplicit` was all it took.
