### PR TITLE
Prevent durationless element being inserted in last measure AND in end elements

### DIFF
--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -613,6 +613,7 @@ def makeMeasures(
         if not match:
             if start == end == oMax:
                 post.storeAtEnd(e)
+                continue
             else:
                 raise stream.StreamException(
                     f'cannot place element {e} with start/end {start}/{end} within any measures')

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -2044,7 +2044,7 @@ class Test(unittest.TestCase):
         obj = expressions.TextExpression('FREEZE')
         s.insert(3, obj)
         s.makeMeasures(inPlace=True)
-        self.assertEqual(len(s.measure(1).getElementsByClass('Expression')), 1)
+        self.assertEqual(len(s.flat.getElementsByClass('Expression')), 1)
 
     def testRemove(self):
         '''Test removing components from a Stream.


### PR DESCRIPTION
Fixes #854 (on the assumption it would be too expensive to add guardrails to check all sites when inserting)

Before, a durationless element coinciding with the end of the stream would be added (on purpose) to the end elements, then (accidentally) also to the last measure.