### PR TITLE
Flatten unnecessary voices in makeTies

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6269,8 +6269,6 @@ class Test(unittest.TestCase):
         n = note.Note()
         v1 = stream.Voice([n])
         m = stream.Measure([v1])
-        xmlOut = self.getXml(m)
-        self.assertIn('<voice>1</voice>', xmlOut)
         n2 = note.Note()
         v2 = stream.Voice([n2])
         m.insert(0, v2)

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6269,6 +6269,9 @@ class Test(unittest.TestCase):
         n = note.Note()
         v1 = stream.Voice([n])
         m = stream.Measure([v1])
+        # Unnecessary voice is removed by makeNotation
+        xmlOut = self.getXml(m)
+        self.assertNotIn('<voice>1</voice>', xmlOut)
         n2 = note.Note()
         v2 = stream.Voice([n2])
         m.insert(0, v2)

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -971,13 +971,6 @@ def makeTies(
     Notes: uses base.Music21Object.splitAtQuarterLength() once it has figured out
     what to split.
 
-    Changed in v. 4 -- inPlace = False by default.
-
-    OMIT_FROM_DOCS
-    TODO: take a list of classes to act as filter on what elements are tied.
-
-    configure ".previous" and ".next" attributes
-
     Previously a note tied from one voice could not make ties into a note
     in the next measure outside of voices.  Fixed May 2017
 
@@ -1001,7 +994,7 @@ def makeTies(
     >>> p.append([m1, m2])
     >>> p2 = p.makeTies()
 
-    test same thing with needed makeTies...creates a possibly unnecessary voice...
+    test same thing with needed makeTies:
 
     >>> p = stream.Part()
     >>> m1 = stream.Measure(number=1)
@@ -1026,8 +1019,7 @@ def makeTies(
         {0.0} <music21.stream.Voice 2>
             {0.0} <music21.note.Note B>
     {1.0} <music21.stream.Measure 2 offset=1.0>
-        {0.0} <music21.stream.Voice 0x105332ac8>
-            {0.0} <music21.note.Note C>
+        {0.0} <music21.note.Note C>
 
     >>> for n in p2.recurse().notes:
     ...     print(n, n.tie)
@@ -1035,7 +1027,15 @@ def makeTies(
     <music21.note.Note B> None
     <music21.note.Note C> <music21.tie.Tie stop>
 
+
+    Changed in v4 -- inPlace = False by default.
+
     Changed in v6 -- all but first attribute are keyword only
+
+    OMIT_FROM_DOCS
+    TODO: take a list of classes to act as filter on what elements are tied.
+
+    configure ".previous" and ".next" attributes
     '''
     from music21 import stream
 
@@ -1198,6 +1198,8 @@ def makeTies(
                     #    mNext])
                     returnObj.insert(mNext.offset, mNext)
         mCount += 1
+    for measure in measureStream:
+        measure.flattenUnnecessaryVoices(inPlace=True)
     del measureStream  # clean up unused streams
 
     if not inPlace:

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -5380,12 +5380,12 @@ class Test(unittest.TestCase):
         s.insert(0, v3)
 
         sPost = s.makeNotation()
-        # voices are retained for all measures after make notation
+        # voices are retained for all measures after makeNotation, unless unnecessary
         self.assertEqual(len(sPost.getElementsByClass('Measure')), 8)
         self.assertEqual(len(sPost.getElementsByClass('Measure')[0].voices), 3)
         self.assertEqual(len(sPost.getElementsByClass('Measure')[1].voices), 3)
-        self.assertEqual(len(sPost.getElementsByClass('Measure')[5].voices), 3)
-        self.assertEqual(len(sPost.getElementsByClass('Measure')[7].voices), 3)
+        self.assertEqual(len(sPost.getElementsByClass('Measure')[4].voices), 2)
+        self.assertEqual(len(sPost.getElementsByClass('Measure')[5].voices), 0)
 
         # s.show()
 


### PR DESCRIPTION
Noticed `makeTies` had a comment about leaving unnecessary voices behind, and figured that was easy to clean up with a call to `flattenUnnecessaryVoices()`.

Then promoted the doctest where that was demo'd (along with some version changed annotations) above the OMIT_FROM_DOCS line.