### PR TITLE
Replace root only once while parsing figure

### DIFF
--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -1026,9 +1026,12 @@ class Test(unittest.TestCase):
         self.assertEqual(cs.pitches[1], pitch.Pitch('D4'))
 
         cs = harmony.ChordSymbol('bb3')
-        self.assertEqual(cs.root(), pitch.Pitch('b3'))
-        self.assertEqual(cs.pitches[0], pitch.Pitch('B3'))
-        self.assertEqual(cs.pitches[1], pitch.Pitch('D#4'))
+        # B, not B-flat
+        self.assertEqual(cs.root(), pitch.Pitch('b2'))
+        # b3 alteration applied to B major triad
+        self.assertEqual(cs.pitches[0], pitch.Pitch('B2'))
+        self.assertEqual(cs.pitches[1], pitch.Pitch('D3'))
+        self.assertEqual(cs.pitches[2], pitch.Pitch('F#3'))
 
     def xtestTranslateB(self):
         '''

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1829,7 +1829,7 @@ class ChordSymbol(Harmony):
             if m1:
                 root = m1.group()
                 # remove the root and bass from the string and any additions/omissions/alterations/
-                st = prelimFigure.replace(m1.group(), '')
+                st = prelimFigure.replace(m1.group(), '', 1)
             else:
                 raise ValueError(f'Chord {prelimFigure} does not begin '
                                  + 'with a valid root note.')
@@ -2605,6 +2605,14 @@ class Test(unittest.TestCase):
         c = chord.Chord(('A#', 'C', 'E'))
         cs = harmony.chordSymbolFromChord(c)
         self.assertEqual(cs.figure, "Chord Symbol Cannot Be Identified")
+
+    def testRegexEdgeCases(self):
+        cs = ChordSymbol('FFr+6')
+        self.assertEqual([p.name for p in cs.pitches], ['F', 'G', 'B', 'D-'])
+        cs = ChordSymbol('dadd6')
+        self.assertEqual([p.name for p in cs.pitches], ['D', 'F#', 'A', 'B'])
+        cs = ChordSymbol('atristan')
+        self.assertEqual([p.name for p in cs.pitches], ['A', 'B#', 'D#', 'F##'])
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover


### PR DESCRIPTION
Fixes #720

Other figures were broken such as "dadd6" or "atristan" where the root being replaced matched case with a letter in the figure.