### PR TITLE
Avoid duplicative part name from StaffGroup object

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1987,6 +1987,19 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
           <group-symbol>brace</group-symbol>
           <group-barline>no</group-barline>
         </part-group>
+
+        Now we avoid printing the name of the group:
+
+        >>> firstStaffGroup.style.hideObjectOnPrint = True
+        >>> mxPartGroup = SX.staffGroupToXmlPartGroup(firstStaffGroup)
+        >>> SX.dump(mxPartGroup)
+        <part-group type="start">
+          <group-name>Voices</group-name>
+          <group-name-display print-object="no" />
+          <group-abbreviation>Ch.</group-abbreviation>
+          <group-symbol>brace</group-symbol>
+          <group-barline>no</group-barline>
+        </part-group>
         '''
         mxPartGroup = Element('part-group')
         mxPartGroup.set('type', 'start')

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1992,6 +1992,9 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         mxPartGroup.set('type', 'start')
         seta = _setTagTextFromAttribute
         seta(staffGroup, mxPartGroup, 'group-name', 'name')
+        if staffGroup.style.hideObjectOnPrint:
+            mxGroupNameDisplay = SubElement(mxPartGroup, 'group-name-display')
+            mxGroupNameDisplay.set('print-object', 'no')
         seta(staffGroup, mxPartGroup, 'group-abbreviation', 'abbreviation')
         mxGroupSymbol = seta(staffGroup, mxPartGroup, 'group-symbol', 'symbol')
         if mxGroupSymbol is not None:

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -224,7 +224,7 @@ class PartStaffExporterMixin:
         Create child <staff> tags under each <note>, <direction>, and <forward> element
         in the <part>s being joined.
 
-        Called by :meth:`~music21.musicxml.m21ToXml.ScoreExporter.joinPartStaffs`
+        Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
 
         >>> from music21.musicxml import testPrimitive
         >>> s = converter.parse(testPrimitive.pianoStaff43a)
@@ -281,7 +281,7 @@ class PartStaffExporterMixin:
         For every <part> after the first, find the corresponding measure in the initial
         <part> and merge the contents by inserting all of the contained elements.
 
-        Called by :meth:`~music21.musicxml.m21ToXml.ScoreExporter.joinPartStaffs`
+        Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
 
         StaffGroup must be a valid one from `joinableGroups()`
         '''
@@ -307,7 +307,7 @@ class PartStaffExporterMixin:
         element representing the initial PartStaff that will soon represent the merged whole.
 
         Called by movePartStaffMeasureContents(), which is in turn called by
-        :meth:`~music21.musicxml.m21ToXml.ScoreExporter.joinPartStaffs`
+        :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
         '''
         DIVIDER_COMMENT = '========================= Measure [NNN] =========================='
         PLACEHOLDER = '[NNN]'
@@ -379,7 +379,7 @@ class PartStaffExporterMixin:
         e.g. RH of piano doesn't appear until m. 40, and earlier music for LH needs
         to be merged first in order to find earliest <attributes>.
 
-        Called by :meth:`~music21.musicxml.m21ToXml.ScoreExporter.joinPartStaffs`
+        Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
 
         >>> from music21.musicxml import testPrimitive
         >>> s = converter.parse(testPrimitive.pianoStaff43a)
@@ -465,7 +465,7 @@ class PartStaffExporterMixin:
         (in the deepcopied stream used for exporting) to ensure <part-group type="stop" />
         is written.
 
-        Called by :meth:`~music21.musicxml.m21ToXml.ScoreExporter.joinPartStaffs`
+        Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
 
         >>> from music21.musicxml import testPrimitive
         >>> s = converter.parse(testPrimitive.pianoStaff43a)

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1711,6 +1711,7 @@ class PartParser(XMLParserBase):
 
         if partStaffs:
             staffGroup = layout.StaffGroup(partStaffs, name=self.stream.partName, symbol='brace')
+            staffGroup.style.hideObjectOnPrint = True  # strictly speaking, hide the name, not the brace
             self.parent.stream.insert(0, staffGroup)
 
         self.appendToScoreAfterParse = False

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1711,7 +1711,7 @@ class PartParser(XMLParserBase):
 
         if partStaffs:
             staffGroup = layout.StaffGroup(partStaffs, name=self.stream.partName, symbol='brace')
-            staffGroup.style.hideObjectOnPrint = True  # strictly speaking, hide the name, not the brace
+            staffGroup.style.hideObjectOnPrint = True  # in truth, hide the name, not the brace
             self.parent.stream.insert(0, staffGroup)
 
         self.appendToScoreAfterParse = False
@@ -5912,6 +5912,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(sgs), 1)
         self.assertEqual(sgs[0].symbol, 'brace')
         self.assertIs(sgs[0].barTogether, True)
+        self.assertIs(sgs[0].style.hideObjectOnPrint, True)
 
     def testInstrumentTranspositionA(self):
         from music21.musicxml import testPrimitive

--- a/music21/romanText/writeRoman.py
+++ b/music21/romanText/writeRoman.py
@@ -520,6 +520,17 @@ class Test(unittest.TestCase):
         m = stream.Measure()
         RnWriter(m)  # or on a measure
 
+        v = stream.Voice()
+        # or theoretically on a voice, but will be empty for lack of measures
+        emptyWriter = RnWriter(v)
+        self.assertEqual(emptyWriter.combinedList, [
+            'Composer: Composer unknown',
+            'Title: Title unknown',
+            'Analyst: ',
+            'Proofreader: ',
+            '',
+        ])
+
         rn = roman.RomanNumeral('viio6', 'G')
         RnWriter(rn)  # and even (perhaps dubiously) directly on other music21 objects
 


### PR DESCRIPTION
After #634 , we use a `StaffGroup` to track grand staff instruments we can merge back to `<part>` elements on xml export.

This was creating duplicate part names and group names on export:

dragged apart so you can see them:
![double-label](https://user-images.githubusercontent.com/38668450/103382258-5547ad80-4abc-11eb-97bf-ef007707453e.png)


Sketched a fix. Will add a test if this is acceptable.