### PR TITLE
WIP: Create Unpitched objects from musicxml; set display step & octave

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4885,7 +4885,7 @@ class Chord(note.NotRest):
             return f'{rootName}-{nameStr}'
 
     @property
-    def pitches(self) -> Tuple[pitch.Pitch, pitch.Unpitched]:
+    def pitches(self) -> Tuple[Union[pitch.Pitch, pitch.Unpitched]]:
         '''
         Get or set a list or tuple of all Pitch objects in this Chord.
 
@@ -4924,7 +4924,7 @@ class Chord(note.NotRest):
         <music21.pitch.Pitch A#4>
         '''
         # noinspection PyTypeChecker
-        pitches: Tuple[pitch.Pitch, pitch.Unpitched] = tuple(
+        pitches: Tuple[Union[pitch.Pitch, pitch.Unpitched]] = tuple(
             component.pitch for component in self._notes)
         return pitches
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4885,7 +4885,7 @@ class Chord(note.NotRest):
             return f'{rootName}-{nameStr}'
 
     @property
-    def pitches(self) -> Tuple[pitch.Pitch]:
+    def pitches(self) -> Tuple[pitch.Pitch, pitch.Unpitched]:
         '''
         Get or set a list or tuple of all Pitch objects in this Chord.
 
@@ -4924,7 +4924,7 @@ class Chord(note.NotRest):
         <music21.pitch.Pitch A#4>
         '''
         # noinspection PyTypeChecker
-        pitches: Tuple[pitch.Pitch] = tuple(component.pitch for component in self._notes)
+        pitches: Tuple[pitch.Pitch, pitch.Unpitched] = tuple(component.pitch for component in self._notes)
         return pitches
 
     @pitches.setter

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4924,7 +4924,8 @@ class Chord(note.NotRest):
         <music21.pitch.Pitch A#4>
         '''
         # noinspection PyTypeChecker
-        pitches: Tuple[pitch.Pitch, pitch.Unpitched] = tuple(component.pitch for component in self._notes)
+        pitches: Tuple[pitch.Pitch, pitch.Unpitched] = tuple(
+            component.pitch for component in self._notes)
         return pitches
 
     @pitches.setter

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1957,6 +1957,8 @@ def midiTrackToStream(
     if conductorPart is not None:
         insertConductorEvents(conductorPart, s, isFirst=isFirst)
 
+    s.makeUnpitched(inPlace=True)
+
     # Only make measures if time signatures have been inserted
     s.makeMeasures(inPlace=True)
     for m in s.getElementsByClass(stream.Measure):

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2999,10 +2999,10 @@ class MeasureParser(XMLParserBase):
         >>> n.pitch.displayOctave
         5
         >>> n.pitch.step
-        unpitched
+        'unpitched'
         >>> n.pitch.octave
-        unpitched
-        >>> n.midi
+        'unpitched'
+        >>> n.pitch.midi
         76
         '''
         if inputM21 is None:

--- a/music21/note.py
+++ b/music21/note.py
@@ -1472,7 +1472,7 @@ class Note(NotRest):
         ''')
 
     @property
-    def pitches(self) -> Tuple[pitch.Pitch, pitch.Unpitched]:
+    def pitches(self) -> Tuple[Union[pitch.Pitch, pitch.Unpitched]]:
         '''
         Return the :class:`~music21.pitch.Pitch` or :class:`~music21.pitch.Unpitched`
         objects in a tuple.

--- a/music21/note.py
+++ b/music21/note.py
@@ -19,7 +19,7 @@ and used to configure, :class:`~music21.note.Note` objects.
 import copy
 import unittest
 
-from typing import Optional, List, Union, Tuple, Iterable
+from typing import Optional, List, Union, Tuple, Iterable, TypeVar
 
 from music21 import base
 from music21 import beam
@@ -1127,7 +1127,7 @@ class NotRest(GeneralNote):
             return True
 
     @property
-    def pitches(self) -> Tuple[pitch.Pitch]:
+    def pitches(self) -> Tuple[Union[pitch.Pitch, pitch.Unpitched]]:
         '''
         Returns an empty tuple.  (Useful for iterating over NotRests since they
         include Notes and Chords
@@ -1135,7 +1135,7 @@ class NotRest(GeneralNote):
         return ()
 
     @pitches.setter
-    def pitches(self, _value: Iterable[pitch.Pitch]):
+    def pitches(self, _value: Iterable[Union[pitch.Pitch, pitch.Unpitched]]):
         pass
 
 
@@ -1274,6 +1274,8 @@ class Note(NotRest):
 
         if pitchName is not None:
             if isinstance(pitchName, pitch.Pitch):
+                self.pitch = pitchName
+            elif isinstance(pitchName, pitch.Unpitched):
                 self.pitch = pitchName
             else:  # assume first argument is pitch
                 self.pitch = pitch.Pitch(pitchName, **keywords)
@@ -1443,9 +1445,10 @@ class Note(NotRest):
         ''')
 
     @property
-    def pitches(self) -> Tuple[pitch.Pitch]:
+    def pitches(self) -> Tuple[pitch.Pitch, pitch.Unpitched]:
         '''
-        Return the :class:`~music21.pitch.Pitch` object in a tuple.
+        Return the :class:`~music21.pitch.Pitch` or :class:`~music21.pitch.Unpitched`
+        objects in a tuple.
         This property is designed to provide an interface analogous to
         that found on :class:`~music21.chord.Chord` so that `[c.pitches for c in s.notes]`
         provides a consistent interface for all objects.
@@ -1485,7 +1488,7 @@ class Note(NotRest):
         return (self.pitch,)
 
     @pitches.setter
-    def pitches(self, value: Iterable[pitch.Pitch]):
+    def pitches(self, value: Iterable[Union[pitch.Pitch, pitch.Unpitched]]):
         if common.isListLike(value) and value:
             self.pitch = value[0]
         else:
@@ -1603,73 +1606,6 @@ class Note(NotRest):
 
 # ------------------------------------------------------------------------------
 # convenience classes
-
-
-# ------------------------------------------------------------------------------
-class Unpitched(NotRest):
-    '''
-    A General class of unpitched objects which appear at different places
-    on the staff.  Examples: percussion notation.
-
-    The `Unpitched` object does not currently do anything and should
-    not be used.
-
-    >>> unp = note.Unpitched()
-
-    Unpitched elements have displayStep and displayOctave
-    which shows where they should be displayed, but they do not have pitch
-    objects:
-
-    >>> unp.displayStep
-    'C'
-    >>> unp.displayOctave
-    4
-    >>> unp.displayStep = 'G'
-    >>> unp.pitch
-    Traceback (most recent call last):
-    AttributeError: 'Unpitched' object has no attribute 'pitch'
-    '''
-
-    def __init__(self):
-        super().__init__()
-        self.displayStep = 'C'
-        self.displayOctave = 4
-        self._storedInstrument = None
-
-    def __eq__(self, other):
-        if not super().__eq__(other):
-            return False
-        if not isinstance(other, Unpitched):
-            return False
-        if self.displayStep != other.displayStep:
-            return False
-        if self.displayOctave != other.displayOctave:
-            return False
-        return True
-
-    def _getStoredInstrument(self):
-        return self._storedInstrument
-
-    def _setStoredInstrument(self, newValue):
-        self._storedInstrument = newValue
-
-    storedInstrument = property(_getStoredInstrument, _setStoredInstrument)
-
-    def displayPitch(self) -> pitch.Pitch:
-        '''
-        returns a pitch object that is the same as the displayStep and displayOctave.
-        it will never have an accidental.
-
-        >>> unp = note.Unpitched()
-        >>> unp.displayStep = 'E'
-        >>> unp.displayOctave = 4
-        >>> unp.displayPitch()
-        <music21.pitch.Pitch E4>
-        '''
-        p = pitch.Pitch()
-        p.step = self.displayStep
-        p.octave = self.displayOctave
-        return p
 
 
 # ------------------------------------------------------------------------------
@@ -2174,7 +2110,7 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER = [Note, Rest, Unpitched, NotRest, GeneralNote, Lyric]
+_DOC_ORDER = [Note, Rest, NotRest, GeneralNote, Lyric]
 
 if __name__ == '__main__':
     # sys.arg test options will be used in mainTest()

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -5072,7 +5072,7 @@ class Unpitched(prebase.ProtoM21Object):
     '''
 
     def __init__(self,
-                 displayName: Optional[Union[str, int]] = None,
+                 displayName: Optional[str] = None,
                  **keywords):
         # No need for super().__init__() on protoM21Object
         self._groups = None
@@ -5091,13 +5091,6 @@ class Unpitched(prebase.ProtoM21Object):
                     self.displayOctave = int(displayName[-1])
                 if displayName[0] in 'ABCDEFG':
                     self.displayStep = displayName[0]
-            if isinstance(displayName, Unpitched):
-                displayPitch = displayName.displayPitch()
-                self.displayStep = displayPitch.step
-                self.displayOctave = displayPitch.octave
-            if isinstance(displayName, Pitch):
-                self.displayStep = displayName.step
-                self.displayOctave = displayName.octave
 
         if keywords:
             if 'displayStep' in keywords:

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -5052,24 +5052,54 @@ class Unpitched(prebase.ProtoM21Object):
     {0.0} <music21.note.Note G>
     {0.5} <music21.note.Note unpitched>
     {1.0} <music21.note.Note unpitched>
+
+    Can be instantiated with note names, but these will create `.displayStep`
+    and `.displayOctave`, not `.name`:
+
+    >>> up = pitch.Unpitched('G4')
+    >>> up.displayStep
+    'G'
+    >>> up.displayOctave
+    4
+    >>> up.name
+    'unpitched'
+    >>> up.midi
+    67
+    >>> up.step
+    'unpitched'
+    >>> up.octave
+    'unpitched'
     '''
 
     def __init__(self,
-                 name: Optional[Union[str, int]] = None,
+                 displayName: Optional[Union[str, int]] = None,
                  **keywords):
         # No need for super().__init__() on protoM21Object
         self._groups = None
 
         self.name = 'unpitched'
+
         self.displayStep = defaults.pitchStep
         self.displayOctave = defaults.pitchOctave
 
         self.accidental = None
 
+        if displayName:
+            if isinstance(displayName, str) and displayName:
+                # Only single digits supported for now
+                if displayName[-1] in '1234567890':
+                    self.displayOctave = int(displayName[-1])
+                if displayName[0] in 'ABCDEFG':
+                    self.displayStep = displayName[0]
+            if isinstance(displayName, Unpitched):
+                displayPitch = displayName.displayPitch()
+                self.displayStep = displayPitch.step
+                self.displayOctave = displayPitch.octave
+            if isinstance(displayName, Pitch):
+                self.displayStep = displayName.step
+                self.displayOctave = displayName.octave
+
         if keywords:
-            if 'name' in keywords:
-                # noinspection PyArgumentList
-                self.name = keywords['name']  # set based on string
             if 'displayStep' in keywords:
                 self.displayStep = keywords['displayStep']
             if 'displayOctave' in keywords:
@@ -5093,14 +5123,6 @@ class Unpitched(prebase.ProtoM21Object):
         if self.displayOctave != other.displayOctave:
             return False
         return True
-
-    def _getStoredInstrument(self):
-        return self._storedInstrument
-
-    def _setStoredInstrument(self, newValue):
-        self._storedInstrument = newValue
-
-    storedInstrument = property(_getStoredInstrument, _setStoredInstrument)
 
     def displayPitch(self) -> Pitch:
         '''

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -6535,6 +6535,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         for e in noteIterator:
             if isinstance(e, note.Note):
+                if 'Unpitched' in e.pitch.classes:
+                    continue
                 if e.pitch.nameWithOctave in tiePitchSet:
                     lastNoteWasTied = True
                 else:
@@ -6563,6 +6565,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
                 for n in list(e):
                     p = n.pitch
+                    if 'Unpitched' in p.classes:
+                        continue
                     if p.nameWithOctave in tiePitchSet:
                         lastNoteWasTied = True
                     else:
@@ -9551,7 +9555,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
     @property
     def pitches(self):
         '''
-        Returns all :class:`~music21.pitch.Pitch` objects found in any
+        Returns all :class:`~music21.pitch.Pitch` or :class:`~music21.pitch.Unpitched`
+        objects found in any
         element in the Stream as a Python List. Elements such as
         Streams, and Chords will have their Pitch objects accumulated as
         well. For that reason, a flat representation is not required.
@@ -9566,6 +9571,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         what someone wants here.
 
         N.B., TODO: This may turn to an Iterator soon.
+
+        TOOD: example with pitch.Unpitched
 
         >>> from music21 import corpus
         >>> a = corpus.parse('bach/bwv324.xml')

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -6429,6 +6429,17 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             setStemDirections=setStemDirections
         )
 
+    def makeUnpitched(self, *, inPlace=False):
+        '''
+        Return a new Stream, or modify in place, with :class:`~music21.pitch.Unpitched`
+        replacing :class:`~music21.pitch.Pitch` objects on any notes having
+        an :class:`~music21.instrument.UnpitchedPercussion` instrument as either
+        a storedInstrument or closest in the stream hierarchy.
+
+        See :func:`~music21.stream.makeNotation.makeUnpitched`.
+        '''
+        return makeNotation.makeUnpitched(self, inPlace=inPlace)
+
     def makeAccidentals(
         self,
         *,

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -917,10 +917,14 @@ def makeUnpitched(s, *, inPlace=False):
         found = n.getInstrument()
         if found and 'UnpitchedPercussion' in found.classes:
             if hasattr(n, 'pitch'):
-                n.pitch = pitch.Unpitched(n.pitch)
+                n.pitch = pitch.Unpitched(
+                    displayName=n.pitch.step + str(n.pitch.octave)
+                )
             elif 'Chord' in n.classes:
                 for innerN in n.notes:
-                    innerN.pitch = pitch.Unpitched(n.pitch)
+                    innerN.pitch = pitch.Unpitched(
+                        displayName=innerN.pitch.step + str(innerN.pitch.octave)
+                    )
 
     if not inPlace:
         return returnObj

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -897,6 +897,33 @@ def makeRests(
     if inPlace is not True:
         return returnObj
 
+def makeUnpitched(s, *, inPlace=False):
+    '''
+    Return a new Stream, or modify in place, with :class:`~music21.pitch.Unpitched`
+    replacing :class:`~music21.pitch.Pitch` objects on any notes having
+    an :class:`~music21.instrument.UnpitchedPercussion` instrument as either
+    a `storedInstrument` or closest in the stream hierarchy. Instrument
+    lookup is done by :meth:`~music21.note.Note.getInstrument`.
+
+    TODO: implement getInstrument
+    TODO: doctest
+    '''
+    if not inPlace:
+        returnObj = s.coreCopyAsDerivation('makeUnpitched')
+    else:
+        returnObj = s
+
+    for n in s.recurse().notes:
+        found = n.getInstrument()
+        if found and 'UnpitchedPercussion' in found.classes:
+            if hasattr(n, 'pitch'):
+                n.pitch = pitch.Unpitched(n.pitch)
+            elif 'Chord' in n.classes:
+                for innerN in n.notes:
+                    innerN.pitch = pitch.Unpitched(n.pitch)
+
+    if not inPlace:
+        return returnObj
 
 def makeTies(
     s,


### PR DESCRIPTION
Not saying I'm the fellow to attack the rest of the percussion tasks, but here's a tiny bite.

WIP PR for discussion: create `Unpitched` objects from musicxml.

**Question:** I have a somewhat negative view of the following TODO in `.pitches()`:
https://github.com/cuthbertLab/music21/blob/96f0922c49b0e37f3c4ef15149521a217cdaf6f0/music21/stream/__init__.py#L9148-L9151

I doubt users will find that intuitive. Percussionists play notes. Plus, the recent changes to allow iterating over properties to not raise removes what I figure was the chief motivation--wasn't it that someone would try to access Unpitched.pitches?