### PR TITLE
makeMeasures no longer flattens part-like substreams

### DIFF
--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -115,8 +115,8 @@ class WindowedAnalysis:
         # need to make sure we only have Measures here, as layout.StaffGroup
         # or similar objs may be retained
         measured.removeByNotOfClass('Measure')
-        if not measured:
-            raise WindowedAnalysisException('Attempted to make ties on a stream without measures')
+        if not measured:  # pragma: no cover
+            raise WindowedAnalysisException('Making measures failed')
         measured.makeTies(inPlace=True)
         return measured
 

--- a/music21/braille/test.py
+++ b/music21/braille/test.py
@@ -638,6 +638,7 @@ class Test(unittest.TestCase):
         bm2.append(note.Rest(quarterLength=4.0))
         bm.append(bm2.flat)
         bm.insert(0, meter.TimeSignature('6/2'))
+        bm = bm.flat
         bm.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False)
         self.s = bm
         self.b = '''

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -1658,7 +1658,7 @@ class Test(unittest.TestCase):
 #             doneAction=doneAction)
 #         b.run()
 
-        b = WindowedKey(a, title=fn,
+        b = WindowedKey(a.flat, title=fn,
                         minWindow=1, windowStep=windowStep,
                         doneAction=doneAction, dpi=300)
         b.run()

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -174,7 +174,7 @@ class Graph(prebase.ProtoM21Object):
         if action in ('show', 'write', None):
             self._doneAction = action
         else:  # pragma: no cover
-            raise GraphException(f'not such done action: {action}')
+            raise GraphException(f'no such done action: {action}')
 
     def nextColor(self):
         '''

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -1590,7 +1590,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
     def removeByNotOfClass(self, classFilterList):
         '''
         Remove all elements not of the specified
-        class or subclass in the Steam in place.
+        class or subclass in the Stream in place.
 
         >>> s = stream.Stream()
         >>> s.append(meter.TimeSignature('4/4'))

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -1735,7 +1735,7 @@ class Test(unittest.TestCase):
         p = converter.parse(self.allaBreveBeamTest)
         with self.assertRaises(stream.StreamException) as cm:
             p.makeMeasures(meterStream=duration.Duration())
-        self.assertEqual(str(cm.exception), 
+        self.assertEqual(str(cm.exception),
             'meterStream is neither a Stream nor a TimeSignature!')
 
 

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -303,22 +303,25 @@ def makeMeasures(
     >>> sMeasures.__class__.__name__
     'Part'
 
-    Demonstrate what makeMeasures will do with inPlace is True:
+    Demonstrate what `makeMeasures` will do with `inPlace` = True:
 
-    >>> sScr = stream.Stream()
-    >>> sScr.insert(0, clef.TrebleClef())
-    >>> sScr.insert(0, meter.TimeSignature('3/4'))
-    >>> sScr.append(note.Note('C4', quarterLength = 3.0))
-    >>> sScr.append(note.Note('D4', quarterLength = 3.0))
-    >>> sScr.makeMeasures(inPlace=True)
+    >>> sScr = stream.Score()
+    >>> sPart = stream.Part()
+    >>> sScr.insert(0, sPart)
+    >>> sPart.insert(0, clef.TrebleClef())
+    >>> sPart.insert(0, meter.TimeSignature('3/4'))
+    >>> sPart.append(note.Note('C4', quarterLength = 3.0))
+    >>> sPart.append(note.Note('D4', quarterLength = 3.0))
+    >>> sPart.makeMeasures(inPlace=True)
     >>> sScr.show('text')
-    {0.0} <music21.stream.Measure 1 offset=0.0>
-        {0.0} <music21.clef.TrebleClef>
-        {0.0} <music21.meter.TimeSignature 3/4>
-        {0.0} <music21.note.Note C>
-    {3.0} <music21.stream.Measure 2 offset=3.0>
-        {0.0} <music21.note.Note D>
-        {3.0} <music21.bar.Barline type=final>
+    {0.0} <music21.stream.Part 0x...>
+        {0.0} <music21.stream.Measure 1 offset=0.0>
+            {0.0} <music21.clef.TrebleClef>
+            {0.0} <music21.meter.TimeSignature 3/4>
+            {0.0} <music21.note.Note C>
+        {3.0} <music21.stream.Measure 2 offset=3.0>
+            {0.0} <music21.note.Note D>
+            {3.0} <music21.bar.Barline type=final>
 
     If after running makeMeasures you run makeTies, it will also split
     long notes into smaller notes with ties.  Lyrics and articulations

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -1730,6 +1730,14 @@ class Test(unittest.TestCase):
                          + ['down', 'noStem', 'double', 'down']
                          )
 
+    def testStreamExceptions(self):
+        from music21 import converter, duration, stream
+        p = converter.parse(self.allaBreveBeamTest)
+        with self.assertRaises(stream.StreamException) as cm:
+            p.makeMeasures(meterStream=duration.Duration())
+        self.assertEqual(str(cm.exception), 
+            'meterStream is neither a Stream nor a TimeSignature!')
+
 
 # -----------------------------------------------------------------------------
 

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -383,13 +383,13 @@ def makeMeasures(
             returnObj = copy.deepcopy(s)
         for substream in returnObj.getElementsByClass('Stream'):
             substream.makeMeasures(meterStream=meterStream,
-                                    refStreamOrTimeRange=refStreamOrTimeRange,
-                                    searchContext=searchContext,
-                                    innerBarline=innerBarline,
-                                    finalBarline=finalBarline,
-                                    bestClef=bestClef,
-                                    inPlace=True,  # copy already made
-                                    )
+                                   refStreamOrTimeRange=refStreamOrTimeRange,
+                                   searchContext=searchContext,
+                                   innerBarline=innerBarline,
+                                   finalBarline=finalBarline,
+                                   bestClef=bestClef,
+                                   inPlace=True,  # copy already made
+                                   )
         if inPlace:
             return
         else:

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -359,6 +359,8 @@ def makeMeasures(
     ['hi', None, None]
 
     Changed in v6 -- all but first attribute are keyword only
+
+    Changed in v7 -- now safe to call `makeMeasures` directly on a score containing parts
     '''
     from music21 import spanner
     from music21 import stream
@@ -373,7 +375,26 @@ def makeMeasures(
     # position components, and sub-streams might hide elements that
     # should be contained
 
-    if s.hasVoices():
+    if s.hasPartLikeStreams():
+        # can't flatten, because it would destroy parts
+        if inPlace:
+            returnObj = s
+        else:
+            returnObj = copy.deepcopy(s)
+        for substream in returnObj.getElementsByClass('Stream'):
+            substream.makeMeasures(meterStream=meterStream,
+                                    refStreamOrTimeRange=refStreamOrTimeRange,
+                                    searchContext=searchContext,
+                                    innerBarline=innerBarline,
+                                    finalBarline=finalBarline,
+                                    bestClef=bestClef,
+                                    inPlace=True,  # copy already made
+                                    )
+        if inPlace:
+            return
+        else:
+            return returnObj
+    elif s.hasVoices():
         # environLocal.printDebug(['make measures found voices'])
         # cannot make flat here, as this would destroy stream partitions
         if s.isSorted:

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -307,12 +307,12 @@ def makeMeasures(
 
     >>> sScr = stream.Score()
     >>> sPart = stream.Part()
-    >>> sScr.insert(0, sPart)
     >>> sPart.insert(0, clef.TrebleClef())
     >>> sPart.insert(0, meter.TimeSignature('3/4'))
     >>> sPart.append(note.Note('C4', quarterLength = 3.0))
     >>> sPart.append(note.Note('D4', quarterLength = 3.0))
-    >>> sPart.makeMeasures(inPlace=True)
+    >>> sScr.insert(0, sPart)
+    >>> sScr.makeMeasures(inPlace=True)
     >>> sScr.show('text')
     {0.0} <music21.stream.Part 0x...>
         {0.0} <music21.stream.Measure 1 offset=0.0>

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -1603,26 +1603,27 @@ class Test(unittest.TestCase):
 
         # this all works fine
         sMeasures = s2.makeMeasures(finalBarline='regular')
-        self.assertEqual(len(sMeasures), 1)
-        self.assertEqual(len(sMeasures.getElementsByClass('Measure')), 1)  # one measure
-        self.assertEqual(len(sMeasures[0]), 3)
+        self.assertEqual(len(sMeasures), 2)  # AltoClef and substream
+        self.assertEqual(len(sMeasures.last().getElementsByClass('Measure')), 1)
+        madeMeasure = sMeasures.recurse().getElementsByClass('Measure').first()
+        self.assertEqual(len(madeMeasure), 3)
         # first is clef
-        self.assertIsInstance(sMeasures[0][0], clef.AltoClef)
+        self.assertIsInstance(madeMeasure.first(), clef.AltoClef)
         # second is sig
-        self.assertEqual(str(sMeasures[0][1]), '<music21.meter.TimeSignature 4/4>')
-        # environLocal.printDebug(['here', sMeasures[0][2]])
+        self.assertEqual(str(madeMeasure[1]), '<music21.meter.TimeSignature 4/4>')
         # sMeasures.show('t')
         # the third element is a Note; we get it from flattening during
         # makeMeasures
-        self.assertTrue(isinstance(sMeasures[0][2], note.Note), sMeasures[0][2])
+        self.assertIsInstance(madeMeasure[2], note.Note)
 
         # this shows the proper output with the proper clef.
         # sMeasures.show()
 
-        # we cannot get clefs from sMeasures b/c that is the topmost
-        # stream container; there are no clefs here, only at a lower leve
+        # new in v7 -- we can still get the topmost clef
+        # because the substream was preserved rather than flattened
+        # no need to destroy the global elements (clef) either
         post = sMeasures.getElementsByClass(clef.Clef)
-        self.assertEqual(len(post), 0)
+        self.assertEqual(len(post), 1)
 
     def testContextNestedB(self):
         '''Testing getting clefs from higher-level streams


### PR DESCRIPTION
`makeMeasures` no longer automatically flattens streams with part-like substreams. Forces the user to `.flat` first if they're OK with that.

It will continue to <s>flatten</s> account for substreams inside measures, such as voices.