### PR TITLE
Make chord/voice boundary agree with quantization units

### DIFF
--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -1940,7 +1940,7 @@ class Test(unittest.TestCase):
         # dealing with midi files that use running status compression
         s = converter.parse(fp)
         self.assertEqual(len(s.parts), 2)
-        self.assertEqual(len(s.parts[0].flat.notes), 748)
+        self.assertEqual(len(s.parts[0].flat.notes), 704)
         self.assertEqual(len(s.parts[1].flat.notes), 856)
 
         # for n in s.parts[0].notes:

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -512,7 +512,8 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
 
     Changed in v.7 -- Uses the last DeltaTime in the list to get the end time.
     '''
-    tOn = 0
+    tOn: int = 0  # ticks
+    tOff: int = 0  # ticks
 
     if inputM21 is None:
         c = chord.Chord()

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -501,6 +501,15 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
     >>> c.duration.quarterLength
     2.0
 
+    Providing fewer than four events won't work.
+
+    >>> c = midi.translate.midiEventsToChord([dt1, me1, me2])
+    Traceback (most recent call last):
+    music21.midi.translate.TranslateException: fewer than 4 events provided to midiEventsToChord:
+    [<MidiEvent DeltaTime, t=0, track=1, channel=None>,
+        <MidiEvent NOTE_ON, t=0, track=1, channel=None, pitch=45, velocity=94>,
+        <MidiEvent NOTE_ON, t=0, track=1, channel=None, pitch=46, velocity=94>]
+
     Changed in v.7 -- Uses the last DeltaTime in the list to get the end time.
     '''
     tOn = 0
@@ -521,7 +530,7 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
     # this is a format provided by the Stream conversion of
     # midi events; it pre groups events for a chord together in nested pairs
     # of abs start time and the event object
-    if isinstance(eventList, list) and isinstance(eventList[0], tuple):
+    if isinstance(eventList, list) and eventList and isinstance(eventList[0], tuple):
         # pairs of pairs
         for onPair, offPair in eventList:
             tOn, eOn = onPair
@@ -533,7 +542,7 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
             v.velocityIsRelative = False  # velocity is absolute coming from
             volumes.append(v)
     # assume it is a flat list
-    else:
+    elif len(eventList) > 3:
         onEvents = eventList[:(len(eventList) // 2)]
         offEvents = eventList[(len(eventList) // 2):]
         # first is always delta time
@@ -549,6 +558,8 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
             v = volume.Volume(velocity=onEvents[i].velocity)
             v.velocityIsRelative = False  # velocity is absolute coming from
             volumes.append(v)
+    else:
+        raise TranslateException(f'fewer than 4 events provided to midiEventsToChord: {eventList}')
 
     c.pitches = pitches
     c.volume = volumes  # can set a list to volume property

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -464,7 +464,8 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
     and :class:`~music21.midi.MidiEvent` objects.  See midiEventsToNote
     for details.
 
-    All DeltaTime objects except the first are ignored.
+    All DeltaTime objects except the first (for the first note on)
+    and last (for the last note off) are ignored.
 
     >>> mt = midi.MidiTrack(1)
 
@@ -481,14 +482,14 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
     >>> me2.velocity = 94
 
     >>> dt3 = midi.DeltaTime(mt)
-    >>> dt3.time = 2048
-
     >>> me3 = midi.MidiEvent(mt)
     >>> me3.type = midi.ChannelVoiceMessages.NOTE_OFF
     >>> me3.pitch = 45
     >>> me3.velocity = 0
 
     >>> dt4 = midi.DeltaTime(mt)
+    >>> dt4.time = 2048
+
     >>> me4 = midi.MidiEvent(mt)
     >>> me4.type = midi.ChannelVoiceMessages.NOTE_OFF
     >>> me4.pitch = 46
@@ -499,6 +500,8 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
     <music21.chord.Chord A2 B-2>
     >>> c.duration.quarterLength
     2.0
+
+    Changed in v.7 -- Uses the last DeltaTime in the list to get the end time.
     '''
     tOn = 0
 

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -529,7 +529,6 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
             v = volume.Volume(velocity=eOn.velocity)
             v.velocityIsRelative = False  # velocity is absolute coming from
             volumes.append(v)
-
     # assume it is a flat list
     else:
         onEvents = eventList[:(len(eventList) // 2)]
@@ -554,8 +553,8 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
     if (tOff - tOn) != 0:
         ticksToDuration(tOff - tOn, ticksPerQuarter, c.duration)
     else:
-        # environLocal.printDebug(['cannot translate found midi event with zero duration:',
-        #                         eventList, c])
+        environLocal.warn(['midi chord with zero duration will be treated as grace',
+                            eventList, c])
         # for now, get grace
         c.getGrace(inPlace=True)
     return c

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -520,15 +520,16 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
     # of abs start time and the event object
     if isinstance(eventList, list) and isinstance(eventList[0], tuple):
         # pairs of pairs
-        tOff = eventList[0][1][0]
-        for onPair, unused_offPair in eventList:
+        for onPair, offPair in eventList:
             tOn, eOn = onPair
+            tOff, unused_eOff = offPair
             p = pitch.Pitch()
             p.midi = eOn.pitch
             pitches.append(p)
             v = volume.Volume(velocity=eOn.velocity)
             v.velocityIsRelative = False  # velocity is absolute coming from
             volumes.append(v)
+
     # assume it is a flat list
     else:
         onEvents = eventList[:(len(eventList) // 2)]

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -536,7 +536,9 @@ def midiEventsToChord(eventList, ticksPerQuarter=None, inputM21=None):
         offEvents = eventList[(len(eventList) // 2):]
         # first is always delta time
         tOn = onEvents[0].time
-        tOff = offEvents[0].time
+        # use the off time of the last chord member
+        # -1 is the event, -2 is the delta time for the event
+        tOff = offEvents[-2].time
         # create pitches for the odd on Events:
         for i in range(1, len(onEvents), 2):
             p = pitch.Pitch()


### PR DESCRIPTION
Fixes #809

The test that had to be adjusted demonstrates the improvement.

```
s = converter.parse('/Users/jwalls/music21/music21/midi/testPrimitive/test09.mid', forceSource=True)
made = s.parts[0].makeMeasures()
made.measure(54).show()
```

**Before**

![voice-chord-before](https://user-images.githubusercontent.com/38668450/106929555-7cf4eb80-66e2-11eb-9345-f69cd540eb25.png)

**After**

![voice-chord-after](https://user-images.githubusercontent.com/38668450/106929570-83836300-66e2-11eb-81ed-ee7558a281a8.png)

**Update:** fixed an existing bug that would have increased in frequency -- when setting duration on MIDI chords, only the first chord member's note off is used. Now we use the last, which I would expect to be more likely to be correct.