### PR TITLE
WIP: Humdrum parser bug when encountering manually-positioned rests

### DIFF
--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -2193,12 +2193,17 @@ def hdStringToNote(contents):
 
     # http://www.lib.virginia.edu/artsandmedia/dmmc/Music/Humdrum/kern_hlp.html#kern
 
-    # 3.2.1 -- pitch
+    # 3.2.1 Pitches and 3.3 Rests
 
     matchedNote = re.search('([a-gA-G]+)', contents)
-
     thisObject = None
-    if matchedNote:
+
+    # Detect rests first, because rests can contain manual positioning information,
+    # which is also detected by the `matchedNote` variable above.
+    if contents.count('r'):
+        thisObject = note.Rest()
+
+    elif matchedNote:
         kernNoteName = matchedNote.group(1)
         step = kernNoteName[0].lower()
         if step == kernNoteName[0]:  # middle C or higher
@@ -2208,9 +2213,6 @@ def hdStringToNote(contents):
         thisObject = note.Note(octave=octave)
         thisObject.step = step
 
-    # 3.3 -- Rests
-    elif contents.count('r'):
-        thisObject = note.Rest()
     else:
         raise HumdrumException(f'Could not parse {contents} for note information')
 


### PR DESCRIPTION
Humdrum notation can (apparently!) contain manual-positioning information for rests, which unfortunately the current code detects as a note.

Details:

In humdrum, a normal eighth note rest might look like `8r`, but the position of this rest can be changed by adding the symbol for a pitch after the `r`; e.g., `8rGG` would mean an eighth note rest but positioned at the vertical space on the staff where the note `GG` is.  I cannot find any definite information on this in the humdrum documentation, unfortunately, but it appears in at least one file on the KernScores website: https://kern.humdrum.org/cgi-bin/ksdata?l=users/craig/ragtime/joplin&file=entertainer.krn&f=kern  (see measure 4).  

For the moment, this can be fixed by detecting rests first, then notes, in the `hdStringToNote` function, however I have no clue if this will break other things in the code, so I've marked this as a work in progress.  I'm hoping to get some clarification from @craigsapp.