### PR TITLE
Avoid creating and overwriting default Duration in musicxml parser

### DIFF
--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2674,7 +2674,8 @@ class MeasureParser(XMLParserBase):
 
         # TODO: beams over rests?
         '''
-        n = note.Note()
+        d = self.xmlToDuration(mxNote)
+        n = note.Note(duration=d)
 
         # send whole note since accidental display not in <pitch>
         self.xmlToPitch(mxNote, n.pitch)
@@ -3043,7 +3044,8 @@ class MeasureParser(XMLParserBase):
         Note that we do NOT set `r`'s `.fullMeasure` to True or always, but keep it as
         "auto" so that changes in time signature, etc. will affect output.
         '''
-        r = note.Rest()
+        d = self.xmlToDuration(mxRest)
+        r = note.Rest(duration=d)
         mxRestTag = mxRest.find('rest')
         if mxRestTag is None:
             raise MusicXMLImportException('do not call xmlToRest on a <note> unless it '
@@ -3121,8 +3123,7 @@ class MeasureParser(XMLParserBase):
                 # this technically puts it in the
                 # wrong place in the sequence, but it won't matter
                 ET.SubElement(mxNote, '<type>eighth</type>')
-
-        self.xmlToDuration(mxNote, n.duration)
+            self.xmlToDuration(mxNote, n.duration)
 
         # type styles
         mxType = mxNote.find('type')


### PR DESCRIPTION
Creating a GeneralNote without a `duration` argument creates a Duration of 1.0 that is later overwritten:

https://github.com/cuthbertLab/music21/blob/7498a6ee3ec2592a097ac243d6042da3b85e8b3d/music21/musicxml/xmlToM21.py#L3260-L3262

Timing script:

```
from timeit import timeit
timeit('mp.xmlToSimpleNote(mxNote)',
setup = '''
from music21.musicxml.xmlToM21 import MeasureParser
from xml.etree.ElementTree import fromstring as El
mp = MeasureParser()
mp.divisions = 10080
mxNote = El('<note pizzicato="yes"><pitch><step>D</step><alter>-1</alter>'
+ '<octave>6</octave></pitch><duration>7560</duration><type>eighth</type><dot/></note>')''',
number=100000)
```

PR: 8.50 vs master: 10.23