### PR TITLE
V7 stripTies(inPlace=True) returns None

### DIFF
--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3407,9 +3407,9 @@ class Test(unittest.TestCase):
 
         qlList = [1.5] * 6 + [1] * 8 + [2] * 6 + [1.5] * 8 + [1] * 4
         for j, ql in enumerate(qlList):
-            # Guarantee that the penultimate element will be a rest
+            # Guarantee that the center element will be a rest
             # So that there is greater likelihood of there being at least two events
-            if random.random() > 0.6 or j == len(qlList) - 2:
+            if random.random() > 0.6 or j == len(qlList) // 2:
                 c = note.Rest()
             else:
                 c = chord.Chord(['c3', 'd-4', 'g5'])

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3407,7 +3407,9 @@ class Test(unittest.TestCase):
 
         qlList = [1.5] * 6 + [1] * 8 + [2] * 6 + [1.5] * 8 + [1] * 4
         for j, ql in enumerate(qlList):
-            if random.random() > 0.6:
+            # Guarantee that the penultimate element will be a rest
+            # So that there is greater likelihood of there being at least two events
+            if random.random() > 0.6 or j == len(qlList) - 2:
                 c = note.Rest()
             else:
                 c = chord.Chord(['c3', 'd-4', 'g5'])

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3407,9 +3407,7 @@ class Test(unittest.TestCase):
 
         qlList = [1.5] * 6 + [1] * 8 + [2] * 6 + [1.5] * 8 + [1] * 4
         for j, ql in enumerate(qlList):
-            # Guarantee that the center element will be a rest
-            # So that there is greater likelihood of there being at least two events
-            if random.random() > 0.6 or j == len(qlList) // 2:
+            if random.random() > 0.6:
                 c = note.Rest()
             else:
                 c = chord.Chord(['c3', 'd-4', 'g5'])
@@ -3437,7 +3435,9 @@ class Test(unittest.TestCase):
         s.insert(0, s2)
 
         mts = streamHierarchyToMidiTracks(s)
-        mtsRepr = repr(mts[0].events) + repr(mts[1].events)
+        # mts[0] is the conductor track
+        self.assertIn("SET_TEMPO", repr(mts[0].events))
+        mtsRepr = repr(mts[1].events) + repr(mts[2].events)
         self.assertGreater(mtsRepr.count('velocity=51'), 2)
         self.assertGreater(mtsRepr.count('velocity=102'), 2)
         # s.show('midi')

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -6579,7 +6579,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         Stream subclasses are retained.
 
         `inPlace` controls whether the input stream is modified or whether a deep copy
-        is made.
+        is made. (New in v7, to conform to the rest of music21, `inPlace=True` returns `None`.)
 
         Presently, this only works if tied notes are sequential in the same voice; ultimately
         this will need to look at .to and .from attributes (if they exist)
@@ -6645,13 +6645,19 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             for p in returnObj.getElementsByClass('Stream'):
                 # already copied if necessary; edit in place
                 p.stripTies(inPlace=True, matchByPitch=matchByPitch)
-            return returnObj  # exit
+            if not inPlace:
+                return returnObj
+            else:
+                return  # exit
 
         if returnObj.hasVoices():
             for v in returnObj.voices:
                 # already copied if necessary; edit in place
                 v.stripTies(inPlace=True, matchByPitch=matchByPitch)
-            return returnObj  # exit
+            if not inPlace:
+                return returnObj
+            else:
+                return  # exit
 
         # need to just get .notesAndRests, as there may be other objects in the Measure
         # that come before the first Note, such as a SystemLayout object
@@ -6792,7 +6798,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # https://github.com/cuthbertLab/music21/issues/266
             returnObj.remove(nTarget, recurse=True)
 
-        return returnObj
+        if not inPlace:
+            return returnObj
 
     def extendTies(self, ignoreRests=False, pitchAttr='nameWithOctave'):
         '''

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -1214,7 +1214,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s.parts[3].flat.notesAndRests), 16)
 
         # second, in place true
-        sPost = s.stripTies(inPlace=True)
+        s.stripTies(inPlace=True)
         self.assertEqual(len(s.parts[0].flat.notesAndRests), 6)
         self.assertEqual(len(s.parts[1].flat.notesAndRests), 5)
         self.assertEqual(len(s.parts[2].flat.notesAndRests), 3)

--- a/music21/test/testStream.py
+++ b/music21/test/testStream.py
@@ -1084,6 +1084,9 @@ class Test(unittest.TestCase):
         s.stripTies(inPlace=True)
         self.assertEqual(len(s.flat.notesAndRests), 2)
 
+        stripped = s.stripTies(inPlace=False)
+        self.assertEqual(len(stripped.flat.notesAndRests), 2)
+
     def testStripTiesConsecutiveInVoiceNotContainer(self):
         '''
         Testing that ties are stripped from notes consecutive in a voice


### PR DESCRIPTION
Now that we don't have to dance with `retainContainers` to get a return value, we can make this banana peel go away (in this example, the call was already commented out but you get the idea):

https://github.com/cuthbertLab/music21/blob/c79932c43beb528dba428641d0e133a836770f5c/music21/features/base.py#L369-L375