### PR TITLE
Further spanner storage optimizations

### DIFF
--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -346,7 +346,7 @@ class Spanner(base.Music21Object):
         return iter(self.spannerStorage)
 
     def __len__(self):
-        return len(self.spannerStorage)
+        return len(self.spannerStorage._elements)
 
     def getSpannedElements(self):
         '''
@@ -370,10 +370,7 @@ class Spanner(base.Music21Object):
         >>> sl.getSpannedElements() == [n1, n2, c1]  # make sure that not sorting
         True
         '''
-        post = []
-        for c in self.spannerStorage.elements:
-            post.append(c)
-        return post
+        return list(self.spannerStorage._elements)
 
     def getSpannedElementsByClass(self, classFilterList):
         '''
@@ -470,7 +467,12 @@ class Spanner(base.Music21Object):
         return spannedElement in self
 
     def __contains__(self, spannedElement):
-        return spannedElement in self.spannerStorage
+        # Cannot check `in` spannerStorage._elements,
+        # because it would check __eq__, not identity.
+        for x in self.spannerStorage._elements:
+            if x is spannedElement:
+                return True
+        return False
 
     def replaceSpannedElement(self, old, new) -> None:
         '''

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -784,7 +784,9 @@ class SpannerBundle(prebase.ProtoM21Object):
         if cacheKey not in self._cache or self._cache[cacheKey] is None:
             post = self.__class__()
             for sp in self._storage:  # storage is a list of spanners
-                if idTarget in sp.getSpannedElementIds():
+                # __contains__() will test for identity, not equality
+                # see Spanner.hasSpannedElement(), which just calls __contains__()
+                if spannedElement in sp:
                     post.append(sp)
             self._cache[cacheKey] = post
         return self._cache[cacheKey]

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -346,6 +346,8 @@ class Spanner(base.Music21Object):
         return iter(self.spannerStorage)
 
     def __len__(self):
+        # Check _elements to avoid StreamIterator overhead.
+        # Safe, because impossible to put spanned elements at end.
         return len(self.spannerStorage._elements)
 
     def getSpannedElements(self):
@@ -370,6 +372,8 @@ class Spanner(base.Music21Object):
         >>> sl.getSpannedElements() == [n1, n2, c1]  # make sure that not sorting
         True
         '''
+        # Check _elements to avoid StreamIterator overhead.
+        # Safe, because impossible to put spanned elements at end.
         return list(self.spannerStorage._elements)
 
     def getSpannedElementsByClass(self, classFilterList):


### PR DESCRIPTION
Sorry for the specific form of torture of getting multiple PRs a day, but it occurred to me (and didn't take long) to check the git blame for the spanner change we just merged in #901.

It was in b9929ef where there were changes system-wide to identity/contains, and I spotted a few other changes from that commit that should be reverted relating to spanner storage.

Update: added another speed improvement -- instead of getting the entire list of spannedElementIds and then checking if `in`, we can just check if the element is in the spanner, which uses the now-optimized `__contains__`, so that we can short-circuit when we find the element.