### PR TITLE
Create <other-technical> instead of raising an exception from untranslatable technical marks

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1795,7 +1795,6 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
             <lyric-language name="verse" xml:lang="fr" />
             <lyric-language name="chorus" xml:lang="en" />
         </defaults>
-
         '''
         if not self.stream.hasStyleInformation:
             return
@@ -4431,6 +4430,14 @@ class MeasureExporter(XMLExporterBase):
         >>> mxFingering = MEX.articulationToXmlTechnical(f)
         >>> MEX.dump(mxFingering)
         <fingering alternate="no" substitution="yes">4</fingering>
+
+        Technical marks too specific to express in musicxml just get other-technical
+
+        >>> g = articulations.OrganIndication()
+        >>> g.displayText = 'unda maris'
+        >>> mxOther = MEX.articulationToXmlTechnical(g)
+        >>> MEX.dump(mxOther)
+        <other-technical>unda maris</other-technical>
         '''
         # these technical have extra information
         # TODO: hammer-on
@@ -4444,8 +4451,8 @@ class MeasureExporter(XMLExporterBase):
                 musicXMLTechnicalName = xmlObjects.TECHNICAL_MARKS_REV[c]
                 break
         if musicXMLTechnicalName is None:
-            raise MusicXMLExportException(
-                f'Cannot translate technical indication {articulationMark} to musicxml')
+            musicXMLTechnicalName = 'other-technical'
+
         mxTechnicalMark = Element(musicXMLTechnicalName)
         if articulationMark.placement is not None:
             mxTechnicalMark.set('placement', articulationMark.placement)
@@ -4473,6 +4480,10 @@ class MeasureExporter(XMLExporterBase):
         # whether it is base-pitch, sounding-pitch, or touching-pitch
         if musicXMLTechnicalName == 'harmonic':
             self.setHarmonic(mxTechnicalMark, articulationMark)
+
+        if (musicXMLTechnicalName == 'other-technical'
+                and articulationMark.displayText is not None):
+            mxTechnicalMark.text = articulationMark.displayText
 
         self.setPrintStyle(mxTechnicalMark, articulationMark)
         # mxArticulations.append(mxArticulationMark)
@@ -4503,7 +4514,7 @@ class MeasureExporter(XMLExporterBase):
           <sounding-pitch />
         </harmonic>
 
-        `~music21.articulations.Harmonic` is probably too general for most uses,
+        :class:`~music21.articulations.Harmonic` is probably too general for most uses,
         but if you use it, you get a harmonic tag with no details:
 
         >>> b = articulations.Harmonic()

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4489,7 +4489,7 @@ class MeasureExporter(XMLExporterBase):
 
         >>> MEXClass = musicxml.m21ToXml.MeasureExporter
 
-        >>> a = articulations.Harmonic()
+        >>> a = articulations.StringHarmonic()
         >>> a.harmonicType = 'artificial'
         >>> a.pitchType = 'sounding'
 
@@ -4502,7 +4502,19 @@ class MeasureExporter(XMLExporterBase):
           <artificial />
           <sounding-pitch />
         </harmonic>
+
+        `~music21.articulations.Harmonic` is probably too general for most uses,
+        but if you use it, you get a harmonic tag with no details:
+
+        >>> b = articulations.Harmonic()
+        >>> mxh2 = Element('harmonic')
+        >>> MEXClass.setHarmonic(mxh2, b)
+        >>> MEXClass.dump(mxh2)
+        <harmonic />
         '''
+        if not hasattr(harm, 'harmonicType'):
+            return
+
         if harm.harmonicType == 'artificial':
             SubElement(mxh, 'artificial')
         elif harm.harmonicType == 'natural':

--- a/music21/musicxml/xmlObjects.py
+++ b/music21/musicxml/xmlObjects.py
@@ -82,6 +82,7 @@ TECHNICAL_MARKS = OrderedDict([('up-bow', articulations.UpBow),
 TECHNICAL_MARKS_REV = OrderedDict([(v, k) for k, v in TECHNICAL_MARKS.items()])
 # too generic until we have an ordered dict. -- we have that now.  Should we not do it?
 del TECHNICAL_MARKS_REV[articulations.TechnicalIndication]
+TECHNICAL_MARKS_REV[articulations.Harmonic] = 'harmonic'
 
 
 # NON-spanner ornaments that go into Expressions


### PR DESCRIPTION
Fixes #759 

`Harmonic` wasn't being exported unless it was `StringHarmonic`, but musicxml has a way to represent this.

Also found a docstring modeling creating `Harmonic` and hacking the attributes in--fixed.

Used `<other-technical>` to represent whatever we can't translate, just like `<other-articulation>` elsewhere. EDIT: on first push I was exporting `<other-articulation`, but I found that musicxml has `<other-technical>`, so updated.

Spot checked the other exceptions that are raised and don't see much value at this time to try to pass m21 objects in and print sites.