### PR TITLE
v7 KeySignature sharps defaults 0 instead of None

### DIFF
--- a/music21/key.py
+++ b/music21/key.py
@@ -281,10 +281,10 @@ class KeySignature(base.Music21Object):
     >>> legal
     <music21.key.Key of c# minor>
 
-    To set a non-traditional Key Signature, create a KeySignature object and then
-    set the alteredPitches list:
+    To set a non-traditional Key Signature, create a KeySignature object
+    with `sharps=None`, and then set the `alteredPitches` list:
 
-    >>> unusual = key.KeySignature()
+    >>> unusual = key.KeySignature(sharps=None)
     >>> unusual.alteredPitches = ['E-', 'G#']
     >>> unusual
     <music21.key.KeySignature of pitches: [E-, G#]>
@@ -294,7 +294,7 @@ class KeySignature(base.Music21Object):
     To set a pitch as displayed in a particular octave, create a non-traditional
     KeySignature and then set pitches with octaves:
 
-    >>> unusual = key.KeySignature()
+    >>> unusual = key.KeySignature(sharps=None)
     >>> unusual.alteredPitches = ['F#4']
     >>> unusual
     <music21.key.KeySignature of pitches: [F#4]>
@@ -306,6 +306,9 @@ class KeySignature(base.Music21Object):
     >>> unusual.accidentalsApplyOnlyToOctave
     False
     >>> unusual.accidentalsApplyOnlyToOctave = True
+
+    Changed in v.7 -- `sharps` defaults to 0 (key of no flats/sharps)
+    rather than `None` for nontraditional keys.
     '''
     _styleClass = style.TextStyle
 
@@ -315,7 +318,7 @@ class KeySignature(base.Music21Object):
 
     classSortOrder = 2
 
-    def __init__(self, sharps=None):
+    def __init__(self, sharps: int = 0):
         super().__init__()
         # position on the circle of fifths, where 1 is one sharp, -1 is one flat
 
@@ -428,7 +431,7 @@ class KeySignature(base.Music21Object):
         Non-standard, non-traditional key signatures can set their own
         altered pitches cache.
 
-        >>> nonTrad = key.KeySignature()
+        >>> nonTrad = key.KeySignature(sharps=None)
         >>> nonTrad.alteredPitches = ['B-', 'F#', 'E-', 'G#']
         >>> nonTrad.alteredPitches
         [<music21.pitch.Pitch B->,
@@ -440,7 +443,7 @@ class KeySignature(base.Music21Object):
 
         Ensure at least something is provided when the user hasn't provided enough info:
 
-        >>> nonTrad2 = key.KeySignature()
+        >>> nonTrad2 = key.KeySignature(sharps=None)
         >>> nonTrad2.alteredPitches
         []
 
@@ -494,7 +497,7 @@ class KeySignature(base.Music21Object):
         >>> g.isNonTraditional
         False
 
-        >>> g = key.KeySignature()
+        >>> g = key.KeySignature(sharps=None)
         >>> g.alteredPitches = [pitch.Pitch('E`')]
         >>> g.isNonTraditional
         True
@@ -1224,7 +1227,7 @@ class Test(unittest.TestCase):
 
     def testBasic(self):
         a = KeySignature()
-        self.assertEqual(a.sharps, None)
+        self.assertEqual(a.sharps, 0)
 
     def testTonalAmbiguityA(self):
         from music21 import corpus, stream

--- a/music21/key.py
+++ b/music21/key.py
@@ -435,11 +435,23 @@ class KeySignature(base.Music21Object):
          <music21.pitch.Pitch F#>,
          <music21.pitch.Pitch E->,
          <music21.pitch.Pitch G#>]
+
+        OMIT_FROM_DOCS
+
+        Ensure at least something is provided when the user hasn't provided enough info:
+
+        >>> nonTrad2 = key.KeySignature()
+        >>> nonTrad2.alteredPitches
+        []
+
         '''
         if self._alteredPitches is not None:
             return self._alteredPitches
 
         post = []
+        if self.sharps is None:
+            return post
+
         if self.sharps > 0:
             pKeep = pitch.Pitch('B')
             if self.sharps > 8:

--- a/music21/key.py
+++ b/music21/key.py
@@ -318,7 +318,7 @@ class KeySignature(base.Music21Object):
 
     classSortOrder = 2
 
-    def __init__(self, sharps: int = 0):
+    def __init__(self, sharps: Optional[int] = 0):
         super().__init__()
         # position on the circle of fifths, where 1 is one sharp, -1 is one flat
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5856,7 +5856,7 @@ class MeasureExporter(XMLExporterBase):
           <mode>major</mode>
         </key>
 
-        >>> ksNonTrad = key.KeySignature()
+        >>> ksNonTrad = key.KeySignature(sharps=None)
         >>> ksNonTrad.alteredPitches = ['C#', 'E-4']
         >>> ksNonTrad
         <music21.key.KeySignature of pitches: [C#, E-4]>

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -5344,7 +5344,7 @@ class MeasureParser(XMLParserBase):
             raise MusicXMLImportException(
                 'For non traditional signatures each step must have an alter')
 
-        ks = key.KeySignature()
+        ks = key.KeySignature(sharps=None)
 
         alteredPitches = []
         for i in range(len(allSteps)):


### PR DESCRIPTION
Fixes #867 

Any interest in also changing the default arg from `sharps=None` to `sharps: int = 0`?