### PR TITLE
Fix the instantiation of GeneralNote with lyrics

### DIFF
--- a/music21/note.py
+++ b/music21/note.py
@@ -375,7 +375,7 @@ class GeneralNote(base.Music21Object):
         self.expressions = []
         self.articulations = []
 
-        if 'lyric' in keywords:
+        if 'lyric' in keywords and keywords['lyric'] is not None:
             self.addLyric(keywords['lyric'])
 
         # note: Chords handle ties differently


### PR DESCRIPTION
Previously, `GeneralNote(lyric=None)` would set a lyric with the literal `None` as a string. Fixes #768.