### PR TITLE
Remove bottlenecks on Chord.isTriad and Chord.isSeventh

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -2067,7 +2067,8 @@ class Chord(note.NotRest):
 
     @cacheMethod
     def isAugmentedTriad(self):
-        '''Returns True if chord is an Augmented Triad, that is,
+        '''
+        Returns True if chord is an Augmented Triad, that is,
         if it contains only notes that are
         either in unison with the root, a major third above the root,
         or an augmented fifth above the
@@ -2078,8 +2079,7 @@ class Chord(note.NotRest):
         (e.g. C-E-Ab is a 2nd inversion aug triad; C-Fb-Ab
         is 1st inversion).  However, B#-Fb-Ab does return False as expected).
 
-        Returns false if is not an augmented triad.
-
+        Returns False if is not an augmented triad.
 
         >>> c = chord.Chord(['C4', 'E4', 'G#4'])
         >>> c.isAugmentedTriad()
@@ -2105,17 +2105,7 @@ class Chord(note.NotRest):
         >>> chord.Chord().isAugmentedTriad()
         False
         '''
-        third = self.third
-        fifth = self.fifth
-
-        if third is None or fifth is None:
-            return False
-
-        for thisPitch in self.pitches:
-            thisInterval = interval.notesToInterval(self.root(), thisPitch)
-            if thisInterval.chromatic.mod12 not in (0, 4, 8):
-                return False
-        return True
+        return self._checkTriadType((3, 12, 0), 4, 8)
 
     @cacheMethod
     def isConsonant(self):
@@ -2270,27 +2260,18 @@ class Chord(note.NotRest):
 
 
         >>> cChord = chord.Chord(['C', 'E-', 'G-'])
-        >>> other = chord.Chord(['C', 'E-', 'F#'])
-
-        >>> cChord.isDiminishedTriad()  # returns True
+        >>> cChord.isDiminishedTriad()
         True
-        >>> other.isDiminishedTriad()  # returns False
+        >>> other = chord.Chord(['C', 'E-', 'F#'])
+        >>> other.isDiminishedTriad()
         False
+
+        OMIT_FROM_DOCS
 
         >>> chord.Chord().isDiminishedTriad()
         False
         '''
-        third = self.third
-        fifth = self.fifth
-
-        if third is None or fifth is None:
-            return False
-        for thisPitch in self.pitches:
-            thisInterval = interval.notesToInterval(self.root(), thisPitch)
-            if thisInterval.chromatic.mod12 not in (0, 3, 6):
-                return False
-
-        return True
+        return self._checkTriadType((3, 10, 0), 3, 6)
 
     @cacheMethod
     def isDominantSeventh(self) -> bool:
@@ -2748,6 +2729,39 @@ class Chord(note.NotRest):
 
         return True
 
+    def _checkTriadType(self, chordAddress, thirdSemitones, fifthSemitones):
+        '''
+        Helper method for `isMajorTriad`, `isMinorTriad`, `isDiminishedTriad`, and
+        `isAugmentedTriad` that checks the chordAddress first, then the number
+        of semitones the third should be and fifth.  Deals with strange corner
+        cases like C, E###, G--- not being a major triad, as quickly as possible.
+        '''
+        # chordTablesAddress takes only 39 microseconds compared to 220 for
+        # rest of routine, so might as well short-circuit for false
+        if self.chordTablesAddress[:3] != chordAddress:
+            return False
+
+        if not self.isTriad():
+            return False
+
+        # these are cached, and guaranteed to be non-None by isTriad()
+        third = self.third
+        fifth = self.fifth
+
+        root = self.root()
+        rootPitchClass = root.pitchClass
+        names = (root.name, third.name, fifth.name)
+        for thisPitch in self.pitches:
+            thisInterval = (thisPitch.pitchClass - rootPitchClass) % 12
+            if (thisPitch is third) and thisInterval != thirdSemitones:
+                return False
+            if (thisPitch is fifth) and thisInterval != fifthSemitones:
+                return False
+            if thisPitch.name not in names:
+                return False
+
+        return True
+
     @cacheMethod
     def isMajorTriad(self):
         '''
@@ -2794,27 +2808,7 @@ class Chord(note.NotRest):
         >>> chord.Chord().isMajorTriad()
         False
         '''
-        # chordTablesAddress takes only 39 microseconds compared to 220 for
-        # rest of routine, so might as well short-circuit for false
-        if self.chordTablesAddress[:3] != (3, 11, -1):
-            return False
-
-        third = self.third
-        fifth = self.fifth
-        if third is None or fifth is None:
-            return False
-
-        root = self.root()
-        for thisPitch in self.pitches:
-            thisInterval = interval.notesToInterval(root, thisPitch)
-            if (thisPitch is third) and (thisInterval.chromatic.mod12 != 4):
-                return False
-            if (thisPitch is fifth) and (thisInterval.chromatic.mod12 != 7):
-                return False
-            if thisPitch.name not in (root.name, third.name, fifth.name):
-                return False
-
-        return True
+        return self._checkTriadType((3, 11, -1), 4, 7)
 
     @cacheMethod
     def isMinorTriad(self):
@@ -2827,10 +2821,10 @@ class Chord(note.NotRest):
         Example:
 
         >>> cChord = chord.Chord(['C', 'E-', 'G'])
-        >>> other = chord.Chord(['C', 'E', 'G'])
-        >>> cChord.isMinorTriad()  # returns True
+        >>> cChord.isMinorTriad()
         True
-        >>> other.isMinorTriad()  # returns False
+        >>> other = chord.Chord(['C', 'E', 'G'])
+        >>> other.isMinorTriad()
         False
 
         OMIT_FROM_DOCS
@@ -2838,25 +2832,7 @@ class Chord(note.NotRest):
         >>> chord.Chord().isMinorTriad()
         False
         '''
-        if self.chordTablesAddress[:3] != (3, 11, 1):
-            return False
-
-        third = self.third
-        fifth = self.fifth
-        if third is None or fifth is None:
-            return False
-
-        root = self.root()
-        for thisPitch in self.pitches:
-            thisInterval = interval.notesToInterval(root, thisPitch)
-            if (thisPitch is third) and (thisInterval.chromatic.mod12 != 3):
-                return False
-            if (thisPitch is fifth) and (thisInterval.chromatic.mod12 != 7):
-                return False
-            if thisPitch.name not in (root.name, third.name, fifth.name):
-                return False
-
-        return True
+        return self._checkTriadType((3, 11, 1), 3, 7)
 
     @cacheMethod
     def isSeventh(self):
@@ -3372,17 +3348,21 @@ class Chord(note.NotRest):
         >>> cChord.semitonesFromChordStep(5)  # C to G
         7
 
-        >>> print(cChord.semitonesFromChordStep(6))  # will return None
+        Omitted chordSteps return None
+
+        >>> print(cChord.semitonesFromChordStep(6))
         None
 
+        Note that the routine returns the semitones to the FIRST third.
+        This chord has two thirds, C and C#
+
         >>> aChord = chord.Chord(['a2', 'c4', 'c#5', 'e#7'])
-        >>> aChord.semitonesFromChordStep(3)  # returns the semitones to the FIRST third.
+        >>> aChord.semitonesFromChordStep(3)
         3
 
         >>> aChord.semitonesFromChordStep(5)
         8
-
-        >>> print(aChord.semitonesFromChordStep(2))  # will return None
+        >>> print(aChord.semitonesFromChordStep(2))
         None
 
 
@@ -5218,8 +5198,10 @@ class Chord(note.NotRest):
         >>> c.hasVolumeInformation()
         True
 
+        Return a new volume that is an average of the components
+
         >>> c.volume.velocityIsRelative = False
-        >>> c.volume  # return a new volume that is an average
+        >>> c.volume
         <music21.volume.Volume realized=0.76>
 
         OMIT_FROM_DOCS


### PR DESCRIPTION
Also speed up containsTriad and containsSeventh

Make helpers for isMajorTriad, isMinorTriad, isDim..., isAug...
Takes away a tiny bit of the speedup, for greater code clarity.

Might slightly reduce code coverage because of reduced length of covered code.