### PR TITLE
Quality: adds hasRepeatedChordStep(1) check in addition to 3 and 5

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4972,12 +4972,17 @@ class Chord(note.NotRest):
         >>> a.quality
         'major'
 
-        Major + Minor = ?? other
+        Chords that contain more than one triad return 'other'
 
+        >>> chord.Chord('C C# E G').quality
+        'other'
         >>> chord.Chord('C E- E G').quality
         'other'
         >>> chord.Chord('C E G- G').quality
         'other'
+
+        Note these two edge cases:
+
         >>> chord.Chord('C D E').quality  # NB! Major 9th....
         'major'
         >>> chord.Chord('C E--').quality
@@ -4996,6 +5001,8 @@ class Chord(note.NotRest):
 
         # environLocal.printDebug(['third, fifth', third, fifth])
         if third is None:
+            return 'other'
+        elif self.hasRepeatedChordStep(1):
             return 'other'
         elif self.hasRepeatedChordStep(3):
             return 'other'


### PR DESCRIPTION
Extends the check for chords containing more than one triad.

Previously hasRepeatedChordStep() was used to check steps 3 and 5, so that:
```
>>> chord.Chord('C E- E G').quality
'other'
>>> chord.Chord('C E G- G').quality
'other'
```

But that still returned 'major' for the following case:
```
>>> chord.Chord('C C# E G').quality
'major'
```

While it's true that there's a major triad in there (CEG), there's also a diminished one (C#EG); it would be more consistent if this cases returns 'other' too.

With this PR, that case now returns 'other'
```
>>> chord.Chord('C C# E G').quality
'other'
```

Note that this does not apply to b2:
```
>>> chord.Chord('C Db E G').quality
'major'
```
