### PR TITLE
Replace spanned elements when stripping ties

### DIFF
--- a/music21/common/objects.py
+++ b/music21/common/objects.py
@@ -306,6 +306,8 @@ class Timer:
 
     >>> t = common.Timer()
     >>> now = t()
+    >>> import time  #_DOCS_HIDE
+    >>> time.sleep(0.01)  #_DOCS_HIDE  -- some systems are extremely fast or have wide deltas
     >>> nowNow = t()
     >>> nowNow > now
     True

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -6676,6 +6676,13 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
                 # set tie to None on first note
                 notes[posConnected[0]].tie = None
+
+                # replace removed elements in spanners
+                for sp in f.spanners:
+                    for index in posConnected[1:]:
+                        if notes[index] in sp:
+                            sp.replaceSpannedElement(notes[index], notes[posConnected[0]])
+
                 posConnected = []  # reset to empty
 
         # all results have been processed
@@ -6689,7 +6696,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # https://github.com/cuthbertLab/music21/issues/266
             returnObj.remove(nTarget, recurse=True)
         returnObj.coreElementsChanged()
-
         if retainContainers:
             return returnObj
         else:

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -6696,6 +6696,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # https://github.com/cuthbertLab/music21/issues/266
             returnObj.remove(nTarget, recurse=True)
         returnObj.coreElementsChanged()
+
         if retainContainers:
             return returnObj
         else:

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -1180,6 +1180,7 @@ class Test(unittest.TestCase):
         self.assertTrue(stripped.spanners[1].isLast(sn1))
 
         # original unchanged
+        self.assertIsNot(s.spanners[0], stripped.spanners[0])
         self.assertTrue(s.spanners[0].isFirst(n1))
         self.assertTrue(s.spanners[0].isLast(n4))
         self.assertTrue(s.spanners[1].isFirst(n1))

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -1171,12 +1171,19 @@ class Test(unittest.TestCase):
         n1, unused_n2, n3, n4 = s.flat.notes
         s.insert(0, music21.spanner.Slur(n1, n4))
         s.insert(0, music21.dynamics.Crescendo(n1, n3))
-        s.stripTies(inPlace=True)
+        stripped = s.stripTies(inPlace=False)
+        sn1 = stripped.flat.notes[0]
 
+        self.assertTrue(stripped.spanners[0].isFirst(sn1))
+        self.assertTrue(stripped.spanners[0].isLast(sn1))
+        self.assertTrue(stripped.spanners[1].isFirst(sn1))
+        self.assertTrue(stripped.spanners[1].isLast(sn1))
+
+        # original unchanged
         self.assertTrue(s.spanners[0].isFirst(n1))
-        self.assertTrue(s.spanners[0].isLast(n1))
+        self.assertTrue(s.spanners[0].isLast(n4))
         self.assertTrue(s.spanners[1].isFirst(n1))
-        self.assertTrue(s.spanners[1].isLast(n1))
+        self.assertTrue(s.spanners[1].isLast(n3))
 
     def testGetElementsByOffsetZeroLength(self):
         '''

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -1158,6 +1158,26 @@ class Test(unittest.TestCase):
         stripped = s.stripTies()
         self.assertEqual(len(stripped.flat.notes), 1)
 
+    def testStripTiesReplaceSpannedElements(self):
+        '''
+        Testing elements in spanners replaced when stripTies removes them.
+        '''
+
+        s = Stream()
+        c = chord.Chord(['C3', 'C5'])
+        s.append(meter.TimeSignature('1/16'))
+        s.append(c)
+        s.makeNotation(inPlace=True)  # makes ties
+        n1, unused_n2, n3, n4 = s.flat.notes
+        s.insert(0, music21.spanner.Slur(n1, n4))
+        s.insert(0, music21.dynamics.Crescendo(n1, n3))
+        s.stripTies(inPlace=True)
+
+        self.assertTrue(s.spanners[0].isFirst(n1))
+        self.assertTrue(s.spanners[0].isLast(n1))
+        self.assertTrue(s.spanners[1].isFirst(n1))
+        self.assertTrue(s.spanners[1].isLast(n1))
+
     def testGetElementsByOffsetZeroLength(self):
         '''
         Testing multiple zero-length elements with mustBeginInSpan:


### PR DESCRIPTION
Spanners would disappear if a terminus was stripped by `stripTies`:

```
sch = corpus.parse('schoenberg/opus19', 6)
sch.stripTies().measure(8).show()
```


Before:

![stripped-no-spanner](https://user-images.githubusercontent.com/38668450/104535555-6b895980-55e4-11eb-855e-bf560ebe6bd6.png)


After:

![stripped-with-spanner](https://user-images.githubusercontent.com/38668450/104535567-6e844a00-55e4-11eb-8b8f-4fe0d45b88fb.png)
