### PR TITLE
Fix crash in AbstractScale.show('scala')

### DIFF
--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -618,8 +618,8 @@ class AbstractScale(Scale):
         if fmt is not None:
             fileFormat, unused_ext = common.findFormat(fmt)
             if fileFormat == 'scala':
-                returnedFilePath = self.write(format, direction=direction)
-                environLocal.launch(format, returnedFilePath, app=app)
+                returnedFilePath = self.write(fileFormat, direction=direction)
+                environLocal.launch(fileFormat, returnedFilePath, app=app)
                 return
         Scale.show(self, fmt=fmt, app=app, **keywords)
 


### PR DESCRIPTION
```
>>> from music21 import *
>>> sc = scale.DiatonicScale('C')
>>> sc.show('scala')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jwalls/music21/music21/scale/__init__.py", line 2436, in show
    self.abstract.show(fmt=fmt, app=app, direction=direction)
  File "/Users/jwalls/music21/music21/scale/__init__.py", line 621, in show
    returnedFilePath = self.write(format, direction=direction)
  File "/Users/jwalls/music21/music21/scale/__init__.py", line 599, in write
    fileFormat, ext = common.findFormat(fmt)
  File "/Users/jwalls/music21/music21/common/formats.py", line 155, in findFormat
    fileFormat = c.regularizeFormat(fmt)
  File "/Users/jwalls/music21/music21/converter/__init__.py", line 946, in regularizeFormat
    fmt = fmt.lower().strip()
AttributeError: 'builtin_function_or_method' object has no attribute 'lower'
```

`format` is a builtin! :-)