### PR TITLE
Set Stem directions consistent with Beaming

### DIFF
--- a/music21/base.py
+++ b/music21/base.py
@@ -3210,7 +3210,7 @@ class Music21Object(prebase.ProtoM21Object):
                     mNumber = m.number
         return mNumber
 
-    def _getMeasureOffset(self, includeMeasurePadding=True):
+    def _getMeasureOffset(self, includeMeasurePadding=True) -> Union[float, fractions.Fraction]:
         # noinspection PyShadowingNames
         '''
         Try to obtain the nearest Measure that contains this object,
@@ -3253,15 +3253,11 @@ class Music21Object(prebase.ProtoM21Object):
             if m is not None:
                 # environLocal.printDebug(['using found Measure for offset access'])
                 try:
+                    offsetLocal = m.elementOffset(self)
                     if includeMeasurePadding:
-                        offsetLocal = m.elementOffset(self) + m.paddingLeft
-                    else:
-                        offsetLocal = m.elementOffset(self)
+                        offsetLocal += m.paddingLeft
                 except SitesException:
-                    try:
-                        offsetLocal = self.offset
-                    except AttributeError:
-                        offsetLocal = 0.0
+                    offsetLocal = self.offset
 
             else:  # hope that we get the right one
                 # environLocal.printDebug(

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -3610,7 +3610,8 @@ class Chord(note.NotRest):
             raise ChordException(f'the given pitch is not in the Chord: {pitchTarget}')
 
     def setStemDirection(self, stem, pitchTarget):
-        '''Given a stem attribute as a string and a pitch object in this Chord,
+        '''
+        Given a stem attribute as a string and a pitch object in this Chord,
         set the stem attribute of that pitch to the value of that stem. Valid
         stem directions are found note.stemDirectionNames (see below).
 

--- a/music21/meter.py
+++ b/music21/meter.py
@@ -2406,7 +2406,7 @@ class MeterSequence(MeterTerminal):
     # --------------------------------------------------------------------------
     # given a quarter note position, return the active index
 
-    def offsetToIndex(self, qLenPos, includeCoincidentBoundaries=False):
+    def offsetToIndex(self, qLenPos, includeCoincidentBoundaries=False) -> int:
         '''
         Given an offset in quarterLengths (0.0 through self.duration.quarterLength), return
         the index of the active MeterTerminal or MeterSequence
@@ -2446,8 +2446,9 @@ class MeterSequence(MeterTerminal):
         '''
         if qLenPos >= self.duration.quarterLength or qLenPos < 0:
             raise MeterException(
-                'cannot access from qLenPos %s where total duration is %s' % (
-                    qLenPos, self.duration.quarterLength))
+                f'cannot access from qLenPos {qLenPos} '
+                + f'where total duration is {self.duration.quarterLength}'
+            )
 
         qPos = 0
         match = None
@@ -3997,7 +3998,7 @@ class TimeSignature(base.Music21Object):
         >>> ts2.getMeasureOffsetOrMeterModulusOffset(n4)
         0.0
         '''
-        mOffset = el._getMeasureOffset()
+        mOffset = el._getMeasureOffset()  # TODO(msc): expose this method and remove private
         tsMeasureOffset = self._getMeasureOffset(includeMeasurePadding=False)
         if (mOffset + tsMeasureOffset) < self.barDuration.quarterLength:
             return mOffset
@@ -4067,8 +4068,8 @@ class TimeSignature(base.Music21Object):
 
         If you want a fractional number for the beat, see `getBeatProportion`.
 
-        TODO: late: In v.1.4 -- getBeat will probably do what getBeatProportion does now...
-
+        TODO: In v7 -- getBeat will probably do what getBeatProportion does now...
+        but just with 1 added to it.
 
         >>> a = meter.TimeSignature('3/4', 3)
         >>> a.getBeat(0)

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -6051,16 +6051,19 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             displayTiedAccidentals=displayTiedAccidentals,
         )
 
-    def makeBeams(self, *, inPlace=False):
+    def makeBeams(self, *, inPlace=False, setStemDirections=True):
         '''
         Return a new Stream, or modify the Stream in place, with beams applied to all
         notes.
 
         See :py:func:`~music21.stream.makeNotation.makeBeams`.
+
+        New in v6.7 -- setStemDirections.
         '''
         return makeNotation.makeBeams(
             self,
             inPlace=inPlace,
+            setStemDirections=setStemDirections
         )
 
     def makeAccidentals(

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -14,7 +14,7 @@
 
 import copy
 import unittest
-from typing import List, Generator
+from typing import List, Generator, Optional
 
 from music21 import beam
 from music21 import clef


### PR DESCRIPTION
Adds method to clef and several functions in makeNotation to set stems consistently for beam groups.

(not 100% needed for most Python applications, but very helpful for fixing problems with beam stem directions after manipulating meter or transposition.  Crucial for music21j which will be getting this soon.)