### PR TITLE
Metronom: fixed fontStyle attribute

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5050,7 +5050,7 @@ class MeasureExporter(XMLExporterBase):
         >>> MEX.dump(MEX.xmlRoot.findall('direction')[1])
         <direction>
           <direction-type>
-            <words default-y="45" enclosure="none" font-style="bold"
+            <words default-y="45" enclosure="none" font-weight="bold"
                 justify="left">slow</words>
           </direction-type>
         </direction>

--- a/music21/style.py
+++ b/music21/style.py
@@ -252,18 +252,30 @@ class TextStyle(Style):
         if value is None:
             self._fontStyle = None
         else:
-            if value.lower() not in ('italic', 'normal', 'bold', 'bolditalic'):
+            value_lower = value.lower()
+            if value_lower in ('italic', 'normal'):
+                self._fontStyle = value_lower
+            elif value_lower == 'bold':
+                self._setWeight('bold')
+            elif value_lower == 'bolditalic':
+                self._fontStyle = 'italic'
+                self._setWeight('bold')
+            else:
                 raise TextFormatException(f'Not a supported fontStyle: {value}')
-            self._fontStyle = value.lower()
 
     fontStyle = property(_getStyle,
                          _setStyle,
                          doc='''
-        Get or set the style, as normal, italic, bold, and bolditalic.
+        Get or set the style, as normal, italic, and bolditalic.
 
         >>> tst = style.TextStyle()
-        >>> tst.fontStyle = 'bold'
+        >>> tst.fontStyle = 'italic'
         >>> tst.fontStyle
+        'italic'
+        >>> tst.fontStyle = 'bolditalic'
+        >>> tst.fontStyle
+        'italic'
+        >>> tst.fontWeight
         'bold'
         ''')
 

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -270,7 +270,7 @@ class TempoText(TempoIndication):
         '''
         if te is None:  # use the stored version if possible
             te = self._textExpression
-        te.style.fontStyle = 'bold'
+        te.style.fontWeight = 'bold'
         if numberImplicit:
             te.style.absoluteY = 20  # if not showing number
         else:


### PR DESCRIPTION
A small fix to an error I stumbled across. 
The value 'bold' does not belong to fontStyle but to fontWeight.

MusicXml don't accept font-style="bold"