### PR TITLE
Added keyContext option in chord.simplifyEnharmonics

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -3796,7 +3796,7 @@ class Chord(note.NotRest):
 
         >>> c.simplifyEnharmonics(inPlace=True, keyContext=key.Key('A-'))
         >>> c.pitches
-        (<music21.pitch.Pitch D->, <music21.pitch.Pitch F>, <music21.pitch.Pitch A>)
+        (<music21.pitch.Pitch D->, <music21.pitch.Pitch F>, <music21.pitch.Pitch A->)
         '''
         if inPlace:
             returnObj = self

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -3776,7 +3776,7 @@ class Chord(note.NotRest):
         if not match:
             raise ChordException(f'the given pitch is not in the Chord: {pitchTarget}')
 
-    def simplifyEnharmonics(self, *, inPlace=False):
+    def simplifyEnharmonics(self, *, inPlace=False, keyContext=None):
         '''
         Calls `pitch.simplifyMultipleEnharmonics` on the pitches of the chord.
 
@@ -3790,13 +3790,20 @@ class Chord(note.NotRest):
         >>> c.simplifyEnharmonics(inPlace=True)
         >>> c.pitches
         (<music21.pitch.Pitch C#>, <music21.pitch.Pitch E#>, <music21.pitch.Pitch G#>)
+
+        If `keyContext` is provided the enharmonics are simplified based on the supplied
+        Key or KeySignature.
+
+        >>> c.simplifyEnharmonics(inPlace=True, keyContext=key.Key('A-'))
+        >>> c.pitches
+        (<music21.pitch.Pitch D->, <music21.pitch.Pitch F>, <music21.pitch.Pitch A>)
         '''
         if inPlace:
             returnObj = self
         else:
             returnObj = copy.deepcopy(self)
 
-        pitches = pitch.simplifyMultipleEnharmonics(self.pitches)
+        pitches = pitch.simplifyMultipleEnharmonics(self.pitches, keyContext=keyContext)
         for i in range(len(pitches)):
             returnObj._notes[i].pitch = pitches[i]
 


### PR DESCRIPTION
As discussed in #869, this provides the ability to simplify enharmonics based on a supllied key, without having to call `pitch.simplifyMultipleEnharmonics` for the pitch objects.

I also believe that a simpler criterion could be added as an option to the `pitch.simplifyMultipleEnharmonics`, for the key context case. Namely, for every pitch choosing between its enharmonics if they belongs to the key pitches (in a greedy manner). 

If you find this useful, I could add it to this PR or create a new one. 