### PR TITLE
Search derivations and id when finding joinableGroups

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1545,7 +1545,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         called by .parse() if the score has individual parts.
 
         Calls makeRests() for the part, then creates a PartExporter for each part,
-        and runs .parse() on that part.  appends the PartExporter to self.partExporterList()
+        and runs .parse() on that part.  appends the PartExporter to self.partExporterList
         '''
         # would like to do something like this but cannot
         # replace object inside of the stream


### PR DESCRIPTION
The patch in #863 to fix showing flat scores was too restrictive. Noticed today when trying to run `s.measure(1).show()`. 

@mscuthbert contributed logic for this in dcb32fc946, so my proposal is to just run it up front when filtering the joinable groups.