### PR TITLE
Speed up elementOffset()

### DIFF
--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1849,7 +1849,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 raise base.SitesException(
                     f'an entry for this object 0x{id(element):x} is not stored in stream {self}')
 
-        if returnSpecial is False and o in OffsetSpecial:
+        # OffsetSpecial.__contains__() is more expensive, so try to fail fast
+        if isinstance(o, str) and returnSpecial is False and o in OffsetSpecial:
             try:
                 return getattr(self, o)
             except AttributeError:  # pragma: no cover


### PR DESCRIPTION
Slightly slower for 'highestTime' but faster for everything else. musicXML parses 20% faster.

master
```
>>> timeit('s.elementOffset(n)',
setup='from music21 import note, stream;n = note.Note();s = stream.Stream([n])')
3.110492326
```

PR
```
>>> timeit('s.elementOffset(n)',
setup='from music21 import note, stream;n = note.Note();s = stream.Stream([n])')
0.410327549999991
```