### PR TITLE
Extended duration symbols in ABC chords (marian-schultz)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ __pycache__/
 .idea/other.xml
 .idea/vcs.xml
 .idea/workspace.xml
-
+.idea/markdown-*.xml
 
 # OSX
 .DS_Store

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -1641,21 +1641,37 @@ class ABCChord(ABCNote):
 
     A subclass of ABCNote.
     '''
-    def __init__(self, src):
+
+    def __init__(self, src: str = ''):
         super().__init__(src)
         # store a list of component objects
         self.subTokens = []
 
     def parse(self, forceKeySignature=None, forceDefaultQuarterLength=None):
+        '''
+            Chord without length modifier: [ceg]
+            Chords with outer length modifier: [ceg]2, [ceg]/2
+            Cords with inner length modifier: [c2e2g2], [c2eg]
+            Cords with inner and outer length modifier: [c2e2g2]/2, [c/2e/2g/2]2
+        '''
+
         self.chordSymbols, nonChordSymStr = self._splitChordSymbols(self.src)
 
-        tokenStr = nonChordSymStr[1:-1]  # remove outer brackets
-        # environLocal.printDebug(['ABCChord:', nonChordSymStr, 'tokenStr', tokenStr])
+        # position of the closing bracket
+        pos = nonChordSymStr.index(']')
+        # Length modifier string behind der chord brackets
+        outerLengthModifierStr = nonChordSymStr[pos + 1:]
+        # String in the chord brackets
+        tokenStr = nonChordSymStr[1:pos]
 
-        self.quarterLength = self.getQuarterLength(
-            nonChordSymStr,
-            forceDefaultQuarterLength=forceDefaultQuarterLength
-        )
+        # environLocal.printDebug(['ABCChord:', nonChordSymStr, 'tokenStr', tokenStr, '
+        # outerLengthModifierStr', outerLengthModifierStr])
+
+        # Get the outer chord length modifier if present
+        outer_lengthModifier = 1.0
+        if outerLengthModifierStr:
+            outer_lengthModifier = self.getQuarterLength(outerLengthModifierStr,
+                                                         forceDefaultQuarterLength=1.0)
 
         if forceKeySignature is not None:
             activeKeySignature = forceKeySignature
@@ -1669,7 +1685,7 @@ class ABCChord(ABCNote):
         # may need to supply key?
         ah.tokenize(tokenStr)
 
-        chordDurationPost = None
+        inner_quarterLength = 0
         # tokens contained here are each ABCNote instances
         for t in ah.tokens:
             # environLocal.printDebug(['ABCChord: subTokens', t])
@@ -1678,14 +1694,22 @@ class ABCChord(ABCNote):
                 t.parse(
                     forceDefaultQuarterLength=self.activeDefaultQuarterLength,
                     forceKeySignature=activeKeySignature)
+
+                if t.isRest:
+                    continue
+
                 # get the quarter length from the sub-tokens
-                # note: assuming these are the same
-                chordDurationPost = t.quarterLength
-            if isinstance(t, ABCNote) and not t.isRest:
+                # All the notes within a chord should normally have the same length,
+                # but if not, the chord duration is that of the first note.
+                if not inner_quarterLength:
+                    inner_quarterLength = t.quarterLength
+
                 self.subTokens.append(t)
 
-        if chordDurationPost is not None:
-            self.quarterLength = chordDurationPost
+
+        # When both inside and outside the chord length modifiers are used,
+        # they should be multiplied. Example: [C2E2G2]3 has the same meaning as [CEG]6.
+        self.quarterLength = outer_lengthModifier * inner_quarterLength
 
 
 # ------------------------------------------------------------------------------
@@ -2193,9 +2217,19 @@ class ABCHandler:
             # get chords
             if c == '[':
                 j = self.pos + 1
+
+                # find closing chord bracket
                 while j < self.srcLen - 1 and self.strSrc[j] != ']':
                     j += 1
+
                 j += 1  # need character that caused break
+
+                # find outer chord length modifier
+                while j < self.srcLen and (self.strSrc[j].isdigit() or self.strSrc[j] in '/'):
+                    j += 1
+
+
+
                 # prepend chord symbol
                 if activeChordSymbol != '':
                     self.currentCollectStr = activeChordSymbol + self.strSrc[self.pos:j]

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -1668,10 +1668,8 @@ class ABCChord(ABCNote):
         # outerLengthModifierStr', outerLengthModifierStr])
 
         # Get the outer chord length modifier if present
-        outer_lengthModifier = 1.0
-
         outer_lengthModifier = self.getQuarterLength(outerLengthModifierStr,
-                                                    forceDefaultQuarterLength=1.0)
+                                                     forceDefaultQuarterLength=1.0)
 
         if forceKeySignature is not None:
             activeKeySignature = forceKeySignature

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -1651,15 +1651,15 @@ class ABCChord(ABCNote):
         '''
             Chord without length modifier: [ceg]
             Chords with outer length modifier: [ceg]2, [ceg]/2
-            Cords with inner length modifier: [c2e2g2], [c2eg]
-            Cords with inner and outer length modifier: [c2e2g2]/2, [c/2e/2g/2]2
+            Chords with inner length modifier: [c2e2g2], [c2eg]
+            Chords with inner and outer length modifier: [c2e2g2]/2, [c/2e/2g/2]2
         '''
 
         self.chordSymbols, nonChordSymStr = self._splitChordSymbols(self.src)
 
         # position of the closing bracket
         pos = nonChordSymStr.index(']')
-        # Length modifier string behind der chord brackets
+        # Length modifier string behind the chord brackets
         outerLengthModifierStr = nonChordSymStr[pos + 1:]
         # String in the chord brackets
         tokenStr = nonChordSymStr[1:pos]
@@ -1669,9 +1669,9 @@ class ABCChord(ABCNote):
 
         # Get the outer chord length modifier if present
         outer_lengthModifier = 1.0
-        if outerLengthModifierStr:
-            outer_lengthModifier = self.getQuarterLength(outerLengthModifierStr,
-                                                         forceDefaultQuarterLength=1.0)
+
+        outer_lengthModifier = self.getQuarterLength(outerLengthModifierStr,
+                                                    forceDefaultQuarterLength=1.0)
 
         if forceKeySignature is not None:
             activeKeySignature = forceKeySignature
@@ -2227,8 +2227,6 @@ class ABCHandler:
                 # find outer chord length modifier
                 while j < self.srcLen and (self.strSrc[j].isdigit() or self.strSrc[j] in '/'):
                     j += 1
-
-
 
                 # prepend chord symbol
                 if activeChordSymbol != '':

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -1649,10 +1649,15 @@ class ABCChord(ABCNote):
 
     def parse(self, forceKeySignature=None, forceDefaultQuarterLength=None):
         '''
-            Chord without length modifier: [ceg]
-            Chords with outer length modifier: [ceg]2, [ceg]/2
-            Chords with inner length modifier: [c2e2g2], [c2eg]
-            Chords with inner and outer length modifier: [c2e2g2]/2, [c/2e/2g/2]2
+        Handles the following types of chords:
+        
+        * Chord without length modifier: [ceg]
+        
+        * Chords with outer length modifier: [ceg]2, [ceg]/2
+        
+        * Chords with inner length modifier: [c2e2g2], [c2eg]
+        
+        * Chords with inner and outer length modifier: [c2e2g2]/2, [c/2e/2g/2]2
         '''
 
         self.chordSymbols, nonChordSymStr = self._splitChordSymbols(self.src)
@@ -1723,7 +1728,7 @@ class ABCHandler:
     define new phrases.  This is useful for parsing extra information from
     the Essen Folksong repertory
 
-    New in v6.2 -- lineBreaksDefinePhrases -- does not yet do anything
+    New in v6.3 -- lineBreaksDefinePhrases -- does not yet do anything
     '''
     def __init__(self, abcVersion=None, lineBreaksDefinePhrases=False):
         # tokens are ABC objects import n a linear stream

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -1650,13 +1650,13 @@ class ABCChord(ABCNote):
     def parse(self, forceKeySignature=None, forceDefaultQuarterLength=None):
         '''
         Handles the following types of chords:
-        
+
         * Chord without length modifier: [ceg]
-        
+
         * Chords with outer length modifier: [ceg]2, [ceg]/2
-        
+
         * Chords with inner length modifier: [c2e2g2], [c2eg]
-        
+
         * Chords with inner and outer length modifier: [c2e2g2]/2, [c/2e/2g/2]2
         '''
 

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -884,7 +884,7 @@ class Test(unittest.TestCase):
                 self.assertIn(pitch_name, chord_symbol[0].pitchNames,
                               'Pitch not in ChordSymbol of abc: "%s"' % abc_text)
 
-    def testAbc21BrokenRythm(self):
+    def testAbc21BrokenRhythm(self):
         # Test the chord symbol for note and chord
         from music21 import abcFormat, note
         from music21.abcFormat import translate
@@ -892,7 +892,7 @@ class Test(unittest.TestCase):
         # default length of this test
         abc_dl = 'L:1/4\n'
 
-        # test abc strings of broken rythm between 2 notes and/or chords and their
+        # test abc strings of broken rhythm between 2 notes and/or chords and their
         # quarter lengths at the default length of 1/4
         # list[tuple(abc: str, value1: int, value2: int)]
         data = [
@@ -934,9 +934,9 @@ class Test(unittest.TestCase):
                              f'Wrong numbers of Notes found in abc: {abc}!')
             ist_left, ist_right = general_notes
             self.assertEqual(ist_left.duration.quarterLength, soll_left,
-                             f'Invalid left note/chord length of abc broken rythm: {abc}')
+                             f'Invalid left note/chord length of abc broken rhythm: {abc}')
             self.assertEqual(ist_right.duration.quarterLength, soll_right,
-                             f'Invalid right note/chord length of abc broken rythm: {abc}')
+                             f'Invalid right note/chord length of abc broken rhythm: {abc}')
 
 
 if __name__ == '__main__':

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -938,5 +938,5 @@ class Test(unittest.TestCase):
 
 if __name__ == '__main__':
     import music21
-    music21.converter.parse(reelsABC21, format='abc').scores[1].show()
+    # music21.converter.parse(reelsABC21, format='abc').scores[1].show()
     music21.mainTest(Test)

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -859,6 +859,23 @@ class Test(unittest.TestCase):
                     self.assertIn(pitch_name, e.pitchNames,
                                   'Pitch not in Chord "%s"' % abc_chord)
 
+    def testAbc21ChordSymbol(self):
+        # Test the chord symbol for note and chord
+        from music21 import abcFormat, harmony
+        from music21.abcFormat import translate
+
+        # default length of this test
+        abc_dl = 'L:1/8\n'
+
+        af = abcFormat.ABCFile()
+        for abc_text in ('"C"C', '"C"[ceg]'):
+            ah = af.readstr(abc_dl + abc_text)
+            part = translate.abcToStreamScore(ah)[1]
+            chord_symbol = part.getElementsByClass(harmony.ChordSymbol)
+            self.assertTrue(chord_symbol, 'No ChordSymbol found in abc: "%s"' % abc_text)
+            for pitch_name in 'CEG':
+                self.assertIn(pitch_name, chord_symbol[0].pitchNames,
+                              'Pitch not in ChordSymbol of abc: "%s"' % abc_text)
 
 
 if __name__ == '__main__':

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -820,7 +820,7 @@ class Test(unittest.TestCase):
         '''
         Translation of ABC Chord variations
         '''
-        from music21 import abcFormat, chord
+        from music21 import abcFormat, chord, stream
         from music21.abcFormat import translate
 
         af = abcFormat.ABCFile()
@@ -831,7 +831,8 @@ class Test(unittest.TestCase):
         for abc_chord in ['[]', '[z]']:
             ah = af.readstr(abc_dl + '[]')
             s = translate.abcToStreamScore(ah)
-            self.assertFalse(s.elements[1].getElementsByClass(chord.Chord),
+            part = s.getElementsByClass(stream.Part)
+            self.assertFalse(part.getElementsByClass(chord.Chord),
                              'Empty chord "%s" in Score' % abc_chord)
 
         # list of test abc chords and their quarter lengths at the default length of 1/8
@@ -854,14 +855,15 @@ class Test(unittest.TestCase):
             s = translate.abcToStreamScore(ah)
             self.assertEqual(s.duration.quarterLength, quarter_length,
                              'invalid duration of chord "%s"' % abc_chord)
-            for e in s.elements[1].getElementsByClass(chord.Chord):
+            part = s.getElementsByClass(stream.Part)
+            for e in part.getElementsByClass(chord.Chord):
                 for pitch_name in 'CEG':
                     self.assertIn(pitch_name, e.pitchNames,
                                   'Pitch not in Chord "%s"' % abc_chord)
 
     def testAbc21ChordSymbol(self):
         # Test the chord symbol for note and chord
-        from music21 import abcFormat, harmony
+        from music21 import abcFormat, harmony, stream
         from music21.abcFormat import translate
 
         # default length of this test
@@ -870,7 +872,7 @@ class Test(unittest.TestCase):
         af = abcFormat.ABCFile()
         for abc_text in ('"C"C', '"C"[ceg]'):
             ah = af.readstr(abc_dl + abc_text)
-            part = translate.abcToStreamScore(ah)[1]
+            part = translate.abcToStreamScore(ah).getElementsByClass(stream.Part)[0]
             chord_symbol = part.getElementsByClass(harmony.ChordSymbol)
             self.assertTrue(chord_symbol, 'No ChordSymbol found in abc: "%s"' % abc_text)
             for pitch_name in 'CEG':

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -838,26 +838,28 @@ class Test(unittest.TestCase):
         # list of test abc chords and their quarter lengths at the default length of 1/8
         # list[tuple(str, int)] = of abc chords and= [( abc_chord: str)]
         abc_chords = [
-            ('[ceg]', 0.5),
-            ('[ceg]2', 1.0),
-            ('[c2e2g2]', 1.0),
-            ('[ce2g]', 0.5),
-            ('[ceg2]', 0.5),
-            ('[c2e2g2]/2', 0.5),
-            ('[c/2e/2g/2]', 0.25),
-            ('[c2e/2g/2]/2', 0.5),
-            ('[c/2e/2g/2]2', 0.5),
-            ('[c/2e/2g/2]/2', 0.125)
+            ('[c_eg]', 0.5, ['C', 'E-', 'G']),
+            ('[ceg]', 0.5, 'CEG'),
+            ('[ceg]2', 1.0,'CEG'),
+            ('[c2e2^g2]', 1.0, ['C','E','G#']),
+            ("[c'e2g]", 0.5, 'CEG'),
+            ('[ce^g2]', 0.5, ['C','E','G#']),
+            ('[c,2e2g2]/2', 0.5, 'CEG'),
+            ("[c/2e'/2=g/2]", 0.25, 'CEG'),
+            ('[c2_e,,/2g/2]/2', 0.5, ['C','E-','G']),
+            ('[c/2e/2g/2]2', 0.5,'CEG'),
+            ('[^c/2e/2g/2]/2', 0.125,['C#','E','G']),
+            ('[ceg]', 0.5, 'CEG'),
         ]
 
-        for abc_chord, quarter_length in abc_chords:
+        for abc_chord, quarter_length, chord_pitches in abc_chords:
             ah = af.readstr(abc_dl + abc_chord)
             s = translate.abcToStreamScore(ah)
             self.assertEqual(s.duration.quarterLength, quarter_length,
                              'invalid duration of chord "%s"' % abc_chord)
-            part = s.getElementsByClass(stream.Part)
+            part = s.getElementsByClass(stream.Part)[0]
             for e in part.getElementsByClass(chord.Chord):
-                for pitch_name in 'CEG':
+                for pitch_name in chord_pitches:
                     self.assertIn(pitch_name, e.pitchNames,
                                   'Pitch not in Chord "%s"' % abc_chord)
 

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -816,6 +816,50 @@ class Test(unittest.TestCase):
         self.assertEqual(notes[8].pitch.midi, 65, 'Natural is ignored')
         self.assertEqual(notes[12].pitch.midi, 72, 'Natural is ignored')
 
+    def testAbc21Chords(self):
+        '''
+        Translation of ABC Chord variations
+        '''
+        from music21 import abcFormat, chord
+        from music21.abcFormat import translate
+
+        af = abcFormat.ABCFile()
+        # default length of this test
+        abc_dl = 'L:1/8\n'
+
+        # Empty Chords should be skipped at all
+        for abc_chord in ['[]', '[z]']:
+            ah = af.readstr(abc_dl + '[]')
+            s = translate.abcToStreamScore(ah)
+            self.assertFalse(s.elements[1].getElementsByClass(chord.Chord),
+                             'Empty chord "%s" in Score' % abc_chord)
+
+        # list of test abc chords and their quarter lengths at the default length of 1/8
+        # list[tuple(str, int)] = of abc chords and= [( abc_chord: str)]
+        abc_chords = [
+            ('[ceg]', 0.5),
+            ('[ceg]2', 1.0),
+            ('[c2e2g2]', 1.0),
+            ('[ce2g]', 0.5),
+            ('[ceg2]', 0.5),
+            ('[c2e2g2]/2', 0.5),
+            ('[c/2e/2g/2]', 0.25),
+            ('[c2e/2g/2]/2', 0.5),
+            ('[c/2e/2g/2]2', 0.5),
+            ('[c/2e/2g/2]/2', 0.125)
+        ]
+
+        for abc_chord, quarter_length in abc_chords:
+            ah = af.readstr(abc_dl + abc_chord)
+            s = translate.abcToStreamScore(ah)
+            self.assertEqual(s.duration.quarterLength, quarter_length,
+                             'invalid duration of chord "%s"' % abc_chord)
+            for e in s.elements[1].getElementsByClass(chord.Chord):
+                for pitch_name in 'CEG':
+                    self.assertIn(pitch_name, e.pitchNames,
+                                  'Pitch not in Chord "%s"' % abc_chord)
+
+
 
 if __name__ == '__main__':
     import music21

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -840,15 +840,15 @@ class Test(unittest.TestCase):
         abc_chords = [
             ('[c_eg]', 0.5, ['C', 'E-', 'G']),
             ('[ceg]', 0.5, 'CEG'),
-            ('[ceg]2', 1.0,'CEG'),
-            ('[c2e2^g2]', 1.0, ['C','E','G#']),
+            ('[ceg]2', 1.0, 'CEG'),
+            ('[c2e2^g2]', 1.0, ['C', 'E', 'G#']),
             ("[c'e2g]", 0.5, 'CEG'),
-            ('[ce^g2]', 0.5, ['C','E','G#']),
+            ('[ce^g2]', 0.5, ['C', 'E', 'G#']),
             ('[c,2e2g2]/2', 0.5, 'CEG'),
             ("[c/2e'/2=g/2]", 0.25, 'CEG'),
-            ('[c2_e,,/2g/2]/2', 0.5, ['C','E-','G']),
-            ('[c/2e/2g/2]2', 0.5,'CEG'),
-            ('[^c/2e/2g/2]/2', 0.125,['C#','E','G']),
+            ('[c2_e,,/2g/2]/2', 0.5, ['C', 'E-', 'G']),
+            ('[c/2e/2g/2]2', 0.5, 'CEG'),
+            ('[^c/2e/2g/2]/2', 0.125, ['C#', 'E', 'G']),
             ('[ceg]', 0.5, 'CEG'),
         ]
 
@@ -881,10 +881,62 @@ class Test(unittest.TestCase):
                 self.assertIn(pitch_name, chord_symbol[0].pitchNames,
                               'Pitch not in ChordSymbol of abc: "%s"' % abc_text)
 
+    def testAbc21BrokenRythm(self):
+        # Test the chord symbol for note and chord
+        from music21 import abcFormat, note, stream
+        from music21.abcFormat import translate
+
+        # default length of this test
+        abc_dl = 'L:1/4\n'
+
+        # test abc strings of broken rythm between 2 notes and/or chords and their
+        # quarter lengths at the default length of 1/4
+        # list[tuple(abc: str, value1: int, value2: int)]
+        data = [
+            ('[ceg]<f', 0.5, 1.5),
+            ('f<[ceg]', 0.5, 1.5),
+            ('c>g', 1.5, 0.5),
+            ('c<g', 0.5, 1.5),
+            ('c>>=g', 1.75, 0.25),
+            ('c<<g', 0.25, 1.75),
+            ('c>>>g', 1.875, 0.125),
+            ('c<<<_g', 0.125, 1.875),
+            ("[ceg]>^f", 1.5, 0.5),
+            ('[ce^g]>>f', 1.75, 0.25),
+            ("[ceg]<<f", 0.25, 1.75),
+            ('[ceg]>>>f', 1.875, 0.125),
+            ("[ceg]<<<f", 0.125, 1.875),
+            ('f>[ceg]', 1.5, 0.5),
+            ('f>>[_ceg]', 1.75, 0.25),
+            ("f'<<[ceg]", 0.25, 1.75),
+            ('f,>>>[ceg]', 1.875, 0.125),
+            ('f<<<[ce_g]', 0.125, 1.875),
+            ('f<<<[ceg]', 0.125, 1.875),
+            ('f2>[ceg]', 3, 0.5),
+            ('[ceg]>f2', 1.5, 1),
+            ('f>[c_eg]2', 1.5, 1),
+            ('[c^eg]2>f', 3, 0.5),
+            ('f2<[ceg]', 1.0, 1.5),
+            ('[ceg]<f2', 0.5, 3),
+            ('f<[ceg]2', 0.5, 3),
+            ('[ceg]2<f', 1.0, 1.5),
+        ]
+
+        af = abcFormat.ABCFile()
+        for abc, soll_left, soll_right in data:
+            ah = af.readstr(abc_dl + abc)
+            part = translate.abcToStreamScore(ah).getElementsByClass(stream.Part)[0]
+            general_notes = part.getElementsByClass(note.GeneralNote)
+            self.assertEqual(len(general_notes), 2,
+                             f'Wrong numbers of Notes found in abc: {abc}!')
+            ist_left, ist_right = general_notes
+            self.assertEqual(ist_left.duration.quarterLength, soll_left,
+                             f'Invalid left note/chord length of abc broken rythm: {abc}')
+            self.assertEqual(ist_right.duration.quarterLength, soll_right,
+                             f'Invalid right note/chord length of abc broken rythm: {abc}')
+
 
 if __name__ == '__main__':
     import music21
-    # music21.converter.parse(reelsABC21, format='abc').scores[1].show()
+    music21.converter.parse(reelsABC21, format='abc').scores[1].show()
     music21.mainTest(Test)
-
-

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -859,11 +859,11 @@ class Test(unittest.TestCase):
                              'invalid duration of chord "%s"' % abc_chord)
 
             notes = s.parts[0].notes
-            Chord = notes[0]
+            chord0 = notes[0]
             self.assertEqual(len(notes), 1, 'Wrong number of chords found,')
-            self.assertIsInstance(Chord, chord.Chord, 'Not a Chord!')
+            self.assertIsInstance(chord0, chord.Chord, 'Not a Chord!')
             for pitch_name in chord_pitches:
-                self.assertIn(pitch_name, Chord.pitchNames,
+                self.assertIn(pitch_name, chord0.pitchNames,
                               'Pitch not in Chord "%s"' % abc_chord)
 
     def testAbc21ChordSymbol(self):

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -820,7 +820,7 @@ class Test(unittest.TestCase):
         '''
         Translation of ABC Chord variations
         '''
-        from music21 import abcFormat, chord, stream
+        from music21 import abcFormat, chord
         from music21.abcFormat import translate
 
         af = abcFormat.ABCFile()
@@ -831,7 +831,7 @@ class Test(unittest.TestCase):
         for abc_chord in ['[]', '[z]']:
             ah = af.readstr(abc_dl + '[]')
             s = translate.abcToStreamScore(ah)
-            part = s.getElementsByClass(stream.Part)
+            part = s.parts[0]
             self.assertFalse(part.getElementsByClass(chord.Chord),
                              'Empty chord "%s" in Score' % abc_chord)
 
@@ -857,15 +857,18 @@ class Test(unittest.TestCase):
             s = translate.abcToStreamScore(ah)
             self.assertEqual(s.duration.quarterLength, quarter_length,
                              'invalid duration of chord "%s"' % abc_chord)
-            part = s.getElementsByClass(stream.Part)[0]
-            for e in part.getElementsByClass(chord.Chord):
-                for pitch_name in chord_pitches:
-                    self.assertIn(pitch_name, e.pitchNames,
-                                  'Pitch not in Chord "%s"' % abc_chord)
+
+            notes = s.parts[0].notes
+            Chord = notes[0]
+            self.assertEqual(len(notes), 1, 'Wrong number of chords found,')
+            self.assertIsInstance(Chord, chord.Chord, 'Not a Chord!')
+            for pitch_name in chord_pitches:
+                self.assertIn(pitch_name, Chord.pitchNames,
+                              'Pitch not in Chord "%s"' % abc_chord)
 
     def testAbc21ChordSymbol(self):
         # Test the chord symbol for note and chord
-        from music21 import abcFormat, harmony, stream
+        from music21 import abcFormat, harmony
         from music21.abcFormat import translate
 
         # default length of this test
@@ -874,7 +877,7 @@ class Test(unittest.TestCase):
         af = abcFormat.ABCFile()
         for abc_text in ('"C"C', '"C"[ceg]'):
             ah = af.readstr(abc_dl + abc_text)
-            part = translate.abcToStreamScore(ah).getElementsByClass(stream.Part)[0]
+            part = translate.abcToStreamScore(ah).parts[0]
             chord_symbol = part.getElementsByClass(harmony.ChordSymbol)
             self.assertTrue(chord_symbol, 'No ChordSymbol found in abc: "%s"' % abc_text)
             for pitch_name in 'CEG':
@@ -883,7 +886,7 @@ class Test(unittest.TestCase):
 
     def testAbc21BrokenRythm(self):
         # Test the chord symbol for note and chord
-        from music21 import abcFormat, note, stream
+        from music21 import abcFormat, note
         from music21.abcFormat import translate
 
         # default length of this test
@@ -925,7 +928,7 @@ class Test(unittest.TestCase):
         af = abcFormat.ABCFile()
         for abc, soll_left, soll_right in data:
             ah = af.readstr(abc_dl + abc)
-            part = translate.abcToStreamScore(ah).getElementsByClass(stream.Part)[0]
+            part = translate.abcToStreamScore(ah).parts[0]
             general_notes = part.getElementsByClass(note.GeneralNote)
             self.assertEqual(len(general_notes), 2,
                              f'Wrong numbers of Notes found in abc: {abc}!')

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -264,7 +264,7 @@ def parseTokens(mh, dst, p, useMeasures):
                 dst.coreAppend(mmObj)
 
         # as ABCChord is subclass of ABCNote, handle first
-        elif isinstance(t, abcFormat.ABCChord):
+        elif isinstance(t, abcFormat.ABCChord) and t.subTokens:
             # may have more than notes?
             pitchNameList = []
             accStatusList = []  # accidental display status list

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -279,15 +279,13 @@ def parseTokens(mh, dst, p, useMeasures):
                     dst.coreElementsChanged()
                 except ValueError:
                     pass  # Exclude malformed chord
-            if t.isRest:
-                n = note.Rest()
-            else:
-                n = note.Note(t.pitchName)
-                if n.pitch.accidental is not None:
-                    n.pitch.accidental.displayStatus = t.accidentalDisplayStatus
 
             # as ABCChord is subclass of ABCNote, handle first
-            if isinstance(t, abcFormat.ABCChord) and t.subTokens:
+            if isinstance(t, abcFormat.ABCChord):
+                # Skip an empty chord
+                if not t.subTokens:
+                    continue
+
                 # may have more than notes?
                 pitchNameList = []
                 accStatusList = []  # accidental display status list
@@ -312,6 +310,13 @@ def parseTokens(mh, dst, p, useMeasures):
 
                 # ql += t.quarterLength
             else:
+                if t.isRest:
+                    n = note.Rest()
+                else:
+                    n = note.Note(t.pitchName)
+                    if n.pitch.accidental is not None:
+                        n.pitch.accidental.displayStatus = t.accidentalDisplayStatus
+
                 n.duration.quarterLength = t.quarterLength
                 if t.activeTuplet:
                     thisTuplet = copy.deepcopy(t.activeTuplet)


### PR DESCRIPTION
Extension for the recognition of chords in ABCFormat according to http://abcnotation.com/wiki/abc:standard:v2.1#chords_and_unisons.

* For chords an outer length modifier is supported
Example:
[ceg]2 == [c2e2g2]
[c3e3g3]2 == [ceg]6 == [c6e6g6]

* The length of the chord is determined by its first note
Example:
[c2e4g8] == [c2e2g2]
* Empty chords are discarded
* Additional unittests for variations of abc Chords
* Fix: Missing chord symbols  for chords
* Additional unittests for chord symbols on note & chords
