### PR TITLE
Fix musicxml validation error on lack of ending number

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5450,6 +5450,9 @@ class MeasureExporter(XMLExporterBase):
                 endingType = 'stop'
             numberList = self.rbSpanners[0].getNumberList()
             numberStr = str(numberList[0])
+            # 0 is not a valid "ending-number"
+            if numberStr == '0':
+                numberStr = ''
             for num in numberList[1:]:
                 numberStr += ',' + str(num)  # comma-separated ending numbers
             mxEnding.set('number', numberStr)
@@ -6236,8 +6239,13 @@ class Test(unittest.TestCase):
         s = converter.parse(testPrimitive.multiDigitEnding)
         x = self.getET(s)
         endings = x.findall('.//ending')
-        self.assertSequenceEqual([e.get('number') for e in endings],
-                                ['1,2', '1,2', '3', '3'])
+        self.assertEqual([e.get('number') for e in endings], ['1,2', '1,2', '3', '3'])
+
+        # m21 represents lack of bracket numbers as 0; musicxml uses ''
+        s.parts[0].getElementsByClass('RepeatBracket')[0].number = 0
+        x = self.getET(s)
+        endings = x.findall('.//ending')
+        self.assertEqual([e.get('number') for e in endings], ['', '', '3', '3'])
 
     def testTextExpressionOffset(self):
         '''Transfer element offset after calling getTextExpression().'''


### PR DESCRIPTION
Missed case from #598 -- musicxml doesn't allow '0' for an ending number; music21 does.

Noticed in corpus example (mozart/k458, 1)