### PR TITLE
Cleanup in v7

### DIFF
--- a/music21/base.py
+++ b/music21/base.py
@@ -62,6 +62,7 @@ from music21.sites import SitesException
 from music21.sorting import SortTuple, ZeroSortTupleLow, ZeroSortTupleHigh
 from music21.common.enums import OffsetSpecial
 from music21.common.numberTools import opFrac
+from music21.common.types import OffsetQL, OffsetQLIn
 from music21 import style  # pylint: disable=unused-import
 from music21 import sites
 from music21 import environment
@@ -709,7 +710,7 @@ class Music21Object(prebase.ProtoM21Object):
     # convenience.  used to be in note.Note, but belongs everywhere:
 
     @property
-    def quarterLength(self) -> Union[float, fractions.Fraction]:
+    def quarterLength(self) -> OffsetQL:
         '''
         Set or Return the Duration as represented in Quarter Length, possibly as a fraction.
 
@@ -724,7 +725,7 @@ class Music21Object(prebase.ProtoM21Object):
         return self.duration.quarterLength
 
     @quarterLength.setter
-    def quarterLength(self, value: Union[int, float, fractions.Fraction]):
+    def quarterLength(self, value: OffsetQLIn):
         self.duration.quarterLength = value
 
     @property
@@ -3266,6 +3267,7 @@ class Music21Object(prebase.ProtoM21Object):
         >>> [n._getMeasureOffset(includeMeasurePadding=False) for n in m.notes]
         [0.0, 0.5, 1.0, 1.5]
         '''
+        # TODO: v7 -- expose as public.
         activeS = self.activeSite
         if activeS is not None and activeS.isMeasure:
             # environLocal.printDebug(['found activeSite as Measure, using for offset'])

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -220,7 +220,7 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
     # SPECIAL METHODS #
 
     def __iter__(self):
-        return common.Iterator(self.beamsList)
+        return iter(self.beamsList)
 
     def __len__(self):
         return len(self.beamsList)

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -75,7 +75,6 @@ To get rid of beams on a note do:
 
 import unittest
 
-from music21 import common
 from music21 import exceptions21
 from music21 import duration
 from music21 import environment

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -479,7 +479,7 @@ class Chord(note.NotRest):
         self._notes[keyIndex] = value
 
     def __iter__(self):
-        return common.Iterator(self._notes)
+        return iter(self._notes)
 
     def __len__(self):
         '''

--- a/music21/common/__init__.py
+++ b/music21/common/__init__.py
@@ -31,6 +31,10 @@ __all__ = [
     'misc',
     'numberTools',
     'objects',
+    'pathTools',
+    'parallel',
+    'types',
+    'weakrefTools',
 ]
 
 from music21 import defaults
@@ -47,8 +51,8 @@ from music21.common.objects import *
 from music21.common.pathTools import *
 from music21.common.parallel import *
 from music21.common.stringTools import *
+from music21.common.types import *
 from music21.common.weakrefTools import *  # including wrapWeakref
-
 
 DEBUG_OFF = 0
 DEBUG_USER = 1

--- a/music21/common/enums.py
+++ b/music21/common/enums.py
@@ -5,7 +5,7 @@
 #
 # Authors:      Michael Scott Cuthbert
 #
-# Copyright:    Copyright © 2009-2015 Michael Scott Cuthbert and the music21 Project
+# Copyright:    Copyright © 2021 Michael Scott Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 from enum import Enum, EnumMeta

--- a/music21/common/objects.py
+++ b/music21/common/objects.py
@@ -22,6 +22,7 @@ __all__ = [
 import collections
 import time
 import weakref
+from music21.common.decorators import deprecated
 
 
 class RelativeCounter(collections.Counter):
@@ -266,26 +267,20 @@ class EqualSlottedObjectMixin(SlottedObjectMixin):
 
 
 # ------------------------------------------------------------------------------
-class Iterator(collections.abc.Iterator):
-    '''A simple Iterator object used to handle iteration of Streams and other
+class Iterator(collections.abc.Iterator):  # pragma: no cover
+    '''
+    A simple Iterator object used to handle iteration of Streams and other
     list-like objects.
 
-    >>> i = common.Iterator([2, 3, 4])
-    >>> for x in i:
-    ...     print(x)
-    2
-    3
-    4
-    >>> for y in i:
-    ...     print(y)
-    2
-    3
-    4
+    Deprecated in v7 -- not needed since Python 2.6 became music21 minimum!
     '''
+    # TODO: remove in v.8
     def __init__(self, data):
         self.data = data
         self.index = 0
 
+    @deprecated('2021 Jan v7', '2022 Jan',
+                'common.Iterator is deprecated.  use `iter(X)` instead.')
     def __iter__(self):
         self.index = 0
         return self

--- a/music21/common/types.py
+++ b/music21/common/types.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+# Name:         common/types.py
+# Purpose:      Music21 Typing aids
+#
+# Authors:      Michael Scott Cuthbert
+#
+# Copyright:    Copyright © 2021 Michael Scott Cuthbert and the music21 Project
+# License:      BSD, see license.txt
+# ------------------------------------------------------------------------------
+from fractions import Fraction
+from typing import Union
+
+from music21.common.enums import OffsetSpecial
+
+OffsetQL = Union[float, Fraction]
+OffsetQLSpecial = Union[float, Fraction, OffsetSpecial]
+OffsetQLIn = Union[int, float, Fraction]

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 '''
 This file makes it easier to access Bach's chorales through various
-numbering schemes and filters and includes the Iterator()
+numbering schemes and filters and includes the corpus.chorales.Iterator()
 class for easily iterating through the chorale collection.
 '''
 
@@ -28,7 +28,7 @@ environLocal = environment.Environment(_MOD)
 class ChoraleList:
     # noinspection SpellCheckingInspection
     '''
-    A searchable list of BachChorales by various numbering systems:
+    A searchable list of Bach's chorales by various numbering systems:
 
     Note that multiple chorales share the same title, so it's best to
     iterate over one of the other lists to get them all.
@@ -491,7 +491,7 @@ class ChoraleList:
 class ChoraleListRKBWV:
     # noinspection SpellCheckingInspection
     '''
-    A searchable list of BachChorales by various numbering systems:
+    A searchable list of Bach's chorales by various numbering systems:
 
     Note that multiple chorales share the same title, so it's best to
     iterate over one of the other lists to get them all.
@@ -951,7 +951,7 @@ class Iterator:
     change the range values to span the entire numberList.
     The iterator can be initialized with three parameters
     (currentNumber, highestNumber, numberingSystem). For example
-    BachChoraleIterator(1, 26,'riemenschneider') iterates
+    corpus.chorales.Iterator(1, 26,'riemenschneider') iterates
     through the riemenschneider numbered chorales from 1 to 26.
     Additionally, the following kwargs can be set:
 
@@ -1078,10 +1078,11 @@ class Iterator:
         and returnType = 'stream'
 
         Notes:
-        Two BachChoraleList objects are created. These should probably
+
+        Two ChoraleList objects are created. These should probably
         be consolidated, but they contain
         different information at this time. Also, there are problems
-        with entries in BachChoraleListRKBWV
+        with entries in ChoraleListRKBWV
         that need to be addressed. Namely, chorales that share the
         same key (and thus overwrite each other)
         and chorales that do not appear to be in the corpus at all.

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -50,7 +50,7 @@ import copy
 import fractions
 import unittest
 from math import inf
-from typing import Union
+from typing import Union, Tuple, Dict, List, Optional, Iterable
 
 from collections import namedtuple
 
@@ -63,21 +63,28 @@ from music21 import environment
 
 from music21.common.objects import SlottedObjectMixin
 from music21.common.numberTools import opFrac
+from music21.common.types import OffsetQL, OffsetQLIn
 
-
-_MOD = 'duration'
-environLocal = environment.Environment(_MOD)
+environLocal = environment.Environment('duration')
 
 DENOM_LIMIT = defaults.limitOffsetDenominator
 
-POSSIBLE_DOTS_IN_TUPLETS = [0, 1]
+POSSIBLE_DOTS_IN_TUPLETS = (0, 1)
 
+
+class DurationException(exceptions21.Music21Exception):
+    pass
+
+
+class TupletException(exceptions21.Music21Exception):
+    pass
 
 # ------------------------------------------------------------------------------
 # duration constants and reference
 
+
 # N.B.: MusicXML uses long instead of longa
-typeToDuration = {
+typeToDuration: Dict[str, float] = {
     'duplex-maxima': 64.0,
     'maxima': 32.0,
     'longa': 16.0,
@@ -97,7 +104,7 @@ typeToDuration = {
     'zero': 0.0,
 }
 
-typeFromNumDict = {
+typeFromNumDict: Dict[float, str] = {
     1.0: 'whole',
     2.0: 'half',
     4.0: 'quarter',
@@ -116,9 +123,9 @@ typeFromNumDict = {
     0.125: 'maxima',
     0.0625: 'duplex-maxima',
 }
-typeFromNumDictKeys = sorted(list(typeFromNumDict.keys()))
+typeFromNumDictKeys: List[float] = sorted(list(typeFromNumDict.keys()))
 
-ordinalTypeFromNum = [
+ordinalTypeFromNum: List[str] = [
     'duplex-maxima',
     'maxima',
     'longa',
@@ -137,10 +144,17 @@ ordinalTypeFromNum = [
     '2048th',
 ]
 
-defaultTupletNumerators = (3, 5, 7, 11, 13)
-extendedTupletNumerators = (3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67,
-                            71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139,
-                            149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199)
+
+defaultTupletNumerators: Tuple[int, ...] = (3, 5, 7, 11, 13)
+
+extendedTupletNumerators: Tuple[int, ...] = (
+    3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67,
+    71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139,
+    149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199,
+)
+
+
+QuarterLengthConversion = namedtuple('QuarterLengthConversion', 'components tuplet')
 
 
 def unitSpec(durationObjectOrObjects):
@@ -184,13 +198,15 @@ def unitSpec(durationObjectOrObjects):
         if not(hasattr(dO, 'tuplets')) or dO.tuplets is None or not dO.tuplets:
             return (dO.quarterLength, dO.type, dO.dots, None, None, None)
         else:
-            return (dO.quarterLength, dO.type, dO.dots,
+            return (dO.quarterLength,
+                    dO.type,
+                    dO.dots,
                     dO.tuplets[0].numberNotesActual,
                     dO.tuplets[0].numberNotesNormal,
                     dO.tuplets[0].durationNormal.type)
 
 
-def nextLargerType(durType):
+def nextLargerType(durType: str) -> str:
     '''
     Given a type (such as 16th or quarter), return the next larger type.
 
@@ -212,10 +228,9 @@ def nextLargerType(durType):
     return ordinalTypeFromNum[thisOrdinal - 1]
 
 
-def nextSmallerType(durType):
+def nextSmallerType(durType: str) -> str:
     '''
     Given a type (such as 16th or quarter), return the next smaller type.
-
 
     >>> duration.nextSmallerType('16th')
     '32nd'
@@ -235,7 +250,7 @@ def nextSmallerType(durType):
     return ordinalTypeFromNum[thisOrdinal + 1]
 
 
-def quarterLengthToClosestType(qLen):
+def quarterLengthToClosestType(qLen: OffsetQLIn):
     '''
     Returns a two-unit tuple consisting of
 
@@ -296,13 +311,12 @@ def quarterLengthToClosestType(qLen):
                                 + f'qLen was: {qLen}')
 
 
-def convertQuarterLengthToType(qLen):
+def convertQuarterLengthToType(qLen: OffsetQLIn) -> str:
     '''
     Return a type if there exists a type that is exactly equal to the
     duration of the provided quarterLength. Similar to
     quarterLengthToClosestType() but this
     function only returns exact matches.
-
 
     >>> duration.convertQuarterLengthToType(2)
     'half'
@@ -319,7 +333,7 @@ def convertQuarterLengthToType(qLen):
     return durationType
 
 
-def dottedMatch(qLen, maxDots=4):
+def dottedMatch(qLen: OffsetQLIn, maxDots=4) -> Tuple[Union[int, bool], Union[str, bool]]:
     '''
     Given a quarterLength, determine if there is a dotted
     (or non-dotted) type that exactly matches. Returns a pair of
@@ -360,7 +374,9 @@ def dottedMatch(qLen, maxDots=4):
     return (False, False)
 
 
-def quarterLengthToNonPowerOf2Tuplet(qLen):
+def quarterLengthToNonPowerOf2Tuplet(
+    qLen: OffsetQLIn
+) -> Tuple['music21.duration.Tuplet', 'music21.duration.DurationTuple']:
     '''
     Slow, last chance function that returns a tuple of a single tuplet, probably with a non
     power of 2 denominator (such as 7:6) that represents the quarterLength and the
@@ -406,9 +422,11 @@ def quarterLengthToNonPowerOf2Tuplet(qLen):
                    ), representativeDuration)
 
 
-def quarterLengthToTuplet(qLen,
-                          maxToReturn=4,
-                          tupletNumerators=defaultTupletNumerators):
+def quarterLengthToTuplet(
+    qLen: OffsetQLIn,
+    maxToReturn=4,
+    tupletNumerators=defaultTupletNumerators
+) -> List['music21.duration.Tuplet']:
     '''
     Returns a list of possible Tuplet objects for a
     given `qLen` (quarterLength). As there may be more than one
@@ -476,10 +494,7 @@ def quarterLengthToTuplet(qLen,
     return post
 
 
-QuarterLengthConversion = namedtuple('QuarterLengthConversion', 'components tuplet')
-
-
-def quarterConversion(qLen):
+def quarterConversion(qLen: OffsetQLIn) -> QuarterLengthConversion:
     '''
     Returns a 2-element namedtuple of (components, tuplet)
 
@@ -491,8 +506,6 @@ def quarterConversion(qLen):
     (All quarterLengths can, technically, be notated as a single unit
     given a complex enough tuplet, as a last resort will look up to 199 as a tuplet type).
 
-
-
     >>> duration.quarterConversion(2)
     QuarterLengthConversion(components=(DurationTuple(type='half', dots=0, quarterLength=2.0),),
         tuplet=None)
@@ -500,8 +513,6 @@ def quarterConversion(qLen):
     >>> duration.quarterConversion(0.5)
     QuarterLengthConversion(components=(DurationTuple(type='eighth', dots=0, quarterLength=0.5),),
         tuplet=None)
-
-
 
     Dots are supported
 
@@ -599,7 +610,6 @@ def quarterConversion(qLen):
 
     This is a very close approximation:
 
-
     >>> duration.quarterConversion(0.18333333333333)
     QuarterLengthConversion(components=(DurationTuple(type='16th', dots=0, quarterLength=0.25),),
         tuplet=<music21.duration.Tuplet 15/11/256th>)
@@ -691,7 +701,12 @@ def quarterConversion(qLen):
     return QuarterLengthConversion((component,), tuplet)
 
 
-def convertTypeToQuarterLength(dType, dots=0, tuplets=None, dotGroups=None):
+def convertTypeToQuarterLength(
+    dType: str,
+    dots=0,
+    tuplets: Optional[List['music21.duration.Tuplet']] = None,
+    dotGroups=None
+) -> OffsetQL:
     # noinspection PyShadowingNames
     '''
     Given a rhythm type (`dType`), number of dots (`dots`), an optional list of
@@ -746,7 +761,7 @@ def convertTypeToQuarterLength(dType, dots=0, tuplets=None, dotGroups=None):
     return qtrLength
 
 
-def convertTypeToNumber(dType):
+def convertTypeToNumber(dType: str) -> float:
     '''
     Convert a duration type string (`dType`) to a numerical scalar representation that shows
     how many of that duration type fits within a whole note.
@@ -779,13 +794,124 @@ def convertTypeToNumber(dType):
     return dTypeFound
 
 
+# -----------------------------------------------------------------------------------
+DurationTuple = namedtuple('DurationTuple', 'type dots quarterLength')
+
+
+def _augmentOrDiminishTuple(self, amountToScale):
+    return durationTupleFromQuarterLength(self.quarterLength * amountToScale)
+
+
+DurationTuple.augmentOrDiminish = _augmentOrDiminishTuple
+
+
+del _augmentOrDiminishTuple
+
+
+def _durationTupleOrdinal(self):
+    '''
+    Converts type to an ordinal number where maxima = 1 and 1024th = 14;
+    whole = 4 and quarter = 6.  Based on duration.ordinalTypeFromNum
+
+    >>> a = duration.DurationTuple('whole', 0, 4.0)
+    >>> a.ordinal
+    4
+
+    >>> b = duration.DurationTuple('maxima', 0, 32.0)
+    >>> b.ordinal
+    1
+
+    >>> c = duration.DurationTuple('1024th', 0, 1/256)
+    >>> c.ordinal
+    14
+    '''
+    ordinalFound = None
+    for i in range(len(ordinalTypeFromNum)):
+        if self.type == ordinalTypeFromNum[i]:
+            ordinalFound = i
+            break
+    if ordinalFound is None:
+        raise DurationException(
+            f'Could not determine durationNumber from {ordinalFound}')
+    return ordinalFound
+
+
+DurationTuple.ordinal = property(_durationTupleOrdinal)
+
+
+_durationTupleCacheTypeDots = {}
+_durationTupleCacheQuarterLength = {}
+
+
+def durationTupleFromQuarterLength(ql=1.0) -> DurationTuple:
+    '''
+    Returns a DurationTuple for a given quarter length
+    if the ql can be expressed as a type and number of dots
+    (no tuplets, no complex duration, etc.).  If it can't be expressed,
+    returns an "inexpressible" DurationTuple.
+
+    >>> dt = duration.durationTupleFromQuarterLength(3.0)
+    >>> dt
+    DurationTuple(type='half', dots=1, quarterLength=3.0)
+
+    If it's not possible, we return an "inexpressible" type:
+
+    >>> dt = duration.durationTupleFromQuarterLength(2.5)
+    >>> dt
+    DurationTuple(type='inexpressible', dots=0, quarterLength=2.5)
+    '''
+    try:
+        return _durationTupleCacheQuarterLength[ql]
+    except KeyError:
+        ql = opFrac(ql)
+        dots, durType = dottedMatch(ql)
+        if durType is not False:
+            nt = DurationTuple(durType, dots, ql)
+            _durationTupleCacheQuarterLength[ql] = nt
+            return nt
+        else:
+            return DurationTuple('inexpressible', 0, ql)
+
+
+def durationTupleFromTypeDots(durType='quarter', dots=0):
+    '''
+    Returns a DurationTuple (which knows its quarterLength) for
+    a given type and dots (no tuplets)
+
+    >>> dt = duration.durationTupleFromTypeDots('quarter', 0)
+    >>> dt
+    DurationTuple(type='quarter', dots=0, quarterLength=1.0)
+    >>> dt2 = duration.durationTupleFromTypeDots('quarter', 0)
+    >>> dt is dt2
+    True
+
+    Also with keyword arguments.
+
+    >>> dt = duration.durationTupleFromTypeDots(durType='zero', dots=0)
+    >>> dt
+    DurationTuple(type='zero', dots=0, quarterLength=0.0)
+
+    OMIT_FROM_DOCS
+
+    >>> dt in duration._durationTupleCacheTypeDots.values()
+    True
+    '''
+    tp = (durType, dots)
+    try:
+        return _durationTupleCacheTypeDots[tp]
+    except KeyError:
+        try:
+            ql = typeToDuration[durType] * common.dotMultiplier(dots)
+        except (KeyError, IndexError) as e:
+            raise DurationException(
+                f'Unknown type: {durType}'
+            ) from e
+        nt = DurationTuple(durType, dots, ql)
+        _durationTupleCacheTypeDots[tp] = nt
+        return nt
+
+
 # -------------------------------------------------------------------------------
-
-
-class TupletException(exceptions21.Music21Exception):
-    pass
-
-
 class Tuplet(prebase.ProtoM21Object):
     '''
     A tuplet object is a representation of a musical tuplet (like a triplet).
@@ -897,7 +1023,6 @@ class Tuplet(prebase.ProtoM21Object):
     # TODO: use __setattr__ to freeze all properties, and make a metaclass
     # exceptions: tuplet type, tuplet id: things that don't affect length
     '''
-
     def __init__(self, *arguments, **keywords):
         self.frozen = False
         # environLocal.printDebug(['creating Tuplet instance'])
@@ -1009,9 +1134,7 @@ class Tuplet(prebase.ProtoM21Object):
     # PRIVATE METHODS #
 
     def _reprInternal(self):
-        # use %r because floats are acceptable for numberNotesNormal, and perhaps
-        # even Fractions...
-        base = f'{self.numberNotesActual}/{self.numberNotesNormal}'
+        base = f'{self.numberNotesActual!r}/{self.numberNotesNormal!r}'
         if self.durationNormal is not None:
             base += f'/{self.durationNormal.type}'
         return base
@@ -1022,8 +1145,7 @@ class Tuplet(prebase.ProtoM21Object):
                 'A frozen tuplet (or one attached to a duration) has immutable length.')
 
     # PUBLIC METHODS #
-
-    def augmentOrDiminish(self, amountToScale):
+    def augmentOrDiminish(self, amountToScale: Union[int, float]):
         '''
         Given a number greater than zero,
         multiplies the current quarterLength of the
@@ -1067,7 +1189,11 @@ class Tuplet(prebase.ProtoM21Object):
         # self.numberNotesNormal = normal
         return post
 
-    def setDurationType(self, durType, dots=0):
+    def setDurationType(
+        self,
+        durType: str,
+        dots=0
+    ):
         '''
         Set both durationActual and durationNormal from either a string type or
         a quarterLength.  optional dots can add dots to a string Type (or I suppose
@@ -1181,7 +1307,7 @@ class Tuplet(prebase.ProtoM21Object):
             durationNormalQuarterLength = 0.5  # eighth notes
         return opFrac(n * durationNormalQuarterLength)
 
-    def tupletMultiplier(self):
+    def tupletMultiplier(self) -> OffsetQL:
         '''
         Get a Fraction() by which to scale the duration that
         this Tuplet is associated with.
@@ -1231,7 +1357,7 @@ class Tuplet(prebase.ProtoM21Object):
         return self._durationActual
 
     @durationActual.setter
-    def durationActual(self, dA):
+    def durationActual(self, dA: Union[DurationTuple, 'Duration']):
         self._checkFrozen()
 
         if isinstance(dA, DurationTuple):
@@ -1245,7 +1371,7 @@ class Tuplet(prebase.ProtoM21Object):
             self._durationActual = durationTupleFromTypeDots(dA, dots=0)
 
     @property
-    def durationNormal(self):
+    def durationNormal(self) -> DurationTuple:
         '''
         durationNormal is a DurationTuple that represents the notes that are
         would be present in the space normally (if there were no tuplets).  For instance, in a 7
@@ -1341,62 +1467,7 @@ class Tuplet(prebase.ProtoM21Object):
         self.numberNotesNormal, self.durationNormal = tupList
 
 
-# -----------------------------------------------------------------------------------
-DurationTuple = namedtuple('DurationTuple', 'type dots quarterLength')
-
-
-def _augmentOrDiminishTuple(self, amountToScale):
-    return durationTupleFromQuarterLength(self.quarterLength * amountToScale)
-
-
-DurationTuple.augmentOrDiminish = _augmentOrDiminishTuple
-
-
-del _augmentOrDiminishTuple
-
-
-def _durationTupleOrdinal(self):
-    '''
-    Converts type to an ordinal number where maxima = 1 and 1024th = 14;
-    whole = 4 and quarter = 6.  Based on duration.ordinalTypeFromNum
-
-    >>> a = duration.DurationTuple('whole', 0, 4.0)
-    >>> a.ordinal
-    4
-
-    >>> b = duration.DurationTuple('maxima', 0, 32.0)
-    >>> b.ordinal
-    1
-
-    >>> c = duration.DurationTuple('1024th', 0, 1/256)
-    >>> c.ordinal
-    14
-    '''
-    ordinalFound = None
-    for i in range(len(ordinalTypeFromNum)):
-        if self.type == ordinalTypeFromNum[i]:
-            ordinalFound = i
-            break
-    if ordinalFound is None:
-        raise DurationException(
-            f'Could not determine durationNumber from {ordinalFound}')
-    return ordinalFound
-
-
-DurationTuple.ordinal = property(_durationTupleOrdinal)
-
-
-_durationTupleCacheTypeDots = {}
-_durationTupleCacheQuarterLength = {}
-
-
 # ------------------------------------------------------------------------------
-
-
-class DurationException(exceptions21.Music21Exception):
-    pass
-
-
 class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
     '''
     Durations are one of the most important objects in music21. A Duration
@@ -1480,12 +1551,14 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         self._quarterLengthNeedsUpdating = False
         self._typeNeedsUpdating = False
 
-        self._unlinkedType = None
-        self._dotGroups = (0,)
-        self._tuplets = ()  # an empty tuple
-        self._qtrLength = 0.0
+        self._unlinkedType: Optional[str] = None
+        self._dotGroups: Tuplet[int, ...] = (0,)
+        self._tuplets: Tuple['Tuplet'] = ()  # an empty tuple
+        self._qtrLength: OffsetQL = 0.0
+
         # DurationTuples go here
-        self._components = []
+        self._components: List[DurationTuple] = []
+
         # defer updating until necessary
         self._quarterLengthNeedsUpdating = False
         self._linked = True
@@ -1522,7 +1595,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             self.client = keywords['client']
 
     # SPECIAL METHODS #
-
     def __eq__(self, other):
         '''
         Two durations are the same if their type, dots, tuplets, and
@@ -1659,14 +1731,31 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         self._componentsNeedUpdating = False
 
     # PUBLIC METHODS #
-    def _getLinked(self):
+    def _getLinked(self) -> bool:
         '''
-        Gets or sets the Linked property -- if linked (default) then type, dots, tuplets are
+        Gets or sets the `.linked` property -- if linked (default) then type, dots, tuplets are
         always coherent with quarterLength.  If not, then they are separate.
+
+        >>> d = duration.Duration(0.5)
+        >>> d.linked
+        True
+
+        Linked durations change other values when one changes:
+
+        >>> d.type = '16th'
+        >>> d.quarterLength
+        0.25
+
+        Unlinked values do not:
+
+        >>> d.linked = False
+        >>> d.type = 'half'
+        >>> d.quarterLength
+        0.25
         '''
         return self._linked
 
-    def _setLinked(self, value):
+    def _setLinked(self, value: bool):
         if value not in (True, False):
             raise DurationException(f'Linked can only be True or False, not {value}')
         if self._quarterLengthNeedsUpdating:
@@ -1677,7 +1766,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
     linked = property(_getLinked, _setLinked)
 
-    def addDurationTuple(self, dur):
+    def addDurationTuple(self, dur: Union[DurationTuple, 'Duration']):
         '''
         Add a DurationTuple or a Duration's components to this Duration.
         Does not simplify the Duration.  For instance, adding two
@@ -1709,7 +1798,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
         self.informClient()
 
-    def appendTuplet(self, newTuplet):
+    def appendTuplet(self, newTuplet: Tuplet) -> None:
         '''
         Adds a new Tuplet to a Duration, sets the Tuplet's .frozen state to True,
         and then informs the client (Note) that the duration has changed.
@@ -1832,10 +1921,10 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
         return post
 
-    def clear(self):
+    def clear(self) -> None:
         '''
         Permit all components to be removed.
-        (It is not clear yet if this is needed: YES! for zero duration!)
+        This is needed for resetting to zero duration.
 
         >>> a = duration.Duration()
         >>> a.quarterLength = 6
@@ -1862,7 +1951,8 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         self.informClient()
 
     def componentIndexAtQtrPosition(self, quarterPosition):
-        '''returns the index number of the duration component sounding at
+        '''
+        returns the index number of the duration component sounding at
         the given quarter position.
 
         Note that for 0 and the last value, the object is returned.
@@ -1895,6 +1985,8 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         self.componentIndexAtQtrPosition(1.5) == d2
         self.componentIndexAtQtrPosition(2.0) == d3
         self.componentIndexAtQtrPosition(2.5) == d3
+
+        Currently sometimes returns the component itself.  Changing in v7.
         '''
         quarterPosition = opFrac(quarterPosition)
 
@@ -2032,7 +2124,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> a.components
         (DurationTuple(type='whole', dots=0, quarterLength=4.0),
          DurationTuple(type='quarter', dots=0, quarterLength=1.0))
-
         '''
         if len(self.components) == 1:
             pass  # nothing to be done
@@ -2046,14 +2137,18 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         '''
         Utility method for testing; a quick way to fill components. This will
         remove any existing values.
+
+        Deprecated in v7.
         '''
         self.components = []
         for x in quarterLengthList:
             self.addDurationTuple(Duration(x))
         self.informClient()
 
-    def getGraceDuration(self, appoggiatura=False) -> Union[
-            'GraceDuration', 'AppoggiaturaDuration']:
+    def getGraceDuration(
+        self,
+        appoggiatura=False
+    ) -> Union['GraceDuration', 'AppoggiaturaDuration']:
         # noinspection PyShadowingNames
         '''
         Return a deepcopy of this Duration as a GraceDuration instance with the same types.
@@ -2074,12 +2169,10 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         (DurationTuple(type='quarter', dots=0, quarterLength=0.0),
          DurationTuple(type='16th', dots=0, quarterLength=0.0))
 
-        D is unchanged.
+        `d` is unchanged.
 
         >>> d.quarterLength
         1.25
-
-
         '''
         if self._componentsNeedUpdating:
             self._updateComponents()
@@ -2098,7 +2191,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         gd.quarterLength = 0.0
         return gd
 
-    def informClient(self):
+    def informClient(self) -> bool:
         '''
         call informSites({'changedAttribute': 'duration', 'quarterLength': quarterLength})
         on any call that changes the quarterLength
@@ -2144,7 +2237,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> a.components[2].type
         'quarter'
         '''
-
         # this may return a Duration object; we are not sure
         sliceIndex = self.componentIndexAtQtrPosition(quarterPosition)
 
@@ -2278,28 +2370,73 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         '''
         Look to components and determine quarter length.
 
-        DEPRECATED -- this is no longer needed except by duration developers
-        and will be removed in v.7
+        Changed in v7. -- made private.  And faster
         '''
-        if self.linked is True:
+        if self.linked is False:
+            return
+
+        if self._dotGroups == (0,) and not self.tuplets and len(self.components) == 1:
+            # do common tasks fast:
+            self._qtrLength = self.components[0].quarterLength
+        else:
             self._qtrLength = opFrac(self.quarterLengthNoTuplets * self.aggregateTupletMultiplier())
-            if self._dotGroups != (0,):
-                for dots in self._dotGroups:
-                    if dots > 0:
-                        self._qtrLength *= common.dotMultiplier(dots)
+            for dots in self._dotGroups:
+                if dots != 0:
+                    self._qtrLength = opFrac(self._qtrLength * common.dotMultiplier(dots))
 
         self._quarterLengthNeedsUpdating = False
 
     # PUBLIC PROPERTIES #
-
     @property
     def components(self):
+        '''
+        Returns or sets a tuple of the component DurationTuples of this
+        Duration object
+
+        >>> d = duration.Duration(1.0)
+        >>> d.components
+        (DurationTuple(type='quarter', dots=0, quarterLength=1.0),)
+
+        Tuplets do not have the tuplet in their components.
+
+        >>> d = duration.Duration(1/3)
+        >>> d.components
+        (DurationTuple(type='eighth', dots=0, quarterLength=0.5),)
+
+
+        With a complex duration it becomes clearer why multiple components are needed.
+        Here is a duration that cannot be expressed as a single note.
+
+        >>> d = duration.Duration(1.25)
+        >>> d.type
+        'complex'
+        >>> d.components
+        (DurationTuple(type='quarter', dots=0, quarterLength=1.0),
+         DurationTuple(type='16th', dots=0, quarterLength=0.25))
+
+        But it can be expressed another way and will output in that way in MusicXML
+        and other readers:
+
+        >>> component0 = duration.DurationTuple(type='eighth', dots=0, quarterLength=0.5)
+        >>> component1 = duration.DurationTuple(type='eighth', dots=1, quarterLength=0.75)
+        >>> d.components = [component0, component1]
+
+        It is allowed but not advised to set components that do not add up
+        to the current (pre-tuplet) quarterLength.  In which case the quarterLength
+        will be adjusted:
+
+        >>> d.components = [component0]
+        >>> d
+        <music21.duration.Duration 0.5>
+        >>> d.type
+        'eighth'
+        '''
         if self._componentsNeedUpdating:
             self._updateComponents()
         return tuple(self._components)
 
     @components.setter
-    def components(self, value):
+    def components(self, value: Iterable[DurationTuple]):
         # previously, self._componentsNeedUpdating was not set here
         # this needs to be set because if _componentsNeedUpdating is True
         # new components will be derived from quarterLength
@@ -2313,13 +2450,12 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             # must be cleared
 
     @property
-    def dotGroups(self):
+    def dotGroups(self) -> Tuple[int, ...]:
         '''
         Dot groups are medieval dotted-dotted notes (written one above another).
         For instance a half note with dotGroups = (1, 1) represents a dotted half note that
         is itself dotted.  Worth 9 eighth notes (dotted-half tied to dotted-quarter).  It
         is not the same as a double-dotted half note, which is only worth 7 eighth notes.
-
 
         >>> from music21 import duration
         >>> a = duration.Duration()
@@ -2341,7 +2477,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             return self._dotGroups
 
     @dotGroups.setter
-    def dotGroups(self, value):
+    def dotGroups(self, value: Tuple[int, ...]):
         if not isinstance(value, tuple):
             raise DurationException('only tuple dotGroups values can be used with this method.')
         # removes dots from all components...
@@ -2352,7 +2488,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         self._quarterLengthNeedsUpdating = True
 
     @property
-    def dots(self):
+    def dots(self) -> int:
         '''
         Returns or sets the number of dots in the Duration
         if it is a simple Duration.
@@ -2383,11 +2519,12 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> complexDuration.quarterLength
         2.875
 
-        This number comes from the first component:
+        In a complex duration, the number of dots comes from the first component:
 
         >>> complexDuration.dots
         0
 
+        But if set, applies to all components:
 
         >>> complexDuration.dots = 1
         >>> complexDuration.components
@@ -2396,8 +2533,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> complexDuration.quarterLength
         3.75
 
-
-        Here's a little easter egg:
+        Dots can go pretty high.
 
         >>> d = duration.Duration('half')
         >>> d.quarterLength
@@ -2409,9 +2545,10 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> d.quarterLength
         3.998046875
 
-        Infinite dots...
+        Infinite dots... (an Easter egg...)
 
         >>> from math import inf
+        >>> d.type = 'half'
         >>> d.dots = inf
         >>> d.quarterLength
         4.0
@@ -2419,7 +2556,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         0
         >>> d.type
         'whole'
-
         '''
         if self._componentsNeedUpdating:
             self._updateComponents()
@@ -2431,10 +2567,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             return 0
 
     @dots.setter
-    def dots(self, value):
-        '''
-        Set dots if a number, as first element
-        '''
+    def dots(self, value: int):
         if self._componentsNeedUpdating:
             self._updateComponents()
         if not common.isNum(value):
@@ -2452,7 +2585,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         self.informClient()
 
     @property
-    def fullName(self):
+    def fullName(self) -> str:
         '''
         Return the most complete representation of this Duration, providing
         dots, type, tuplet, and quarter length representation.
@@ -2551,7 +2684,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         return outMsg
 
     @property
-    def isComplex(self):
+    def isComplex(self) -> bool:
         '''
         Returns True if this Duration has more than one DurationTuple object on
         the `component` list.  That is to say if it's a single Duration that
@@ -2583,14 +2716,31 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             return False
 
     @property
-    def ordinal(self):
+    def ordinal(self) -> Union[int, str, None]:
         '''
-        Get the ordinal value of the Duration.
+        Get the ordinal value of the Duration, where whole is 4,
+        half is 5, etc.
 
         >>> d = duration.Duration()
         >>> d.quarterLength = 2.0
         >>> d.ordinal
         5
+        >>> d.type = '16th'
+        >>> d.ordinal
+        8
+
+        Complex values have an ordinal of the string 'complex'.  This might
+        change to NaN in v8.
+
+        >>> d.quarterLength = 2.5
+        >>> d.ordinal
+        'complex'
+
+        Zero durations have an ordinal of None
+
+        >>> d2 = duration.Duration(0.0)
+        >>> print(d2.ordinal)
+        None
         '''
         if self._componentsNeedUpdating:
             self._updateComponents()
@@ -2603,11 +2753,15 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             return None
 
     @property
-    def quarterLengthNoTuplets(self):
+    def quarterLengthNoTuplets(self) -> float:
         '''
         Returns the quarter length of the duration without taking into account triplets.
 
-        Does not cache...
+        Does not cache.
+
+        >>> d = duration.Duration(1/3)
+        >>> d.quarterLengthNoTuplets
+        0.5
         '''
         if self._componentsNeedUpdating:
             self._updateComponents()
@@ -2615,12 +2769,12 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         # tested, does return 0 if no components
         return sum([c.quarterLength for c in self._components])
 
-    def _getQuarterLength(self):
+    def _getQuarterLength(self) -> OffsetQL:
         if self._quarterLengthNeedsUpdating:
             self._updateQuarterLength()
         return self._qtrLength
 
-    def _setQuarterLength(self, value):
+    def _setQuarterLength(self, value: OffsetQLIn):
         if self.linked is False:
             self._qtrLength = value
         elif (self._qtrLength != value
@@ -2680,11 +2834,10 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> b.quarterLength = 1/3
         >>> b.quarterLength
         Fraction(1, 3)
-
         ''')
 
     @property
-    def tuplets(self):
+    def tuplets(self) -> Tuple[Tuplet, ...]:
         '''
         return a tuple of Tuplet objects
         '''
@@ -2693,18 +2846,17 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         return self._tuplets
 
     @tuplets.setter
-    def tuplets(self, tupletTuple):
+    def tuplets(self, tupletTuple: Iterable[Tuplet]):
         # environLocal.printDebug(['assigning tuplets in Duration', tupletTuple])
         self._tuplets = tuple(tupletTuple)
         self._quarterLengthNeedsUpdating = True
 
-    def aggregateTupletMultiplier(self):
+    def aggregateTupletMultiplier(self) -> OffsetQL:
         '''
         Returns the multiple of all the tuplet multipliers as an opFrac.
 
         This method is needed for MusicXML time-modification among other
         places.
-
 
         No tuplets...
 
@@ -2726,14 +2878,18 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> complexDur.aggregateTupletMultiplier()
         Fraction(8, 15)
         '''
-        currentMultiplier = 1
+        if not self.tuplets:
+            # do common cases fast.
+            return 1.0
+
+        currentMultiplier = 1.0
         for thisTuplet in self.tuplets:
             currentMultiplier *= thisTuplet.tupletMultiplier()
         return common.opFrac(currentMultiplier)
 
     # PUBLIC PROPERTIES #
     @property
-    def type(self):
+    def type(self) -> str:
         '''
         Get or set the type of the Duration.
 
@@ -2756,7 +2912,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             return 'zero'
 
     @type.setter
-    def type(self, value):
+    def type(self, value: str):
         # need to check that type is valid
         if value not in ordinalTypeFromNum and value not in ('inexpressible', 'complex'):
             raise DurationException(f'no such type exists: {value}')
@@ -2769,75 +2925,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
         else:
             self._unlinkedType = value
-
-
-def durationTupleFromQuarterLength(ql=1.0):
-    '''
-    Returns a DurationTuple for a given quarter length
-    if the ql can be expressed as a type and number of dots
-    (no tuplets, no complex duration, etc.).  If it can't be expressed,
-    returns an "inexpressible" DurationTuple.
-
-    >>> dt = duration.durationTupleFromQuarterLength(3.0)
-    >>> dt
-    DurationTuple(type='half', dots=1, quarterLength=3.0)
-
-    If it's not possible, we return an "inexpressible" type:
-
-    >>> dt = duration.durationTupleFromQuarterLength(2.5)
-    >>> dt
-    DurationTuple(type='inexpressible', dots=0, quarterLength=2.5)
-
-    '''
-    try:
-        return _durationTupleCacheQuarterLength[ql]
-    except KeyError:
-        ql = opFrac(ql)
-        dots, durType = dottedMatch(ql)
-        if durType is not False:
-            nt = DurationTuple(durType, dots, ql)
-            _durationTupleCacheQuarterLength[ql] = nt
-            return nt
-        else:
-            return DurationTuple('inexpressible', 0, ql)
-
-
-def durationTupleFromTypeDots(durType='quarter', dots=0):
-    '''
-    Returns a DurationTuple (which knows its quarterLength) for
-    a given type and dots (no tuplets)
-
-    >>> dt = duration.durationTupleFromTypeDots('quarter', 0)
-    >>> dt
-    DurationTuple(type='quarter', dots=0, quarterLength=1.0)
-    >>> dt2 = duration.durationTupleFromTypeDots('quarter', 0)
-    >>> dt is dt2
-    True
-
-    Also with keyword arguments.
-
-    >>> dt = duration.durationTupleFromTypeDots(durType='zero', dots=0)
-    >>> dt
-    DurationTuple(type='zero', dots=0, quarterLength=0.0)
-
-    OMIT_FROM_DOCS
-
-    >>> dt in duration._durationTupleCacheTypeDots.values()
-    True
-    '''
-    tp = (durType, dots)
-    try:
-        return _durationTupleCacheTypeDots[tp]
-    except KeyError:
-        try:
-            ql = typeToDuration[durType] * common.dotMultiplier(dots)
-        except (KeyError, IndexError) as e:
-            raise DurationException(
-                f'Unknown type: {durType}'
-            ) from e
-        nt = DurationTuple(durType, dots, ql)
-        _durationTupleCacheTypeDots[tp] = nt
-        return nt
 
 
 class GraceDuration(Duration):
@@ -2884,10 +2971,12 @@ class GraceDuration(Duration):
 
     # TODO: What does 'amount of time' mean here?
     _DOC_ATTR = {
-        'stealTimePrevious': '''Number from 0 to 1 or None (default) for the amount of time
-                to steal from the previous note.''',
-        'stealTimeFollowing': '''Number from 0 to 1 or None (default) for the amount of time
-                to steal from the following note.'''
+        'stealTimePrevious': '''
+                Float number from 0.0 to 1.0, or None (default) for the proportion
+                of the previous duration to steal from the previous note.''',
+        'stealTimeFollowing': '''
+                Float number from 0.0 to 1.0 or None (default) for the proportion
+                of the following duration to steal from the following note.'''
     }
 
     isGrace = True
@@ -2913,19 +3002,17 @@ class GraceDuration(Duration):
             newComponents.append(DurationTuple(c.type, c.dots, 0.0))
         self.components = newComponents  # set new components
 
-        self._makeTime = None
+        # make time is encoded in musicxml as divisions; here it can
+        # by a duration; but should it be the duration suggested by the grace?
+        self._makeTime = False
         self._slash = None
         self.slash = True  # can be True, False, or None; make None go to True?
         # values are unit interval percentages
-        self.stealTimePrevious = None
-        self.stealTimeFollowing = None
-        # make time is encoded in musicxml as divisions; here it can
-        # by a duration; but should it be the duration suggested by the grace?
-        # TODO- Decide if 'make-time' 'grace' notes should be Grace notes at all...
-        self.makeTime = False
+        self.stealTimePrevious: Union[float, None] = None
+        self.stealTimeFollowing: Union[float, None] = None
+
 
     # PUBLIC PROPERTIES #
-
     @property
     def makeTime(self):
         '''

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5802,7 +5802,7 @@ class MeasureExporter(XMLExporterBase):
             return mxTime
 
         # always get a flat version to display any subdivisions created
-        fList = [(mt.numerator, mt.denominator) for mt in ts.displaySequence.flat._partition]
+        fList = [(mt.numerator, mt.denominator) for mt in ts.displaySequence.flat]
         if ts.summedNumerator:
             # this will try to reduce any common denominators into
             # a common group

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -344,7 +344,7 @@ class Spanner(base.Music21Object):
         return self.spannerStorage.__getitem__(key)
 
     def __iter__(self):
-        return common.Iterator(self.spannerStorage)
+        return iter(self.spannerStorage)
 
     def __len__(self):
         return len(self.spannerStorage)

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -16,8 +16,7 @@ some sort of connection between them.  A slur is one type of spanner -- it might
 connect notes in different Measure objects or even between different parts.
 
 This package defines some of the most common spanners.  Other spanners
-can be found in modules such as :ref:`moduleDynamics` (for things such as crescendos)
-or in :ref:`moduleMeter` (a ritardando, for instance).
+can be found in modules such as :ref:`moduleDynamics` (for things such as crescendos).
 '''
 import unittest
 import copy

--- a/music21/stream/__init__.py
+++ b/music21/stream/__init__.py
@@ -14,7 +14,7 @@
 from music21.exceptions21 import StreamException, ImmutableStreamException
 from music21.stream.base import (
     Stream, Opus, Score, Part, PartStaff, Measure, Voice,
-    SpannerStorage, VariantStorage,
+    SpannerStorage, VariantStorage, System,
 )
 from music21.stream import core
 from music21.stream import enums

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -13762,10 +13762,8 @@ class SpannerStorage(Stream):
 
         # environLocal.printDebug('keywords', keywords)
 
-
     # NOTE: for serialization, this will need to properly tag
     # the spanner parent by updating the scaffolding code.
-
     def coreSelfActiveSite(self, el):
         '''
         Never set activeSite to spannerStorage

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -22,6 +22,7 @@ from music21 import duration
 from music21 import exceptions21
 from music21 import expressions
 from music21 import note
+from music21 import spanner
 from music21 import style
 
 from music21 import environment
@@ -729,12 +730,12 @@ class MetronomeMark(TempoIndication):
         return MetronomeMark(text=self.text, number=newNumber,
                              referent=duration.Duration(quarterLength))
 
-#     def getEquivalentByNumber(self, number):
-#         '''
-#         Return a new MetronomeMark object that has an equivalent speed but different number and
-#         referent values based on a supplied tempo number.
-#         '''
-#         pass
+    # def getEquivalentByNumber(self, number):
+    #     '''
+    #     Return a new MetronomeMark object that has an equivalent speed but different number and
+    #     referent values based on a supplied tempo number.
+    #     '''
+    #     pass
 
     def getMaintainedNumberWithReferent(self, referent):
         '''
@@ -1062,11 +1063,11 @@ class MetricModulation(TempoIndication):
         if self._newMetronome is not None:
             return self._newMetronome.number
 
-#     def _setNumber(self, value, updateTextFromNumber=True):
-#         if not common.isNum(value):
-#             raise MetricModulationException('cannot set number to a string')
-#         self._newMetronome.number = value
-#         self._oldMetronome.number = value
+    # def _setNumber(self, value, updateTextFromNumber=True):
+    #     if not common.isNum(value):
+    #         raise MetricModulationException('cannot set number to a string')
+    #     self._newMetronome.number = value
+    #     self._oldMetronome.number = value
 
     # --------------------------------------------------------------------------
     # high-level configuration methods
@@ -1267,8 +1268,29 @@ def interpolateElements(element1, element2, sourceStream,
 
 
 # ------------------------------------------------------------------------------
-class Test(unittest.TestCase):
+class TempoChangeSpanner(spanner.Spanner):
+    '''
+    Spanners showing tempo-change.  They do nothing right now.
+    '''
+    pass
 
+
+class RitardandoSpanner(TempoChangeSpanner):
+    '''
+    Spanner representing a slowing down.
+    '''
+    pass
+
+
+class AccelerandoSpanner(TempoChangeSpanner):
+    '''
+    Spanner representing a speeding up.
+    '''
+    pass
+
+
+# ------------------------------------------------------------------------------
+class Test(unittest.TestCase):
     def testCopyAndDeepcopy(self):
         '''Test copying all objects defined in this module
         '''
@@ -1636,7 +1658,9 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER = [MetronomeMark, TempoText, MetricModulation, interpolateElements]
+_DOC_ORDER = [MetronomeMark, TempoText, MetricModulation, TempoIndication,
+              AccelerandoSpanner, RitardandoSpanner, TempoChangeSpanner,
+              interpolateElements]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add types in Duration

Deprecate common.Iterator (since Py2.6 was required)

Create common.types

Fix docs in corpus.chorales

Speed up Duration._updateQuarterLength

TimeSignature's default of 4/4 is explicit.

Lots of cleanups in meter/core