### PR TITLE
Add proper documentation to RomanNumeral for the first time

### DIFF
--- a/documentation/source/developerReference/documenting.rst
+++ b/documentation/source/developerReference/documenting.rst
@@ -354,11 +354,13 @@ is from chord.py::
         'beams': 'A :class:`music21.note.Beams` object.',
         }
         # update inherited _DOC_ATTR dictionary
-        note.NotRest._DOC_ATTR.update(_DOC_ATTR)
-        _DOC_ATTR = note.NotRest._DOC_ATTR
+        _DOC_ATTR.update(note.NotRest._DOC_ATTR)
 
         def __init__(self, notes = [], **keywords):
             pass
+
+However, you will rarely need to do this, since the documentation will point to
+the inherited docs automatically.
 
 Documenting Class-Level Methods
 -----------------------------------------------------------------

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -213,8 +213,10 @@ class Harmony(chord.Chord):
             self.bass(self._overrides['root'])
 
         updatePitches = keywords.get('updatePitches', True)
-        if (updatePitches and self._figure is not None
-                or 'root' in self._overrides or 'bass' in self._overrides):
+        if (updatePitches
+                and self._figure # == '' or is not None
+                or 'root' in self._overrides
+                or 'bass' in self._overrides):
             self._updatePitches()
         self._updateBasedOnXMLInput(keywords)
 
@@ -306,7 +308,7 @@ class Harmony(chord.Chord):
     @figure.setter
     def figure(self, value):
         self._figure = value
-        if self._figure is not None:
+        if self._figure:
             self._parseFigure()
             self._updatePitches()
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -214,7 +214,7 @@ class Harmony(chord.Chord):
 
         updatePitches = keywords.get('updatePitches', True)
         if (updatePitches
-                and self._figure # == '' or is not None
+                and self._figure  # == '' or is not None
                 or 'root' in self._overrides
                 or 'bass' in self._overrides):
             self._updatePitches()

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -17,7 +17,7 @@ import enum
 import unittest
 import copy
 import re
-from typing import Union
+from typing import Union, Optional, List, Tuple
 
 from collections import namedtuple
 
@@ -53,14 +53,15 @@ ENDWITHFLAT_RE = re.compile(r'[b\-]$')
 _scaleCache = {}
 _keyCache = {}
 
+# create a single notation object for RN initialization, for type-checking,
+# but it will always be replaced.
+_NOTATION_SINGLETON = fbNotation.Notation()
 
-def _getKeyFromCache(keyStr):
+
+def _getKeyFromCache(keyStr: str) -> key.Key:
     '''
     get a key from the cache if it is there; otherwise
     create a new key and put it in the cache and return it.
-
-    :param keyStr: str
-    :rtype: key.Key
     '''
     if keyStr in _keyCache:
         keyObj = _keyCache[keyStr]
@@ -1437,6 +1438,9 @@ class RomanNumeral(harmony.Harmony):
     >>> rn4.figure = 'I'
     >>> rn2 == rn4
     True
+
+    Changed in v6.5 -- caseMatters is keyword only. It along with sixthMinor and
+    seventhMinor are now the only allowable keywords to pass in.
     '''
     # TODO: document better! what is inherited and what is new?
 
@@ -1449,39 +1453,396 @@ class RomanNumeral(harmony.Harmony):
     _secondarySlashRegex = re.compile(r'(.*?)/([#a-np-zA-NP-Z].*)')
 
     _DOC_ATTR = {
-        'scaleCardinality': '''
-            Probably you should not need to change this, but stores how many
-            notes are in the scale; defaults to 7 for diatonic, obviously.
+        'addedSteps': '''
+            Returns a list of the added steps, each as a tuple of
+            modifier as a string (which might be empty) and a chord factor as an int.
+        
+            >>> rn = roman.RomanNumeral('V7[addb6]', 'C')
+            >>> rn.addedSteps
+            [('-', 6)]
+            >>> rn.pitches
+            (<music21.pitch.Pitch G4>,
+             <music21.pitch.Pitch B4>,
+             <music21.pitch.Pitch D5>,
+             <music21.pitch.Pitch E-5>,
+             <music21.pitch.Pitch F5>)    
+
+            You can add multiple added steps:
+            
+            >>> strange = roman.RomanNumeral('V7[addb6][add#6][add-8]')
+            >>> strange.addedSteps
+            [('-', 6), ('#', 6), ('-', 8)]
+            >>> ' '.join([p.nameWithOctave for p in strange.pitches])
+            'G4 B4 D5 E-5 E#5 F5 G-5'
+
+            NOTE: The modifier name is currently changed from 'b' to '-', but
+            this might change in a future version to match `bracketedAlteration`.
+            ''',
+        'bracketedAlterations': '''
+            Returns a list of the bracketed alterations, each as a tuple of
+            modifier as a string and a chord factor as an int.
+            
+            >>> rn = roman.RomanNumeral('V7[b5]')
+            >>> rn.bracketedAlterations
+            [('b', 5)]
+            >>> rn.pitches
+            (<music21.pitch.Pitch G4>, 
+             <music21.pitch.Pitch B4>, 
+             <music21.pitch.Pitch D-5>, 
+             <music21.pitch.Pitch F5>)
+            
+            NOTE: The bracketed alteration name is currently left as 'b', but
+            this might change in a future version to match `addedSteps`. 
+             
+            The difference between a bracketed alteration and just
+            putting b5 in is that, a bracketed alteration changes
+            notes already present in a chord and does not imply that
+            the normally present notes would be missing.  Here, the
+            presence of 7 and b5 means that no 3rd should appear
+            
+            >>> rn2 = roman.RomanNumeral('V7b5')
+            >>> rn2.bracketedAlterations
+            []
+            >>> len(rn2.pitches)
+            3
+            >>> [p.step for p in rn2.pitches]
+            ['G', 'D', 'F']
+            
+            
+            NOTE: currently there is a bug and this chord is returning
+            D-natural instead of D-flat.  This will be fixed soon.
+            
+            Changed in v6.5 -- always returns a list, even if it is empty.
             ''',
         'caseMatters': '''
             Boolean to determine whether the case (upper or lowercase) of the
             figure determines whether it is major or minor.  Defaults to True;
             not everything has been tested with False yet.
+            
+            >>> roman.RomanNumeral('viiø7', 'd').caseMatters
+            True
+            ''',
+        'figuresWritten': '''
+            Returns a string containing any figured-bass figures as passed in:
+            
+            >>> roman.RomanNumeral('V65').figuresWritten
+            '65'
+            >>> roman.RomanNumeral('V').figuresWritten
+            ''
+            >>> roman.RomanNumeral('Fr43', 'c').figuresWritten
+            '43'
+            >>> roman.RomanNumeral('I7#5b3').figuresWritten
+            '7#5b3'
+            
+            Note that the `o` and `ø` symbols are quality designations and not
+            figures:
+            
+            >>> roman.RomanNumeral('viio6').figuresWritten
+            '6'
+            >>> roman.RomanNumeral('viiø7').figuresWritten
+            '7'
+            ''',
+        'figuresNotationObj': '''
+            Returns a :class:`~music21.figuredBass.notation.Notation` object
+            that represents the figures in a RomanNumeral
+
+            >>> rn = roman.RomanNumeral('V65')
+            >>> notationObj = rn.figuresNotationObj
+            >>> notationObj
+            <music21.figuredBass.notation.Notation 6,5>
+            >>> notationObj.numbers
+            (6, 5, 3)
+            
+            >>> rn = roman.RomanNumeral('Ib75#3')
+            >>> notationObj = rn.figuresNotationObj
+            >>> notationObj.numbers
+            (7, 5, 3)
+            >>> notationObj.modifiers
+            (<modifier b <accidental flat>>, 
+             <modifier None None>, 
+             <modifier # <accidental sharp>>)            
+            ''',
+        'frontAlterationAccidental': '''
+            An optional :class:`~music21.pitch.Accidental` object 
+            representing the chromatic alteration of a RomanNumeral, if any
+    
+            >>> roman.RomanNumeral('bII43/vi', 'C').frontAlterationAccidental
+            <accidental flat>
+
+            >>> roman.RomanNumeral('##IV').frontAlterationAccidental
+            <accidental double-sharp>
+            
+            For most roman numerals this will be None:
+            
+            >>> roman.RomanNumeral('V', 'f#').frontAlterationAccidental
+            
+            Changing this value will not change existing pitches.
+    
+            Changed in v6.5 -- always returns a string, never None
+            ''',
+        'frontAlterationString': '''
+            A string representing the chromatic alteration of a RomanNumeral, if any
+
+            >>> roman.RomanNumeral('bII43/vi', 'C').frontAlterationString
+            'b'
+            >>> roman.RomanNumeral('V', 'f#').frontAlterationString
+            ''
+
+            Changing this value will not change existing pitches.
+
+            Changed in v6.5 -- always returns a string, never None
+            ''',
+        'frontAlterationTransposeInterval': '''
+            An optional :class:`~music21.interval.Interval` object
+            representing the transposition of a chromatically altered chord from
+            the normal scale degree:
+
+            >>> sharpFour = roman.RomanNumeral('#IV', 'C')
+            >>> sharpFour.frontAlterationTransposeInterval
+            <music21.interval.Interval A1>
+            >>> sharpFour.frontAlterationTransposeInterval.niceName            
+            'Augmented Unison'            
+            
+            Flats, as in this Neapolitan (bII6) chord, are given as diminished unisons:
+            
+            >>> roman.RomanNumeral('N6', 'C').frontAlterationTransposeInterval
+            <music21.interval.Interval d1>
+
+
+            Most RomanNumerals will have None and not a perfect unison for this value
+            (this is for the speed of creating objects)
+                                    
+            >>> intv = roman.RomanNumeral('V', 'e-').frontAlterationTransposeInterval
+            >>> intv is None
+            True
+            
+            Changing this value will not change existing pitches.
+            
+            N.B. the deprecated property `.scaleOffset` is identical 
+            to `.frontAlterationTransposeInterval` and will be removed in v7
+            ''',
+        'impliedQuality': '''
+            The quality of the chord implied by the figure:
+            
+            >>> roman.RomanNumeral('V', 'C').impliedQuality
+            'major'
+            >>> roman.RomanNumeral('ii65', 'C').impliedQuality
+            'minor'
+            >>> roman.RomanNumeral('viio7', 'C').impliedQuality
+            'diminished'
+            
+            The impliedQuality can differ from the actual quality
+            if there are not enough notes to satisfy the implied quality,
+            as in this half-diminished chord on vii which does not also
+            have a seventh:
+            
+            >>> incorrectSeventh = roman.RomanNumeral('vii/o', 'C')
+            >>> incorrectSeventh.impliedQuality
+            'half-diminished'
+            >>> incorrectSeventh.quality
+            'diminished'
+            
+            >>> powerChordMinor = roman.RomanNumeral('v[no3]', 'C')
+            >>> powerChordMinor.impliedQuality
+            'minor'
+            >>> powerChordMinor.quality
+            'other'
+            
+            If case does not matter then an empty quality is implied:
+            
+            >>> roman.RomanNumeral('II', 'C', caseMatters=False).impliedQuality
+            ''
+            
+            ''',
+        'impliedScale': '''
+            If no key or scale is passed in as the second object, then
+            impliedScale will be set to C major:
+            
+            >>> roman.RomanNumeral('V').impliedScale
+            <music21.scale.MajorScale C major>
+            
+            Otherwise this will be empty:
+            
+            >>> roman.RomanNumeral('V', key.Key('D')).impliedScale            
+            ''',
+        'omittedSteps': '''
+            A list of integers showing chord factors that have been
+            specifically omitted:
+            
+            >>> emptyNinth = roman.RomanNumeral('V9[no7][no5]', 'C')
+            >>> emptyNinth.omittedSteps
+            [7, 5]
+            >>> emptyNinth.pitches
+            (<music21.pitch.Pitch G4>, 
+             <music21.pitch.Pitch B4>, 
+             <music21.pitch.Pitch A5>)
+             
+            Usually an empty list:
+            
+            >>> roman.RomanNumeral('IV6').omittedSteps
+            []
             ''',
         'pivotChord': '''
             Defaults to None; if not None, stores another interpretation of the
             same RN in a different key; stores a RomanNumeral object.
+            
+            While not enforced, for consistency the pivotChord should be
+            the new interpretation going forward (to the right on the staff)
+            
+            >>> rn = roman.RomanNumeral('V7/IV', 'C')
+            >>> rn.pivotChord is None
+            True
+            >>> rn.pivotChord = roman.RomanNumeral('V7', 'F')
             ''',
-        'sixthMinor': '''
-            How should vi, vio and VI be parsed in minor?
-            Defaults to Minor67Default.QUALITY
+        'primaryFigure': '''
+            A string representing everything before the slash
+            in a RomanNumeral with applied chords.  In other roman numerals
+            it is the same as `figure`:
+
+            >>> rn = roman.RomanNumeral('bII43/vi', 'C')
+            >>> rn.primaryFigure
+            'bII43'
+
+            >>> rnSimple = roman.RomanNumeral('V6', 'a')
+            >>> rnSimple.primaryFigure
+            'V6'
+
+            Changing this value will not change existing pitches.
+            ''',
+        'romanNumeralAlone': '''
+            Returns a string of just the roman numeral part (I-VII or i-vii) of
+            the figure:
+
+            >>> roman.RomanNumeral('V6').romanNumeralAlone
+            'V'
+
+            Chromatic alterations and secondary numerals are omitted:
+
+            >>> rn = roman.RomanNumeral('#II7/vi', 'C')
+            >>> rn.romanNumeralAlone
+            'II'
+            
+            Neapolitan chords are changed to 'II':
+            
+            >>> roman.RomanNumeral('N6').romanNumeralAlone
+            'II'
+            
+            Currently augmented-sixth chords return the "national" base.  But this
+            behavior may change in future versions:
+            
+            >>> roman.RomanNumeral('It6').romanNumeralAlone
+            'It'
+            >>> roman.RomanNumeral('Ger65').romanNumeralAlone
+            'Ger'
+
+            This will be controversial in some circles, but it's based on a root in
+            isolation, and does not imply tonic quality:
+            
+            >>> roman.RomanNumeral('Cad64').romanNumeralAlone
+            'I'
+            ''',
+        'scaleCardinality': '''
+            Stores how many notes are in the scale; defaults to 7 for diatonic, obviously.
+
+            >>> roman.RomanNumeral('IV', 'a').scaleCardinality
+            7
+            
+            Probably you should not need to change this.  And most code is untested
+            with other cardinalities.  But it is (in theory) possible to create
+            roman numerals on octatonic scales, etc.
+
+            Changing this value will not change existing pitches.
+            ''',
+        'scaleDegree': '''
+            An int representing what degree of the scale the figure
+            (or primary figure in the case of secondary/applied numerals)
+            is on.  Discounts any front alterations:
+
+            >>> roman.RomanNumeral('vi', 'E').scaleDegree
+            6
+
+            Note that this is 2, not 1.5 or 6 or 6.5 or something like that:
+
+            >>> roman.RomanNumeral('bII43/vi', 'C').scaleDegree
+            2
+
+            Empty RomanNumeral objects have the special scaleDegree of 0:
+
+            >>> roman.RomanNumeral().scaleDegree
+            0
+
+            Changing this value will not change existing pitches.
+
+            Changed in v6.5 -- empty RomanNumeral objects get scaleDegree 0, not None.
+            ''',
+        'secondaryRomanNumeral': '''
+            An optional roman.RomanNumeral object that represents the part
+            after the slash in a secondary/applied RomanNumeral object.  For instance,
+            in the roman numeral, `C: V7/vi`, the `secondaryRomanNumeral` would be
+            the roman numeral `C: vi`.  The key of the `secondaryRomanNumeral`
+            is the key of the original RomanNumeral.  In cases such as
+            V/V/V, the `secondaryRomanNumeral` can itself have a
+            `secondaryRomanNumeral`.
+
+            >>> rn = roman.RomanNumeral('V7/vi', 'C')
+            >>> rn.secondaryRomanNumeral
+            <music21.roman.RomanNumeral vi in C major>
+            ''',
+        'secondaryRomanNumeralKey': '''
+            An optional key.Key object for secondary/applied RomanNumeral that 
+            represents the key that the part of the figure *before* the slash
+            will be interpreted in.  For instance in the roman numeral,
+            `C: V7/vi`, the `secondaryRomanNumeralKey` would be `a minor`, since
+            the vi (submediant) refers to an a-minor triad, and thus the `V7`
+            part is to be read as the dominant seventh in `a minor`.
+
+            >>> rn = roman.RomanNumeral('V7/vi', 'C')
+            >>> rn.secondaryRomanNumeralKey
+            <music21.key.Key of a minor>
             ''',
         'seventhMinor': '''
             How should vii, viio,  and VII be parsed in minor?
-            Defaults to Minor67Default.QUALITY
-        ''',
+            Defaults to Minor67Default.QUALITY.
+
+            This value should be passed into the constructor initially.
+            Changing it after construction will not change the pitches.            
+            ''',
+        'sixthMinor': '''
+            How should vi, vio and VI be parsed in minor?
+            Defaults to Minor67Default.QUALITY.
+            
+            This value should be passed into the constructor initially.
+            Changing it after construction will not change the pitches.
+            ''',
+        'useImpliedScale': '''
+            A boolean indicating whether an implied scale is being used:
+            
+            >>> roman.RomanNumeral('V').useImpliedScale
+            True
+            >>> roman.RomanNumeral('V', 'A').useImpliedScale
+            False
+            ''',
     }
 
     # INITIALIZER #
 
-    def __init__(self, figure=None, keyOrScale=None, caseMatters=True, **keywords):
-        self.primaryFigure = None
-        self.secondaryRomanNumeral = None
-        self.secondaryRomanNumeralKey = None
+    def __init__(
+        self,
+        figure: Union[str, int] = '',
+        keyOrScale=None,
+        *,
+        caseMatters=True,
+        updatePitches=True,
+        sixthMinor=Minor67Default.QUALITY,
+        seventhMinor=Minor67Default.QUALITY,
+    ):
+        self.primaryFigure: str = ''
+        self.secondaryRomanNumeral: Optional['RomanNumeral'] = None
+        self.secondaryRomanNumeralKey: Optional['key.Key'] = None
 
-        self.pivotChord = None
-        self.caseMatters = caseMatters
-        self.scaleCardinality = 7
+        self.pivotChord: Optional['RomanNumeral'] = None
+        self.caseMatters: bool = caseMatters
+        self.scaleCardinality: int = 7
 
         if isinstance(figure, int):
             self.caseMatters = False
@@ -1502,34 +1863,42 @@ class RomanNumeral(harmony.Harmony):
         self._figure = figure
         # This is set when _setKeyOrScale() is called:
         self._scale = None
-        self.scaleDegree = None
-        self.frontAlterationString = None
-        self.frontAlterationTransposeInterval = None
-        self.frontAlterationAccidental = None
-        self.romanNumeralAlone = None
-        self.figuresWritten = None
-        self.figuresNotationObj = None
+        self.scaleDegree: int = 0
+        self.frontAlterationString: str = ''
+        self.frontAlterationTransposeInterval: Optional[interval.Interval] = None
+        self.frontAlterationAccidental: Optional[pitch.Accidental] = None
+        self.romanNumeralAlone: str = ''
+        self.figuresWritten: str = ''
+        self.figuresNotationObj: fbNotation.Notation = _NOTATION_SINGLETON
+        if not figure:
+            self.figuresNotationObj = fbNotation.Notation()  # do not allow changing singleton
 
-        self.impliedQuality = None
-        self.impliedScale = None
-        self.scaleOffset = None
-        self.useImpliedScale = False
-        self.bracketedAlterations = None
-        self.omittedSteps = []
-        self.addedSteps = []
+        self.impliedQuality: str = ''
+
+        # scaleOffset is completely redundant with frontAlterationTransposeInterval
+        # and will be removed in v7.0.
+        self.scaleOffset: Optional[interval.Interval] = None
+
+        self.impliedScale: Optional[scale.Scale] = None
+        self.useImpliedScale: bool = False
+        self.bracketedAlterations: List[Tuple[str, int]] = []
+        self.omittedSteps: List[int] = []
+        self.addedSteps: List[Tuple[str, int]] = []
         # do not update pitches.
         self._parsingComplete = False
         self.key = keyOrScale
-        self.sixthMinor = keywords.get('sixthMinor', Minor67Default.QUALITY)
-        self.seventhMinor = keywords.get('seventhMinor', Minor67Default.QUALITY)
+        self.sixthMinor = sixthMinor
+        self.seventhMinor = seventhMinor
 
-        updatePitches = keywords.get('updatePitches', True)
         super().__init__(figure, updatePitches=updatePitches)
         self._parsingComplete = True
         self._functionalityScore = None
+
         # It is sometimes helpful to know if this is the first chord after a
-        # key change.
+        # key change.  This has been moved to Editorial immediately, and will
+        # be REMOVED in v7
         self.followsKeyChange = False
+        self.editorial.followsKeyChange = False
 
     # SPECIAL METHODS #
 
@@ -1569,7 +1938,8 @@ class RomanNumeral(harmony.Harmony):
         (workingFigure, useScale) = self._correctForSecondaryRomanNumeral(useScale)
 
         if workingFigure == 'Cad64':
-            if useScale.mode == 'minor':
+            # since useScale can be a scale, it might not have a mode
+            if hasattr(useScale, 'mode') and useScale.mode == 'minor':
                 workingFigure = 'i64'
             else:
                 workingFigure = 'I64'
@@ -1629,7 +1999,7 @@ class RomanNumeral(harmony.Harmony):
 
     def _correctBracketedPitches(self):
         # correct bracketed figures
-        if self.bracketedAlterations is None:
+        if not self.bracketedAlterations:
             return
         for (alterNotation, chordStep) in self.bracketedAlterations:
             alterNotation = re.sub('b', '-', alterNotation)
@@ -1809,7 +2179,7 @@ class RomanNumeral(harmony.Harmony):
             secondaryRomanNumeral = RomanNumeral(
                 secondaryFigure,
                 useScale,
-                self.caseMatters,
+                caseMatters=self.caseMatters,
             )
             self.secondaryRomanNumeral = secondaryRomanNumeral
             if secondaryRomanNumeral.quality == 'minor':
@@ -1910,8 +2280,6 @@ class RomanNumeral(harmony.Harmony):
         '''
         matches = self._bracketedAlterationRegex.finditer(workingFigure)
         for m in matches:
-            if self.bracketedAlterations is None:
-                self.bracketedAlterations = []
             matchAlteration = m.group(1)
             matchDegree = int(m.group(2))
             newTuple = (matchAlteration, matchDegree)
@@ -1957,6 +2325,9 @@ class RomanNumeral(harmony.Harmony):
         self.frontAlterationString = frontAlterationString
         self.frontAlterationTransposeInterval = frontAlterationTransposeInterval
         self.frontAlterationAccidental = frontAlterationAccidental
+
+        # Remove this in v7.
+        self.scaleOffset = self.frontAlterationTransposeInterval
         return workingFigure
 
     def _parseRNAloneAmidstAug6(self, workingFigure, useScale):
@@ -2024,9 +2395,6 @@ class RomanNumeral(harmony.Harmony):
 
             workingFigure = self._augmentedSixthRegex.sub('', workingFigure)
             self.romanNumeralAlone = romanNumeralAlone
-            if self.bracketedAlterations is None:
-                self.bracketedAlterations = []
-
             if romanNumeralAlone != 'Fr':
                 fixTuple = ('#', 1)
                 self.bracketedAlterations.append(fixTuple)
@@ -2098,7 +2466,7 @@ class RomanNumeral(harmony.Harmony):
         '''
         def sharpen(wFig):
             changeFrontAlteration(interval.Interval('A1'), 1)
-            # If root is in the figure, unsharpen to avoid double-sharpening
+            # If root is in the figure, lower the root to avoid double-sharpening
             if '##' in wFig:
                 wFig = wFig.replace('##8', '#8')
             elif '#2' in wFig:
@@ -2222,8 +2590,6 @@ class RomanNumeral(harmony.Harmony):
             self.pitches = pitches
 
         self._matchAccidentalsToQuality(self.impliedQuality)
-
-        self.scaleOffset = self.frontAlterationTransposeInterval
 
         # run this before omittedSteps and added steps so that
         # they don't change the sense of root.
@@ -2604,6 +2970,34 @@ class RomanNumeral(harmony.Harmony):
         self._functionalityScore = value
 
 
+# Override the documentation for a property
+RomanNumeral.figure.__doc__ = '''
+    Gives a string representation of the roman numeral, which
+    is usually the same as what you passed in as a string:
+    
+    >>> roman.RomanNumeral('bVII65/V', 'C').figure
+    'bVII65/V'
+    
+    There are a few exceptions.  If the RomanNumeral is initialized
+    with an int, then it is converted to a string:
+    
+    >>> roman.RomanNumeral(2).figure
+    'II'
+    
+    A `0` used for `o` in a diminished seventh chord is converted to `o`,
+    and the `/o` form of half-diminished is converted to `ø`:
+    
+    >>> roman.RomanNumeral('vii07').figure
+    'viio7'
+    >>> roman.RomanNumeral('vii/o7').figure
+    'viiø7'
+    
+    Changing this value will not change existing pitches.            
+    
+    Changed in v6.5 -- empty RomanNumerals now have figure of '' not None
+    '''
+
+
 # -----------------------------------------------------------------------------
 
 
@@ -2641,12 +3035,12 @@ class Test(unittest.TestCase):
 
     def testFigure(self):
         r1 = RomanNumeral('V')
-        self.assertEqual(r1.scaleOffset, None)
+        self.assertEqual(r1.frontAlterationTransposeInterval, None)
         self.assertEqual(r1.pitches, chord.Chord(['G4', 'B4', 'D5']).pitches)
         r1 = RomanNumeral('bbVI6')
         self.assertEqual(r1.figuresWritten, '6')
-        self.assertEqual(r1.scaleOffset.chromatic.semitones, -2)
-        self.assertEqual(r1.scaleOffset.diatonic.directedNiceName,
+        self.assertEqual(r1.frontAlterationTransposeInterval.chromatic.semitones, -2)
+        self.assertEqual(r1.frontAlterationTransposeInterval.diatonic.directedNiceName,
                          'Descending Doubly-Diminished Unison')
         cM = scale.MajorScale('C')
         r2 = RomanNumeral('ii', cM)

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -1456,7 +1456,7 @@ class RomanNumeral(harmony.Harmony):
         'addedSteps': '''
             Returns a list of the added steps, each as a tuple of
             modifier as a string (which might be empty) and a chord factor as an int.
-        
+
             >>> rn = roman.RomanNumeral('V7[addb6]', 'C')
             >>> rn.addedSteps
             [('-', 6)]
@@ -1465,10 +1465,10 @@ class RomanNumeral(harmony.Harmony):
              <music21.pitch.Pitch B4>,
              <music21.pitch.Pitch D5>,
              <music21.pitch.Pitch E-5>,
-             <music21.pitch.Pitch F5>)    
+             <music21.pitch.Pitch F5>)
 
             You can add multiple added steps:
-            
+
             >>> strange = roman.RomanNumeral('V7[addb6][add#6][add-8]')
             >>> strange.addedSteps
             [('-', 6), ('#', 6), ('-', 8)]
@@ -1481,25 +1481,25 @@ class RomanNumeral(harmony.Harmony):
         'bracketedAlterations': '''
             Returns a list of the bracketed alterations, each as a tuple of
             modifier as a string and a chord factor as an int.
-            
+
             >>> rn = roman.RomanNumeral('V7[b5]')
             >>> rn.bracketedAlterations
             [('b', 5)]
             >>> rn.pitches
-            (<music21.pitch.Pitch G4>, 
-             <music21.pitch.Pitch B4>, 
-             <music21.pitch.Pitch D-5>, 
+            (<music21.pitch.Pitch G4>,
+             <music21.pitch.Pitch B4>,
+             <music21.pitch.Pitch D-5>,
              <music21.pitch.Pitch F5>)
-            
+
             NOTE: The bracketed alteration name is currently left as 'b', but
-            this might change in a future version to match `addedSteps`. 
-             
+            this might change in a future version to match `addedSteps`.
+
             The difference between a bracketed alteration and just
             putting b5 in is that, a bracketed alteration changes
             notes already present in a chord and does not imply that
             the normally present notes would be missing.  Here, the
             presence of 7 and b5 means that no 3rd should appear
-            
+
             >>> rn2 = roman.RomanNumeral('V7b5')
             >>> rn2.bracketedAlterations
             []
@@ -1507,24 +1507,23 @@ class RomanNumeral(harmony.Harmony):
             3
             >>> [p.step for p in rn2.pitches]
             ['G', 'D', 'F']
-            
-            
+
             NOTE: currently there is a bug and this chord is returning
             D-natural instead of D-flat.  This will be fixed soon.
-            
+
             Changed in v6.5 -- always returns a list, even if it is empty.
             ''',
         'caseMatters': '''
             Boolean to determine whether the case (upper or lowercase) of the
             figure determines whether it is major or minor.  Defaults to True;
             not everything has been tested with False yet.
-            
+
             >>> roman.RomanNumeral('viiø7', 'd').caseMatters
             True
             ''',
         'figuresWritten': '''
             Returns a string containing any figured-bass figures as passed in:
-            
+
             >>> roman.RomanNumeral('V65').figuresWritten
             '65'
             >>> roman.RomanNumeral('V').figuresWritten
@@ -1533,10 +1532,10 @@ class RomanNumeral(harmony.Harmony):
             '43'
             >>> roman.RomanNumeral('I7#5b3').figuresWritten
             '7#5b3'
-            
+
             Note that the `o` and `ø` symbols are quality designations and not
             figures:
-            
+
             >>> roman.RomanNumeral('viio6').figuresWritten
             '6'
             >>> roman.RomanNumeral('viiø7').figuresWritten
@@ -1552,32 +1551,32 @@ class RomanNumeral(harmony.Harmony):
             <music21.figuredBass.notation.Notation 6,5>
             >>> notationObj.numbers
             (6, 5, 3)
-            
+
             >>> rn = roman.RomanNumeral('Ib75#3')
             >>> notationObj = rn.figuresNotationObj
             >>> notationObj.numbers
             (7, 5, 3)
             >>> notationObj.modifiers
-            (<modifier b <accidental flat>>, 
-             <modifier None None>, 
-             <modifier # <accidental sharp>>)            
+            (<modifier b <accidental flat>>,
+             <modifier None None>,
+             <modifier # <accidental sharp>>)
             ''',
         'frontAlterationAccidental': '''
-            An optional :class:`~music21.pitch.Accidental` object 
+            An optional :class:`~music21.pitch.Accidental` object
             representing the chromatic alteration of a RomanNumeral, if any
-    
+
             >>> roman.RomanNumeral('bII43/vi', 'C').frontAlterationAccidental
             <accidental flat>
 
             >>> roman.RomanNumeral('##IV').frontAlterationAccidental
             <accidental double-sharp>
-            
+
             For most roman numerals this will be None:
-            
+
             >>> roman.RomanNumeral('V', 'f#').frontAlterationAccidental
-            
+
             Changing this value will not change existing pitches.
-    
+
             Changed in v6.5 -- always returns a string, never None
             ''',
         'frontAlterationString': '''
@@ -1600,95 +1599,94 @@ class RomanNumeral(harmony.Harmony):
             >>> sharpFour = roman.RomanNumeral('#IV', 'C')
             >>> sharpFour.frontAlterationTransposeInterval
             <music21.interval.Interval A1>
-            >>> sharpFour.frontAlterationTransposeInterval.niceName            
-            'Augmented Unison'            
-            
+            >>> sharpFour.frontAlterationTransposeInterval.niceName
+            'Augmented Unison'
+
             Flats, as in this Neapolitan (bII6) chord, are given as diminished unisons:
-            
+
             >>> roman.RomanNumeral('N6', 'C').frontAlterationTransposeInterval
             <music21.interval.Interval d1>
 
-
             Most RomanNumerals will have None and not a perfect unison for this value
             (this is for the speed of creating objects)
-                                    
+
             >>> intv = roman.RomanNumeral('V', 'e-').frontAlterationTransposeInterval
             >>> intv is None
             True
-            
+
             Changing this value will not change existing pitches.
-            
-            N.B. the deprecated property `.scaleOffset` is identical 
+
+            N.B. the deprecated property `.scaleOffset` is identical
             to `.frontAlterationTransposeInterval` and will be removed in v7
             ''',
         'impliedQuality': '''
             The quality of the chord implied by the figure:
-            
+
             >>> roman.RomanNumeral('V', 'C').impliedQuality
             'major'
             >>> roman.RomanNumeral('ii65', 'C').impliedQuality
             'minor'
             >>> roman.RomanNumeral('viio7', 'C').impliedQuality
             'diminished'
-            
+
             The impliedQuality can differ from the actual quality
             if there are not enough notes to satisfy the implied quality,
             as in this half-diminished chord on vii which does not also
             have a seventh:
-            
+
             >>> incorrectSeventh = roman.RomanNumeral('vii/o', 'C')
             >>> incorrectSeventh.impliedQuality
             'half-diminished'
             >>> incorrectSeventh.quality
             'diminished'
-            
+
             >>> powerChordMinor = roman.RomanNumeral('v[no3]', 'C')
             >>> powerChordMinor.impliedQuality
             'minor'
             >>> powerChordMinor.quality
             'other'
-            
+
             If case does not matter then an empty quality is implied:
-            
+
             >>> roman.RomanNumeral('II', 'C', caseMatters=False).impliedQuality
             ''
-            
+
             ''',
         'impliedScale': '''
             If no key or scale is passed in as the second object, then
             impliedScale will be set to C major:
-            
+
             >>> roman.RomanNumeral('V').impliedScale
             <music21.scale.MajorScale C major>
-            
+
             Otherwise this will be empty:
-            
-            >>> roman.RomanNumeral('V', key.Key('D')).impliedScale            
+
+            >>> roman.RomanNumeral('V', key.Key('D')).impliedScale
             ''',
         'omittedSteps': '''
             A list of integers showing chord factors that have been
             specifically omitted:
-            
+
             >>> emptyNinth = roman.RomanNumeral('V9[no7][no5]', 'C')
             >>> emptyNinth.omittedSteps
             [7, 5]
             >>> emptyNinth.pitches
-            (<music21.pitch.Pitch G4>, 
-             <music21.pitch.Pitch B4>, 
+            (<music21.pitch.Pitch G4>,
+             <music21.pitch.Pitch B4>,
              <music21.pitch.Pitch A5>)
-             
+
             Usually an empty list:
-            
+
             >>> roman.RomanNumeral('IV6').omittedSteps
             []
             ''',
         'pivotChord': '''
             Defaults to None; if not None, stores another interpretation of the
             same RN in a different key; stores a RomanNumeral object.
-            
+
             While not enforced, for consistency the pivotChord should be
             the new interpretation going forward (to the right on the staff)
-            
+
             >>> rn = roman.RomanNumeral('V7/IV', 'C')
             >>> rn.pivotChord is None
             True
@@ -1721,15 +1719,15 @@ class RomanNumeral(harmony.Harmony):
             >>> rn = roman.RomanNumeral('#II7/vi', 'C')
             >>> rn.romanNumeralAlone
             'II'
-            
+
             Neapolitan chords are changed to 'II':
-            
+
             >>> roman.RomanNumeral('N6').romanNumeralAlone
             'II'
-            
+
             Currently augmented-sixth chords return the "national" base.  But this
             behavior may change in future versions:
-            
+
             >>> roman.RomanNumeral('It6').romanNumeralAlone
             'It'
             >>> roman.RomanNumeral('Ger65').romanNumeralAlone
@@ -1737,7 +1735,7 @@ class RomanNumeral(harmony.Harmony):
 
             This will be controversial in some circles, but it's based on a root in
             isolation, and does not imply tonic quality:
-            
+
             >>> roman.RomanNumeral('Cad64').romanNumeralAlone
             'I'
             ''',
@@ -1746,7 +1744,7 @@ class RomanNumeral(harmony.Harmony):
 
             >>> roman.RomanNumeral('IV', 'a').scaleCardinality
             7
-            
+
             Probably you should not need to change this.  And most code is untested
             with other cardinalities.  But it is (in theory) possible to create
             roman numerals on octatonic scales, etc.
@@ -1789,7 +1787,7 @@ class RomanNumeral(harmony.Harmony):
             <music21.roman.RomanNumeral vi in C major>
             ''',
         'secondaryRomanNumeralKey': '''
-            An optional key.Key object for secondary/applied RomanNumeral that 
+            An optional key.Key object for secondary/applied RomanNumeral that
             represents the key that the part of the figure *before* the slash
             will be interpreted in.  For instance in the roman numeral,
             `C: V7/vi`, the `secondaryRomanNumeralKey` would be `a minor`, since
@@ -1805,18 +1803,18 @@ class RomanNumeral(harmony.Harmony):
             Defaults to Minor67Default.QUALITY.
 
             This value should be passed into the constructor initially.
-            Changing it after construction will not change the pitches.            
+            Changing it after construction will not change the pitches.
             ''',
         'sixthMinor': '''
             How should vi, vio and VI be parsed in minor?
             Defaults to Minor67Default.QUALITY.
-            
+
             This value should be passed into the constructor initially.
             Changing it after construction will not change the pitches.
             ''',
         'useImpliedScale': '''
             A boolean indicating whether an implied scale is being used:
-            
+
             >>> roman.RomanNumeral('V').useImpliedScale
             True
             >>> roman.RomanNumeral('V', 'A').useImpliedScale
@@ -2974,26 +2972,26 @@ class RomanNumeral(harmony.Harmony):
 RomanNumeral.figure.__doc__ = '''
     Gives a string representation of the roman numeral, which
     is usually the same as what you passed in as a string:
-    
+
     >>> roman.RomanNumeral('bVII65/V', 'C').figure
     'bVII65/V'
-    
+
     There are a few exceptions.  If the RomanNumeral is initialized
     with an int, then it is converted to a string:
-    
+
     >>> roman.RomanNumeral(2).figure
     'II'
-    
+
     A `0` used for `o` in a diminished seventh chord is converted to `o`,
     and the `/o` form of half-diminished is converted to `ø`:
-    
+
     >>> roman.RomanNumeral('vii07').figure
     'viio7'
     >>> roman.RomanNumeral('vii/o7').figure
     'viiø7'
-    
-    Changing this value will not change existing pitches.            
-    
+
+    Changing this value will not change existing pitches.
+
     Changed in v6.5 -- empty RomanNumerals now have figure of '' not None
     '''
 

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -204,7 +204,7 @@ def _copySingleMeasure(t, p, kCurrent):
                     # should not happen
                     raise RomanTextTranslateException(
                         'attempting to copy a measure but no past key definitions are found')
-                if rnPast.followsKeyChange is True:
+                if rnPast.editorial.get('followsKeyChange'):
                     kCurrent = rnPast.key
                 elif rnPast.pivotChord is not None:
                     kCurrent = rnPast.pivotChord.key
@@ -268,7 +268,7 @@ def _copyMultipleMeasures(t, p, kCurrent):
                     # should not happen
                     raise RomanTextTranslateException(
                         'attempting to copy a measure but no past key definitions are found')
-                if rnPast.followsKeyChange is True:
+                if rnPast.editorial.get('followsKeyChange'):
                     kCurrent = rnPast.key
                 elif rnPast.pivotChord is not None:
                     kCurrent = rnPast.pivotChord.key
@@ -840,10 +840,10 @@ class PartTranslator:
             # 19.01
 
             if self.setKeyChangeToken is True:
-                rn.followsKeyChange = True
+                rn.editorial.followsKeyChange = True
                 self.setKeyChangeToken = False
             else:
-                rn.followsKeyChange = False
+                rn.editorial.followsKeyChange = False
         except (roman.RomanNumeralException,
                 exceptions21.Music21CommonException):  # pragma: no cover
             # environLocal.printDebug(f' cannot create RN from: {a.src}')


### PR DESCRIPTION
Makes a small tiny changes mostly for empty roman numerals.

`.followsKeyChange` and `.scaleOffset` are deprecated and will be removed in v7