### PR TITLE
Provide more examples of setting .id on Voice objects

### DIFF
--- a/documentation/source/usersGuide/usersGuide_58_sitesContext.ipynb
+++ b/documentation/source/usersGuide/usersGuide_58_sitesContext.ipynb
@@ -217,8 +217,7 @@
     }
    ],
    "source": [
-    "v = stream.Voice()\n",
-    "v.id = 1\n",
+    "v = stream.Voice(id=1)\n",
     "v.append(es)\n",
     "es.sites.getSiteCount()"
    ]

--- a/documentation/source/usersGuide/usersGuide_58_sitesContext.ipynb
+++ b/documentation/source/usersGuide/usersGuide_58_sitesContext.ipynb
@@ -218,6 +218,7 @@
    ],
    "source": [
     "v = stream.Voice()\n",
+    "v.id = 1\n",
     "v.append(es)\n",
     "es.sites.getSiteCount()"
    ]
@@ -291,7 +292,7 @@
     {
      "data": {
       "text/plain": [
-       "[<music21.stream.Voice 0x10d4c7860>]"
+       "[<music21.stream.Voice 1>]"
       ]
      },
      "execution_count": 11,
@@ -385,7 +386,7 @@
      "text": [
       "None\n",
       "<music21.stream.Measure 1 offset=0.0>\n",
-      "<music21.stream.Voice 0x10d4c7860>\n",
+      "<music21.stream.Voice 1>\n",
       "<music21.stream.Measure 10 offset=0.0>\n"
      ]
     }
@@ -412,7 +413,7 @@
      "output_type": "stream",
      "text": [
       "<music21.stream.Measure 10 offset=0.0>\n",
-      "<music21.stream.Voice 0x10d4c7860>\n",
+      "<music21.stream.Voice 1>\n",
       "<music21.stream.Measure 1 offset=0.0>\n"
      ]
     }
@@ -439,7 +440,7 @@
      "output_type": "stream",
      "text": [
       "2.0 <music21.stream.Measure 1 offset=0.0>\n",
-      "0.0 <music21.stream.Voice 0x10d4c7860>\n",
+      "0.0 <music21.stream.Voice 1>\n",
       "20.0 <music21.stream.Measure 10 offset=0.0>\n"
      ]
     }
@@ -472,7 +473,7 @@
        "             (4504830192,\n",
        "              <music21.sites.SiteRef 0/0 to <music21.stream.Measure 1 offset=0.0>>),\n",
        "             (4518082656,\n",
-       "              <music21.sites.SiteRef 1/1 to <music21.stream.Voice 0x10d4c7860>>),\n",
+       "              <music21.sites.SiteRef 1/1 to <music21.stream.Voice 1>>),\n",
        "             (4518134560,\n",
        "              <music21.sites.SiteRef 2/2 to <music21.stream.Measure 10 offset=0.0>>)])"
       ]

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -5598,8 +5598,8 @@ class MeasureParser(XMLParserBase):
         True
         >>> len(MP.stream)
         2
-        >>> len(MP.stream.getElementsByClass('Voice'))
-        2
+        >>> list(MP.stream.getElementsByClass('Voice'))
+        [<music21.stream.Voice 1>, <music21.stream.Voice 2>]
         '''
         mxm = self.mxMeasure
         for mxn in mxm.findall('note'):

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -2748,9 +2748,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         `recurse=True` should not be necessary to find elements in streams
         without substreams, such as a loose Voice:
 
-        >>> v = stream.Voice([note.Note(quarterLength=5.5)])
+        >>> v = stream.Voice([note.Note(quarterLength=5.5)], id=1)
         >>> v.splitAtDurations()
-        (<music21.stream.Voice ...,)
+        (<music21.stream.Voice 1>,)
         >>> [n.duration for n in v.notes]
         [<music21.duration.Duration 4.0>, <music21.duration.Duration 1.5>]
 
@@ -12199,9 +12199,6 @@ class Voice(Stream):
     '''
     recursionType = 'elementsFirst'
     classSortOrder = 5
-
-    def _reprInternal(self):
-        return str(self.id)
 
 
 # -----------------------------------------------------------------------------

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -2750,7 +2750,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         >>> v = stream.Voice([note.Note(quarterLength=5.5)])
         >>> v.splitAtDurations()
-        (<music21.stream.Voice 0x106020430>,)
+        (<music21.stream.Voice ...,)
         >>> [n.duration for n in v.notes]
         [<music21.duration.Duration 4.0>, <music21.duration.Duration 1.5>]
 
@@ -12199,6 +12199,9 @@ class Voice(Stream):
     '''
     recursionType = 'elementsFirst'
     classSortOrder = 5
+
+    def _reprInternal(self):
+        return str(self.id)
 
 
 # -----------------------------------------------------------------------------

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -1026,7 +1026,7 @@ def makeTies(
         {0.0} <music21.stream.Voice 2>
             {0.0} <music21.note.Note B>
     {1.0} <music21.stream.Measure 2 offset=1.0>
-        {0.0} <music21.stream.Voice 0x105332ac8>
+        {0.0} <music21.stream.Voice ...>
             {0.0} <music21.note.Note C>
 
     >>> for n in p2.recurse().notes:

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -1026,7 +1026,7 @@ def makeTies(
         {0.0} <music21.stream.Voice 2>
             {0.0} <music21.note.Note B>
     {1.0} <music21.stream.Measure 2 offset=1.0>
-        {0.0} <music21.stream.Voice ...>
+        {0.0} <music21.stream.Voice 0x105332ac8>
             {0.0} <music21.note.Note C>
 
     >>> for n in p2.recurse().notes:


### PR DESCRIPTION
<s>Figured it would be a small win to at least print .id rather than the memory location, but was this considered and rejected before?</s> <s>The MusicXML parser sets random numbers for voice IDs--is there a desire to hide this from users?</s>

EDIT: I see this is done after all -- just a matter of sprucing up some examples to model that this works!