### PR TITLE
Update Sphinx example for block-quoting code

### DIFF
--- a/documentation/source/developerReference/documenting.rst
+++ b/documentation/source/developerReference/documenting.rst
@@ -137,36 +137,35 @@ The documentation looks like this:
 .. image:: images/completebach.*
     :width: 300
 
-Finally, if there is a section of your documentation that you'd rather sphinx
+Finally, if there is a section of your documentation that you'd rather Sphinx
 not format at all, append two colons to the last line of formatted text,
 followed by a space, followed by the *indented* text block, followed by a
-space. Text written after this space will be formatted. For example, in your
-code write:
+space. Text written after this space will be formatted. This is useful for
+block-quoting example code. For example, in your code write::
 
-::
+    ...blah blah blah this text is formatted. Now I want to block-quote
+    some example code, so I put two colons::
 
-    ...blah blah blah this text is formatted. now I'm ready for not-formatted
-    text, so I put two colons::
+        this text is NOT formatted
+        it must be indented
 
-        this text is NOT formatted it must be indented
+        line breaks and spacing will be preserved
+        **bold** sphinx formatting unobserved
 
-        line breaks and spacing is preserved **bold** sphinx formatting is not
-        observed
-
-    Now I'm back to sphinx formatting...**now this is bold!*
+    Now I am back to Sphinx formatting, outside the block. **now this is bold!**
 
 The documentation looks like this:
 
-...blah blah blah this text is formatted. now I'm ready for not-formatted text,
-so I put two colons:
+...blah blah blah this text is formatted. Now I want to block-quote
+some example code, so I put two colons::
 
     this text is NOT formatted
     it must be indented
 
-    line breaks and spacing is preserved
-    **bold** sphinx formatting is not observed
+    line breaks and spacing will be preserved
+    **bold** sphinx formatting unobserved
 
-Now I'm back to sphinx formatting. **now this is bold!**
+Now I am back to Sphinx formatting, outside the block. **now this is bold!**
 
 
 Displaying only some of the test code in the documentation

--- a/documentation/source/developerReference/documenting.rst
+++ b/documentation/source/developerReference/documenting.rst
@@ -146,10 +146,10 @@ block-quoting example code. For example, in your code write::
     ...blah blah blah this text is formatted. Now I want to block-quote
     some example code, so I put two colons::
 
-        this text is NOT formatted
+        this text IS NOT formatted
         it must be indented
 
-        line breaks and spacing will be preserved
+        line breaks AND spacing will be preserved
         **bold** sphinx formatting unobserved
 
     Now I am back to Sphinx formatting, outside the block. **now this is bold!**
@@ -159,10 +159,10 @@ The documentation looks like this:
 ...blah blah blah this text is formatted. Now I want to block-quote
 some example code, so I put two colons::
 
-    this text is NOT formatted
+    this text IS NOT formatted
     it must be indented
 
-    line breaks and spacing will be preserved
+    line breaks AND spacing will be preserved
     **bold** sphinx formatting unobserved
 
 Now I am back to Sphinx formatting, outside the block. **now this is bold!**


### PR DESCRIPTION
Fixes #790 
New screenshot:

![block-quoting-updated](https://user-images.githubusercontent.com/38668450/105633986-b77c9f80-5e29-11eb-84cf-eb69bfde54a5.png)
