### PR TITLE
Chord symbol fixes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,4 +13,5 @@ exclude_lines =
     if debug:
     if self.debug:
     class TestExternal(unittest.TestCase):
+    def x_test
     pragma: no cover

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -972,7 +972,7 @@ class Chord(note.NotRest):
                 newbass = common.cleanedFlatNotation(newbass)
                 newbass = pitch.Pitch(newbass)
             # try to set newbass to be a pitch in the chord if possible
-            foundBassInChord = False
+            foundBassInChord: bool = False
             for p in self.pitches:  # first by identity
                 if newbass is p:
                     foundBassInChord = True
@@ -988,8 +988,12 @@ class Chord(note.NotRest):
             if not foundBassInChord:  # finally by name
                 for p in self.pitches:
                     if p.name == newbass.name:
+                        foundBassInChord = True
                         newbass = p
                         break
+
+            if not foundBassInChord:  # it's not there, needs to be added
+                self.pitches = (newbass, *(p for p in self.pitches))
 
             self._overrides['bass'] = newbass
             self._cache['bass'] = newbass

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -926,21 +926,6 @@ class Chord(note.NotRest):
         >>> cmaj1stInv.bass()
         <music21.pitch.Pitch E3>
 
-        The bass is usually defined to the lowest note in the chord,
-        but we want to be able to override this.  You might want an implied
-        bass for instance some people (following the music theorist
-        Rameau) call a diminished seventh chord (vii7)
-        a dominant chord with an omitted bass -- here we will specify the bass
-        to be a note not in the chord:
-
-        >>> vo9 = chord.Chord(['B3', 'D4', 'F4', 'A-4'])
-        >>> vo9.bass()
-        <music21.pitch.Pitch B3>
-
-        >>> vo9.bass(pitch.Pitch('G3'))
-        >>> vo9.bass()
-        <music21.pitch.Pitch G3>
-
         By default this method uses an algorithm to find the bass among the
         chord's pitches, if no bass has been previously specified. If this is
         not intended, set find to False when calling this method, and 'None'
@@ -3163,11 +3148,28 @@ class Chord(note.NotRest):
         >>> r is lotsOfNotes.pitches[1]
         True
 
+        You might want to supply an implied root. For instance, some people
+        (following the music theorist Rameau) call a diminished seventh chord (vii7)
+        a dominant chord with an omitted root -- here we will specify the root
+        to be a note not in the chord:
+
+        >>> vo9 = chord.Chord(['B3', 'D4', 'F4', 'A-4'])
+        >>> vo9.root()
+        <music21.pitch.Pitch B3>
+
+        >>> vo9.root(pitch.Pitch('G3'))
+        >>> vo9.root()
+        <music21.pitch.Pitch G3>
+
+        Pitches left untouched:
+
+        >>> [p.nameWithOctave for p in vo9.pitches]
+        ['B3', 'D4', 'F4', 'A-4']
 
         By default this method uses an algorithm to find the root among the
         chord's pitches, if no root has been previously specified. If this is
         not intended, set find to False when calling this method, and 'None'
-        will be returned if no root is specified
+        will be returned if no root is specified.
 
         >>> c = chord.Chord(['E3', 'G3', 'B4'])
         >>> c.root(find=False) is None

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2806,7 +2806,7 @@ class Test(unittest.TestCase):
         self.assertEqual(pitches, ChordSymbol('Aminmaj7').pitches)
         self.assertEqual(pitches, ChordSymbol('Am#7').pitches)
 
-    def x_testRootBassParsing(self):
+    def testRootBassParsing(self):
         """
         This tests a bug where the root and bass were wrongly parsed,
         since the matched root and bass were globally removed from figure,
@@ -2826,7 +2826,7 @@ class Test(unittest.TestCase):
           </harmony>
         """
         figure = 'E7/E-'
-        pitches = ('E-3', 'E3', 'G#3', 'B3', 'D4')
+        pitches = ('E-2', 'E3', 'G#3', 'B3', 'D4')
         self.runTestOnChord(xmlString, figure, pitches)
 
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1945,7 +1945,7 @@ class ChordSymbol(Harmony):
         ['C3', 'E-3', 'G3']
 
         >>> [str(pi) for pi in CS(root='C', bass='B', kind='major-ninth').pitches]
-        ['B2', 'C3', 'D3', 'E3', 'G3']
+        ['B1', 'D2', 'C3', 'E3', 'G3']
 
         >>> [str(pi) for pi in CS(root='D', bass='F', kind='minor-seventh').pitches]
         ['F3', 'A3', 'C4', 'D4']
@@ -1971,7 +1971,7 @@ class ChordSymbol(Harmony):
         >>> CS('E7omit5/G#').bass().nameWithOctave
         'G#2'
         >>> CS('E9omit5/G#').root().nameWithOctave
-        'E3'
+        'E4'
         >>> CS('E11omit3').root().nameWithOctave
         'E2'
         '''
@@ -2000,6 +2000,7 @@ class ChordSymbol(Harmony):
 
         # render in the 3rd octave by default
         self._overrides['root'].octave = 3
+        self._overrides['bass'].octave = 3
 
         if self._notationString():
             pitches = fbScale.getSamplePitches(self._overrides['root'], self._notationString())
@@ -2008,6 +2009,8 @@ class ChordSymbol(Harmony):
         else:
             pitches = []
             pitches.append(self._overrides['root'])
+            if self._overrides['bass'] not in pitches:
+                pitches.append(self._overrides['bass'])
 
         pitches = self._adjustOctaves(pitches)
 
@@ -2922,7 +2925,7 @@ class Test(unittest.TestCase):
         self.assertEqual(pitches, cs2.pitches)
         self.assertEqual(pitches, cs3.pitches)
 
-        # There was a bug where the bass was E3, because E-2 was assume to be
+        # There was a bug where the bass was E3, because E-2 was assumed to be
         # in the chord.
         self.assertEqual('E-2', cs1.bass().nameWithOctave)
 
@@ -3042,16 +3045,12 @@ class Test(unittest.TestCase):
         # self.assertEqual(cs1.root(), cs2.root())
         # self.assertEqual(cs1.bass(), cs2.bass())
 
-    def x_testChordWithoutKind(self):
-        """
-        This verifies that the chord creation doesn't fail with an index out
-        of range exception when no chord kind is specified.
-        """
+    def testChordWithoutKind(self):
         cs = ChordSymbol(root='C', bass='E')
 
         self.assertEqual(1, cs.inversion())
-        self.assertEqual('C3', str(cs.root()))
-        self.assertEqual('E2', str(cs.bass()))
+        self.assertEqual('C4', str(cs.root()))
+        self.assertEqual('E3', str(cs.bass()))
 
 
     def x_testAddSubtractAlterations(self):
@@ -3155,6 +3154,6 @@ _DOC_ORDER = [Harmony, chordSymbolFigureFromChord, ChordSymbol, ChordStepModific
 
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test)  # , runTest='testClassSortOrderHarmony')
+    music21.mainTest(Test)  # , runTest='testChordWithoutKind')
 
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2664,109 +2664,6 @@ class Test(unittest.TestCase):
         self.assertEqual(cs1.bass(), cs2.bass())
         self.assertEqual(cs1.bass(), cs3.bass())
 
-    def x_testChordStepFromFigure(self):
-        xmlString = """
-          <harmony>
-            <root>
-              <root-step>G</root-step>
-            </root>
-            <kind text="7alt">dominant</kind>
-            <degree>
-              <degree-value>5</degree-value>
-              <degree-alter>0</degree-alter>
-              <degree-type>subtract</degree-type>
-            </degree>
-            <degree>
-              <degree-value>9</degree-value>
-              <degree-alter>-1</degree-alter>
-              <degree-type>add</degree-type>
-            </degree>
-            <degree>
-              <degree-value>9</degree-value>
-              <degree-alter>1</degree-alter>
-              <degree-type>add</degree-type>
-            </degree>
-            <degree>
-              <degree-value>11</degree-value>
-              <degree-alter>1</degree-alter>
-              <degree-type>add</degree-type>
-            </degree>
-            <degree>
-              <degree-value>13</degree-value>
-              <degree-alter>-1</degree-alter>
-              <degree-type>add</degree-type>
-            </degree>
-          </harmony>
-        """
-        figure = 'G7 subtract 5 add b9 add #9 add #11 add b13'
-        pitches = ('G2', 'B2', 'F3', 'A-3', 'A#3', 'C#4', 'E-4')
-        self.runTestOnChord(xmlString, figure, pitches)
-
-        figure = 'G7 subtract5 addb9 add#9 add#11 addb13'
-        self.runTestOnChord(xmlString, figure, pitches)
-
-        figure = 'G7subtract5addb9add#9add#11addb13'
-        self.runTestOnChord(xmlString, figure, pitches)
-
-        #########
-
-        xmlString = """
-            <harmony>
-            <root>
-              <root-step>C</root-step>
-            </root>
-            <kind text="7b9">dominant</kind>
-            <degree>
-              <degree-value>9</degree-value>
-              <degree-alter>-1</degree-alter>
-              <degree-type>add</degree-type>
-            </degree>
-          </harmony>
-        """
-        figure = 'C7 b9'
-        pitches = ('C3', 'E3', 'G3', 'B-3', 'D-4')
-
-        self.runTestOnChord(xmlString, figure, pitches)
-
-        figure = 'C7 add b9'
-        self.runTestOnChord(xmlString, figure, pitches)
-
-        # Test alter
-        cs = ChordSymbol('A7 alter #5')
-        self.assertEqual('(<music21.pitch.Pitch A2>, <music21.pitch.Pitch '
-                         'C#3>, <music21.pitch.Pitch E#3>, '
-                         '<music21.pitch.Pitch G3>)', str(cs.pitches))
-
-        #########
-
-        xmlString = """
-          <harmony>
-            <root>
-              <root-step>A</root-step>
-              </root>
-            <kind>dominant</kind>
-            <degree>
-              <degree-value>5</degree-value>
-              <degree-alter>1</degree-alter>
-              <degree-type>alter</degree-type>
-              </degree>
-            <degree>
-              <degree-value>9</degree-value>
-              <degree-alter>1</degree-alter>
-              <degree-type>add</degree-type>
-              </degree>
-            <degree>
-              <degree-value>11</degree-value>
-              <degree-alter>1</degree-alter>
-              <degree-type>add</degree-type>
-              </degree>
-            </harmony>
-        """
-        figure = 'A7 alter #5 add #9 add #11'
-        pitches = ('A2', 'C#3', 'E#3', 'G3', 'B#3', 'D#4')
-
-        self.runTestOnChord(xmlString, figure, pitches)
-
     def testChordWithBass(self):
 
         xmlString = """
@@ -2962,40 +2859,6 @@ class Test(unittest.TestCase):
         self.assertEqual(pitches, cs2.pitches)
         self.assertEqual(pitches, cs3.pitches)
 
-    def x_testPower(self):
-        """
-        power chords should not have inversions
-        """
-
-        from xml.etree.ElementTree import fromstring as EL
-        from music21 import musicxml
-
-        pitches = ('E2', 'A2', 'E3')
-        pitches = tuple(pitch.Pitch(p) for p in pitches)
-
-        xmlString = """
-          <harmony>
-            <root>
-              <root-step>A</root-step>
-            </root>
-            <kind text="5">power</kind>
-            <bass>
-              <bass-step>E</bass-step>
-            </bass>
-          </harmony>
-        """
-
-        MP = musicxml.xmlToM21.MeasureParser()
-        mxHarmony = EL(xmlString)
-
-        cs1 = MP.xmlToChordSymbol(mxHarmony)
-        cs2 = ChordSymbol(cs1.figure)
-        cs3 = ChordSymbol('Apower/E')
-
-        self.assertEqual(pitches, cs1.pitches)
-        self.assertEqual(pitches, cs2.pitches)
-        self.assertEqual(pitches, cs3.pitches)
-
     def testNinth(self):
         """
         This tests a bug in _adjustOctaves.
@@ -3056,11 +2919,151 @@ class Test(unittest.TestCase):
         self.assertEqual('E3', str(cs.bass()))
 
 
-    def x_testAddSubtractAlterations(self):
+    def x_testChordStepFromFigure(self):
+        '''To make this work, will need some regex work.
+        See Alex's work @ https://github.com/cuthbertLab/music21/pull/383'''
+
+        xmlString = """
+          <harmony>
+            <root>
+              <root-step>G</root-step>
+            </root>
+            <kind text="7alt">dominant</kind>
+            <degree>
+              <degree-value>5</degree-value>
+              <degree-alter>0</degree-alter>
+              <degree-type>subtract</degree-type>
+            </degree>
+            <degree>
+              <degree-value>9</degree-value>
+              <degree-alter>-1</degree-alter>
+              <degree-type>add</degree-type>
+            </degree>
+            <degree>
+              <degree-value>9</degree-value>
+              <degree-alter>1</degree-alter>
+              <degree-type>add</degree-type>
+            </degree>
+            <degree>
+              <degree-value>11</degree-value>
+              <degree-alter>1</degree-alter>
+              <degree-type>add</degree-type>
+            </degree>
+            <degree>
+              <degree-value>13</degree-value>
+              <degree-alter>-1</degree-alter>
+              <degree-type>add</degree-type>
+            </degree>
+          </harmony>
+        """
+        figure = 'G7 subtract 5 add b9 add #9 add #11 add b13'
+        pitches = ('G2', 'B2', 'F3', 'A-3', 'A#3', 'C#4', 'E-4')
+        self.runTestOnChord(xmlString, figure, pitches)
+
+        figure = 'G7 subtract5 addb9 add#9 add#11 addb13'
+        self.runTestOnChord(xmlString, figure, pitches)
+
+        figure = 'G7subtract5addb9add#9add#11addb13'
+        self.runTestOnChord(xmlString, figure, pitches)
+
+        #########
+
+        xmlString = """
+            <harmony>
+            <root>
+              <root-step>C</root-step>
+            </root>
+            <kind text="7b9">dominant</kind>
+            <degree>
+              <degree-value>9</degree-value>
+              <degree-alter>-1</degree-alter>
+              <degree-type>add</degree-type>
+            </degree>
+          </harmony>
+        """
+        figure = 'C7 b9'
+        pitches = ('C3', 'E3', 'G3', 'B-3', 'D-4')
+
+        self.runTestOnChord(xmlString, figure, pitches)
+
+        figure = 'C7 add b9'
+        self.runTestOnChord(xmlString, figure, pitches)
+
+        # Test alter
+        cs = ChordSymbol('A7 alter #5')
+        self.assertEqual('(<music21.pitch.Pitch A2>, <music21.pitch.Pitch '
+                         'C#3>, <music21.pitch.Pitch E#3>, '
+                         '<music21.pitch.Pitch G3>)', str(cs.pitches))
+
+        #########
+
+        xmlString = """
+          <harmony>
+            <root>
+              <root-step>A</root-step>
+              </root>
+            <kind>dominant</kind>
+            <degree>
+              <degree-value>5</degree-value>
+              <degree-alter>1</degree-alter>
+              <degree-type>alter</degree-type>
+              </degree>
+            <degree>
+              <degree-value>9</degree-value>
+              <degree-alter>1</degree-alter>
+              <degree-type>add</degree-type>
+              </degree>
+            <degree>
+              <degree-value>11</degree-value>
+              <degree-alter>1</degree-alter>
+              <degree-type>add</degree-type>
+              </degree>
+            </harmony>
+        """
+        figure = 'A7 alter #5 add #9 add #11'
+        pitches = ('A2', 'C#3', 'E#3', 'G3', 'B#3', 'D#4')
+
+        self.runTestOnChord(xmlString, figure, pitches)
+
+    def x_testExpressSusUsingAlterations(self):
         ch1 = ChordSymbol('F7 add 4 subtract 3')
         ch2 = ChordSymbol('F7sus4')
 
         self.assertEqual(ch1.pitches, ch2.pitches)
+
+    def x_testPower(self):
+        """
+        power chords should not have inversions
+        """
+
+        from xml.etree.ElementTree import fromstring as EL
+        from music21 import musicxml
+
+        pitches = ('E2', 'A2', 'E3')
+        pitches = tuple(pitch.Pitch(p) for p in pitches)
+
+        xmlString = """
+          <harmony>
+            <root>
+              <root-step>A</root-step>
+            </root>
+            <kind text="5">power</kind>
+            <bass>
+              <bass-step>E</bass-step>
+            </bass>
+          </harmony>
+        """
+
+        MP = musicxml.xmlToM21.MeasureParser()
+        mxHarmony = EL(xmlString)
+
+        cs1 = MP.xmlToChordSymbol(mxHarmony)
+        cs2 = ChordSymbol(cs1.figure)
+        cs3 = ChordSymbol('Apower/E')
+
+        self.assertEqual(pitches, cs1.pitches)
+        self.assertEqual(pitches, cs2.pitches)
+        self.assertEqual(pitches, cs3.pitches)
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1949,7 +1949,7 @@ class ChordSymbol(Harmony):
         ['C3', 'E-3', 'G3']
 
         >>> [str(pi) for pi in CS(root='C', bass='B', kind='major-ninth').pitches]
-        ['B1', 'D2', 'C3', 'E3', 'G3']
+        ['B2', 'C3', 'D3', 'E3', 'G3']
 
         >>> [str(pi) for pi in CS(root='D', bass='F', kind='minor-seventh').pitches]
         ['F3', 'A3', 'C4', 'D4']
@@ -1975,10 +1975,11 @@ class ChordSymbol(Harmony):
         >>> CS('E7omit5/G#').bass().nameWithOctave
         'G#2'
         >>> CS('E9omit5/G#').root().nameWithOctave
-        'E4'
+        'E3'
         >>> CS('E11omit3').root().nameWithOctave
         'E2'
-        '''
+
+        # This constant was here for use in a prior implementation of inversions
         nineElevenThirteen = (
             'dominant-11th',
             'dominant-13th',
@@ -1990,6 +1991,7 @@ class ChordSymbol(Harmony):
             'minor-13th',
             'minor-ninth',
         )
+        '''
 
         if 'root' not in self._overrides or 'bass' not in self._overrides or self.chordKind is None:
             return
@@ -2038,12 +2040,9 @@ class ChordSymbol(Harmony):
 
         if inversionNum not in (0, None):
             for p in pitches[0:inversionNum]:
-                if self.chordKind in nineElevenThirteen:
-                    # bump octave up by two for ninths, elevenths, and thirteenths
-                    p.octave = p.octave + 2
-                    # this creates more spacing....
-                else:
-                    # only bump up by one for triads and sevenths.
+                p.octave = p.octave + 1
+                # Repeat if 9th/11th/13th chord in 3rd inversion or greater
+                if inversionNum > 3:
                     p.octave = p.octave + 1
 
             # if after bumping up the octaves, there are still pitches below bass pitch

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1978,19 +1978,6 @@ class ChordSymbol(Harmony):
         'E3'
         >>> CS('E11omit3').root().nameWithOctave
         'E2'
-
-        # This constant was here for use in a prior implementation of inversions
-        nineElevenThirteen = (
-            'dominant-11th',
-            'dominant-13th',
-            'dominant-ninth',
-            'major-11th',
-            'major-13th',
-            'major-ninth',
-            'minor-11th',
-            'minor-13th',
-            'minor-ninth',
-        )
         '''
 
         if 'root' not in self._overrides or 'bass' not in self._overrides or self.chordKind is None:

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1647,6 +1647,10 @@ class ChordSymbol(Harmony):
             '''
             pitchToAppend = sc.pitchFromDegree(hD.degree, rootPitch)
             if hD.interval and hD.interval.semitones != 0:
+                # added degrees are relative to dominant chords, which have all major degrees
+                # except for the seventh which is minor, thus the transposition down one half step
+                if hD.degree == 7 and self.chordKind is not None and self.chordKind != '':
+                    pitchToAppend = pitchToAppend.transpose(-1)
                 pitchToAppend = pitchToAppend.transpose(hD.interval)
             if hD.degree >= 7:
                 pitchToAppend.octave = pitchToAppend.octave + 1
@@ -2798,7 +2802,9 @@ class Test(unittest.TestCase):
         pitches = tuple(pitch.Pitch(p) for p in pitches)
         self.assertEqual(pitches, ChordSymbol('AmM7').pitches)
         self.assertEqual(pitches, ChordSymbol('Aminmaj7').pitches)
-        # self.assertEqual(pitches, ChordSymbol('Am#7').pitches)
+        pitches = ('A1', 'C2', 'E2', 'G#3')
+        pitches = tuple(pitch.Pitch(p) for p in pitches)
+        self.assertEqual(pitches, ChordSymbol('Am#7').pitches)
 
     def testRootBassParsing(self):
         """

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1991,7 +1991,7 @@ class ChordSymbol(Harmony):
             'minor-ninth',
         )
 
-        if 'root' not in self._overrides or self.chordKind is None:
+        if 'root' not in self._overrides or 'bass' not in self._overrides or self.chordKind is None:
             return
 
         # create figured bass scale with root as scale

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2767,7 +2767,7 @@ class Test(unittest.TestCase):
 
         self.runTestOnChord(xmlString, figure, pitches)
 
-    def x_testChordWithBass(self):
+    def testChordWithBass(self):
 
         xmlString = """
           <harmony>
@@ -2782,7 +2782,11 @@ class Test(unittest.TestCase):
           </harmony>
           """
         figure = 'A7/G'
-        pitches = ('G2', 'A2', 'C#3', 'E3')
+        pitches = ('G2', 'A3', 'C#4', 'E4', 'G4')
+        # TODO: Get rid of the extra G once we do something about ChordSymbol construction,
+        # since currently bass() is called before updatePitches()
+        # and each of them is creating a G
+        # https://github.com/cuthbertLab/music21/issues/793
 
         self.runTestOnChord(xmlString, figure, pitches)
 
@@ -3153,5 +3157,5 @@ _DOC_ORDER = [Harmony, chordSymbolFigureFromChord, ChordSymbol, ChordStepModific
 
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test)  # , runTest='testInversion')
+    music21.mainTest(Test)  # , runTest='testChordWithBass')
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2034,6 +2034,8 @@ class ChordSymbol(Harmony):
             self.inversion(None, transposeOnSet=False)
             inversionNum = None
 
+        pitches = list(self._adjustPitchesForChordStepModifications(pitches))
+
         if inversionNum not in (0, None):
             for p in pitches[0:inversionNum]:
                 if self.chordKind in nineElevenThirteen:
@@ -2052,8 +2054,6 @@ class ChordSymbol(Harmony):
             for p in pitches:
                 if p.diatonicNoteNum < self._overrides['bass'].diatonicNoteNum:
                     p.octave = p.octave + 1
-
-        pitches = list(self._adjustPitchesForChordStepModifications(pitches))
 
         while self._hasPitchAboveC4(pitches):
             for thisPitch in pitches:
@@ -2784,7 +2784,7 @@ class Test(unittest.TestCase):
         figure = 'A7/G'
         pitches = ('G2', 'A3', 'C#4', 'E4', 'G4')
         # TODO: Get rid of the extra G once we do something about ChordSymbol construction,
-        # since currently bass() is called before updatePitches()
+        # since currently bass() is called before _updatePitches()
         # and each of them is creating a G
         # https://github.com/cuthbertLab/music21/issues/793
 
@@ -2834,7 +2834,7 @@ class Test(unittest.TestCase):
         self.runTestOnChord(xmlString, figure, pitches)
 
 
-    def x_testChordStepBass(self):
+    def testChordStepBass(self):
         """
         This tests a bug where the chord modification (add 2) was placed at a
         wrong octave, resulting in a D bass instead of the proper E.
@@ -2930,11 +2930,11 @@ class Test(unittest.TestCase):
         # in the chord.
         self.assertEqual('E-3', cs1.bass().nameWithOctave)
 
-    def x_testSus2Bass(self):
+    def testSus2Bass(self):
         from xml.etree.ElementTree import fromstring as EL
         from music21 import musicxml
 
-        pitches = ('E2', 'C3', 'D3', 'G3')
+        pitches = ('E3', 'G3', 'C4', 'D4')
         pitches = tuple(pitch.Pitch(p) for p in pitches)
 
         xmlString = """
@@ -2956,7 +2956,7 @@ class Test(unittest.TestCase):
         cs2 = ChordSymbol(cs1.figure)
         cs3 = ChordSymbol('Csus2/E')
 
-        self.assertEqual('E2', cs1.bass().nameWithOctave)
+        self.assertEqual('E3', cs1.bass().nameWithOctave)
 
         self.assertEqual(pitches, cs1.pitches)
         self.assertEqual(pitches, cs2.pitches)
@@ -3157,5 +3157,5 @@ _DOC_ORDER = [Harmony, chordSymbolFigureFromChord, ChordSymbol, ChordStepModific
 
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test)  # , runTest='testChordWithBass')
+    music21.mainTest(Test)  # , runTest='testChordStepBass')
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -59,7 +59,7 @@ CHORD_TYPES = collections.OrderedDict([
     ('major-seventh', ['1,3,5,7', ['maj7', 'M7']]),  # Y
     ('minor-major-seventh', ['1,-3,5,7', ['mM7', 'm#7', 'minmaj7']]),  # Y: 'major-minor'
     ('minor-seventh', ['1,-3,5,-7', ['m7', 'min7']]),  # Y
-    ('augmented-major seventh', ['1,3,#5,7', ['+M7', 'augmaj7']]),  # N
+    ('augmented-major-seventh', ['1,3,#5,7', ['+M7', 'augmaj7']]),  # N
     ('augmented-seventh', ['1,3,#5,-7', ['7+', '+7', 'aug7']]),  # Y
     ('half-diminished-seventh', ['1,-3,-5,-7', ['ø7', 'm7b5']]),  # Y: 'half-diminished'
     ('diminished-seventh', ['1,-3,-5,--7', ['o7', 'dim7']]),  # Y
@@ -792,7 +792,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
 
     >>> c = chord.Chord(['F3', 'A3', 'C#4', 'E4'])
     >>> harmony.chordSymbolFigureFromChord(c, True)
-    ('F+M7', 'augmented-major seventh')
+    ('F+M7', 'augmented-major-seventh')
 
     >>> c = chord.Chord(['C3', 'E3', 'G#3', 'B-3'])
     >>> harmony.chordSymbolFigureFromChord(c, True)
@@ -2782,29 +2782,23 @@ class Test(unittest.TestCase):
 
         self.runTestOnChord(xmlString, figure, pitches)
 
-    def x_testChordFlatSharpInFigure(self):
-
-        xmlString = """
-          <harmony>
-            <root>
-              <root-step>G</root-step>
-            </root>
-            <kind text="9+">augmented-dominant-ninth</kind>
-          </harmony>
-        """
+    def testChordFlatSharpInFigure(self):
+        # Octave placement of this A2 neither great nor intolerable
         pitches = ('G2', 'A2', 'B2', 'D#3', 'F3')
         figure = 'G+9'
-        self.runTestOnChord(xmlString, figure, pitches)
+        cs = ChordSymbol(figure)
+        self.assertEqual(cs.pitches, tuple(pitch.Pitch(p) for p in pitches))
 
+        pitches = ('G2', 'B2', 'D#3', 'F3', 'A3')
         figure = 'G9#5'
-        self.runTestOnChord(xmlString, figure, pitches)
-
+        cs = ChordSymbol(figure)
+        self.assertEqual(cs.pitches, tuple(pitch.Pitch(p) for p in pitches))
 
         pitches = ('A2', 'C3', 'E3', 'G#3')
         pitches = tuple(pitch.Pitch(p) for p in pitches)
         self.assertEqual(pitches, ChordSymbol('AmM7').pitches)
         self.assertEqual(pitches, ChordSymbol('Aminmaj7').pitches)
-        self.assertEqual(pitches, ChordSymbol('Am#7').pitches)
+        # self.assertEqual(pitches, ChordSymbol('Am#7').pitches)
 
     def testRootBassParsing(self):
         """
@@ -3151,5 +3145,5 @@ _DOC_ORDER = [Harmony, chordSymbolFigureFromChord, ChordSymbol, ChordStepModific
 
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test)  # , runTest='testBassNotInChord')
+    music21.mainTest(Test)  # , runTest='testChordFlatSharpInFigure')
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2892,14 +2892,11 @@ class Test(unittest.TestCase):
         self.assertEqual(pitches, cs2.pitches)
         self.assertEqual(pitches, cs3.pitches)
 
-    def x_testWrongBass(self):
-        """
-        Bug where bass isn't in chord.
-        """
+    def testBassNotInChord(self):
         from xml.etree.ElementTree import fromstring as EL
         from music21 import musicxml
 
-        pitches = ('E-2', 'C3', 'E3', 'G3')
+        pitches = ('E-3', 'E3', 'G3', 'C4')
         pitches = tuple(pitch.Pitch(p) for p in pitches)
 
         xmlString = """
@@ -2925,9 +2922,9 @@ class Test(unittest.TestCase):
         self.assertEqual(pitches, cs2.pitches)
         self.assertEqual(pitches, cs3.pitches)
 
-        # There was a bug where the bass was E3, because E-2 was assumed to be
+        # There was a bug where the bass was E3, because E-3 was assumed to be
         # in the chord.
-        self.assertEqual('E-2', cs1.bass().nameWithOctave)
+        self.assertEqual('E-3', cs1.bass().nameWithOctave)
 
     def x_testSus2Bass(self):
         from xml.etree.ElementTree import fromstring as EL
@@ -3154,6 +3151,5 @@ _DOC_ORDER = [Harmony, chordSymbolFigureFromChord, ChordSymbol, ChordStepModific
 
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test)  # , runTest='testChordWithoutKind')
-
+    music21.mainTest(Test)  # , runTest='testBassNotInChord')
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -3024,8 +3024,8 @@ class Test(unittest.TestCase):
         </harmony>
         """
 
-        # pitches = ('E3','G3','C4')
-        # pitches = tuple(pitch.Pitch(p) for p in pitches)
+        pitches = ('E2', 'G2', 'C3')
+        pitches = tuple(pitch.Pitch(p) for p in pitches)
 
         MP = musicxml.xmlToM21.MeasureParser()
         mxHarmony = EL(xmlString)
@@ -3036,11 +3036,13 @@ class Test(unittest.TestCase):
         self.assertEqual(1, cs1.inversion())
         self.assertEqual(1, cs2.inversion())
 
-        # self.assertEqual(cs1.pitches, pitches)
-        # self.assertEqual(cs2.pitches, pitches)
+        pitches = ('E3', 'G3', 'C4')
+        pitches = tuple(pitch.Pitch(p) for p in pitches)
+        self.assertEqual(cs1.pitches, pitches)
+        self.assertEqual(cs2.pitches, pitches)
 
-        # self.assertEqual(cs1.root(), cs2.root())
-        # self.assertEqual(cs1.bass(), cs2.bass())
+        self.assertEqual(cs1.root(), cs2.root())
+        self.assertEqual(cs1.bass(), cs2.bass())
 
     def testChordWithoutKind(self):
         cs = ChordSymbol(root='C', bass='E')
@@ -3151,5 +3153,5 @@ _DOC_ORDER = [Harmony, chordSymbolFigureFromChord, ChordSymbol, ChordStepModific
 
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test)  # , runTest='testChordFlatSharpInFigure')
+    music21.mainTest(Test)  # , runTest='testInversion')
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -3035,10 +3035,6 @@ class Test(unittest.TestCase):
         """
         power chords should not have inversions
         """
-
-        from xml.etree.ElementTree import fromstring as EL
-        from music21 import musicxml
-
         pitches = ('E2', 'A2', 'E3')
         pitches = tuple(pitch.Pitch(p) for p in pitches)
 
@@ -3053,17 +3049,9 @@ class Test(unittest.TestCase):
             </bass>
           </harmony>
         """
+        figure = 'Apower/E'
 
-        MP = musicxml.xmlToM21.MeasureParser()
-        mxHarmony = EL(xmlString)
-
-        cs1 = MP.xmlToChordSymbol(mxHarmony)
-        cs2 = ChordSymbol(cs1.figure)
-        cs3 = ChordSymbol('Apower/E')
-
-        self.assertEqual(pitches, cs1.pitches)
-        self.assertEqual(pitches, cs2.pitches)
-        self.assertEqual(pitches, cs3.pitches)
+        self.runTestOnChord(xmlString, figure, pitches)
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4595,6 +4595,7 @@ class MeasureParser(XMLParserBase):
                 pass
         # TODO: print-style
 
+        clearBassOverride: bool = False
         mxBass = mxHarmony.find('bass')
         if mxBass is not None:
             # required
@@ -4608,6 +4609,10 @@ class MeasureParser(XMLParserBase):
             cs.bass(b)
         else:
             cs.bass(r)  # set the bass to the root if root is none
+            # only for the purpose of getting _updatePitches() to run
+            # then, we will need to get rid of this untruthful override
+            # since there may be an inversion!
+            clearBassOverride: bool = True
 
         mxDegrees = mxHarmony.findall('degree')
 
@@ -4624,6 +4629,21 @@ class MeasureParser(XMLParserBase):
             # environLocal.printDebug(['xmlToChordSymbol(): Harmony object', h])
             if cs.root().name != r.name:
                 cs.root(r)
+
+        if clearBassOverride:
+            if cs.inversion() == 0:
+                cs.bass(cs.getChordStep(1))
+            elif cs.inversion() == 1:
+                cs.bass(cs.getChordStep(3))
+            elif cs.inversion() == 2:
+                cs.bass(cs.getChordStep(5))
+            elif cs.inversion() == 3:
+                cs.bass(cs.getChordStep(7))
+            elif cs.inversion() == 4:
+                cs.bass(cs.getChordStep(9))
+            elif cs.inversion() == 5:
+                cs.bass(cs.getChordStep(11))
+            cs._updatePitches()
 
         # TODO: frame
         if mxFrame is not None:

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4630,19 +4630,10 @@ class MeasureParser(XMLParserBase):
             if cs.root().name != r.name:
                 cs.root(r)
 
-        if clearBassOverride:
-            if cs.inversion() == 0:
-                cs.bass(cs.getChordStep(1))
-            elif cs.inversion() == 1:
-                cs.bass(cs.getChordStep(3))
-            elif cs.inversion() == 2:
-                cs.bass(cs.getChordStep(5))
-            elif cs.inversion() == 3:
-                cs.bass(cs.getChordStep(7))
-            elif cs.inversion() == 4:
-                cs.bass(cs.getChordStep(9))
-            elif cs.inversion() == 5:
-                cs.bass(cs.getChordStep(11))
+        if clearBassOverride and cs.inversion() is not None:
+            # 0 inversion = step 1; 2nd inversion = step 5; 4th inversion = step 9, etc.
+            wantedStep = (cs.inversion() * 2) + 1
+            cs.bass(cs.getChordStep(wantedStep))
             cs._updatePitches()
 
         # TODO: frame


### PR DESCRIPTION
- Tests authored by @a-papadopoulos in #383
- Passing tests enabled, failing tests disabled
- Fix: set bass pitch when there is no chord; set default octave on bass pitches
- Fix: add bass note to chord's pitches when not in harmony
- Standardize `augmented-major seventh` to `augmented-major-seventh` like every other type
- Fix: treat "add" alterations on the seventh degree against a minor-seventh baseline, per musicXML spec
- Fix: parse inversions from musicXML when only `<inversion>` is present and `<bass>` is absent
- Fix: add chord step modifications before performing bass octave corrections

TODO: ~~one fix per commit to get the other tests to pass~~ What's left is just the "add", "omit", "subtract" business which is sticky and probably needs its own PR. I left those tests commented out with a link to #383.