### PR TITLE
MuseScore package is once again just MuseScore 3

### DIFF
--- a/music21/environment.py
+++ b/music21/environment.py
@@ -395,10 +395,10 @@ class _EnvironmentCore:
             for name, value in [
                 ('lilypondPath', 'lilypond'),
                 ('musicxmlPath',
-                 common.cleanpath(r'%PROGRAMFILES%\MuseScore 3.5\MuseScore.exe')
+                 common.cleanpath(r'%PROGRAMFILES%\MuseScore 3\MuseScore.exe')
                  ),
                 ('musescoreDirectPNGPath',
-                 common.cleanpath(r'%PROGRAMFILES%\MuseScore 3.5\MuseScore.exe')
+                 common.cleanpath(r'%PROGRAMFILES%\MuseScore 3\MuseScore.exe')
                  ),
             ]:
                 self.__setitem__(name, value)  # use for key checking
@@ -421,13 +421,13 @@ class _EnvironmentCore:
                 ('lilypondPath',
                  '/Applications/Lilypond.app/Contents/Resources/bin/lilypond'),
                 ('musicxmlPath',
-                 '/Applications/MuseScore 3.5.app/Contents/MacOS/mscore'),
+                 '/Applications/MuseScore 3.app/Contents/MacOS/mscore'),
                 ('graphicsPath', previewLocation),
                 ('vectorPath', previewLocation),
                 ('pdfPath', previewLocation),
                 ('midiPath', '/Applications/Utilities/QuickTime Player 7.app'),
                 ('musescoreDirectPNGPath',
-                 '/Applications/MuseScore 3.5.app/Contents/MacOS/mscore'),
+                 '/Applications/MuseScore 3.app/Contents/MacOS/mscore'),
             ]:
                 self.__setitem__(name, value)  # use for key checking
 
@@ -1489,8 +1489,8 @@ class Test(unittest.TestCase):
   <preference name="manualCoreCorpusPath" />
   <preference name="midiPath" value="/Applications/Utilities/QuickTime Player 7.app" />
   <preference name="musescoreDirectPNGPath"
-      value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
-  <preference name="musicxmlPath" value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
+      value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
+  <preference name="musicxmlPath" value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
   <preference name="pdfPath" value="/System/Applications/Preview.app" />
   <preference name="showFormat" value="musicxml" />
   <preference name="vectorPath" value="/System/Applications/Preview.app" />
@@ -1544,8 +1544,8 @@ class Test(unittest.TestCase):
   <preference name="manualCoreCorpusPath" />
   <preference name="midiPath" value="/Applications/Utilities/QuickTime Player 7.app" />
   <preference name="musescoreDirectPNGPath"
-      value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
-  <preference name="musicxmlPath" value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
+      value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
+  <preference name="musicxmlPath" value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
   <preference name="pdfPath" value="/System/Applications/Preview.app" />
   <preference name="showFormat" value="musicxml" />
   <preference name="vectorPath" value="/System/Applications/Preview.app" />
@@ -1600,8 +1600,8 @@ class Test(unittest.TestCase):
   <preference name="manualCoreCorpusPath" />
   <preference name="midiPath" value="w" />
   <preference name="musescoreDirectPNGPath"
-      value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
-  <preference name="musicxmlPath" value="/Applications/MuseScore 3.5.app/Contents/MacOS/mscore" />
+      value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
+  <preference name="musicxmlPath" value="/Applications/MuseScore 3.app/Contents/MacOS/mscore" />
   <preference name="pdfPath" value="/System/Applications/Preview.app" />
   <preference name="showFormat" value="musicxml" />
   <preference name="vectorPath" value="/System/Applications/Preview.app" />


### PR DESCRIPTION
Apparently this summer when I bumped the default MuseScore path to MuseScore 3.5.app, I caught the brief period when they weren't using just "MuseScore 3.app":

August 2020 (3.5.0)
(only 3.5.1 is accessible today?)
![Screen Shot 2020-12-17 at 10 57 39 PM](https://user-images.githubusercontent.com/38668450/102572918-4aa01800-40bb-11eb-914d-daaebe6d8454.png)

October 2020 (3.5.2)
![Screen Shot 2020-12-17 at 10 58 32 PM](https://user-images.githubusercontent.com/38668450/102572978-6b686d80-40bb-11eb-94d1-78ee70de26c6.png)


- [ ] would be great to have someone test on Windows or at least unzip the MuseScore package and report back with what the .exe is called