### PR TITLE
Filtering out null channel values

### DIFF
--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -1433,14 +1433,15 @@ class MidiTrack(prebase.ProtoM21Object):
 
     def getChannels(self):
         '''
-        Get all channels used in this Track (sorted)
+        Get all channels (excluding None) used in this Track (sorted)
 
         >>> mt = midi.MidiTrack(index=2)
         >>> noteOn = midi.MidiEvent(type=midi.ChannelVoiceMessages.NOTE_ON, channel=14)
         >>> noteOn2 = midi.MidiEvent(type=midi.ChannelVoiceMessages.NOTE_ON, channel=5)
         >>> noteOn3 = midi.MidiEvent(type=midi.ChannelVoiceMessages.NOTE_ON, channel=14)
+        >>> noteOn4 = midi.MidiEvent(type=midi.ChannelVoiceMessages.PROGRAM_CHANGE, channel=None)
 
-        >>> mt.events = [noteOn, noteOn2, noteOn3]
+        >>> mt.events = [noteOn, noteOn2, noteOn3, noteOn4]
 
         >>> mt.getChannels()
         [5, 14]

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -1447,7 +1447,7 @@ class MidiTrack(prebase.ProtoM21Object):
         '''
         post = []
         for e in self.events:
-            if e.channel not in post:
+            if e.channel not in post and e.channel is not None:
                 post.append(e.channel)
         return sorted(post)
 

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3074,7 +3074,7 @@ class Test(unittest.TestCase):
         # s.show('midi')
         mts = streamHierarchyToMidiTracks(s)
         # print(mts[0])
-        self.assertEqual(mts[0].getChannels(), [None])  # Conductor track
+        self.assertEqual(mts[0].getChannels(), [])  # Conductor track
         self.assertEqual(mts[1].getChannels(), [1])
         self.assertEqual(mts[2].getChannels(), [2])
         self.assertEqual(mts[3].getChannels(), [3])


### PR DESCRIPTION
Python3 specific bug:
track.getChannels throws an exception if one of the channels is None.
This is because the channels are being sorted, and python3 no longer allows comparison between int and None.

I don't have enough context, so feel free to close this PR and put up the correct fix instead.

Steps to REPRO:

1. Download midi file: 
`wget https://github.com/bearpelican/musicautobot/raw/master/data/midi/examples/A%20Thousand%20Miles%20-%20Vanessa%20Carlton%20-%20Verse-And-Pre-Chorus.mid`
2. Run Following
```python
import music21
file = 'A Thousand Miles - Vanessa Carlton - Verse-And-Pre-Chorus.mid'

mf = music21.midi.MidiFile()
mf.open(file)
mf.read()
mf.close()

[t.getChannels() for t in mf.tracks]
```

<img width="805" alt="Screen Shot 2021-01-13 at 14 51 48" src="https://user-images.githubusercontent.com/980342/104416493-e33c9180-55ae-11eb-8744-fc5482fcaa6e.png">
