### PR TITLE
Import and export multi-key piano staves

### DIFF
--- a/music21/environment.py
+++ b/music21/environment.py
@@ -1564,6 +1564,10 @@ class Test(unittest.TestCase):
         os.access(Environment().getDefaultRootTempDir(), stat.S_IRWXU),
         'test will programmatically set read/write/exec permissions on this dir'
     )
+    @unittest.skipIf(
+        common.getPlatform() == 'win',
+        'os.chmod does not have the intended effect on Windows'
+    )
     def testGetTempFile(self):
         import getpass
         import stat

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -441,17 +441,25 @@ class PartStaffExporterMixin:
         ...
         </measure>
         '''
+        # Is this source multi-key?
+        initialM21Key: Optional[KeySignature] = None
+        multiKey: bool = False
+        for ps in group:
+            if initialM21Key is None:
+                for ks in ps.recurse().getElementsByClass(KeySignature):
+                    initialM21Key = ks
+                    break
+            else:
+                firstKeySubsequentStaff = None
+                for ks in ps.recurse().getElementsByClass(KeySignature):
+                    firstKeySubsequentStaff = ks
+                    break
+                if firstKeySubsequentStaff != initialM21Key:
+                    multiKey = True
+                    break
+
         initialPartStaffRoot: Optional[Element] = None
         mxAttributes: Optional[Element] = None
-        initialM21Key: Optional[KeySignature] = group[0].flat.keySignature
-        multiKey: bool = False
-
-        for ps in group[1:]:
-            subsequentKey = ps.flat.keySignature
-            if subsequentKey != initialM21Key:
-                multiKey = True
-                break
-
         for i, ps in enumerate(group):
             staffNumber: int = i + 1  # 1-indexed
 

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -410,7 +410,7 @@ class PartStaffExporterMixin:
 
         >>> from music21.musicxml import testPrimitive
         >>> xmlDir = common.getSourceFilePath() / 'musicxml' / 'lilypondTestSuite'
-        >>> s = converter.parse(xmlDir / '43b-Multistaff-DifferentKeys.xml')
+        >>> s = converter.parse(xmlDir / '43b-MultiStaff-DifferentKeys.xml')
         >>> SX = musicxml.m21ToXml.ScoreExporter(s)
         >>> root = SX.parse()
         >>> m1 = root.find('part/measure')

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -398,8 +398,8 @@ class PartStaffExporterMixin:
 
     def setEarliestAttributesAndClefsPartStaff(self, group: StaffGroup):
         '''
-        Set the <staff> and <clef> information on the earliest measure <attributes> tag
-        in the <part> representing the joined PartStaffs.
+        Set the <staff>, <key>, and <clef> information on the earliest measure <attributes>
+        tag in the <part> representing the joined PartStaffs.
 
         Need the earliest <attributes> tag, which may not exist in the merged <part>
         until moved there by movePartStaffMeasureContents() --

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1660,8 +1660,8 @@ class PartParser(XMLParserBase):
             'Clef',
             'Dynamic',
             'Expression',
-            'KeySignature',
             'GeneralNote',
+            'KeySignature',
             'StaffLayout',
         ]
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1660,6 +1660,7 @@ class PartParser(XMLParserBase):
             'Clef',
             'Dynamic',
             'Expression',
+            'KeySignature',
             'GeneralNote',
             'StaffLayout',
         ]

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -261,6 +261,7 @@ class StreamIterator(prebase.ProtoM21Object):
         True
         '''
         # Prevent infinite loop in feature extractor task serialization
+        # TODO: investigate if this can be removed once iter becomes iter()
         if attr == 'srcStream':
             return None
 


### PR DESCRIPTION
Fixes #808 

LMK if you prefer that I not use `.keySignature` as a lookup, but it seemed more convenient than recursing and checking if not None, etc.