### PR TITLE
Import and export polymetric grand staffs

### DIFF
--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -20,6 +20,7 @@ from xml.etree.ElementTree import Element, SubElement
 
 from music21.key import KeySignature  # for typing
 from music21.layout import StaffGroup
+from music21.meter import TimeSignature  # for typing
 from music21 import stream  # for typing
 from music21.musicxml import helpers
 from music21.musicxml.xmlObjects import MusicXMLExportException
@@ -398,8 +399,8 @@ class PartStaffExporterMixin:
 
     def setEarliestAttributesAndClefsPartStaff(self, group: StaffGroup):
         '''
-        Set the <staff>, <key>, and <clef> information on the earliest measure <attributes>
-        tag in the <part> representing the joined PartStaffs.
+        Set the <staff>, <key>, <time>, and <clef> information on the earliest
+        measure <attributes> tag in the <part> representing the joined PartStaffs.
 
         Need the earliest <attributes> tag, which may not exist in the merged <part>
         until moved there by movePartStaffMeasureContents() --
@@ -407,6 +408,8 @@ class PartStaffExporterMixin:
         to be merged first in order to find earliest <attributes>.
 
         Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
+
+        Multiple keys:
 
         >>> from music21.musicxml import testPrimitive
         >>> xmlDir = common.getSourceFilePath() / 'musicxml' / 'lilypondTestSuite'
@@ -440,23 +443,68 @@ class PartStaffExporterMixin:
           </attributes>
         ...
         </measure>
+
+        Multiple meters (not very well supported by MusicXML readers):
+
+        >>> from music21.musicxml import testPrimitive
+        >>> s = converter.parse(testPrimitive.pianoStaffPolymeter)
+        >>> SX = musicxml.m21ToXml.ScoreExporter(s)
+        >>> root = SX.parse()
+        >>> m1 = root.find('part/measure')
+        >>> SX.dump(m1)
+        <measure number="1">
+            <attributes>
+            <divisions>10080</divisions>
+            <key>
+                <fifths>0</fifths>
+            </key>
+            <time number="1">
+                <beats>4</beats>
+                <beat-type>4</beat-type>
+            </time>
+            <time number="2">
+                <beats>2</beats>
+                <beat-type>2</beat-type>
+            </time>
+            <staves>2</staves>
+            <clef number="1">
+                <sign>G</sign>
+                <line>2</line>
+            </clef>
+            <clef number="2">
+                <sign>F</sign>
+                <line>4</line>
+            </clef>
+            </attributes>
+        ...
+        </measure>    
         '''
-        # Is this source multi-key?
-        initialM21Key: Optional[KeySignature] = None
-        multiKey: bool = False
-        for ps in group:
-            if initialM21Key is None:
-                for ks in ps.recurse().getElementsByClass(KeySignature):
-                    initialM21Key = ks
-                    break
-            else:
-                firstKeySubsequentStaff = None
-                for ks in ps.recurse().getElementsByClass(KeySignature):
-                    firstKeySubsequentStaff = ks
-                    break
-                if firstKeySubsequentStaff != initialM21Key:
-                    multiKey = True
-                    break
+
+        def isMultiAttribute(m21Class, comparison: str ='__eq__') -> bool:
+            '''
+            Return True if the first instance of m21Class in a subsequent staff
+            does not compare to the first instance of that class
+            in the initial staff using `comparison`.
+            '''
+            initialM21Instance: Optional[m21Class] = None
+            for ps in group:
+                if initialM21Instance is None:
+                    for instance in ps.recurse().getElementsByClass(m21Class):
+                        initialM21Instance = instance
+                        break
+                else:
+                    firstInstanceSubsequentStaff = None
+                    for instance in ps.recurse().getElementsByClass(m21Class):
+                        firstInstanceSubsequentStaff = instance
+                        break
+                    if firstInstanceSubsequentStaff is not None:
+                        comparisonWrapper = getattr(firstInstanceSubsequentStaff, comparison)
+                        if not comparisonWrapper(initialM21Instance):
+                            return True
+            return False
+
+        multiKey: bool = isMultiAttribute(KeySignature)
+        multiMeter: bool = isMultiAttribute(TimeSignature, comparison='ratioEqual')
 
         initialPartStaffRoot: Optional[Element] = None
         mxAttributes: Optional[Element] = None
@@ -484,6 +532,10 @@ class PartStaffExporterMixin:
                     key1 = mxAttributes.find('key')
                     if key1:
                         key1.set('number', '1')
+                if multiMeter:
+                    meter1 = mxAttributes.find('time')
+                    if meter1:
+                        meter1.set('number', '1')
 
             # Subsequent PartStaffs in group: set additional clefs on mxAttributes
             else:
@@ -509,6 +561,15 @@ class PartStaffExporterMixin:
                         tagList=['staff-details', 'transpose', 'directive', 'measure-style']
                     )
 
+                if multiMeter:
+                    oldMeter: Optional[Element] = thisPartStaffRoot.find('measure/attributes/time')
+                    if oldMeter:
+                        oldMeter.set('number', str(staffNumber))
+                        helpers.insertBeforeElements(
+                            mxAttributes,
+                            oldMeter,
+                            tagList=['staves']
+                        )
                 if multiKey:
                     oldKey: Optional[Element] = thisPartStaffRoot.find('measure/attributes/key')
                     if oldKey:

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -477,10 +477,10 @@ class PartStaffExporterMixin:
             </clef>
             </attributes>
         ...
-        </measure>    
+        </measure>
         '''
 
-        def isMultiAttribute(m21Class, comparison: str ='__eq__') -> bool:
+        def isMultiAttribute(m21Class, comparison: str = '__eq__') -> bool:
             '''
             Return True if the first instance of m21Class in a subsequent staff
             does not compare to the first instance of that class

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -18,9 +18,9 @@ import unittest
 import xml.etree.ElementTree as ET
 from xml.etree.ElementTree import Element, SubElement
 
-from music21.key import KeySignature  # for typing
+from music21.key import KeySignature
 from music21.layout import StaffGroup
-from music21.meter import TimeSignature  # for typing
+from music21.meter import TimeSignature
 from music21 import stream  # for typing
 from music21.musicxml import helpers
 from music21.musicxml.xmlObjects import MusicXMLExportException

--- a/music21/musicxml/testPrimitive.py
+++ b/music21/musicxml/testPrimitive.py
@@ -18070,6 +18070,52 @@ tupletsImplied = '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 '''
 
 
+pianoStaffPolymeter = '''<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 0.6b Partwise//EN"
+ "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise>
+    <identification>
+        <miscellaneous>
+            <miscellaneous-field name="description">Polymeter on a grand staff</miscellaneous-field>
+        </miscellaneous>
+    </identification>
+    <part-list>
+        <score-part id="P1">
+            <part-name>MusicXML Part</part-name>
+        </score-part>
+    </part-list>
+    <part id="P1">
+        <measure number="1">
+            <attributes>
+                <divisions>96</divisions>
+                <key><fifths>0</fifths></key>
+                <time number="1"><beats>4</beats><beat-type>4</beat-type></time>
+                <time number="2"><beats>2</beats><beat-type>2</beat-type></time>
+                <staves>2</staves>
+                <clef number="1"><sign>G</sign><line>2</line></clef>
+                <clef number="2"><sign>F</sign><line>4</line></clef>
+            </attributes>
+            <note>
+                <pitch><step>F</step><octave>4</octave></pitch>
+                <duration>384</duration>
+                <voice>1</voice>
+                <type>whole</type>
+                <staff>1</staff>
+            </note>
+            <backup><duration>384</duration></backup>
+            <note>
+                <pitch><step>B</step><octave>2</octave></pitch>
+                <duration>384</duration>
+                <voice>2</voice>
+                <type>whole</type>
+                <staff>2</staff>
+            </note>
+        </measure>
+    </part>
+</score-partwise>
+'''
+
+
 ALL = [
     articulations01, pitches01a, directions31a, lyricsMelisma61d, notations32a,  # 0
     restsDurations02a, rhythmDurations03a, chordsThreeNotesDuration21c,  # 5
@@ -18085,7 +18131,7 @@ ALL = [
     mixedVoices1a, mixedVoices1b, mixedVoices2,  # 37
     colors01, triplets01, textBoxes01, octaveShifts33d,  # 40
     unicodeStrNoNonAscii, unicodeStrWithNonAscii,  # 44
-    tremoloTest, hiddenRests, multiDigitEnding, tupletsImplied  # 46
+    tremoloTest, hiddenRests, multiDigitEnding, tupletsImplied, pianoStaffPolymeter  # 46
 ]
 
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1665,6 +1665,7 @@ class PartParser(XMLParserBase):
             'GeneralNote',
             'KeySignature',
             'StaffLayout',
+            'TimeSignature',
         ]
 
         uniqueStaffKeys: List[int] = self._getUniqueStaffKeys()
@@ -5104,7 +5105,6 @@ class MeasureParser(XMLParserBase):
                 pass
                 # TODO: support, but not as musicxml style -- reduces by 1/3 the numerator...
                 # this should be done by changing the displaySequence directly.
-        # TODO: attr: number (which staff... is this done?)
 
         return ts
 
@@ -5242,7 +5242,6 @@ class MeasureParser(XMLParserBase):
                     except exceptions21.Music21Exception:
                         pass  # mxKeyMode might not be a valid mode -- in which case ignore...
         self.mxKeyOctaves(mxKey, ks)
-        # TODO: attr: number
         self.setPrintStyle(mxKey, ks)
         self.setPrintObject(mxKey, ks)
 


### PR DESCRIPTION
Spotted this while we were working on templates and multi-keys.

Polymetric grand staffs were imported before templates, but then templates sort of broke it (just like keys) by letting the template copy the top meter into the bottom staff, leaving the bottom staff with two meters.

Then, export wasn't ever supported, but now it is.