### PR TITLE
Pylint -- remove unnecessary comprehensions

### DIFF
--- a/music21/graph/axis.py
+++ b/music21/graph/axis.py
@@ -1289,7 +1289,7 @@ class CountingAxis(Axis):
         if not common.isIterable(countAxes):
             countAxes = (countAxes,)
 
-        axesIndices = tuple([self.axisDataMap[axisName] for axisName in countAxes])
+        axesIndices = tuple(self.axisDataMap[axisName] for axisName in countAxes)
         thisIndex = self.axisDataMap[self.axisName]
         selector = itemgetter(*axesIndices)
         relevantData = [selector(innerTuple) for innerTuple in client.data]

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -150,7 +150,7 @@ class ProtoM21Object:
         try:
             return self._classTupleCacheDict[self.__class__]
         except KeyError:
-            classTuple = tuple([x.__name__ for x in self.__class__.mro()])
+            classTuple = tuple(x.__name__ for x in self.__class__.mro())
             self._classTupleCacheDict[self.__class__] = classTuple
             return classTuple
 

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -766,7 +766,7 @@ class CTRule(prebase.ProtoM21Object):
         # third pass, make empty content duplicate previous content.
         for content, sep, numReps in measureGroups2:
             contentSplit = content.split()
-            if sep == '|' and all([y.startswith('[') or y == '' for y in contentSplit]):
+            if sep == '|' and all(y.startswith('[') or y == '' for y in contentSplit):
                 content = ' '.join(contentSplit)
                 if content:
                     content += ' '

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -4775,7 +4775,7 @@ class Test(unittest.TestCase):
         post = s.sliceByQuarterLengths(0.125, inPlace=False)
         # post.show()
 
-        self.assertTrue(all([n.tie is not None for n in post.notesAndRests]))
+        self.assertTrue(all(n.tie is not None for n in post.notesAndRests))
 
         s = Stream()
         n1 = note.Note()


### PR DESCRIPTION
Fixes code failing on the new Pylint check for unnecessary comprehensions when generators will do.