### PR TITLE
cleanup core methods that were leaking

### DIFF
--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -1935,9 +1935,8 @@ def partitionByInstrument(streamObj):
     3
 
     # TODO: this step might not be necessary...
-
     >>> for p in s2.parts:
-    ...     unused = p.makeRests(fillGaps=True, inPlace=True)
+    ...     p.makeRests(fillGaps=True, inPlace=True)
 
     # TODO: this step SHOULD not be necessary (.template())...
 
@@ -1971,7 +1970,6 @@ def partitionByInstrument(streamObj):
             {2.0} <music21.note.Note E>
             {3.0} <music21.note.Note F>
         {4.0} <music21.stream.Measure 2 offset=4.0>
-            {0.0} <music21.instrument.AltoSaxophone 'Alto Saxophone'>
             {0.0} <music21.note.Note G>
             {1.0} <music21.note.Note A>
             {2.0} <music21.note.Note B>
@@ -1994,10 +1992,7 @@ def partitionByInstrument(streamObj):
             {0.0} <music21.note.Note C#>
             {4.0} <music21.bar.Barline type=final>
 
-
     TODO: parts should be in Score Order. Coincidence that this almost works.
-    TODO: note redundant Alto Saxophone... instrument --
-
     TODO: use proper recursion to make a copy of the stream.
     '''
     from music21 import stream
@@ -2019,6 +2014,7 @@ def partitionByInstrument(streamObj):
     # first, find all unique instruments
     instrumentIterator = s.recurse().getElementsByClass('Instrument')
     if not instrumentIterator:
+        # TODO(msc): v7 return s.
         return None  # no partition is available
 
     names = OrderedDict()  # store unique names
@@ -2071,6 +2067,9 @@ def partitionByInstrument(streamObj):
                     # it is possible to enter an element twice because the getElementsByOffset
                     # might return something twice if it's at the same offset as the
                     # instrument switch...
+
+    for inst in post.recurse().getElementsByClass('Instrument'):
+        inst.duration.quarterLength = 0
     return post
 
 
@@ -2449,6 +2448,30 @@ class Test(unittest.TestCase):
 
         post = instrument.partitionByInstrument(s1)
         self.assertEqual(len(post), 2)  # 4 instruments
+
+    # def testPartitionByInstrumentDocTest(self):
+    #     '''
+    #     For debugging the doctest.
+    #     '''
+    #     from music21 import instrument, converter, stream
+    #     p1 = converter.parse("tinynotation: 4/4 c4  d  e  f  g  a  b  c'  c1")
+    #     p2 = converter.parse("tinynotation: 4/4 C#4 D# E# F# G# A# B# c#  C#1")
+    #
+    #     p1.getElementsByClass('Measure')[0].insert(0.0, instrument.Piccolo())
+    #     p1.getElementsByClass('Measure')[0].insert(2.0, instrument.AltoSaxophone())
+    #     p1.getElementsByClass('Measure')[1].insert(3.0, instrument.Piccolo())
+    #
+    #     p2.getElementsByClass('Measure')[0].insert(0.0, instrument.Trombone())
+    #     p2.getElementsByClass('Measure')[0].insert(3.0, instrument.Piccolo())  # not likely...
+    #     p2.getElementsByClass('Measure')[1].insert(1.0, instrument.Trombone())
+    #
+    #     s = stream.Score()
+    #     s.insert(0, p1)
+    #     s.insert(0, p2)
+    #     s2 = instrument.partitionByInstrument(s)
+    #     for p in s2.parts:
+    #         p.makeRests(fillGaps=True, inPlace=True)
+
 
 
 # ------------------------------------------------------------------------------

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -2473,7 +2473,6 @@ class Test(unittest.TestCase):
     #         p.makeRests(fillGaps=True, inPlace=True)
 
 
-
 # ------------------------------------------------------------------------------
 # define presented order in documentation
 _DOC_ORDER = [Instrument]

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -795,12 +795,11 @@ def makeRests(
         #    'offsets used in makeRests', oLowTarget, oHighTarget,
         #    len(refStreamOrTimeRange)])
     if returnObj.hasVoices():
-        bundle = returnObj.voices
+        bundle = list(returnObj.voices)
     else:
         bundle = [returnObj]
 
     for v in bundle:
-        v.coreElementsChanged()  # required to get correct offset times
         oLow = v.lowestOffset
         oHigh = v.highestTime
 
@@ -812,7 +811,7 @@ def makeRests(
             r.style.hideObjectOnPrint = hideRests
             # environLocal.printDebug(['makeRests(): add rests', r, r.duration])
             # place at oLowTarget to reach to oLow
-            v.coreInsert(oLowTarget, r)
+            v.insert(oLowTarget, r)
 
         # create rest from end to highest
         qLen = oHighTarget - oHigh
@@ -822,8 +821,8 @@ def makeRests(
             r.duration.quarterLength = qLen
             r.style.hideObjectOnPrint = hideRests
             # place at oHigh to reach to oHighTarget
-            v.coreInsert(oHigh, r)
-        v.coreElementsChanged()  # must update otherwise might add double r
+            v.insert(oHigh, r)
+
 
         if fillGaps:
             gapStream = v.findGaps()
@@ -832,24 +831,9 @@ def makeRests(
                     r = note.Rest()
                     r.duration.quarterLength = e.duration.quarterLength
                     r.style.hideObjectOnPrint = hideRests
-                    v.coreInsert(e.offset, r)
-        v.coreElementsChanged()
+                    v.insert(e.offset, r)
         # environLocal.printDebug(['post makeRests show()', v])
 
-        # NOTE: this sorting has been found to be necessary, as otherwise
-        # the resulting Stream is not sorted and does not get sorted in
-        # preparing musicxml output
-        # TODO: a lot has changed since 2009 -- check if this is still true...
-        if v.autoSort:
-            v.sort()
-
-    # with auto sort no longer necessary.
-
-    # s.isSorted = False
-    # changes elements
-#         returnObj.coreElementsChanged()
-#         if returnObj.autoSort:
-#             returnObj.sort()
     if inPlace is not True:
         return returnObj
 

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -5190,8 +5190,10 @@ class Test(unittest.TestCase):
         '''
         from music21 import corpus
         s = corpus.parse('schoenberg/opus19/movement6')
-        # s.show()
+        # s.show('text')
         m1 = s.parts[0].getElementsByClass('Measure')[0]
+        # m1.show('text')
+
         self.assertEqual(m1.highestTime, 1.0)
         self.assertEqual(m1.paddingLeft, 3.0)
         self.assertEqual(m1.duration.quarterLength, 1.0)


### PR DESCRIPTION
This is the patch file attached to #722 

Fixes a bug in partitionByInstrument, where instrument objects were left with non-zero durations.

Fixes findGaps not putting the stream back in order

Removed some places where coreElementsChanged() was being called inside subroutines where it should have been called before the routine.

Removed a few coreInserts at the cleanup stage of PartStaff creation -- too few to be worth the bugs.