### PR TITLE
Retain midi channel

### DIFF
--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -422,10 +422,10 @@ class MidiEvent:
     A model of a MIDI event, including note-on, note-off, program change,
     controller change, any many others.
 
-    MidiEvent objects are paired (preceded) by :class:`~music21.midi.base.DeltaTime`
+    MidiEvent objects are paired (preceded) by :class:`~music21.midi.DeltaTime`
     objects in the list of events in a MidiTrack object.
 
-    The `track` argument must be a :class:`~music21.midi.base.MidiTrack` object.
+    The `track` argument must be a :class:`~music21.midi.MidiTrack` object.
 
     The `type` attribute is an enumeration of a Midi event from the ChannelVoiceMessages
     or metaEvents enums.
@@ -434,7 +434,7 @@ class MidiEvent:
 
     The `time` attribute is an integer duration of the event in ticks. This value
     can be zero. This value is not essential, as ultimate time positioning is
-    determined by :class:`~music21.midi.base.DeltaTime` objects.
+    determined by :class:`~music21.midi.DeltaTime` objects.
 
     The `pitch` attribute is only defined for note-on and note-off messages.
     The attribute stores an integer representation (0-127, with 60 = middle C).
@@ -1121,12 +1121,12 @@ class MidiEvent:
 
 class DeltaTime(MidiEvent):
     r'''
-    A :class:`~music21.midi.base.MidiEvent` subclass that stores the
+    A :class:`~music21.midi.MidiEvent` subclass that stores the
     time change (in ticks) since the start or since the last MidiEvent.
 
     Pairs of DeltaTime and MidiEvent objects are the basic presentation of temporal data.
 
-    The `track` argument must be a :class:`~music21.midi.base.MidiTrack` object.
+    The `track` argument must be a :class:`~music21.midi.MidiTrack` object.
 
     Time values are in integers, representing ticks.
 

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -353,6 +353,7 @@ def midiEventsToNote(eventList, ticksPerQuarter=None, inputM21=None):
     n.volume.velocity = eOn.velocity
     n.volume.velocityIsRelative = False  # not relative coming from MIDI
     # n._midiVelocity = eOn.velocity
+    n.editorial['channel'] = eOn.channel
     # here we are handling an issue that might arise with double-stemmed notes
     if (tOff - tOn) != 0:
         ticksToDuration(tOff - tOn, ticksPerQuarter, n.duration)
@@ -506,6 +507,7 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
         c = chord.Chord()
     else:
         c = inputM21
+    c.editorial['channels'] = []
 
     if ticksPerQuarter is None:
         ticksPerQuarter = defaults.ticksPerQuarter
@@ -526,6 +528,7 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
             p = pitch.Pitch()
             p.midi = eOn.pitch
             pitches.append(p)
+            c.editorial['channels'].append(eOn.channel)
             v = volume.Volume(velocity=eOn.velocity)
             v.velocityIsRelative = False  # velocity is absolute coming from
             volumes.append(v)
@@ -541,6 +544,7 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
             p = pitch.Pitch()
             p.midi = onEvents[i].pitch
             pitches.append(p)
+            c.editorial['channels'].append(onEvents[i].channel)
             v = volume.Volume(velocity=onEvents[i].velocity)
             v.velocityIsRelative = False  # velocity is absolute coming from
             volumes.append(v)
@@ -3596,6 +3600,17 @@ class Test(unittest.TestCase):
         s.insert(0, p)
         conductor = conductorStream(s)
         self.assertEqual(conductor.priority, -3)
+
+    def testChannelParsed(self):
+        from music21 import converter
+
+        dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
+        fp = dirLib / 'test05.mid'
+        s = converter.parse(fp)
+        # Note
+        self.assertEqual(s.flat.notes[0].editorial['channel'], 1)
+        # Chord
+        self.assertEqual(s.flat.notes[1].editorial['channels'], [1, 1, 1])
 
 
 # ------------------------------------------------------------------------------

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -460,8 +460,8 @@ def noteToMidiEvents(inputM21, includeDeltaTime=True, channel=1):
 def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
     # noinspection PyShadowingNames
     '''
-    Creates a Chord from a list of :class:`~music21.midi.base.DeltaTime`
-    and :class:`~music21.midi.base.MidiEvent` objects.  See midiEventsToNote
+    Creates a Chord from a list of :class:`~music21.midi.DeltaTime`
+    and :class:`~music21.midi.MidiEvent` objects.  See midiEventsToNote
     for details.
 
     All DeltaTime objects except the first are ignored.
@@ -901,7 +901,7 @@ def keySignatureToMidiEvents(ks: 'music21.key.KeySignature', includeDeltaTime=Tr
     :class:`~music21.key.KeySignature` object to
     a two-element list of midi events,
     where the first is an empty DeltaTime (unless includeDeltaTime is False) and the second
-    is a KEY_SIGNATURE :class:`~music21.midi.base.MidiEvent`
+    is a KEY_SIGNATURE :class:`~music21.midi.MidiEvent`
 
     >>> ks = key.KeySignature(2)
     >>> ks
@@ -2198,7 +2198,7 @@ def streamHierarchyToMidiTracks(
 ):
     '''
     Given a Stream, Score, Part, etc., that may have substreams (i.e.,
-    a hierarchy), return a list of :class:`~music21.midi.base.MidiTrack` objects.
+    a hierarchy), return a list of :class:`~music21.midi.MidiTrack` objects.
 
     acceptableChannelList is a list of MIDI Channel numbers that can be used or None.
     If None, then 1-9, 11-16 are used (10 being reserved for percussion).
@@ -2335,7 +2335,7 @@ def streamToMidiFile(
 ) -> 'music21.midi.MidiFile':
     # noinspection PyShadowingNames
     '''
-    Converts a Stream hierarchy into a :class:`~music21.midi.base.MidiFile` object.
+    Converts a Stream hierarchy into a :class:`~music21.midi.MidiFile` object.
 
     >>> s = stream.Stream()
     >>> n = note.Note('g#')
@@ -2528,7 +2528,7 @@ def midiFileToStream(
 
         score = converter.parse('path/to/file.mid')
 
-    Convert a :class:`~music21.midi.base.MidiFile` object to a
+    Convert a :class:`~music21.midi.MidiFile` object to a
     :class:`~music21.stream.Stream` object.
 
     The `inputM21` object can specify an existing Stream (or Stream subclass) to fill.


### PR DESCRIPTION
Resolves #465

Store the channel parsed from a midi note on `.editorial['channel']` for note; `.editorial['channels']` for chord.

Update MIDI docs: `midi.base` is just `midi` now.