### PR TITLE
Restore two coreElementsChanged() calls

### DIFF
--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -10856,6 +10856,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                     # insert shift + offset w/ voice
                     returnObj.coreInsert(shiftOffset + e.getOffsetBySite(v), e)
                 returnObj.remove(v)
+            returnObj.coreElementsChanged()
 
         if not inPlace:
             return returnObj
@@ -11314,6 +11315,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         # Now fix measure numbers given the saved information
         returnObj._fixMeasureNumbers(deletedMeasures, insertedMeasures)
+
+        # have to clear cached variants, as they are no longer the same
+        returnObj.coreElementsChanged()
 
         if not inPlace:
             return returnObj


### PR DESCRIPTION
Restore two calls removed in #803
- flattenUnnecessaryVoices calls remove(), which calls coreElementsChanged, but remove() might need correct offsets when doing its work
- And activateVariants() just looks like a review comment was missed.