### PR TITLE
Fix braille line length rendering

### DIFF
--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -1012,8 +1012,8 @@ class BrailleSegment(text.BrailleText):
             self.cancelOutgoingKeySig = partKeywords['cancelOutgoingKeySig']
         if 'dummyRestLength' in partKeywords:
             self.dummyRestLength = partKeywords['dummyRestLength']
-        if 'lineLength' in partKeywords:
-            self.lineLength = partKeywords['lineLength']
+        if 'maxLineLength' in partKeywords:
+            self.lineLength = partKeywords['maxLineLength']
         if 'showFirstMeasureNumber' in partKeywords:
             self.showFirstMeasureNumber = partKeywords['showFirstMeasureNumber']
         if 'showHand' in partKeywords:

--- a/music21/braille/test.py
+++ b/music21/braille/test.py
@@ -1841,7 +1841,7 @@ class Test(unittest.TestCase):
         '''
 
     def test_example10_2(self):
-        self.methodArgs = {'dummyRestLength': 5, 'lineLength': 20}
+        self.methodArgs = {'dummyRestLength': 5, 'maxLineLength': 20}
         bm = converter.parse('tinynotation: 4/4 e8 f# g# a b- gn e c f a g c a2').flat
         bm.insert(0, key.KeySignature(-1))
         bm.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False)
@@ -1857,7 +1857,7 @@ class Test(unittest.TestCase):
         '''
 
     def test_example10_3(self):
-        self.methodArgs = {'dummyRestLength': 10, 'lineLength': 21}
+        self.methodArgs = {'dummyRestLength': 10, 'maxLineLength': 21}
         bm = converter.parse('tinynotation: 6/8 e8 f# g# a b- g e c f a g c a2.').flat
         bm.insert(0, key.KeySignature(-1))
         bm.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False)

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -356,11 +356,13 @@ class Test(unittest.TestCase):
         x = objectToBraille(s, maxLineLength=12)
         self.assertEqual([len(line) for line in x.splitlines()], [12, 12, 12])
 
-    def x_testSplitMeasure(self):
-        '''TODO: fix how time signature beat groupings are inspected.'''
+    def testSplitNoteGroupingLineLength(self):
+        '''Tests loosening the constraint on trailing spaces when there is
+        no other solution.'''
         from music21 import converter
         s = converter.parse('tinyNotation: 2/4 c4 d e f8 g a2 B2 c4. d8 e2')
-        unused_x = objectToBraille(s, maxLineLength=10)
+        x = objectToBraille(s, maxLineLength=10)
+        self.assertEqual([len(line) for line in x.splitlines()], [10, 10, 7, 10])
 
 
 if __name__ == '__main__':

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -350,16 +350,20 @@ class BrailleTranslateException(exceptions21.Music21Exception):
 
 class Test(unittest.TestCase):
 
-    def x_testTranslateRespectsLineLength(self):
-        # does not yet work.
+    def testTranslateRespectsLineLength(self):
         from music21 import converter
         s = converter.parse('tinyNotation: 2/4 c4 d e f8 g a2 B2 c4. d8 e2')
-        x = objectToBraille(s, maxLineLength=10)
-        for line in x:
-            self.assertLessEqual(len(line), 10)
+        x = objectToBraille(s, maxLineLength=12)
+        for line in x.splitlines():
+            self.assertLessEqual(len(line), 12)
+
+    def x_testSplitMeasure(self):
+        '''TODO: fix how time signature beat groupings are inspected.'''
+        from music21 import converter
+        s = converter.parse('tinyNotation: 2/4 c4 d e f8 g a2 B2 c4. d8 e2')
+        unused_x = objectToBraille(s, maxLineLength=10)
 
 
 if __name__ == '__main__':
     import music21
     music21.mainTest(Test)
-

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -354,8 +354,7 @@ class Test(unittest.TestCase):
         from music21 import converter
         s = converter.parse('tinyNotation: 2/4 c4 d e f8 g a2 B2 c4. d8 e2')
         x = objectToBraille(s, maxLineLength=12)
-        for line in x.splitlines():
-            self.assertLessEqual(len(line), 12)
+        self.assertEqual([len(line) for line in x.splitlines()], [12, 12, 12])
 
     def x_testSplitMeasure(self):
         '''TODO: fix how time signature beat groupings are inspected.'''
@@ -367,3 +366,4 @@ class Test(unittest.TestCase):
 if __name__ == '__main__':
     import music21
     music21.mainTest(Test)
+


### PR DESCRIPTION
Two fixes:
- parse maxLineLength keyword
- fix a constraint on trailing whitespace that was demanding impossible solutions in short line length scenarios, better to leave some whitespace than to give up (just so happens that your original test, with the dotted quarter, hit precisely at the right location on the line!)