### PR TITLE
Composite Lyric objects

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (6, 6, 0)  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (6, 6, 1)  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'6.6.0'
+'6.6.1'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/musicxml/lilypondTestSuite/61l-Lyrics-Elisions-Syllables.xml
+++ b/music21/musicxml/lilypondTestSuite/61l-Lyrics-Elisions-Syllables.xml
@@ -8,9 +8,9 @@
           61j but the syllables in the lyrics have &lt;syllabic&gt;
           information in addition to
           &lt;elision&gt;.
-          Note one is a standard lyric (begin).  
+          Note one is a standard lyric (begin).
           Note 2 has an elision this time, but same syllabic (middle)
-          Note 3 has two syllables with different syllabics (middle, end)
+          Note 3 has two syllables with different syllabic tags (middle, end)
           Note 4 has three syllables with begin, middle, end.
       </miscellaneous-field>
     </miscellaneous>
@@ -53,7 +53,7 @@
       </note>
       <note>
         <pitch>
-          <step>C</step>
+          <step>D</step>
           <octave>5</octave>
         </pitch>
         <duration>1</duration>
@@ -69,7 +69,7 @@
       </note>
       <note>
         <pitch>
-          <step>C</step>
+          <step>E</step>
           <octave>5</octave>
         </pitch>
         <duration>1</duration>
@@ -85,7 +85,7 @@
       </note>
       <note>
         <pitch>
-          <step>C</step>
+          <step>F</step>
           <octave>5</octave>
         </pitch>
         <duration>1</duration>
@@ -94,10 +94,10 @@
         <lyric number="1">
           <syllabic>begin</syllabic>
           <text>f</text>
-          <elision/>
+          <elision>_</elision>
           <syllabic>middle</syllabic>
           <text>g</text>
-          <elision/>
+          <elision>~</elision>
           <syllabic>end</syllabic>
           <text>h</text>
         </lyric>

--- a/music21/note.py
+++ b/music21/note.py
@@ -90,8 +90,8 @@ class NoteException(exceptions21.Music21Exception):
 class NotRestException(exceptions21.Music21Exception):
     pass
 
-# ------------------------------------------------------------------------------
 
+# ------------------------------------------------------------------------------
 SYLLABIC_CHOICES: List[Optional[str]] = [
     None, 'begin', 'single', 'end', 'middle', 'composite',
 ]
@@ -184,7 +184,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
     def __init__(self, text=None, number=1, **kwargs):
         super().__init__()
         self._identifier: Optional[str] = None
-        self._number: optional[int] = None
+        self._number: Optional[int] = None
         self._text: Optional[str] = None
         self._syllabic = None
         self.components: Optional[List['music21.note.Lyric']] = None
@@ -238,8 +238,11 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
             return self._text
         else:
             text_out = self.components[0].text
+            if text_out is None:
+                text_out = ''
             for component in self.components[1:]:
-                text_out += component.elisionBefore + component.text
+                componentText = component.text if component.text is not None else ''
+                text_out += component.elisionBefore + componentText
             return text_out
 
     @text.setter
@@ -530,7 +533,7 @@ class GeneralNote(base.Music21Object):
         # this sets the stored duration defined in Music21Object
         super().__init__(duration=tempDuration)
 
-        self.lyrics = []  # a list of lyric objects
+        self.lyrics: List[Lyric] = []  # a list of lyric objects
         self.expressions = []
         self.articulations = []
 

--- a/music21/note.py
+++ b/music21/note.py
@@ -19,7 +19,7 @@ and used to configure, :class:`~music21.note.Note` objects.
 import copy
 import unittest
 
-from typing import Optional
+from typing import Optional, List, Union
 
 from music21 import base
 from music21 import beam
@@ -92,6 +92,10 @@ class NotRestException(exceptions21.Music21Exception):
 
 # ------------------------------------------------------------------------------
 
+SYLLABIC_CHOICES: List[Optional[str]] = [
+    None, 'begin', 'single', 'end', 'middle', 'composite',
+]
+
 
 class Lyric(prebase.ProtoM21Object, style.StyleMixin):
     '''
@@ -117,7 +121,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
     <music21.note.Lyric number=3 syllabic=single text='hel-'>
 
     Lyrics have four properties: text, number, identifier, syllabic (single,
-    begin, middle, end)
+    begin, middle, end, or (not in musicxml) composite)
 
     >>> l3.text
     'hel-'
@@ -135,9 +139,33 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
     the same as the number, but in cases where a string identifier is present,
     it will be different.
 
-    Both music21 and musicxml support multiple lyric objects in the same stanza,
+    Both music21 and musicxml support multiple `Lyric` objects in the same stanza,
     for instance, if there is an elision on a note then multiple lyrics with
-    different syllabics can appear on a single note.
+    different syllabics can appear on a single note.  In music21 these are supported
+    by setting .components into a list of `Lyric` object.  For instance in
+    the madrigal "Il bianco e dolce cigno", the "co" and "e" of "bianco e"
+    are elided into a single lyric:
+
+    >>> bianco = note.Lyric()
+    >>> co = note.Lyric('co', syllabic='end')
+    >>> e = note.Lyric('e', syllabic='single')
+    >>> bianco.components = [co, e]
+    >>> bianco.isComposite
+    True
+    >>> bianco.text
+    'co e'
+    >>> bianco.syllabic
+    'composite'
+    >>> e.elisionBefore = '_'
+    >>> bianco.text
+    'co_e'
+
+    >>> [component.syllabic for component in bianco.components]
+    ['end', 'single']
+
+    Custom elision elements for composite components will be supported later.
+
+    New in v6.7 -- composite components, elisionBefore
     '''
     _styleClass = style.TextStylePlacement
     # CLASS VARIABLES #
@@ -145,25 +173,32 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
     __slots__ = (
         '_identifier',
         '_number',
-        'syllabic',
-        'text',
+        '_syllabic',
+        '_text',
+        'components',
+        'elisionBefore',
     )
 
     # INITIALIZER #
 
     def __init__(self, text=None, number=1, **kwargs):
         super().__init__()
-        self._identifier = None
-        self._number = None
+        self._identifier: Optional[str] = None
+        self._number: optional[int] = None
+        self._text: Optional[str] = None
+        self._syllabic = None
+        self.components: Optional[List['music21.note.Lyric']] = None
+        self.elisionBefore = ' '
 
-        # these are set by setTextAndSyllabic
-        self.text = None
-        # given as begin, middle, end, or single
-        self.syllabic = kwargs.get('syllabic', None)
         applyRaw = kwargs.get('applyRaw', False)
 
+        # these are set by setTextAndSyllabic
         if text is not None:
             self.setTextAndSyllabic(text, applyRaw)
+
+        # given as begin, middle, end, or single
+        if 'syllabic' in kwargs:
+            self.syllabic = kwargs['syllabic']
 
         self.number = number
         self.identifier = kwargs.get('identifier', None)
@@ -183,6 +218,72 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         return out
 
     # PUBLIC PROPERTIES #
+    @property
+    def isComposite(self) -> bool:
+        '''
+        Returns True if this Lyric has composite elements,
+        for instance, is multiple lyrics placed together.
+        '''
+        return bool(self.components)
+
+    @property
+    def text(self) -> Optional[str]:
+        '''
+        Gets or sets the text of the lyric.  For composite lyrics, set
+        the text of individual components instead of setting the text here.
+
+        Setting the text of a composite lyric wipes out the components
+        '''
+        if not self.isComposite:
+            return self._text
+        else:
+            text_out = self.components[0].text
+            for component in self.components[1:]:
+                text_out += component.elisionBefore + component.text
+            return text_out
+
+    @text.setter
+    def text(self, newText: Optional[str]):
+        if self.isComposite:
+            self.components = None
+        self._text = newText
+
+    @property
+    def syllabic(self) -> Optional[str]:
+        '''
+        Returns or sets the syllabic property of a lyric.
+
+        >>> fragment = note.Lyric('frag', syllabic='begin')
+        >>> fragment.syllabic
+        'begin'
+        >>> fragment.rawText
+        'frag-'
+        >>> fragment.syllabic = 'end'
+        >>> fragment.rawText
+        '-frag'
+
+        Illegal values raise a LyricException
+
+        >>> fragment.syllabic = 'slide'
+        Traceback (most recent call last):
+        music21.note.LyricException: Syllabic value 'slide' is not in
+            note.SYLLABIC_CHOICES, namely:
+            [None, 'begin', 'single', 'end', 'middle', 'composite']
+        '''
+        if self.isComposite:
+            return 'composite'
+        else:
+            return self._syllabic
+
+
+    @syllabic.setter
+    def syllabic(self, newSyllabic):
+        if newSyllabic not in SYLLABIC_CHOICES:
+            raise LyricException(
+                f'Syllabic value {newSyllabic!r} is not in '
+                + f'note.SYLLABIC_CHOICES, namely: {SYLLABIC_CHOICES}'
+            )
+        self._syllabic = newSyllabic
 
     @property
     def identifier(self) -> str:
@@ -222,7 +323,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         >>> l.rawText
         'hel-'
 
-        >>> l = note.Lyric('-lo')
+        >>> l = note.Lyric('lo', syllabic='end')
         >>> l.rawText
         '-lo'
 
@@ -233,15 +334,40 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         >>> l = note.Lyric('bye')
         >>> l.rawText
         'bye'
+
+        Composite lyrics take their endings from the first and last components:
+
+        >>> composite = note.Lyric()
+        >>> co = note.Lyric('co', syllabic='end')
+        >>> e = note.Lyric('e', syllabic='single')
+        >>> e.elisionBefore = '_'
+        >>> composite.components = [co, e]
+        >>> composite.rawText
+        '-co_e'
+        >>> e.syllabic = 'middle'
+        >>> composite.rawText
+        '-co_e-'
         '''
-        if self.syllabic == 'begin':
-            return self.text + '-'
-        elif self.syllabic == 'middle':
-            return '-' + self.text + '-'
-        elif self.syllabic == 'end':
-            return '-' + self.text
+        text = self.text
+        if not self.isComposite:
+            syllabic = self.syllabic
+            if syllabic == 'begin':
+                return text + '-'
+            elif syllabic == 'middle':
+                return '-' + text + '-'
+            elif syllabic == 'end':
+                return '-' + text
+            else:
+                return text
         else:
-            return self.text
+            firstSyllabic = self.components[0].syllabic
+            lastSyllabic = self.components[-1].syllabic
+            if firstSyllabic in ['middle', 'end']:
+                text = '-' + text
+            if lastSyllabic in ['begin', 'middle']:
+                text += '-'
+            return text
+
 
     @rawText.setter
     def rawText(self, t):
@@ -277,7 +403,9 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
     def setTextAndSyllabic(self, rawText: str, applyRaw: bool = False) -> None:
         '''
         Given a setting for rawText and applyRaw,
-        sets the syllabic type for a lyric based on the rawText:
+        sets the syllabic type for a lyric based on the rawText.  Useful for
+        parsing raw text from, say, an OMR score.  Or just to quickly set text
+        and syllabic.
 
         >>> l = note.Lyric()
         >>> l.setTextAndSyllabic('hel-')
@@ -285,6 +413,37 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         'hel'
         >>> l.syllabic
         'begin'
+        >>> l.setTextAndSyllabic('-lo')
+        >>> l.text
+        'lo'
+        >>> l.syllabic
+        'end'
+        >>> l.setTextAndSyllabic('the')
+        >>> l.text
+        'the'
+        >>> l.syllabic
+        'single'
+
+        If applyRaw is True then this will assume you actually want hyphens
+        in the text, and if syllabic is None, sets it to 'single'
+
+        >>> l = note.Lyric()
+        >>> l.setTextAndSyllabic('hel-', applyRaw=True)
+        >>> l.text
+        'hel-'
+        >>> l.syllabic
+        'single'
+
+        If applyRaw is True, other syllabic settings except None are retained
+
+        >>> l.syllabic = 'begin'
+        >>> l.setTextAndSyllabic('-lo', applyRaw=True)
+        >>> l.text
+        '-lo'
+        >>> l.syllabic
+        'begin'
+
+        This method wipes out components.
         '''
         # do not want to do this unless we are sure this is not a string
         # possible might alter unicode or other string-like representations
@@ -303,7 +462,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
             self.syllabic = 'middle'
         else:  # assume single
             self.text = rawText
-            if self.syllabic is None or self.syllabic is False:
+            if self.syllabic is None or not applyRaw:
                 self.syllabic = 'single'
 
 
@@ -417,9 +576,13 @@ class GeneralNote(base.Music21Object):
         allText = [ly.text for ly in self.lyrics]
         return '\n'.join(allText)
 
-    def _setLyric(self, value: str) -> None:
+    def _setLyric(self, value: Union[str, Lyric, None]) -> None:
         self.lyrics = []
-        if value in (None, False):
+        if value is None:
+            return
+
+        if isinstance(value, Lyric):
+            self.lyrics.append(value)
             return
 
         if not isinstance(value, str):
@@ -462,6 +625,19 @@ class GeneralNote(base.Music21Object):
         [<music21.note.Lyric number=1 syllabic=single text='1. Hi'>,
          <music21.note.Lyric number=2 syllabic=single text='2. Bye'>]
 
+
+        You can also set a lyric with a lyric object directly:
+
+        >>> b = note.Note('B5')
+        >>> ly = note.Lyric('bon-')
+        >>> b.lyric = ly
+        >>> b.lyrics
+        [<music21.note.Lyric number=1 syllabic=begin text='bon'>]
+        >>> b.lyric
+        'bon'
+
+        Changed in v6.7 -- added setting to a Lyric object.  Removed undocumented
+        setting to False instead of setting to None
         ''')
 
     def addLyric(self,

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -527,6 +527,7 @@ class Test(unittest.TestCase):
         self.assertEqual(match[0].mEnd, 2)
         self.assertEqual(match[0].identifier, 1)
 
+
 # ------------------------------------------------------------------------------
 # define presented order in documentation
 _DOC_ORDER = [LyricSearcher]

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -338,7 +338,8 @@ class LyricSearcher:
     #     lineBreakStart += len(LINEBREAK_TOKEN)
     #     return lineBreakStart
 
-    def _reSearch(self, r: re.Pattern) -> List[SearchMatch]:
+    def _reSearch(self, r: 're.Pattern') -> List[SearchMatch]:
+        # note: cannot use re.Pattern w/o quotes until Python 3.6 is no longer supported
         locations = []
         for m in r.finditer(self._indexText):
             absoluteFoundPos, absoluteEndPos = m.span()
@@ -416,7 +417,6 @@ class Test(unittest.TestCase):
         runSearch()
 
     def testMultipleVerses(self):
-        import re
         from music21 import converter, search
 
         # noinspection SpellCheckingInspection

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -11,14 +11,23 @@
 '''
 Classes for searching for Lyric objects.
 '''
-import unittest
-from collections import namedtuple
+import re
+from collections import namedtuple, OrderedDict
 from typing import Optional, List
+import unittest
+
 from music21.exceptions21 import Music21Exception
+from music21 import note
 # from music21 import common
 
+LINEBREAK_TOKEN = ' // '
 
-class IndexedLyric(namedtuple('IndexedLyric', 'el start end measure lyric text')):
+_attrList = 'el start end measure lyric text identifier absoluteStart absoluteEnd'.split()
+
+class IndexedLyric(namedtuple(
+    'IndexedLyric',
+    'el start end measure lyric text identifier absoluteStart absoluteEnd',
+)):
     '''
     A Lyric that has been indexed to its attached element and position in a Stream.
 
@@ -36,10 +45,25 @@ class IndexedLyric(namedtuple('IndexedLyric', 'el start end measure lyric text')
                  in the stream.  Same as .el.measureNumber''',
         'lyric': '''The :class:`~music21.note.Lyric` object itself''',
         'text': '''The text of the lyric as a string.''',
+        'identifier': '''The identifier of the lyric''',
+        'absoluteStart': '''the position, not in the current identifier, but in all the lyrics''',
+        'absoluteEnd': '''the end position in all the lyrics'''
     }
+    def __repr__(self):
+        return (f'IndexedLyric(el={self.el!r}, start={self.start!r}, end={self.end!r}, '
+                + f'measure={self.measure!r}, lyric={self.lyric!r}, text={self.text!r}, '
+                + f'identifier={self.identifier!r})')
+
+    def modify(self, **kw):
+        '''
+        see docs for SortTuple for what this does
+        '''
+        outList = [kw.get(attr, getattr(self, attr)) for attr in _attrList]
+        return self.__class__(*outList)
 
 
-class SearchMatch(namedtuple('SearchMatch', 'mStart mEnd matchText els indices')):
+
+class SearchMatch(namedtuple('SearchMatch', 'mStart mEnd matchText els indices identifier')):
     '''
     A lightweight object representing the match (if any) for a search.
     '''
@@ -54,13 +78,15 @@ class SearchMatch(namedtuple('SearchMatch', 'mStart mEnd matchText els indices')
                                  search this will be the text that matched the regular
                                  expression''',
                  'els': '''A list of all lyric-containing elements that matched this text.''',
-                 'indices': '''A list'''
+                 'indices': '''A list of IndexedLyric objects that match''',
+                 'identifier': '''The identifier of (presumably all,
+                                  but at least the first) lyric to match''',
                  }
 
     def __repr__(self):
-        return 'SearchMatch(mStart={0}, mEnd={1}, matchText={2}, els={3}, indices=[...])'.format(
-            repr(self.mStart), repr(self.mEnd), repr(self.matchText), repr(self.els)
-        )
+        return (f'SearchMatch(mStart={self.mStart!r}, mEnd={self.mEnd!r}, '
+                + f'matchText={self.matchText!r}, els={self.els!r}, indices=[...], '
+                + f'identifier={self.identifier!r})')
 
 
 class LyricSearcherException(Music21Exception):
@@ -112,9 +138,16 @@ class LyricSearcher:
         '''
         if self._indexText is None:
             self.index()
-        return self._indexText
+        return self._indexText or ''
+
+    @property
+    def indexTuples(self) -> List[IndexedLyric]:
+        if self._indexText is None:  # correct -- check text to see if has run.
+            self.index()
+        return self._indexTuples
 
     def index(self, s=None) -> List[IndexedLyric]:
+        # noinspection PyShadowingNames
         '''
         A method that indexes the Stream's lyrics and returns the list
         of IndexedLyric objects.
@@ -128,44 +161,90 @@ class LyricSearcher:
         >>> ls = search.lyrics.LyricSearcher(p0)
         >>> pp(ls.index()[0:5])
         [IndexedLyric(el=<music21.note.Note C>, start=0, end=2, measure=1,
-             lyric=<music21.note.Lyric number=1 syllabic=single text='Et'>, text='Et'),
+             lyric=<music21.note.Lyric number=1 syllabic=single text='Et'>, text='Et',
+             identifier=1),
          IndexedLyric(el=<music21.note.Note D>, start=3, end=5, measure=2,
-             lyric=<music21.note.Lyric number=1 syllabic=single text='in'>, text='in'),
+             lyric=<music21.note.Lyric number=1 syllabic=single text='in'>, text='in',
+             identifier=1),
          IndexedLyric(el=<music21.note.Note F>, start=6, end=9, measure=2,
-             lyric=<music21.note.Lyric number=1 syllabic=begin text='ter'>, text='ter'),
+             lyric=<music21.note.Lyric number=1 syllabic=begin text='ter'>, text='ter',
+             identifier=1),
          IndexedLyric(el=<music21.note.Note F>, start=9, end=11, measure=3,
-             lyric=<music21.note.Lyric number=1 syllabic=end text='ra'>, text='ra'),
+             lyric=<music21.note.Lyric number=1 syllabic=end text='ra'>, text='ra',
+             identifier=1),
          IndexedLyric(el=<music21.note.Note A>, start=12, end=15, measure=3,
-             lyric=<music21.note.Lyric number=1 syllabic=single text='pax'>, text='pax')]
+             lyric=<music21.note.Lyric number=1 syllabic=single text='pax'>, text='pax',
+             identifier=1)]
+
+        Changed in v6.7 -- indexed lyrics get an identifier.
         '''
         if s is None:
             s = self.stream
         else:
             self.stream = s
 
-        index = []
-        iText = ''
-        lastSyllabic = None
+        indexByIdentifier = OrderedDict()
+        iTextByIdentifier = OrderedDict()
+        lastSyllabicByIdentifier = OrderedDict()
 
         for n in s.recurse().getElementsByClass('NotRest'):
-            ls = n.lyrics
+            ls: List[note.Lyric] = n.lyrics
             if not ls:
                 continue
+            mNum = n.measureNumber
             for ly in ls:
-                if ly is not None and ly.text != '' and ly.text is not None:
-                    posStart = len(iText)
-                    mNum = n.measureNumber
-                    txt = ly.text
-                    if lastSyllabic in ('begin', 'middle', None):
-                        iText += txt
-                    else:
-                        iText += ' ' + txt
-                        posStart += 1
-                    il = IndexedLyric(n, posStart, posStart + len(txt), mNum, ly, txt)
-                    index.append(il)
+                if not ly.text:  # not empty and not None
+                    continue
+                lyIdentifier = ly.identifier
+                if lyIdentifier not in iTextByIdentifier:
+                    iTextByIdentifier[lyIdentifier] = ''
+                    lastSyllabicByIdentifier[lyIdentifier] = None
+                    indexByIdentifier[lyIdentifier] = []
+
+                iText = iTextByIdentifier[lyIdentifier]
+                lastSyllabic = lastSyllabicByIdentifier[lyIdentifier]
+                index = indexByIdentifier[lyIdentifier]
+
+                posStart = len(iText)
+                txt = ly.text
+                if lastSyllabic in ('begin', 'middle', None):
+                    iText += txt
+                else:
+                    iText += ' ' + txt
+                    posStart += 1
+
+                iTextByIdentifier[lyIdentifier] = iText
+                il = IndexedLyric(n, posStart, posStart + len(txt), mNum, ly, txt,
+                                  lyIdentifier, 0, 0)
+                index.append(il)
+                if not ly.isComposite:
                     lastSyllabic = ly.syllabic
+                else:
+                    lastSyllabic = ly.components[-1].syllabic
+                lastSyllabicByIdentifier[lyIdentifier] = lastSyllabic
+
+        indexPreliminary = []
+        for oneIdentifierIndex in indexByIdentifier.values():
+            indexPreliminary.extend(oneIdentifierIndex)
+
+        absolutePosShift = 0
+        lastIdentifier = None
+        lastEnd = 0
+        index = []
+        oneIndex: IndexedLyric
+        for oneIndex in indexPreliminary:
+            if oneIndex.identifier != lastIdentifier:
+                absolutePosShift = lastEnd
+                if lastEnd != 0:
+                    absolutePosShift += len(LINEBREAK_TOKEN)
+            lastIdentifier = oneIndex.identifier
+            newIndex = oneIndex.modify(absoluteStart=oneIndex.start + absolutePosShift,
+                                       absoluteEnd=oneIndex.end + absolutePosShift)
+            lastEnd = newIndex.absoluteEnd
+            index.append(newIndex)
 
         self._indexTuples = index
+        iText = LINEBREAK_TOKEN.join(iTextByIdentifier.values())
         self._indexText = iText
         return index
 
@@ -180,7 +259,7 @@ class LyricSearcher:
         >>> ls = search.lyrics.LyricSearcher(p0)
         >>> ls.search('pax')
         [SearchMatch(mStart=3, mEnd=3, matchText='pax', els=(<music21.note.Note A>,),
-                        indices=[...])]
+                        indices=[...], identifier=1)]
 
         Search a regular expression that takes into account non-word characters such as commas
 
@@ -188,7 +267,8 @@ class LyricSearcher:
         >>> sm = ls.search(agnus)
         >>> sm
         [SearchMatch(mStart=49, mEnd=55, matchText='Agnus Dei, Filius Patris',
-                        els=(<music21.note.Note G>,...<music21.note.Note G>), indices=[...])]
+                        els=(<music21.note.Note G>,...<music21.note.Note G>), indices=[...],
+                        identifier=1)]
         >>> sm[0].mStart, sm[0].mEnd
         (49, 55)
         '''
@@ -207,7 +287,7 @@ class LyricSearcher:
                 f'{textOrRe} is not a string or RE with the finditer() function')
 
         if plainText is True:
-            return self._plainTextSearch(textOrRe)
+            return self._reSearch(re.compile(textOrRe))
         else:
             return self._reSearch(textOrRe)
 
@@ -232,50 +312,39 @@ class LyricSearcher:
         '''
         indices = []
         for i in self._indexTuples:
-            if i.end >= posStart and i.start <= posEnd:
+            if i.absoluteEnd >= posStart and i.absoluteStart <= posEnd:
                 indices.append(i)
         if not indices:
             raise LyricSearcherException(f'Could not find position {posStart} in text')
         return indices
 
-    def _plainTextSearch(self, t: str) -> List[SearchMatch]:
-        '''
-        Take in a string and find in the indexed text where t is in the lyrics.
-        '''
-        locations = []
-        start = 0
-        tLen = len(t)
+    # def _findLineBreakBeforePos(self, pos: int):
+    #     '''
+    #     Finds the position of the first character after the closest lineBreak
+    #     '''
+    #     lineBreakStart = -1 * len(LINEBREAK_TOKEN)
+    #
+    #     loopBreaker = 10_000
+    #     while True and loopBreaker:
+    #         loopBreaker -= 1
+    #         nextLineBreakPos = self._indexText.find(LINEBREAK_TOKEN,
+    #                                                 lineBreakStart + len(LINEBREAK_TOKEN))
+    #         if nextLineBreakPos == -1:
+    #             break
+    #         if nextLineBreakPos > pos:
+    #             break
+    #         lineBreakStart = nextLineBreakPos
+    #
+    #     lineBreakStart += len(LINEBREAK_TOKEN)
+    #     return lineBreakStart
 
-        loopBreaker = 10_000_000
-        while True and loopBreaker:
-            loopBreaker -= 1
-            foundPos: int = self._indexText.find(t, start)
-            if foundPos == -1:
-                break
-
-            indices: List[IndexedLyric] = self._findObjsInIndexByPos(
-                foundPos,
-                foundPos + tLen - 1
-            )
-            indexStart = indices[0]
-            indexEnd = indices[-1]
-
-            sm = SearchMatch(mStart=indexStart.measure,
-                             mEnd=indexEnd.measure,
-                             matchText=t,
-                             els=tuple(thisIndex.el for thisIndex in indices),
-                             indices=indices)
-            locations.append(sm)
-            start = foundPos + 1
-
-        return locations
-
-    def _reSearch(self, r) -> List[SearchMatch]:
+    def _reSearch(self, r: re.Pattern) -> List[SearchMatch]:
         locations = []
         for m in r.finditer(self._indexText):
-            foundPos, endPos = m.span()
+            absoluteFoundPos, absoluteEndPos = m.span()
             matchText = m.group(0)
-            indices = self._findObjsInIndexByPos(foundPos, endPos - 1)
+
+            indices = self._findObjsInIndexByPos(absoluteFoundPos, absoluteEndPos - 1)
             indexStart = indices[0]
             indexEnd = indices[-1]
 
@@ -283,7 +352,9 @@ class LyricSearcher:
                              mEnd=indexEnd.measure,
                              matchText=matchText,
                              els=tuple(thisIndex.el for thisIndex in indices),
-                             indices=indices)
+                             indices=indices,
+                             identifier=indices[0].identifier,
+                             )
             locations.append(sm)
         return locations
 
@@ -295,6 +366,9 @@ class Test(unittest.TestCase):
     pass
 
     def testMultipleLyricsInNote(self):
+        '''
+        This score uses a non-breaking space as an elision
+        '''
         from music21 import converter, search
 
         partXML = '''
@@ -326,14 +400,26 @@ class Test(unittest.TestCase):
             </part>
         </score-partwise>
         '''
-        stream = converter.parse(partXML, format='MusicXML')
-        ls = search.lyrics.LyricSearcher(stream)
-        # assertions...
-        self.assertEqual(ls.indexText, "lala")
+        s = converter.parse(partXML, format='MusicXML')
+        ly = s.flat.notes[0].lyrics[0]
 
-    def testMultipleLyricsInNoteDifferentSyllabic(self):
+        def runSearch():
+            ls = search.lyrics.LyricSearcher(s)
+            self.assertEqual(ls.indexText, "la la")
+
+        runSearch()
+        ly.components[0].syllabic = 'begin'
+        ly.components[1].syllabic = 'end'
+        runSearch()
+        ly.components[0].syllabic = 'single'
+        ly.components[1].syllabic = 'single'
+        runSearch()
+
+    def testMultipleVerses(self):
+        import re
         from music21 import converter, search
 
+        # noinspection SpellCheckingInspection
         partXML = '''
         <score-partwise>
             <part-list>
@@ -346,6 +432,25 @@ class Test(unittest.TestCase):
                     <note>
                         <pitch>
                             <step>G</step>
+                            <octave>4</octave>
+                        </pitch>
+                        <duration>2</duration>
+                        <voice>1</voice>
+                        <type>half</type>
+                        <lyric number="1">
+                            <syllabic>single</syllabic>
+                            <text>hi</text>
+                        </lyric>
+                        <lyric number="2">
+                            <syllabic>single</syllabic>
+                            <text>bye</text>
+                        </lyric>
+                    </note>
+                </measure>
+                <measure number="2">
+                    <note>
+                        <pitch>
+                            <step>A</step>
                             <octave>4</octave>
                         </pitch>
                         <duration>1</duration>
@@ -353,58 +458,74 @@ class Test(unittest.TestCase):
                         <type>quarter</type>
                         <lyric number="1">
                             <syllabic>begin</syllabic>
-                            <text>ja</text>
-                            <elision> </elision>
-                            <syllabic>end</syllabic>
-                            <text>ja</text>
+                            <text>there!</text>
+                        </lyric>
+                        <lyric number="2">
+                            <syllabic>begin</syllabic>
+                            <text>Mi</text>
                         </lyric>
                     </note>
-                </measure>
-            </part>
-        </score-partwise>
-        '''
-        stream = converter.parse(partXML, format='MusicXML')
-        ls = search.lyrics.LyricSearcher(stream)
-        # assertions...
-        self.assertEqual(ls.indexText, "jaja")
-
-    def testMultipleLyricsInNoteSingle(self):
-        from music21 import converter, search
-
-        partXML = '''
-        <score-partwise>
-            <part-list>
-                <score-part id="P1">
-                <part-name>MusicXML Part</part-name>
-                </score-part>
-            </part-list>
-            <part id="P1">
-                <measure number="1">
                     <note>
                         <pitch>
-                            <step>G</step>
+                            <step>B</step>
                             <octave>4</octave>
                         </pitch>
                         <duration>1</duration>
                         <voice>1</voice>
                         <type>quarter</type>
-                        <lyric number="1">
-                            <syllabic>single</syllabic>
-                            <text>ja</text>
-                            <elision> </elision>
-                            <syllabic>single</syllabic>
-                            <text>ja</text>
+                        <lyric number="2">
+                            <syllabic>end</syllabic>
+                            <text>chael.</text>
                         </lyric>
                     </note>
                 </measure>
             </part>
         </score-partwise>
         '''
-        stream = converter.parse(partXML, format='MusicXML')
-        ls = search.lyrics.LyricSearcher(stream)
-        # assertions...
-        self.assertEqual(ls.indexText, "ja ja")
+        s = converter.parse(partXML, format='MusicXML')
+        ls = search.lyrics.LyricSearcher(s)
+        self.assertEqual(ls.indexText, "hi there! // bye Michael.")
+        tuples = ls.indexTuples
+        self.assertEqual(len(tuples), 5)
+        notes = list(s.flat.notes)
+        self.assertIs(tuples[0].lyric, notes[0].lyrics[0])
+        self.assertIs(tuples[1].lyric, notes[1].lyrics[0])
+        self.assertIs(tuples[2].lyric, notes[0].lyrics[1])
+        self.assertIs(tuples[3].lyric, notes[1].lyrics[1])
+        self.assertIs(tuples[4].lyric, notes[2].lyrics[0])
 
+        match = ls.search('Michael')
+        self.assertEqual(len(match), 1)
+        m0 = match[0]
+        self.assertEqual(m0.mStart, 2)
+        self.assertEqual(m0.mEnd, 2)
+        self.assertEqual(m0.els, (notes[1], notes[2]))
+        self.assertEqual(m0.identifier, 2)
+        self.assertEqual(len(m0.indices), 2)
+        self.assertIs(m0.indices[0].lyric, notes[1].lyrics[1])
+        self.assertIs(m0.indices[1].lyric, notes[2].lyrics[0])
+
+        e_with_letter = re.compile(r'e[a-z]')
+        match = ls.search(e_with_letter)
+        self.assertEqual(len(match), 2)
+        m0 = match[0]
+        self.assertEqual(m0.mStart, 2)
+        self.assertEqual(m0.mEnd, 2)
+        self.assertEqual(m0.matchText, 'er')
+        self.assertEqual(m0.identifier, 1)
+        self.assertEqual(m0.els, (notes[1],))
+        m1 = match[1]
+        self.assertEqual(m1.mStart, 2)
+        self.assertEqual(m1.mEnd, 2)
+        self.assertEqual(m1.matchText, 'el')
+        self.assertEqual(m1.identifier, 2)
+        self.assertEqual(m1.els, (notes[2],))
+
+        match = ls.search('i t')
+        self.assertEqual(len(match), 1)
+        self.assertEqual(match[0].mStart, 1)
+        self.assertEqual(match[0].mEnd, 2)
+        self.assertEqual(match[0].identifier, 1)
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation


### PR DESCRIPTION
Changes #673 and #666 to deal with multiple syllables in a single verse in a different way:

Lyric objects gain a .components[] list which is a list of subservient note.Lyric() objects representing multiple lyrics in a single verse (like "co_e" in "Il bianco e dolce cigno" or "th'an" in Hark the Herald Angels sing, "With th'angelic host proclaim")  -- in these cases a `.isComposite` boolean is true, and the syllabic is set to "composite" -- roundtrips to musicxml.

I appreciate @DIDONEproject work on putting a list in the .text and .syllabic attributes, but this ended up other code in real-world scenarios, so a new direction needed to be taken.  DIDONE and others who rely on the direction used since November 2020 will need to refactor.  Though if you only want the .text attribute after parsing, it should work fine.