### PR TITLE
Add part and measure context to MusicXML exceptions

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6152,7 +6152,8 @@ class Test(unittest.TestCase):
         p.insert(note.Note(quarterLength=(4 / 2048)))
         s.insert(p)
 
-        msg = 'In part (Offstage Trumpet), measure (1): Cannot convert "2048th" duration to MusicXML (too short).'
+        msg = 'In part (Offstage Trumpet), measure (1): '
+        msg += 'Cannot convert "2048th" duration to MusicXML (too short).'
         with self.assertRaises(MusicXMLExportException) as error:
             s.write()
         self.assertEqual(str(error.exception), msg)

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5378,14 +5378,14 @@ class MeasureExporter(XMLExporterBase):
         >>> a.direction = None
         >>> b = MEX.beamToXml(a)
         Traceback (most recent call last):
-        music21.musicxml.xmlObjects.MusicXMLExportException:
-            partial beam defined without a proper direction set (set to None)
+        music21.musicxml.xmlObjects.MusicXMLExportException: partial beam defined
+            without a proper direction set (set to None)
 
         >>> a.type = 'crazy'
         >>> b = MEX.beamToXml(a)
         Traceback (most recent call last):
-        music21.musicxml.xmlObjects.MusicXMLExportException:
-            unexpected beam type encountered (crazy)
+        music21.musicxml.xmlObjects.MusicXMLExportException: unexpected beam type
+            encountered (crazy)
         '''
         mxBeam = Element('beam')
         _synchronizeIds(mxBeam, beamObject)

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4581,13 +4581,13 @@ class MeasureExporter(XMLExporterBase):
         >>> nc.write()
         Traceback (most recent call last):
         music21.musicxml.xmlObjects.MusicXMLExportException:
-            NoChord object's chordKindStr must be non-empty
+             In part (None), measure (1): NoChord object's chordKindStr must be non-empty
 
         >>> nc.chordKind = None
         >>> nc.write()
         Traceback (most recent call last):
         music21.musicxml.xmlObjects.MusicXMLExportException:
-            NoChord object's chordKind must be 'none'
+             In part (None), measure (1): NoChord object's chordKind must be 'none'
 
         '''
         if cs.writeAsChord is True:

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5379,14 +5379,13 @@ class MeasureExporter(XMLExporterBase):
         >>> b = MEX.beamToXml(a)
         Traceback (most recent call last):
         music21.musicxml.xmlObjects.MusicXMLExportException:
-            In part (), measure (): partial beam defined
-            without a proper direction set (set to None)
+            partial beam defined without a proper direction set (set to None)
 
         >>> a.type = 'crazy'
         >>> b = MEX.beamToXml(a)
         Traceback (most recent call last):
         music21.musicxml.xmlObjects.MusicXMLExportException:
-            In part (), measure (): unexpected beam type encountered (crazy)
+            unexpected beam type encountered (crazy)
         '''
         mxBeam = Element('beam')
         _synchronizeIds(mxBeam, beamObject)

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6150,7 +6150,7 @@ class Test(unittest.TestCase):
         s = stream.Score()
         p = stream.Part()
         p.partName = 'Offstage Trumpet'
-        p.insert(note.Note(quarterLength=(4/2048)))
+        p.insert(note.Note(quarterLength=(4 / 2048)))
         s.insert(p)
 
         msg = 'In part (Offstage Trumpet), measure (1): Cannot convert "2048th" duration to MusicXML (too short).'

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -57,10 +57,6 @@ environLocal = environment.Environment(_MOD)
 
 # ------------------------------------------------------------------------------
 
-class NoteheadException(MusicXMLExportException):
-    pass
-
-
 def typeToMusicXMLType(value):
     '''Convert a music21 type to a MusicXML type.
 

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -272,6 +272,13 @@ class PartStaffExporterMixin:
             <staff>2</staff>
           </note>
         </measure>
+
+        Fails if attempted a second time:
+
+        >>> root = SX.parse()
+        Traceback (most recent call last):
+        music21.musicxml.xmlObjects.MusicXMLExportException:
+            In part (MusicXML Part), measure (1): Attempted to create a second <staff> tag
         '''
         initialPartStaffRoot: Optional[Element] = None
         for i, ps in enumerate(group):
@@ -289,6 +296,7 @@ class PartStaffExporterMixin:
                 except MusicXMLExportException as e:
                     e.partName = ps.partName
                     e.measureNumber = mxMeasure.get('number')
+                    raise e
 
             if initialPartStaffRoot is None:
                 initialPartStaffRoot = thisPartStaffRoot

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -54,7 +54,7 @@ def addStaffTags(measure: Element, staffNumber: int, tagList: Optional[List[str]
     >>> addStaffTags(elem, 2, tagList=['note', 'forward', 'direction'])
     Traceback (most recent call last):
     music21.musicxml.xmlObjects.MusicXMLExportException:
-        Attempted to create a second <staff> tag for an element in m. 1
+        In part (), measure (1): Attempted to create a second <staff> tag
 
     The function doesn't accept elements other than <measure>:
 
@@ -68,9 +68,9 @@ def addStaffTags(measure: Element, staffNumber: int, tagList: Optional[List[str]
     for tagName in tagList:
         for tag in measure.findall(tagName):
             if tag.find('staff') is not None:
-                mNum = measure.get('number')
-                raise MusicXMLExportException('Attempted to create a second <staff> tag '
-                                              f'for an element in m. {mNum}')
+                e = MusicXMLExportException('Attempted to create a second <staff> tag')
+                e.measureNumber = measure.get('number')
+                raise e
             mxStaff = Element('staff')
             mxStaff.text = str(staffNumber)
             helpers.insertBeforeElements(tag, mxStaff,
@@ -280,11 +280,15 @@ class PartStaffExporterMixin:
 
             # Create <staff> tags under <note>, <direction>, <forward>, <harmony> tags
             for mxMeasure in thisPartStaffRoot.findall('measure'):
-                addStaffTags(
+                try:
+                    addStaffTags(
                     mxMeasure,
                     staffNumber,
                     tagList=['note', 'direction', 'forward', 'harmony']
                 )
+                except MusicXMLExportException as e:
+                    e.partName = ps.partName
+                    e.measureNumber = mxMeasure.get('number')
 
             if initialPartStaffRoot is None:
                 initialPartStaffRoot = thisPartStaffRoot
@@ -330,7 +334,7 @@ class PartStaffExporterMixin:
         sourceMeasure = None  # Set back to None when disposed of
         insertions = {}
 
-        # Walk through <measures> of the target <part>, compare to measure numbers in `ps`
+        # Walk through <measures> of the target <part>, compare measure numbers
         for i, targetMeasure in enumerate(target):
             if targetMeasure.tag != 'measure':
                 continue
@@ -453,8 +457,9 @@ class PartStaffExporterMixin:
                 if oldClef is not None and mxAttributes is not None:
                     clefsInMxAttributesAlready = mxAttributes.findall('clef')
                     if len(clefsInMxAttributesAlready) >= staffNumber:
-                        raise MusicXMLExportException(
-                            'Attempted to add more clefs than staffs')  # pragma: no cover
+                        e = MusicXMLExportException('Attempted to add more clefs than staffs')
+                        e.partName = ps.partName
+                        raise e
 
                     # Set initial clef for this staff
                     newClef = Element('clef')

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -282,10 +282,10 @@ class PartStaffExporterMixin:
             for mxMeasure in thisPartStaffRoot.findall('measure'):
                 try:
                     addStaffTags(
-                    mxMeasure,
-                    staffNumber,
-                    tagList=['note', 'direction', 'forward', 'harmony']
-                )
+                        mxMeasure,
+                        staffNumber,
+                        tagList=['note', 'direction', 'forward', 'harmony']
+                    )
                 except MusicXMLExportException as e:
                     e.partName = ps.partName
                     e.measureNumber = mxMeasure.get('number')

--- a/music21/musicxml/xmlObjects.py
+++ b/music21/musicxml/xmlObjects.py
@@ -100,7 +100,9 @@ ORNAMENT_MARKS = {'trill-mark': expressions.Trill,
                   # TODO: 'accidental-mark' -- something else...
                   }
 
-class MusicXMLExportException(exceptions21.Music21Exception):
+# ------------------------------------------------------------------------------
+
+class MusicXMLException(exceptions21.Music21Exception):
     def __init__(self, message):
         super().__init__(message)
         self.measureNumber: str = ''
@@ -111,6 +113,14 @@ class MusicXMLExportException(exceptions21.Music21Exception):
         if self.measureNumber or self.partName:
             msg = f'In part ({self.partName}), measure ({self.measureNumber}): ' + msg
         return msg
+
+
+class MusicXMLExportException(MusicXMLException):
+    pass
+
+
+class MusicXMLImportException(MusicXMLException):
+    pass
 
 
 # ------------------------------------------------------------------------------

--- a/music21/musicxml/xmlObjects.py
+++ b/music21/musicxml/xmlObjects.py
@@ -101,7 +101,16 @@ ORNAMENT_MARKS = {'trill-mark': expressions.Trill,
                   }
 
 class MusicXMLExportException(exceptions21.Music21Exception):
-    pass
+    def __init__(self, message):
+        super().__init__(message)
+        self.measureNumber: str = ''
+        self.partName: str = ''
+
+    def __str__(self):
+        msg = super().__str__()
+        if self.measureNumber or self.partName:
+            msg = f'In part ({self.partName}), measure ({self.measureNumber}): ' + msg
+        return msg
 
 
 # ------------------------------------------------------------------------------

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1808,10 +1808,9 @@ class PartParser(XMLParserBase):
         measureParser = MeasureParser(mxMeasure, parent=self)
         try:
             measureParser.parse()
-        except Exception as e:  # pylint: disable=broad-except
-            if isinstance(e, MusicXMLImportException):
-                e.measureNumber = measureParser.measureNumber
-                e.partName = self.stream.partName
+        except MusicXMLImportException as e:
+            e.measureNumber = measureParser.measureNumber
+            e.partName = self.stream.partName
             raise e
         self.lastMeasureParser = measureParser
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -25,6 +25,7 @@ import xml.etree.ElementTree as ET
 from music21 import common
 from music21 import exceptions21
 from music21.musicxml import xmlObjects
+from music21.musicxml.xmlObjects import MusicXMLImportException
 
 # modules that import this include converter.py.
 # thus, cannot import these here
@@ -67,24 +68,6 @@ StaffReferenceType = Dict[int, List[base.Music21Object]]
 
 # const
 NO_STAFF_ASSIGNED = 0
-
-
-# ------------------------------------------------------------------------------
-class MusicXMLImportException(exceptions21.Music21Exception):
-    def __init__(self, message):
-        super().__init__(message)
-        self.measureNumber: str = ''
-        self.partName: str = ''
-
-    def __str__(self):
-        msg = super().__str__()
-        if self.measureNumber or self.partName:
-            msg = f'In part ({self.partName}), measure ({self.measureNumber}): ' + msg
-        return msg
-
-
-class XMLBarException(MusicXMLImportException):
-    pass
 
 
 # ------------------------------------------------------------------------------
@@ -160,7 +143,7 @@ def musicXMLTypeToType(value):
     'quarter'
     >>> musicxml.xmlToM21.musicXMLTypeToType(None)
     Traceback (most recent call last):
-    music21.musicxml.xmlToM21.MusicXMLImportException:
+    music21.musicxml.xmlObjects.MusicXMLImportException:
         found unknown MusicXML type: None
     '''
     # MusicXML uses long instead of longa
@@ -2752,7 +2735,7 @@ class MeasureParser(XMLParserBase):
         >>> mxBeam = EL('<beam>crazy</beam>')
         >>> a = MP.xmlToBeam(mxBeam)
         Traceback (most recent call last):
-        music21.musicxml.xmlToM21.MusicXMLImportException:
+        music21.musicxml.xmlObjects.MusicXMLImportException:
              unexpected beam type encountered (crazy)
         '''
         if inputM21 is None:

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -77,7 +77,10 @@ class MusicXMLImportException(exceptions21.Music21Exception):
         self.partName: str = ''
 
     def __str__(self):
-        return f'In part ({self.partName}), measure ({self.measureNumber}): ' + super().__str__()
+        msg = super().__str__()
+        if self.measureNumber or self.partName:
+            msg = f'In part ({self.partName}), measure ({self.measureNumber}): ' + msg
+        return msg
 
 
 class XMLBarException(MusicXMLImportException):
@@ -158,7 +161,7 @@ def musicXMLTypeToType(value):
     >>> musicxml.xmlToM21.musicXMLTypeToType(None)
     Traceback (most recent call last):
     music21.musicxml.xmlToM21.MusicXMLImportException:
-    In part (), measure (): found unknown MusicXML type: None
+        found unknown MusicXML type: None
     '''
     # MusicXML uses long instead of longa
     if value not in duration.typeToDuration:
@@ -2750,7 +2753,7 @@ class MeasureParser(XMLParserBase):
         >>> a = MP.xmlToBeam(mxBeam)
         Traceback (most recent call last):
         music21.musicxml.xmlToM21.MusicXMLImportException:
-        In part (), measure (): unexpected beam type encountered (crazy)
+             unexpected beam type encountered (crazy)
         '''
         if inputM21 is None:
             beamOut = beam.Beam()

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -5648,7 +5648,6 @@ class Test(unittest.TestCase):
         mxPart = self.EL('<part><measure><note><type>thirty-tooth</type></note></measure></part>')
 
         PP = PartParser(mxPart=mxPart, mxScorePart=mxScorePart)
-        PP.stream.partName = 'electronics'
         PP.partId = '1'
 
         msg = 'In part (Elec.), measure (0): found unknown MusicXML type: thirty-tooth'

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3663,9 +3663,7 @@ class MeasureParser(XMLParserBase):
                 try:
                     sp = spb[0]
                 except IndexError:
-                    raise MusicXMLImportException('Error in getting DynamicWedges...'
-                                                  + 'Measure no. ' + str(self.measureNumber)
-                                                  + ' ' + str(self.parent.partId))
+                    raise MusicXMLImportException('Error in getting DynamicWedges')
                 sp.completeStatus = True
                 # will only have a target if this follows the note
                 if targetLast is not None:


### PR DESCRIPTION
There were two existing efforts to do this--`measureParsingError()` which wasn't tested/functioning, and a try block on `xmlToSimpleNote()`--but it was simple enough to just abstract this to the exception classes.