### PR TITLE
minor typo in usersGuide_20_examples2.ipynb

### DIFF
--- a/documentation/source/usersGuide/usersGuide_20_examples2.ipynb
+++ b/documentation/source/usersGuide/usersGuide_20_examples2.ipynb
@@ -740,7 +740,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can figure out what approximately what note that is by creating a new `Note` object:"
+    "We can figure out approximately what note that is by creating a new `Note` object:"
    ]
   },
   {


### PR DESCRIPTION
"figure out what approximately what note" > "figure out approximately what note"