### PR TITLE
Faster implementation of hyphenToCamelCase

### DIFF
--- a/music21/common/stringTools.py
+++ b/music21/common/stringTools.py
@@ -87,33 +87,34 @@ def getNumFromStr(usrStr: str, numbers: str = '0123456789') -> Tuple[str, str]:
 
 def hyphenToCamelCase(usrStr: str, replacement: str = '-') -> str:
     '''
-    given a hyphen-connected-string, change it to
+    Given a hyphen-connected-string, change it to
     a camelCaseConnectedString.
 
     The replacement can be specified to be something besides a hyphen.
-
-    This code is from:
-
-    http://stackoverflow.com/questions/4303492/
-    how-can-i-simplify-this-conversion-from-underscore-to-camelcase-in-python
 
     >>> common.hyphenToCamelCase('movement-name')
     'movementName'
 
     >>> common.hyphenToCamelCase('movement_name', replacement='_')
     'movementName'
-    '''
-    PATTERN = re.compile(r'''
-    (?<!\A)  # not at the start of the string
-    ''' + replacement + r'''
-    (?=[a-zA-Z])  # followed by a letter
-    ''', re.VERBOSE)  # @UndefinedVariable
 
-    tokens = PATTERN.split(usrStr)
-    response = tokens.pop(0).lower()
-    for remain in tokens:
-        response += remain.capitalize()
-    return response
+    Safe to call on a string lacking the replacement character:
+
+    >>> common.hyphenToCamelCase('voice')
+    'voice'
+
+    And on "words" beginning with numbers:
+
+    >>> common.hyphenToCamelCase('music-21')
+    'music21'
+    '''
+    post = ''
+    for i, word in enumerate(usrStr.split(replacement)):
+        if i == 0:
+            post = word
+        else:
+            post += word.capitalize()
+    return post
 
 
 def camelCaseToHyphen(usrStr: str, replacement: str = '-') -> str:


### PR DESCRIPTION
cProfile shows me this will speed up musicxml parsing by about 8%, since compiling a regex every time a note is parsed is expensive.

master
```
>>> from timeit import timeit
>>> timeit('music21.common.hyphenToCamelCase("relative-x")', setup='import music21')
4.062028805999999
```

PR
```
>>> from timeit import timeit
>>> timeit('music21.common.hyphenToCamelCase("relative-x")', setup='import music21')
1.016820898000006
```

The only difference in behavior is this, but I see this as acceptable (we don't have XML attributes named with numbers), and I documented it:

master
```
>>> music21.common.hyphenToCamelCase('music-21')
'music-21'
```

PR
```
>>> music21.common.hyphenToCamelCase('music-21')
'music21'
```

I could add a check for this to get the old behavior, but I don't think we need the old behavior.