### PR TITLE
fix the mxml export for unspecified font-style values 'bold' and 'bolditalic'

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -873,6 +873,16 @@ class XMLExporterBase:
         >>> XB.setFont(mxObj, te)
         >>> XB.dump(mxObj)
         <text font-family="Courier,monospaced" font-size="24" font-style="italic">hi</text>
+
+        >>> te.style.fontStyle = 'bold'
+        >>> XB.setFont(mxObj, te)
+        >>> XB.dump(mxObj)
+        <text font-family="Courier,monospaced" font-size="24" font-weight="bold">hi</text>
+
+        >>> te.style.fontStyle = 'bolditalic'
+        >>> XB.setFont(mxObj, te)
+        >>> XB.dump(mxObj)
+        <text font-family="Courier,monospaced" font-size="24" font-weight="bold" font-style="italic">hi</text>
         '''
         musicXMLNames = ('font-style', 'font-size', 'font-weight')
         m21Names = ('fontStyle', 'fontSize', 'fontWeight')

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -874,15 +874,18 @@ class XMLExporterBase:
         >>> XB.dump(mxObj)
         <text font-family="Courier,monospaced" font-size="24" font-style="italic">hi</text>
 
+        >>> XB = musicxml.m21ToXml.XMLExporterBase()
+        >>> mxObj = El('<text>hi</text>')
+        >>> te = expressions.TextExpression('hi!')
         >>> te.style.fontStyle = 'bold'
         >>> XB.setFont(mxObj, te)
         >>> XB.dump(mxObj)
-        <text font-family="Courier,monospaced" font-size="24" font-weight="bold">hi</text>
+        <text font-weight="bold">hi</text>
 
         >>> te.style.fontStyle = 'bolditalic'
         >>> XB.setFont(mxObj, te)
         >>> XB.dump(mxObj)
-        <text font-family="Courier,monospaced" font-size="24" font-weight="bold" font-style="italic">hi</text>
+        <text font-style="italic" font-weight="bold">hi</text>
         '''
         musicXMLNames = ('font-style', 'font-size', 'font-weight')
         m21Names = ('fontStyle', 'fontSize', 'fontWeight')

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -884,6 +884,15 @@ class XMLExporterBase:
         else:
             return
 
+        if hasattr(st, 'fontStyle'):
+            # mxml does not support bold or bolditalic as font-style value
+            if st.fontStyle == 'bold':
+                mxObject.set('font-weight', 'bold')
+                mxObject.attrib.pop('font-style', None)
+            elif st.fontStyle == 'bolditalic':
+                mxObject.set('font-weight', 'bold')
+                mxObject.set('font-style', 'italic')
+
         if hasattr(st, 'fontFamily') and st.fontFamily:
             if common.isIterable(st.fontFamily):
                 mxObject.set('font-family', ','.join(st.fontFamily))

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5069,7 +5069,7 @@ class MeasureExporter(XMLExporterBase):
         >>> MEX.dump(MEX.xmlRoot.findall('direction')[1])
         <direction>
           <direction-type>
-            <words default-y="45" enclosure="none" font-style="bold"
+            <words default-y="45" enclosure="none" font-weight="bold"
                 justify="left">slow</words>
           </direction-type>
         </direction>


### PR DESCRIPTION
I have fixed an incompatibility between the fontStyle property of music21 and the corresponding font-style property in mxml.
Unlike music21, mxml does not know  font-styles 'bold' and 'bolditalic'. 

When exporting, the font-style values are changed to compatible values and properties in the mxml output as follows
a.) 
For fontStyle='bold' in music21, font-weight="bold" is set in mxml.  (The font-style property is removed in mxml)

b.)
For fontStyle='bolditalic' in music21 font-weight='bold' and font-style='italic' is set in mxml.

I added 2 Testcases for this issue, and the bug in my personal usecase is solved too ;) 
