### PR TITLE
Refine missing spanners in measures()

### DIFF
--- a/documentation/docbuild/writers.py
+++ b/documentation/docbuild/writers.py
@@ -10,7 +10,7 @@
 # Copyright:    Copyright © 2013-15 Michael Scott Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
-
+import logging
 import os
 import pathlib
 import re
@@ -29,6 +29,17 @@ environLocal = environment.Environment('docbuild.writers')
 
 class DocumentationWritersException(exceptions21.Music21Exception):
     pass
+
+
+class _BuildDirectoryFilter(logging.Filter):
+    def filter(self, record):
+        msg = record.getMessage()
+        if not msg.startswith('Making directory'):
+            return True
+        dirMade = msg[len('Making directory '):].strip()
+        if not os.path.exists(dirMade):
+            return True
+        return False
 
 class DocumentationWriter:
     '''
@@ -443,6 +454,7 @@ class IPythonNotebookReSTWriter(ReSTWriter):
         app.initialize(argv=['--to', 'rst', '--output', outputPath,
                              str(ipythonNotebookFilePath)])
         app.writer.build_directory = str(ipythonNotebookFilePath.parent)
+        app.writer.log.addFilter(_BuildDirectoryFilter())
         app.start()
         return True
 

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -1674,7 +1674,10 @@ def prepareSlurredNotes(music21Part, **keywords):
         try:
             beginIndex = allNotes.index(firstNote)
             endIndex = allNotes.index(lastNote)
-        except exceptions21.StreamException:
+        except exceptions21.StreamException:  # pragma: no cover
+            # there might be a case where a slur is present in a Stream but where
+            # the elements of the slur are no longer present in the stream,
+            # such as if they were manually removed.  It is rare, but why this is here.
             continue
 
         delta = abs(endIndex - beginIndex) + 1

--- a/music21/common/enums.py
+++ b/music21/common/enums.py
@@ -72,7 +72,7 @@ class BooleanEnum(Enum):
         if isinstance(other, self.__class__):
             return super().__eq__(other)
         v = self.value
-        if v == other:
+        if v == other:  # pylint: disable=comparison-with-callable  # pylint having Enum problems
             return True
         elif self.is_bool_tuple(v):
             if v[0] is other:

--- a/music21/common/enums.py
+++ b/music21/common/enums.py
@@ -26,26 +26,64 @@ class StrEnumMeta(EnumMeta):
 
 class BooleanEnum(Enum):
     '''
-    An enum that replaces a boolean, except the "is"
+    An enum that replaces a boolean, except the "is" part, and
+    allows specifying multiple values that
 
     >>> from music21.common.enums import BooleanEnum
     >>> class Maybe(BooleanEnum):
     ...    YES = True
     ...    NO = False
     ...    MAYBE = 0.5
+    ...    NOT_A_CHANCE = (False, 'not a chance')
+    ...    DEFINITELY = (True, 'of course!')
     >>> bool(Maybe.YES)
     True
     >>> bool(Maybe.NO)
     False
+    >>> bool(Maybe.MAYBE)
+    True
+    >>> bool(Maybe.NOT_A_CHANCE)
+    False
+    >>> bool(Maybe.DEFINITELY)
+    True
     >>> Maybe.MAYBE == 0.5
     True
+    >>> Maybe.NOT_A_CHANCE == 'not a chance'
+    True
+    >>> Maybe.NOT_A_CHANCE == False
+    True
+    >>> Maybe.NOT_A_CHANCE == True
+    False
+    >>> Maybe.NOT_A_CHANCE == 'not any chance'
+    False
+    >>> Maybe.DEFINITELY == 'of course!'
+    True
+    >>> Maybe.NOT_A_CHANCE == (False, 'not a chance')
+    True
     '''
-    def __eq__(self, other):
-        if super().__eq__(other):
+    @staticmethod
+    def is_bool_tuple(v):
+        if isinstance(v, tuple) and len(v) == 2 and isinstance(v[0], bool):
             return True
-        return self.value() == other
+        else:
+            return False
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return super().__eq__(other)
+        v = self.value
+        if v == other:
+            return True
+        elif self.is_bool_tuple(v):
+            if v[0] is other:
+                return True
+            return v[1] == other
+        return False
 
     def __bool__(self):
+        v = self.value
+        if self.is_bool_tuple(v):
+            return v[0]
         return bool(self.value)
 
     def __repr__(self):
@@ -98,17 +136,23 @@ class GatherSpanners(BooleanEnum):
 
     >>> GatherSpanners.ALL
     <GatherSpanners.ALL>
+    >>> bool(GatherSpanners.ALL)
+    True
 
     Indicates no relevant spanners will be gathered:
 
     >>> GatherSpanners.NONE
     <GatherSpanners.NONE>
+    >>> bool(GatherSpanners.NONE)
+    False
 
     Indicates only spanners where all of their members are in the excerpt
     will be gathered:
 
     >>> GatherSpanners.COMPLETE_ONLY
     <GatherSpanners.COMPLETE_ONLY>
+    >>> bool(GatherSpanners.COMPLETE_ONLY)
+    True
     '''
     ALL = True
     NONE = False

--- a/music21/common/enums.py
+++ b/music21/common/enums.py
@@ -24,6 +24,34 @@ class StrEnumMeta(EnumMeta):
             return False
 
 
+class BooleanEnum(Enum):
+    '''
+    An enum that replaces a boolean, except the "is"
+
+    >>> from music21.common.enums import BooleanEnum
+    >>> class Maybe(BooleanEnum):
+    ...    YES = True
+    ...    NO = False
+    ...    MAYBE = 0.5
+    >>> bool(Maybe.YES)
+    True
+    >>> bool(Maybe.NO)
+    False
+    >>> Maybe.MAYBE == 0.5
+    True
+    '''
+    def __eq__(self, other):
+        if super().__eq__(other):
+            return True
+        return self.value() == other
+
+    def __bool__(self):
+        return bool(self.value)
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__}.{self.name}>'
+
+
 class OffsetSpecial(str, Enum, metaclass=StrEnumMeta):
     '''
     An enum that represents special offsets.
@@ -58,6 +86,33 @@ class OffsetSpecial(str, Enum, metaclass=StrEnumMeta):
         'highestTime'
         '''
         return str(self.value)
+
+
+class GatherSpanners(BooleanEnum):
+    '''
+    An enumeration for how to gather missing spanners
+
+    >>> from music21.common.enums import GatherSpanners
+
+    Indicates all relevant spanners will be gathered:
+
+    >>> GatherSpanners.ALL
+    <GatherSpanners.ALL>
+
+    Indicates no relevant spanners will be gathered:
+
+    >>> GatherSpanners.NONE
+    <GatherSpanners.NONE>
+
+    Indicates only spanners where all of their members are in the excerpt
+    will be gathered:
+
+    >>> GatherSpanners.COMPLETE_ONLY
+    <GatherSpanners.COMPLETE_ONLY>
+    '''
+    ALL = True
+    NONE = False
+    COMPLETE_ONLY = 'completeOnly'
 
 
 if __name__ == '__main__':

--- a/music21/common/enums.py
+++ b/music21/common/enums.py
@@ -27,7 +27,11 @@ class StrEnumMeta(EnumMeta):
 class BooleanEnum(Enum):
     '''
     An enum that replaces a boolean, except the "is" part, and
-    allows specifying multiple values that
+    allows specifying multiple values that can specify whether they
+    equate to True or False.
+
+    Useful for taking an element that was previously True/False and
+    replacing it in a backwards-compatible way with an Enum.
 
     >>> from music21.common.enums import BooleanEnum
     >>> class Maybe(BooleanEnum):
@@ -68,11 +72,13 @@ class BooleanEnum(Enum):
         else:
             return False
 
+    # pylint having Enum problems with classes as usual.
+    # pylint: disable=comparison-with-callable
     def __eq__(self, other):
         if isinstance(other, self.__class__):
             return super().__eq__(other)
         v = self.value
-        if v == other:  # pylint: disable=comparison-with-callable  # pylint having Enum problems
+        if v == other:
             return True
         elif self.is_bool_tuple(v):
             if v[0] is other:

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2492,7 +2492,7 @@ class PartExporter(XMLExporterBase):
             stream.makeNotation.makeTupletBrackets(measureStream, inPlace=True)
 
         if not self.spannerBundle:
-            self.spannerBundle = spanner.SpannerBundle(measureStream.flat)
+            self.spannerBundle = measureStream.spannerBundle
 
     def getXmlScorePart(self):
         '''
@@ -6098,8 +6098,8 @@ class MeasureExporter(XMLExporterBase):
         '''
         Makes a set of spanners from repeat brackets
         '''
-        self.rbSpanners = self.spannerBundle.getBySpannedElement(
-            self.stream).getByClass('RepeatBracket')
+        spannersOnStream = self.spannerBundle.getBySpannedElement(self.stream)
+        self.rbSpanners = spannersOnStream.getByClass('RepeatBracket')
 
     def setTranspose(self):
         '''

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -336,13 +336,14 @@ class TsvHandler:
         for thisChord in self.chordList:
             offsetInMeasure = thisChord.beat - 1  # beats always measured in quarter notes
             measureNumber = thisChord.measure
+            m21Measure = p.measure(measureNumber)
 
             if thisChord.representationType == 'DCML':
                 thisChord._changeRepresentation()
 
             thisM21Chord = thisChord.tabToM21()  # In either case.
 
-            p.measure(measureNumber).insert(offsetInMeasure, thisM21Chord)
+            m21Measure.insert(offsetInMeasure, thisM21Chord)
 
         self.m21stream = s
 
@@ -356,7 +357,6 @@ class TsvHandler:
         Works like the .template() method,
         except that we don't have a score to base the template on as such.
         '''
-
         s = stream.Score()
         p = stream.Part()
 
@@ -380,7 +380,7 @@ class TsvHandler:
 
         currentOffset = 0
 
-        previousMeasure = self.chordList[0].measure - 1  # Covers pickups
+        previousMeasure: int = self.chordList[0].measure - 1  # Covers pickups
         for entry in self.chordList:
             if entry.measure == previousMeasure:
                 continue

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -21,7 +21,7 @@ or in :ref:`moduleMeter` (a ritardando, for instance).
 '''
 import unittest
 import copy
-from typing import Union, List
+from typing import Union, List, Optional
 
 from music21 import exceptions21
 from music21 import base
@@ -233,10 +233,10 @@ class Spanner(base.Music21Object):
             else:
                 proc.append(arg)
         self.addSpannedElements(proc)
-#         if len(arguments) > 1:
-#             self.spannerStorage.append(arguments)
-#         elif len(arguments) == 1:  # assume a list is first arg
-#                 self.spannerStorage.append(c)
+        # if len(arguments) > 1:
+        #     self.spannerStorage.append(arguments)
+        # elif len(arguments) == 1:  # assume a list is first arg
+        #         self.spannerStorage.append(c)
 
         # parameters that spanners need in loading and processing
         # local id is the id for the local area; used by musicxml
@@ -598,7 +598,7 @@ class Spanner(base.Music21Object):
 # ------------------------------------------------------------------------------
 class SpannerBundle(prebase.ProtoM21Object):
     '''
-    A utility object for collecting and processing
+    An advanced utility object for collecting and processing
     collections of Spanner objects. This is necessary because
     often processing routines that happen at many different
     levels need access to the same collection of spanners.
@@ -611,26 +611,23 @@ class SpannerBundle(prebase.ProtoM21Object):
     If a Stream or Stream subclass is provided as an argument,
     all Spanners on this Stream will be accumulated herein.
 
-    Not to be confused with SpannerStorage (which stores Elements that are spanned)
+    Not to be confused with SpannerStorage (which is a Stream class inside
+    a spanner that stores Elements that are spanned)
+
+    Changed in v7: only argument must be a List of spanners.  Creators of SpannerBundles
+    are required to check that this constraint is True
     '''
 
-    def __init__(self, *arguments, **keywords):
+    def __init__(self, spanners: Optional[List[Spanner]] = None):
         self._cache = {}  # cache is defined on Music21Object not ProtoM21Object
-        self._storage = []  # a simple List, not a Stream
-        for arg in arguments:
-            if common.isListLike(arg):  # spanners are iterable but not list-like.
-                for e in arg:
-                    self._storage.append(e)
-            # take a Stream and use its .spanners property to get all spanners
-            # elif 'Stream' in arg.classes:
-            elif arg.isStream:
-                for e in arg.spanners:
-                    self._storage.append(e)
-            # assume its a spanner
-            elif 'Spanner' in arg.classes:
-                self._storage.append(arg)
 
-        # a special spanners, stored in storage, can be identified in the
+        self._storage: List[Spanner]
+        if spanners:
+            self._storage = spanners[:]  # a simple List, not a Stream
+        else:
+            self._storage = []
+
+        # special spanners, stored in storage, can be identified in the
         # SpannerBundle as missing a spannedElement; the next obj that meets
         # the class expectation will then be assigned and the spannedElement
         # cleared
@@ -858,7 +855,7 @@ class SpannerBundle(prebase.ProtoM21Object):
 
     def getByClass(self, className):
         '''
-        Given a spanner class, return a bundle of all Spanners of the desired class.
+        Given a spanner class, return a new SpannerBundle of all Spanners of the desired class.
 
         >>> su1 = spanner.Slur()
         >>> su2 = layout.StaffGroup()
@@ -870,7 +867,10 @@ class SpannerBundle(prebase.ProtoM21Object):
 
         Classes can be strings (short class) or classes.
 
-        >>> list(sb.getByClass(spanner.Slur)) == [su1]
+        >>> slurs = sb.getByClass(spanner.Slur)
+        >>> slurs
+        <music21.spanner.SpannerBundle of size 1>
+        >>> list(slurs) == [su1]
         True
         >>> list(sb.getByClass('Slur')) == [su1]
         True
@@ -878,15 +878,6 @@ class SpannerBundle(prebase.ProtoM21Object):
         True
         '''
         # NOTE: this is called very frequently: optimize
-#         post = self.__class__()
-#         for sp in self._storage:
-#             if isinstance(className, str):
-#                 if className in sp.classes:
-#                     post.append(sp)
-#             else:
-#                 if isinstance(sp, className):
-#                     post.append(sp)
-#         return post
 
         cacheKey = f'getByClass-{className}'
         if cacheKey not in self._cache or self._cache[cacheKey] is None:
@@ -1899,7 +1890,7 @@ class Test(unittest.TestCase):
         s = stream.Stream()
         s.append(su3)
         s.append(su4)
-        sb2 = spanner.SpannerBundle(s)
+        sb2 = spanner.SpannerBundle(list(s))
         self.assertEqual(len(sb2), 2)
         self.assertEqual(sb2[0], su3)
         self.assertEqual(sb2[1], su4)
@@ -1926,7 +1917,7 @@ class Test(unittest.TestCase):
         self.assertEqual(n1.getSpannerSites(), [su1, su2])
         self.assertEqual(n3.getSpannerSites(), [su1, su2])
 
-        sb1 = spanner.SpannerBundle(su1, su2)
+        sb1 = spanner.SpannerBundle([su1, su2])
         sb2 = copy.deepcopy(sb1)
         self.assertEqual(sb1[0].getSpannedElements(), [n1, n3])
         self.assertEqual(sb2[0].getSpannedElements(), [n1, n3])
@@ -1972,7 +1963,7 @@ class Test(unittest.TestCase):
         n4a = note.Note()
         # n5a = note.Note()
 
-        sb1 = spanner.SpannerBundle(su1, su2, su3)
+        sb1 = spanner.SpannerBundle([su1, su2, su3])
         self.assertEqual(len(sb1), 3)
         self.assertEqual(list(sb1), [su1, su2, su3])
 
@@ -2242,7 +2233,7 @@ class Test(unittest.TestCase):
         objects through make measure calls.
         '''
         from music21 import stream, note, chord
-
+        from music21.spanner import Ottava   #  need to do it this way for classSet
         s = stream.Stream()
         s.repeatAppend(chord.Chord(['c-3', 'g4']), 12)
         # s.repeatAppend(note.Note(), 12)
@@ -2305,15 +2296,15 @@ class Test(unittest.TestCase):
     def testCrescendoA(self):
         from music21 import stream, note, dynamics
         s = stream.Stream()
-#         n1 = note.Note('C')
-#         n2 = note.Note('D')
-#         n3 = note.Note('E')
-#
-#         s.append(n1)
-#         s.append(note.Note('A'))
-#         s.append(n2)
-#         s.append(note.Note('B'))
-#         s.append(n3)
+        # n1 = note.Note('C')
+        # n2 = note.Note('D')
+        # n3 = note.Note('E')
+        #
+        # s.append(n1)
+        # s.append(note.Note('A'))
+        # s.append(n2)
+        # s.append(note.Note('B'))
+        # s.append(n3)
 
         # s.repeatAppend(chord.Chord(['c-3', 'g4']), 12)
         s.repeatAppend(note.Note(type='half'), 4)
@@ -2447,6 +2438,7 @@ class Test(unittest.TestCase):
 
     def testOneElementSpanners(self):
         from music21 import note
+        from music21.spanner import Spanner
 
         n1 = note.Note()
         sp = Spanner()
@@ -2459,6 +2451,7 @@ class Test(unittest.TestCase):
     def testRemoveSpanners(self):
         from music21 import stream
         from music21 import note
+        from music21.spanner import Slur
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -2482,6 +2475,7 @@ class Test(unittest.TestCase):
         from music21 import stream
         from music21 import note
         from music21 import converter
+        from music21.spanner import Slur
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -2500,6 +2494,8 @@ class Test(unittest.TestCase):
 
     def testDeepcopyJustSpannerAndNotes(self):
         from music21 import note, clef
+        from music21.spanner import Spanner
+
         n1 = note.Note('g')
         n2 = note.Note('f#')
         c1 = clef.AltoClef()
@@ -2515,6 +2511,8 @@ class Test(unittest.TestCase):
 
     def testDeepcopySpannerInStreamNotNotes(self):
         from music21 import note, clef, stream
+        from music21.spanner import Spanner
+
         n1 = note.Note('g')
         n2 = note.Note('f#')
         c1 = clef.AltoClef()
@@ -2534,6 +2532,8 @@ class Test(unittest.TestCase):
 
     def testDeepcopyNotesInStreamNotSpanner(self):
         from music21 import note, clef, stream
+        from music21.spanner import Spanner
+
         n1 = note.Note('g')
         n2 = note.Note('f#')
         c1 = clef.AltoClef()
@@ -2555,6 +2555,8 @@ class Test(unittest.TestCase):
 
     def testDeepcopyNotesAndSpannerInStream(self):
         from music21 import note, stream
+        from music21.spanner import Spanner
+
         n1 = note.Note('g')
         n2 = note.Note('f#')
 
@@ -2578,6 +2580,8 @@ class Test(unittest.TestCase):
 
     def testDeepcopyStreamWithSpanners(self):
         from music21 import note, stream
+        from music21.spanner import Slur
+
         n1 = note.Note()
         su1 = Slur((n1,))
         s = stream.Stream()
@@ -2600,6 +2604,7 @@ class Test(unittest.TestCase):
 
     def testGetSpannedElementIds(self):
         from music21 import note
+        from music21.spanner import Spanner
 
         n1 = note.Note('g')
         n2 = note.Note('f#')

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -269,14 +269,12 @@ class Spanner(base.Music21Object):
             ignoreAttributes = ignoreAttributes - removeFromIgnore
 
         if 'spannerStorage' in ignoreAttributes:
-            for c in self.spannerStorage:
-                try:
-                    new.spannerStorage.append(c)
-                except exceptions21.StreamException:
-                    pass
-                    # there is a bug where it is possible for
-                    # an element to appear twice in spannerStorage
-                    # this is the TODO item
+            # there used to be a bug here where spannerStorage would
+            # try to append twice.  I've removed the guardrail here in v7.
+            # because I'm pretty sure we have solved it.
+            for c in self.spannerStorage._elements:
+                new.spannerStorage.coreAppend(c)
+            new.spannerStorage.coreElementsChanged(updateIsFlat=False)
         return new
 
     def __deepcopy__(self, memo=None):

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -1784,7 +1784,7 @@ class Glissando(Spanner):
 
 # ------------------------------------------------------------------------------
 
-
+# pylint: disable=redefined-outer-name
 class Test(unittest.TestCase):
 
     def setUp(self):
@@ -2231,7 +2231,7 @@ class Test(unittest.TestCase):
         objects through make measure calls.
         '''
         from music21 import stream, note, chord
-        from music21.spanner import Ottava   #  need to do it this way for classSet
+        from music21.spanner import Ottava   # need to do it this way for classSet
         s = stream.Stream()
         s.repeatAppend(chord.Chord(['c-3', 'g4']), 12)
         # s.repeatAppend(note.Note(), 12)

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -1770,7 +1770,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         * In v6.7 -- also runs coreElementsChanged()
 
         * In v7. -- addElement is removed; see
-        :meth:`~music21.stream.core.StreamCoreMixin.coreSetElementOffset`
+            :meth:`~music21.stream.core.StreamCoreMixin.coreSetElementOffset`
         '''
         self.coreSetElementOffset(element,
                                   offset,
@@ -9728,6 +9728,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> s = stream.Stream()
         >>> s.insert(1.0, note.Note('E', type='half'))
         >>> s.insert(5.0, note.Note('F', type='whole'))
+        >>> s.storeAtEnd(bar.Barline('final'))
         >>> gapStream = s.findGaps()
         >>> gapStream.show('text', addEndTimes=True)
         {0.0 - 1.0} <music21.note.Rest rest>
@@ -9797,10 +9798,10 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             return self._cache['isGapless']
         else:
             if self.findGaps() is None:
-                self._cache['Gapless'] = True
+                self._cache['isGapless'] = True
                 return True
             else:
-                self._cache['Gapless'] = False
+                self._cache['isGapless'] = False
                 return False
 
     def getOverlaps(self):

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -3771,7 +3771,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                  numberStart,
                  numberEnd,
                  collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature'),
-                 gatherSpanners=True,
+                 gatherSpanners=GatherSpanners.ALL,
                  indicesNotNumbers=False):
         '''
         Get a region of Measures based on a start and end Measure number
@@ -12970,7 +12970,7 @@ class Score(Stream):
                  numberStart,
                  numberEnd,
                  collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature'),
-                 gatherSpanners=True,
+                 gatherSpanners=GatherSpanners.ALL,
                  indicesNotNumbers=False):
         # noinspection PyShadowingNames
         '''

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -538,7 +538,7 @@ class StreamCoreMixin:
         {0.0} <music21.spanner.Slur <music21.note.Note C><music21.note.Note D>>
         {1.0} <music21.note.Note D>
 
-        Now, the same Stream, but insert is False, so it will returns a list of
+        Now, the same Stream, but insert is False, so it will return a list of
         Spanners that should be inserted, rather than inserting them.
 
         >>> s = getStream()
@@ -620,7 +620,9 @@ class StreamCoreMixin:
 
         If `constrainingSpannerBundle` is set then only spanners also present in
         that spannerBundle are added.  This can be useful, for instance, in restoring
-        spanners from an excerpt that might already have spanners removed.
+        spanners from an excerpt that might already have spanners removed.  In
+        Jacob Tyler Walls's brilliant phrasing, it prevents regrowing zombie spanners
+        the you thought you had killed.
 
         Here we will constrain only to spanners also present in another Stream:
 
@@ -631,7 +633,7 @@ class StreamCoreMixin:
         {0.0} <music21.note.Note C>
         {1.0} <music21.note.Note D>
 
-        Now with the same constraint, but we will but the Slur into the other stream.
+        Now with the same constraint, but we will put the Slur into the other stream.
 
         >>> sl = s.notes.first().getSpannerSites()[0]
         >>> s2.insert(0, sl)

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -21,7 +21,7 @@ remain stable.
 
 All functions here will eventually begin with `.core`.
 '''
-from typing import List, Dict, Union, Tuple
+from typing import List, Dict, Union, Tuple, Optional
 from fractions import Fraction
 import unittest
 

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -493,7 +493,12 @@ class StreamCoreMixin:
             self._cache[cacheKey] = hashedElementTree
         return self._cache[cacheKey]
 
-    def coreGatherMissingSpanners(self, recurse=True, requireAllPresent=True, insert=True):
+    def coreGatherMissingSpanners(
+        self,
+        recurse=True,
+        requireAllPresent=True,
+        insert=True
+    ) -> Optional[List['music21.spanner.Spanner']]:
         '''
         find all spanners that are referenced by elements in the
         (recursed if recurse=True) stream and either inserts them in the Stream
@@ -505,18 +510,22 @@ class StreamCoreMixin:
         Because spanners are stored weakly in .sites this is only guaranteed to find
         the spanners in cases where the spanner is in another stream that is still active.
 
-        Here's a little helper function since we'll make the same Stream several times:
+        Here's a little helper function since we'll make the same Stream several times,
+        with two slurred notes, but without the slur itself.  Python's garbage collection
+        will get rid of the slur if we do not prevent it
 
+        >>> preventGarbageCollection = []
         >>> def getStream():
         ...    s = stream.Stream()
         ...    n = note.Note('C')
         ...    m = note.Note('D')
         ...    sl = spanner.Slur(n, m)
-        ...    n.bogusAttributeNotWeakref = sl  # prevent garbage collecting sl
+        ...    preventGarbageCollection.append(sl)
         ...    s.append([n, m])
         ...    return s
 
-
+        Okay now we have a Stream with two slurred notes, but without the slur.
+        `coreGatherMissingSpanners()` will put it in at the beginning.
 
         >>> s = getStream()
         >>> s.show('text')
@@ -528,7 +537,8 @@ class StreamCoreMixin:
         {0.0} <music21.spanner.Slur <music21.note.Note C><music21.note.Note D>>
         {1.0} <music21.note.Note D>
 
-        Insert is False:
+        Now, the same Stream, but insert is False, so it will returns a list of
+        Spanners that should be inserted, rather than inserting them.
 
         >>> s = getStream()
         >>> spList = s.coreGatherMissingSpanners(insert=False)
@@ -538,7 +548,9 @@ class StreamCoreMixin:
         {0.0} <music21.note.Note C>
         {1.0} <music21.note.Note D>
 
-        Not all elements are present:
+
+        Now we'll remove the second note so not all elements of the slur
+        are present, which by default will not insert the Slur:
 
         >>> s = getStream()
         >>> s.remove(s[-1])
@@ -547,12 +559,16 @@ class StreamCoreMixin:
         >>> s.coreGatherMissingSpanners()
         >>> s.show('text')
         {0.0} <music21.note.Note C>
+
+        But with `requireAllPresent=False`, the spanner appears!
+
         >>> s.coreGatherMissingSpanners(requireAllPresent=False)
         >>> s.show('text')
         {0.0} <music21.note.Note C>
         {0.0} <music21.spanner.Slur <music21.note.Note C><music21.note.Note D>>
 
-        Test recursion:
+        With `recurse=False`, then spanners are not gathered inside the inner
+        stream:
 
         >>> t = stream.Part()
         >>> s = getStream()
@@ -563,7 +579,8 @@ class StreamCoreMixin:
             {0.0} <music21.note.Note C>
             {1.0} <music21.note.Note D>
 
-        Default: with recursion:
+
+        But the default acts with recursion:
 
         >>> t.coreGatherMissingSpanners()
         >>> t.show('text')
@@ -573,10 +590,12 @@ class StreamCoreMixin:
         {0.0} <music21.spanner.Slur <music21.note.Note C><music21.note.Note D>>
 
 
-        Make sure that spanners already in the stream are not put there twice:
+        Spanners already in the stream are not put there again:
 
         >>> s = getStream()
-        >>> sl = s[0].getSpannerSites()[0]
+        >>> sl = s.notes.first().getSpannerSites()[0]
+        >>> sl
+        <music21.spanner.Slur <music21.note.Note C><music21.note.Note D>>
         >>> s.insert(0, sl)
         >>> s.coreGatherMissingSpanners()
         >>> s.show('text')
@@ -584,11 +603,11 @@ class StreamCoreMixin:
         {0.0} <music21.spanner.Slur <music21.note.Note C><music21.note.Note D>>
         {1.0} <music21.note.Note D>
 
-        And with recursion?
+        Also does not happen with recursion.
 
         >>> t = stream.Part()
         >>> s = getStream()
-        >>> sl = s[0].getSpannerSites()[0]
+        >>> sl = s.notes.first().getSpannerSites()[0]
         >>> s.insert(0, sl)
         >>> t.insert(0, s)
         >>> t.coreGatherMissingSpanners()
@@ -597,6 +616,8 @@ class StreamCoreMixin:
             {0.0} <music21.note.Note C>
             {0.0} <music21.spanner.Slur <music21.note.Note C><music21.note.Note D>>
             {1.0} <music21.note.Note D>
+
+
         '''
         sb = self.spannerBundle
         if recurse is True:
@@ -623,7 +644,7 @@ class StreamCoreMixin:
 
         if insert is False:
             return collectList
-        else:
+        elif collectList:  # do not run elementsChanged if nothing here.
             for sp in collectList:
                 self.coreInsert(0, sp)
             self.coreElementsChanged(updateIsFlat=False)

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -414,9 +414,8 @@ class StreamCoreMixin:
         A low-level object for Spanner management. This is a read-only property.
         '''
         if 'spannerBundle' not in self._cache or self._cache['spannerBundle'] is None:
-            sf = self.flat
-            sp = sf.spanners.stream()
-            self._cache['spannerBundle'] = spanner.SpannerBundle(sp)
+            spanners = self.recurse(classFilter=(spanner.Spanner,), restoreActiveSites=False)
+            self._cache['spannerBundle'] = spanner.SpannerBundle(list(spanners))
         return self._cache['spannerBundle']
 
     def asTimespans(self, classList=None, flatten=True):

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -874,7 +874,7 @@ class StreamIterator(prebase.ProtoM21Object):
             return e
         return None
 
-    def getElementsByClass(self, classFilterList):
+    def getElementsByClass(self, classFilterList, *, returnClone=True):
         '''
         Add a filter to the Iterator to remove all elements
         except those that match one
@@ -910,9 +910,9 @@ class StreamIterator(prebase.ProtoM21Object):
         <music21.note.Rest rest>
 
         '''
-        return self.addFilter(filters.ClassFilter(classFilterList))
+        return self.addFilter(filters.ClassFilter(classFilterList), returnClone=returnClone)
 
-    def getElementsNotOfClass(self, classFilterList):
+    def getElementsNotOfClass(self, classFilterList, *, returnClone=True):
         '''
         Adds a filter, removing all Elements that do not
         match the one or more classes in the `classFilterList`.
@@ -946,9 +946,9 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> len(found)
         25
         '''
-        return self.addFilter(filters.ClassNotFilter(classFilterList))
+        return self.addFilter(filters.ClassNotFilter(classFilterList), returnClone=returnClone)
 
-    def getElementsByGroup(self, groupFilterList):
+    def getElementsByGroup(self, groupFilterList, *, returnClone=True):
         '''
         >>> n1 = note.Note('C')
         >>> n1.groups.append('trombone')
@@ -973,7 +973,7 @@ class StreamIterator(prebase.ProtoM21Object):
         D
         E
         '''
-        return self.addFilter(filters.GroupFilter(groupFilterList))
+        return self.addFilter(filters.GroupFilter(groupFilterList), returnClone=returnClone)
 
     def getElementsByOffset(
         self,
@@ -985,6 +985,7 @@ class StreamIterator(prebase.ProtoM21Object):
         mustBeginInSpan=True,
         includeElementsThatEndAtStart=True,
         stopAfterEnd=True,
+        returnClone=True,
     ) -> 'StreamIterator':
         '''
         Adds a filter keeping only Music21Objects that
@@ -1232,7 +1233,8 @@ class StreamIterator(prebase.ProtoM21Object):
                 mustBeginInSpan=mustBeginInSpan,
                 includeElementsThatEndAtStart=includeElementsThatEndAtStart,
                 stopAfterEnd=stopAfterEnd,
-            )
+            ),
+            returnClone=returnClone
         )
 
     # ------------------------------------------------------------


### PR DESCRIPTION
* measures() is more open to what spanners can appear in it (even if just one note of a slur is present, for instance)
* add enum GatherSpanners to determine what types of spanners can appear.
* constrain gatherSpanners in measures() to only those present in the parent stream.
* speedup coreGatherMissingSpanners to only call elementsChanged if any spanners have been inserted.
* filter out obnoxious and wrong making directory warns in building docs
* explain why some try: in braille.segment are there.
* findGaps -- correct cache and check storeAtEnd