### PR TITLE
voicesToParts() now preserves Instruments

### DIFF
--- a/documentation/source/usersGuide/usersGuide_12_music21object.ipynb
+++ b/documentation/source/usersGuide/usersGuide_12_music21object.ipynb
@@ -850,7 +850,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A `Music21Object` that is inside one or more Streams should be able to get its most recently stream via its `.activeSite` attribute.  We've put `n` in `s`, which is called (now incorrectly) `'empty stream'`, so n's `.activeSite` should be `s`."
+    "A `Music21Object` that is inside one or more Streams should be able to get its most recently referenced stream via its `.activeSite` attribute.  We've put `n` in `s`, which is called (now incorrectly) `'empty stream'`, so n's `.activeSite` should be `s`."
    ]
   },
   {

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -10608,6 +10608,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> ce = c.voicesToParts()
         >>> ce.show('t')
         {0.0} <music21.stream.Part Piano-v0>
+            {0.0} <music21.instrument.Instrument 'P1: Piano: '>
             {0.0} <music21.stream.Measure 1 offset=0.0>
                 {0.0} <music21.clef.TrebleClef>
                 {0.0} <music21.key.Key of D major>
@@ -10623,6 +10624,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 {0.0} <music21.note.Rest rest>
                 {4.0} <music21.bar.Barline type=final>
         {0.0} <music21.stream.Part Piano-v1>
+            {0.0} <music21.instrument.Instrument 'P1: Piano: '>
             {0.0} <music21.stream.Measure 1 offset=0.0>
                 {0.0} <music21.clef.BassClef>
                 {0.0} <music21.key.Key of D major>
@@ -10756,6 +10758,10 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                         continue
                     pInner = partDict[voiceIdInner]
                     pInner.insert(self.elementOffset(mInner), copy.deepcopy(mActive))
+
+        # Place references to any instruments from the original part into the new parts
+        for p in s.parts:
+            p.mergeElements(self, classFilterList=('Instrument',))
 
         if self.hasMeasures():
             for m in self.iter.getElementsByClass('Measure'):

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1171,7 +1171,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         in the other Stream in this Stream. This does not make
         copies of any elements, but simply stores all of them in this Stream.
 
-        Optionally, provide a list of classes to exclude with the `classFilter` list.
+        Optionally, provide a list of classes to include with the `classFilter` list.
 
         This method provides functionality like a shallow copy,
         but manages locations properly, only copies elements,
@@ -1191,6 +1191,16 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         True
         >>> s1[1] is s2[1]
         True
+
+        >>> viola = instrument.Viola()
+        >>> trumpet = instrument.Trumpet()
+        >>> s1.insert(0, viola)
+        >>> s1.insert(0, trumpet)
+        >>> s2.mergeElements(s1, classFilterList=('BrassInstrument',))
+        >>> len(s2)
+        3
+        >>> viola in s2
+        False
         '''
         if classFilterList is not None:
             classFilterSet = set(classFilterList)


### PR DESCRIPTION
Fixes #902 

Depends on the Instrument being at the level containing the Measure (such as Part), which is the standard.

Continues to use `mergeElements` like the rest of the routine -- which will create shallow references, so the same `Instrument` will be in both parts in the resulting score. But it appears that is how the rest of the routine works today.