### PR TITLE
Fix RNs like V7b5

### DIFF
--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -85,7 +85,6 @@ class ReductiveNote(prebase.ProtoM21Object):
     }
 
     def __init__(self, specification, inputNote, measureIndex, measureOffset):
-        super().__init__()
         self._specification = specification
 
         self._note = None  # store a reference to the note this is attached to

--- a/music21/base.py
+++ b/music21/base.py
@@ -354,7 +354,7 @@ class Music21Object(prebase.ProtoM21Object):
     }
 
     def __init__(self, *arguments, **keywords):
-        super().__init__()
+        # do not call super().__init__() since it just wastes time
         # None is stored as the internal location of an obj w/o any sites
         self._activeSite = None  # type: Optional['music21.stream.Stream']
         # offset when no activeSite is available

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -152,7 +152,7 @@ class Beam(prebase.ProtoM21Object, EqualSlottedObjectMixin, style.StyleMixin):
     # INITIALIZER #
     # pylint: disable=redefined-builtin
     def __init__(self, type=None, direction=None, number=None):  # type is okay @ReservedAssignment
-        super().__init__()
+        super().__init__()  # must call for style.
         self.type = type  # start, stop, continue, partial
         self.direction = direction  # left or right for partial
         self.independentAngle = None
@@ -212,6 +212,7 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
     # INITIALIZER #
 
     def __init__(self):
+        # no need for super() call w/ ProtoM21 and EqualSlottedObject
         self.beamsList = []
         self.feathered = False
         self.id = id(self)

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -1471,6 +1471,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
     def __init__(self, *arguments, **keywords):
         # First positional argument is assumed to be type string or a quarterLength.
+        # no need for super() on ProtoM21 or SlottedObjectMixin
 
         # store a reference to the object that has this duration object as a property
         self._client = None

--- a/music21/editorial.py
+++ b/music21/editorial.py
@@ -166,7 +166,7 @@ class Comment(prebase.ProtoM21Object, style.StyleMixin):
     'red'
     '''
     def __init__(self, text=None):
-        super().__init__()
+        super().__init__()  # needed for StyleMixin
         self.text = text
         self.isFootnote = False
         self.isReference = False

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -1733,12 +1733,11 @@ class Pitch(prebase.ProtoM21Object):
     def __init__(self,
                  name: Optional[Union[str, int]] = None,
                  **keywords):
+        # No need for super().__init__() on protoM21Object
         self._groups = None
 
         if isinstance(name, type(self)):
             name = name.nameWithOctave
-
-        # super().__init__(**keywords)
 
         # this should not be set, as will be updated when needed
         self._step = defaults.pitchStep  # this is only the pitch step

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -26,16 +26,41 @@ from typing import (
     Tuple,
 )
 
-# ## Notes:
-# adding ProtoM21Object added 0.03 microseconds to creation time (2.51 to 2.54)
-# well worth it.
-
 
 class ProtoM21Object:
     '''
-    A class for pseudo-m21 objects to inherit from.
+    A class for pseudo-m21 objects to inherit from.  Any object can inherit from
+    ProtoM21Object and it makes sense for anything a user is likely to encounter
+    to inherit from it.  Certain translators, etc. can choose to skip it.
 
-    Cannot be put into streams.
+    >>> class PitchCounter(prebase.ProtoM21Object):
+    ...     def _reprInternal(self):
+    ...         return 'no pitches'
+
+    >>> pc = PitchCounter()
+    >>> pc.classes
+    ('PitchCounter', 'ProtoM21Object', 'object')
+    >>> PitchCounter in pc.classSet
+    True
+    >>> pc.isClassOrSubclass(('music21.note.Note',))
+    False
+    >>> repr(pc)
+    '<music21.PitchCounter no pitches>'
+
+
+    ProtoM21Objects, like other Python primitives, cannot be put into streams --
+    this is what base.Music21Object does.
+
+    A ProtoM21Object defines several methods relating to unified representation
+    and keeping track of the classes of the object.  It has no instance attributes
+    or properties, and thus adds a very small creation time impact: recent
+    tests show that an empty object with an empty `__init__()` method can
+    be created in about 175ns while an empty object that subclasses ProtoM21Object
+    with the same empty `__init__()` takes only 180ns, or a 5ns impact.  On
+    real objects, the creation time percentage hit is usually much smaller.
+
+    ProtoM21Objects have no __init__() defined, so do not call super().__init__() on
+    objects that only inherit from ProtoM21Object unless you like wasting 200ns.
     '''
 
     # define order to present names in documentation; use strings

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -131,8 +131,8 @@ class Edge(prebase.ProtoM21Object):
     >>> e1.direction
     'ascending'
     '''
+    # noinspection PyShadowingBuiltins
     # pylint: disable=redefined-builtin
-
     def __init__(self,
                  intervalData=None,
                  id=None,  # id is okay: @ReservedAssignment
@@ -308,8 +308,9 @@ class Node(prebase.ProtoM21Object, common.SlottedObjectMixin):
     '''
     __slots__ = ('id', 'degree', 'weight')
 
+    # noinspection PyShadowingBuiltins
     # pylint: disable=redefined-builtin
-    def __init__(self, id=None, degree=None, weight=1.0):  # id is okay: @ReservedAssignment
+    def __init__(self, id=None, degree=None, weight=1.0):
         # store id, either as string, such as terminusLow, or a number.
         # ids are unique to any node in the network
         self.id = id

--- a/music21/stream/filters.py
+++ b/music21/stream/filters.py
@@ -63,8 +63,8 @@ class StreamFilter(prebase.ProtoM21Object):
     '''
     derivationStr = 'streamFilter'
 
-    def __init__(self):
-        pass  # store streamIterator?
+    # def __init__(self):
+    #     pass  # store streamIterator?
 
     # commented out to make faster, but will be called if exists.
     # def reset(self):

--- a/music21/style.py
+++ b/music21/style.py
@@ -469,7 +469,7 @@ class StyleMixin(common.SlottedObjectMixin):
     __slots__ = ('_style', '_editorial')
 
     def __init__(self):
-        super().__init__()
+        #  no need to call super().__init__() on SlottedObjectMixin
         self._style = None
         self._editorial = None
 

--- a/music21/tie.py
+++ b/music21/tie.py
@@ -103,7 +103,7 @@ class Tie(prebase.ProtoM21Object, SlottedObjectMixin):
 
     # pylint: disable=redefined-builtin
     def __init__(self, type='start'):  # @ReservedAssignment
-        # super().__init__()
+        # super().__init__()  # no need for ProtoM21Object or SlottedObjectMixin
         if type not in self.VALID_TIE_TYPES:
             raise TieException(
                 f'Type must be one of {self.VALID_TIE_TYPES}, not {type}')


### PR DESCRIPTION
Do not require that the chord matches the impliedQuality IF the adjustment to a chordStep has been explicitly set.

Also fix up some confusion on when to call init() on a ProtoM21Object subclass (almost never)