### PR TITLE
getSpannedElementIds() checks _elements

### DIFF
--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -396,8 +396,9 @@ class Spanner(base.Music21Object):
     def getSpannedElementIds(self):
         '''
         Return all id() for all stored objects.
+        Performance critical.
         '''
-        return [id(n) for n in self.spannerStorage]
+        return [id(n) for n in self.spannerStorage._elements]
 
     def addSpannedElements(self,
                            spannedElements: Union['music21.base.Music21Object',


### PR DESCRIPTION
Dramatic speed improvement for musicxml export.

<s>95%</s> 76% of the time in musicxml export after `makeNotation()` for this corpus example --i.e. inside `parseWellFormedObject()`--is spent in `getSpannedElementIds()`:

EDIT: updated to use `ScoreExporter` to ensure I wasn't counting calls during makeNotation:

master
```
>>> s = corpus.parse('cpebach')
>>> sx = musicxml.m21ToXml.ScoreExporter(s)
>>> cProfile.run('sx.parse()', sort='cumtime')
         3441542 function calls (3429186 primitive calls) in 2.838 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    2.839    2.839 {built-in method builtins.exec}
        1    0.000    0.000    2.839    2.839 <string>:1(<module>)
        1    0.000    0.000    2.839    2.839 m21ToXml.py:1361(parse)
        1    0.000    0.000    2.672    2.672 m21ToXml.py:1543(parsePartlikeScore)
        2    0.001    0.000    2.658    1.329 m21ToXml.py:2349(parse)
       64    0.001    0.000    2.635    0.041 m21ToXml.py:2699(parse)
       64    0.000    0.000    2.425    0.038 m21ToXml.py:2719(mainElementsParse)
       78    0.006    0.000    2.422    0.031 m21ToXml.py:2744(parseFlatElements)
      942    0.012    0.000    2.384    0.003 m21ToXml.py:2813(parseOneElement)
     1006    0.078    0.000    2.257    0.002 spanner.py:746(getBySpannedElement)
   137822    0.165    0.000    2.178    0.000 spanner.py:396(getSpannedElementIds)
   137822    0.183    0.000    1.311    0.000 spanner.py:400(<listcomp>)
   415643    0.779    0.000    1.148    0.000 iterator.py:156(__next__)
   138463    0.109    0.000    0.707    0.000 base.py:291(__iter__)
   139634    0.376    0.000    0.609    0.000 iterator.py:92(__init__)
   419959    0.298    0.000    0.298    0.000 iterator.py:525(updateActiveInformation)

```

PR
```
>>> cProfile.run('sx.parse()', sort='cumtime')
         1236511 function calls (1224153 primitive calls) in 0.770 seconds
```

master
```
>>> timeit('sp.getSpannedElementIds()', setup='import music21;
sp=music21.spanner.Spanner();
sp.spannerStorage.repeatAppend(music21.base.Music21Object(), 3)')
12.924463299
```

PR
```
>>> timeit('sp.getSpannedElementIds()', setup='import music21;
sp=music21.spanner.Spanner();
sp.spannerStorage.repeatAppend(music21.base.Music21Object(), 3)')
0.7765598250000068
```