### PR TITLE
Miscellany

### DIFF
--- a/music21/base.py
+++ b/music21/base.py
@@ -2055,6 +2055,8 @@ class Music21Object(prebase.ProtoM21Object):
             activeS = self.activeSite  # might be None...
             if activeS is None:
                 return None
+            if className is not None and not common.isListLike(className):
+                className = (className,)
             asTree = activeS.asTree(classList=className, flatten=False)
             prevNode = asTree.getNodeBefore(self.sortTuple())
             if prevNode is None:

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -1678,8 +1678,8 @@ def prepareSlurredNotes(music21Part, **keywords):
 
     allNotes = music21Part.flat.notes.stream()
     for slur in music21Part.spannerBundle.getByClass(spanner.Slur):
-        firstNote = slur[0]
-        lastNote = slur[1]
+        firstNote = slur.getFirst()
+        lastNote = slur.getLast()
 
         try:
             beginIndex = allNotes.index(firstNote)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -643,7 +643,8 @@ class ConverterHumdrum(SubConverter):
 
     def parseData(self, humdrumString, number=None):
         '''
-        Open Humdrum data from a string -- calls humdrum.parseData()
+        Open Humdrum data from a string -- calls
+        :meth:`~music21.humdrum.spineParser.HumdrumDataCollection.parse()`.
 
         >>> humData = ('**kern\\n*M2/4\\n=1\\n24r\\n24g#\\n24f#\\n24e\\n24c#\\n' +
         ...     '24f\\n24r\\n24dn\\n24e-\\n24gn\\n24e-\\n24dn\\n*-')

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -321,9 +321,9 @@ def checkConsecutivePossibilities(music21Stream, functionToApply, color="#FF0000
             for partNumber in partNumberTuple:
                 if color is not None:
                     noteA = allParts[partNumber - 1].iter.getElementsByOffset(
-                        initOffsetA, initOffsetA, mustBeginInSpan=False)[0]
+                        initOffsetA, initOffsetA, mustBeginInSpan=False).first()
                     noteB = allParts[partNumber - 1].iter.getElementsByOffset(
-                        initOffsetB, initOffsetB, mustBeginInSpan=False)[0]
+                        initOffsetB, initOffsetB, mustBeginInSpan=False).first()
                     noteA.style.color = color
                     noteB.style.color = color
             if debug is True:

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -1768,12 +1768,12 @@ def deduplicate(s: Stream, inPlace: bool = False) -> Stream:
     >>> s1 = stream.Stream()
     >>> s1.insert(4, i1)
     >>> s1.insert(4, i2)
-    >>> s1.getInstruments().elements
-    (<music21.instrument.Instrument 'Semi-Hollow Body'>,...
-    <music21.instrument.Instrument 'Electric Guitar: '>)
+    >>> list(s1.getInstruments())
+    [<music21.instrument.Instrument 'Semi-Hollow Body'>,
+        <music21.instrument.Instrument 'Electric Guitar: '>]
     >>> post = instrument.deduplicate(s1)
-    >>> post.getInstruments().elements
-    (<music21.instrument.Instrument 'Electric Guitar: Semi-Hollow Body'>,)
+    >>> list(post.getInstruments())
+    [<music21.instrument.Instrument 'Electric Guitar: Semi-Hollow Body'>]
 
     One `Instrument` instance and one subclass instance, with `inPlace` and parts:
 
@@ -1788,15 +1788,15 @@ def deduplicate(s: Stream, inPlace: bool = False) -> Stream:
     >>> p2.append([instrument.Flute(), instrument.Flute()])
     >>> s2.insert(0, p1)
     >>> s2.insert(0, p2)
-    >>> p1.getInstruments().elements
-    (<music21.instrument.Instrument 'Piccolo: '>, <music21.instrument.Piccolo 'Piccolo'>)
-    >>> p2.getInstruments().elements
-    (<music21.instrument.Flute 'Flute'>, <music21.instrument.Flute 'Flute'>)
+    >>> list(p1.getInstruments())
+    [<music21.instrument.Instrument 'Piccolo: '>, <music21.instrument.Piccolo 'Piccolo'>]
+    >>> list(p2.getInstruments())
+    [<music21.instrument.Flute 'Flute'>, <music21.instrument.Flute 'Flute'>]
     >>> s2 = instrument.deduplicate(s2, inPlace=True)
-    >>> p1.getInstruments().elements
-    (<music21.instrument.Piccolo 'Piccolo: Piccolo'>,)
-    >>> p2.getInstruments().elements
-    (<music21.instrument.Flute 'Flute'>,)
+    >>> list(p1.getInstruments())
+    [<music21.instrument.Piccolo 'Piccolo: Piccolo'>]
+    >>> list(p2.getInstruments())
+    [<music21.instrument.Flute 'Flute'>]
     '''
     if inPlace:
         returnObj = s

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3597,7 +3597,7 @@ class Test(unittest.TestCase):
         fp = dirLib / 'test16.mid'
         s = converter.parse(fp)
         self.assertEqual(len(s.parts.first().measure(1).voices), 2)
-        els = s.parts[0].flat.getElementsByOffset(0.5)
+        els = s.parts.first().flat.getElementsByOffset(0.5)
         self.assertSequenceEqual([e.duration.quarterLength for e in els], [0, 1])
 
     def testRepeatsExpanded(self):

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1873,8 +1873,6 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         </appearance>
         '''
         st = self.stream.style
-        if not hasattr(st, 'lineWidths'):
-            return  # TODO: remove in v.5 release after all old data is gone.
 
         if (not st.lineWidths
                 and not st.noteSizes

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -762,12 +762,12 @@ class XMLExporterBase:
             stObj = m21Object.style
 
         if not common.isIterable(musicXMLNames):
-            musicXMLNames = [musicXMLNames]
+            musicXMLNames = (musicXMLNames,)
 
         if m21Names is None:
-            m21Names = [common.hyphenToCamelCase(x) for x in musicXMLNames]
+            m21Names = (common.hyphenToCamelCase(x) for x in musicXMLNames)
         elif not common.isIterable(m21Names):
-            m21Names = [m21Names]
+            m21Names = (m21Names,)
 
         for xmlName, m21Name in zip(musicXMLNames, m21Names):
             try:

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6150,7 +6150,7 @@ class MeasureExporter(XMLExporterBase):
         if not instSubStream:
             return None
 
-        instSubObj = instSubStream[0]
+        instSubObj = instSubStream.first()
         if instSubObj.transposition is None:
             return None
         self.transpositionInterval = instSubObj.transposition

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 '''
 A mixin to ScoreExporter that includes the capabilities for producing a single
-MusicXML `<part>` from multiple music21 PartStaff objects.
+MusicXML `<part>` from multiple music21 `PartStaff` objects.
 '''
 from typing import Dict, List, Optional
 import unittest
@@ -28,7 +28,7 @@ from music21.musicxml.xmlObjects import MusicXMLExportException
 def addStaffTags(measure: Element, staffNumber: int, tagList: Optional[List[str]] = None):
     '''
     For a <measure> tag `measure`, add a <staff> grandchild to any instance of
-    a child tag of a type in `tagList`. Raise if a <staff> grandchild already exists.
+    a child tag of a type in `tagList`.
 
     >>> from xml.etree.ElementTree import fromstring as El
     >>> from music21.musicxml.partStaffExporter import addStaffTags
@@ -140,8 +140,8 @@ class PartStaffExporterMixin:
     def joinableGroups(self) -> List[StaffGroup]:
         '''
         Returns a list of :class:`~music21.layout.StaffGroup` objects that
-        represent PartStaff objects that can be joined together into a single
-        MusicXML `<part>`:
+        represent :class:`~music21.stream.PartStaff` objects that can be
+        joined into a single MusicXML `<part>`:
 
         >>> s = stream.Score()
 
@@ -243,7 +243,7 @@ class PartStaffExporterMixin:
         Create child <staff> tags under each <note>, <direction>, and <forward> element
         in the <part>s being joined.
 
-        Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
+        Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`.
 
         >>> from music21.musicxml import testPrimitive
         >>> s = converter.parse(testPrimitive.pianoStaff43a)
@@ -314,7 +314,8 @@ class PartStaffExporterMixin:
 
         Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
 
-        StaffGroup must be a valid one from `joinableGroups()`
+        StaffGroup must be a valid one from
+        :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinableGroups`.
         '''
 
         target = self.getRootForPartStaff(group[0])
@@ -337,8 +338,10 @@ class PartStaffExporterMixin:
         Move elements from subsequent PartStaff's measures into `target`: the <part>
         element representing the initial PartStaff that will soon represent the merged whole.
 
-        Called by movePartStaffMeasureContents(), which is in turn called by
-        :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
+        Called by
+        :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.movePartStaffMeasureContents`,
+        which is in turn called by
+        :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`.
         '''
         DIVIDER_COMMENT = '========================= Measure [NNN] =========================='
         PLACEHOLDER = '[NNN]'
@@ -583,8 +586,8 @@ class PartStaffExporterMixin:
     def cleanUpSubsequentPartStaffs(self, group: StaffGroup):
         '''
         Now that the contents of all PartStaffs in `group` have been represented
-        by a single :class:`PartExporter`, remove the obsolete `PartExporter`s from
-        `self.partExporterList` so that they are not included in the export.
+        by a single :class:`~music21.musicxml.m21ToXml.PartExporter`, remove any
+        obsolete `PartExporter` from `self.partExporterList`.
 
         In addition, remove any obsolete `PartStaff` from the `StaffGroup`
         (in the deepcopied stream used for exporting) to ensure <part-group type="stop" />

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -243,7 +243,7 @@ class PartStaffExporterMixin:
         Create child <staff> tags under each <note>, <direction>, and <forward> element
         in the <part>s being joined.
 
-        Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`.
+        Called by :meth:`joinPartStaffs`.
 
         >>> from music21.musicxml import testPrimitive
         >>> s = converter.parse(testPrimitive.pianoStaff43a)
@@ -312,10 +312,10 @@ class PartStaffExporterMixin:
         For every <part> after the first, find the corresponding measure in the initial
         <part> and merge the contents by inserting all of the contained elements.
 
-        Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
+        Called by :meth:`joinPartStaffs`
 
         StaffGroup must be a valid one from
-        :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinableGroups`.
+        :meth:`joinableGroups`.
         '''
 
         target = self.getRootForPartStaff(group[0])
@@ -339,9 +339,9 @@ class PartStaffExporterMixin:
         element representing the initial PartStaff that will soon represent the merged whole.
 
         Called by
-        :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.movePartStaffMeasureContents`,
+        :meth:`movePartStaffMeasureContents`,
         which is in turn called by
-        :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`.
+        :meth:`joinPartStaffs`.
         '''
         DIVIDER_COMMENT = '========================= Measure [NNN] =========================='
         PLACEHOLDER = '[NNN]'
@@ -413,7 +413,7 @@ class PartStaffExporterMixin:
         e.g. RH of piano doesn't appear until m. 40, and earlier music for LH needs
         to be merged first in order to find earliest <attributes>.
 
-        Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
+        Called by :meth:`joinPartStaffs`
 
         Multiple keys:
 
@@ -593,7 +593,7 @@ class PartStaffExporterMixin:
         (in the deepcopied stream used for exporting) to ensure <part-group type="stop" />
         is written.
 
-        Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
+        Called by :meth:`joinPartStaffs`
 
         >>> from music21.musicxml import testPrimitive
         >>> s = converter.parse(testPrimitive.pianoStaff43a)

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -369,12 +369,12 @@ class XMLParserBase:
             stObj = None
 
         if not common.isIterable(musicXMLNames):
-            musicXMLNames = [musicXMLNames]
+            musicXMLNames = (musicXMLNames,)
 
         if m21Names is None:
-            m21Names = [common.hyphenToCamelCase(x) for x in musicXMLNames]
+            m21Names = (common.hyphenToCamelCase(x) for x in musicXMLNames)
         elif not common.isIterable(m21Names):
-            m21Names = [m21Names]
+            m21Names = (m21Names,)
 
         for xmlName, m21Name in zip(musicXMLNames, m21Names):
             mxValue = mxObject.get(xmlName)

--- a/music21/note.py
+++ b/music21/note.py
@@ -1321,14 +1321,11 @@ class Note(NotRest):
         if other is None or not isinstance(other, Note):
             return NotImplemented
 
-        retVal = super().__eq__(other)
-        if retVal is not True:
-            return retVal
-
         # checks pitch.octave, pitch.accidental, uses Pitch.__eq__
         if self.pitch != other.pitch:
             return False
-        return True
+
+        return super().__eq__(other)
 
     def __lt__(self, other):
         '''

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -428,10 +428,10 @@ class Spanner(base.Music21Object):
         # presently, this does not look for redundancies
         if not common.isListLike(spannedElements):
             spannedElements = [spannedElements]
-        else:
+        if arguments:
             spannedElements = spannedElements[:]  # copy
-        # assume all other arguments
-        spannedElements += arguments
+            # assume all other arguments
+            spannedElements += arguments
         # environLocal.printDebug(['addSpannedElements():', spannedElements])
         for c in spannedElements:
             if c is None:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -836,10 +836,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         '''
         clefList = self.iter.getElementsByClass('Clef').getElementsByOffset(0)
         # casting to list added 20microseconds...
-        if not clefList:
-            return None
-        else:
-            return clefList[0]
+        return clefList.first()
 
     @clef.setter
     def clef(self, clefObj: Optional['music21.clef.Clef']):
@@ -904,10 +901,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         # environLocal.printDebug([
         #    'matched Measure classes of type TimeSignature', tsList, len(tsList)])
         # only return timeSignatures at offset = 0.0
-        if not tsList:
-            return None
-        else:
-            return tsList[0]
+        return tsList.first()
 
     @timeSignature.setter
     def timeSignature(self, tsObj: Optional['music21.meter.TimeSignature']):
@@ -2049,7 +2043,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         Chords can also be inserted into rests:
 
-        >>> s3.getElementsByOffset(2.0)[0]
+        >>> s3.getElementsByOffset(2.0).first()
         <music21.note.Rest rest>
         >>> s3.insertIntoNoteOrChord(2.0, chord.Chord('C4 E4 G#4'))
         >>> s3.show('text')
@@ -8223,10 +8217,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         mdList = self.getElementsByClass('Metadata')
         # only return metadata that has an offset = 0.0
         mdList = mdList.getElementsByOffset(0)
-        if not mdList:
-            return None
-        else:
-            return mdList[0]
+        return mdList.first()
 
     def _setMetadata(self, metadataObj):
         '''
@@ -13396,7 +13387,7 @@ class Score(Stream):
 
         # find greatest divisor for each measure at a time
         # if no measures this will be zero
-        mStream = returnObj.parts[0].getElementsByClass('Measure')
+        mStream = returnObj.parts.first().getElementsByClass('Measure')
         mCount = len(mStream)
         if mCount == 0:
             mCount = 1  # treat as a single measure
@@ -13598,7 +13589,7 @@ class Score(Stream):
         >>> len(post.flat.notes)
         165
         '''
-        post = self.parts[0].template(fillWithRests=False, retainVoices=False)
+        post = self.parts.first().template(fillWithRests=False, retainVoices=False)
         for i, m in enumerate(post.getElementsByClass('Measure')):
             for p in self.parts:
                 mNew = copy.deepcopy(p.getElementsByClass('Measure')[i]).flat
@@ -13761,7 +13752,7 @@ class Opus(Stream):
         mdNew = metadata.Metadata()
 
         for s in self.scores:
-            p = s.parts[0]  # assuming only one part
+            p = s.parts.first()  # assuming only one part
             sNew.insert(0, p)
 
             md = s.metadata

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -161,14 +161,14 @@ class StreamIterator(prebase.ProtoM21Object):
             else:
                 self.sectionIndex = self.index
 
-            self.index += 1  # increment early in case of an error.
-
             try:
-                e = self.srcStreamElements[self.index - 1]
+                e = self.srcStreamElements[self.index]
             except IndexError:
                 # this may happen if the number of elements has changed
+                self.index += 1
                 continue
 
+            self.index += 1
             if self.matchesFilters(e) is False:
                 continue
 

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -462,12 +462,10 @@ def makeMeasures(
     # del clefList
     clefObj = srcObj.clef or srcObj.getContextByClass('Clef')
     if clefObj is None:
-        clefList = list(srcObj.iter.getElementsByClass('Clef').getElementsByOffset(0))
+        clefObj = srcObj.iter.getElementsByClass('Clef').getElementsByOffset(0).first()
         # only return clefs that have offset = 0.0
-        if not clefList:
+        if not clefObj:
             clefObj = clef.bestClef(srcObj, recurse=True)
-        else:
-            clefObj = clefList[0]
 
     # environLocal.printDebug([
     #    'makeMeasures(): first clef found after copying and flattening',

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1337,7 +1337,7 @@ class Test(unittest.TestCase):
 
         attackedTogether = stream1.simultaneousAttacks(stream2)
         self.assertEqual(len(attackedTogether), 3)  # nx1, nx2, nx4
-        thisNote = stream2.getElementsByOffset(attackedTogether[1])[0]
+        thisNote = stream2.getElementsByOffset(attackedTogether[1]).first()
         self.assertIs(thisNote, n22)
 
         playingWhenAttacked = stream1.playingWhenAttacked(n23)

--- a/music21/style.py
+++ b/music21/style.py
@@ -107,18 +107,17 @@ class Style(ProtoM21Object):
     def _setAbsoluteY(self, value):
         if value is None:
             self._absoluteY = None
+        elif value == 'above':
+            self._absoluteY = 10
+        elif value == 'below':
+            self._absoluteY = -70
         else:
-            if value == 'above':
-                value = 10
-            elif value == 'below':
-                value = -70
             try:
-                value = common.numToIntOrFloat(value)
+                self._absoluteY = common.numToIntOrFloat(value)
             except ValueError as ve:
                 raise TextFormatException(
                     f'Not a supported absoluteY position: {value!r}'
                 ) from ve
-            self._absoluteY = value
 
     absoluteY = property(_getAbsoluteY,
                          _setAbsoluteY,

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -182,7 +182,7 @@ def asTree(inputStream, flatten=False, classList=None, useTimespans=False, group
     >>> etFlat.getPositionAfter(0.5)
     SortTuple(atEnd=0, offset=1.0, priority=0, classSortOrder=20, isNotGrace=1, insertIndex=...)
 
-    >>> etFlatNotes = tree.fromStream.asTree(score, flatten=True, classList=[note.Note])
+    >>> etFlatNotes = tree.fromStream.asTree(score, flatten=True, classList=(note.Note,))
     >>> etFlatNotes
     <ElementTree {12} (0.0 <0.20...> to 8.0) <music21.stream.Score exampleScore>>
 

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -1899,7 +1899,7 @@ def _getNextElements(s, v, numberOfElements=1):
                                                   mustFinishInSpan=False,
                                                   mustBeginInSpan=True,
                                                   classList=[vClass])
-        returnElement = potentialTargets[0]
+        returnElement = potentialTargets.first()
 
     else:
         replacementDuration = v.replacementDuration
@@ -1910,7 +1910,7 @@ def _getNextElements(s, v, numberOfElements=1):
                                                   mustFinishInSpan=False,
                                                   mustBeginInSpan=True,
                                                   classList=[vClass])
-        returnElement = potentialTargets[0]
+        returnElement = potentialTargets.first()
 
 
     return returnElement
@@ -1982,7 +1982,7 @@ def _getPreviousElement(s, v):
         mustFinishInSpan=False,
         mustBeginInSpan=True,
     ).getElementsByClass(vClass)
-    returnElement = potentialTargets[-1]
+    returnElement = potentialTargets.last()
 
     return returnElement
 


### PR DESCRIPTION
- Fix doc for humdrum `parseData()`
- Remove check for not hasattr(st, 'lineWidths')

- Model calling list() instead of  .elements in doctest

- Fixes #831 -- use `getFirst()` to index into slurs

- Documentation cleanup in partStaffExporter (Sphinx problem with python reserved word)

- Bugfix in `previous()` -- put className in a tuple before passing as classList

- Speed up `Note.__eq__()`

- Prefer tuples to lists in `setStyleAttributes` (hottest function in parser)

- Slight speed up to `Iterator.__next__()`
    Avoid doing self.index - 1

- Optimize `addSpannedElements()`

- Speed up `_setAbsoluteY()` for values 'above' and 'below'
    `numToIntOrFloat()` was being called.

- More uses of `.first()`