### PR TITLE
Add cases to isWellFormedNotation

### DIFF
--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9281,13 +9281,23 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> o2 = stream.Opus([s2])
         >>> o2.isWellFormedNotation()
         False
+
+        Only Measures and Voices are allowed to contain notes and rests directly:
+        >>> m.isWellFormedNotation()
+        True
+        >>> s2.append(note.Rest())
+        >>> s2.isWellFormedNotation()
+        False
         '''
         def allSubstreamsHaveMeasures(testStream):
             return all(s.hasMeasures() for s in testStream.getElementsByClass('Stream'))
 
-        # if a measure, we assume we are well-formed
-        if 'Measure' in self.classes:
+        # if a measure or voice, we assume we are well-formed
+        if 'Measure' in self.classes or 'Voice' in self.classes:
             return True
+        # all other Stream classes are not well-formed if they have "loose" notes
+        elif self.getElementsByClass('GeneralNote'):
+            return False
         elif 'Part' in self.classes:
             if self.hasMeasures():
                 return True

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9283,7 +9283,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         False
         '''
         def allSubstreamsHaveMeasures(testStream):
-            return all([s.hasMeasures() for s in testStream.getElementsByClass('Stream')])
+            return all(s.hasMeasures() for s in testStream.getElementsByClass('Stream'))
 
         # if a measure, we assume we are well-formed
         if 'Measure' in self.classes:
@@ -9292,7 +9292,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             if self.hasMeasures():
                 return True
         elif 'Opus' in self.classes:
-            return all([allSubstreamsHaveMeasures(s) for s in self.scores])
+            return all(allSubstreamsHaveMeasures(s) for s in self.scores)
         elif self.hasPartLikeStreams():
             return allSubstreamsHaveMeasures(self)
         # all other conditions are not well-formed notation

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9269,29 +9269,32 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> s.parts[0].getElementsByClass('Measure').first().isWellFormedNotation()
         True
 
-        >>> s = stream.Score()
+        >>> s2 = stream.Score()
         >>> m = stream.Measure()
-        >>> s.append(m)
-        >>> s.isWellFormedNotation()
+        >>> s2.append(m)
+        >>> s2.isWellFormedNotation()
+        False
+
+        >>> o = stream.Opus([s])
+        >>> o.isWellFormedNotation()
+        True
+        >>> o2 = stream.Opus([s2])
+        >>> o2.isWellFormedNotation()
         False
         '''
+        def allSubstreamsHaveMeasures(testStream):
+            return all([s.hasMeasures() for s in testStream.getElementsByClass('Stream')])
+
         # if a measure, we assume we are well-formed
         if 'Measure' in self.classes:
             return True
         elif 'Part' in self.classes:
             if self.hasMeasures():
                 return True
+        elif 'Opus' in self.classes:
+            return all([allSubstreamsHaveMeasures(s) for s in self.scores])
         elif self.hasPartLikeStreams():
-            # higher constraint than has part-like streams: has sub-streams
-            # with Measures
-            match = 0
-            count = 0
-            for s in self.getElementsByClass('Stream'):
-                count += 1
-                if s.hasMeasures():
-                    match += 1
-            if match == count:
-                return True
+            return allSubstreamsHaveMeasures(self)
         # all other conditions are not well-formed notation
         return False
 


### PR DESCRIPTION
Previously, Opus objects would always fail `isWellFormedNotation()`.

Update: now, we fail streams that have "loose" notes and rests and aren't a Measure or Voice.

My hunch is that if we sew up the gaps in `isWellFormedNotation` then we can more quickly answer user questions by just directing them to this method.