### PR TITLE
v7 makeRests defaults inPlace=False

### DIFF
--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -6265,11 +6265,13 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         refStreamOrTimeRange=None,
         fillGaps=False,
         timeRangeFromBarDuration=False,
-        inPlace=True,
+        inPlace=False,
         hideRests=False,
     ):
         '''
         Calls :py:func:`~music21.stream.makeNotation.makeRests`.
+
+        Changed in v.7, inPlace=False by default.
         '''
         return makeNotation.makeRests(
             self,

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -789,8 +789,6 @@ def makeRests(
     Changed in v6 -- all but first attribute are keyword only
 
     Changed in v7 -- `inPlace` defaults False.
-
-    Obviously there are problems TODO: fix them
     '''
     from music21 import stream
 

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -681,7 +681,7 @@ def makeRests(
     refStreamOrTimeRange=None,
     fillGaps=False,
     timeRangeFromBarDuration=False,
-    inPlace=True,
+    inPlace=False,
     hideRests=False,
 ):
     '''
@@ -788,10 +788,9 @@ def makeRests(
 
     Changed in v6 -- all but first attribute are keyword only
 
-    Obviously there are problems TODO: fix them
+    Changed in v7 -- `inPlace` defaults False.
 
-    OMIT_FROM_DOCS
-    TODO: default inPlace=False
+    Obviously there are problems TODO: fix them
     '''
     from music21 import stream
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1880,7 +1880,7 @@ class Test(unittest.TestCase):
             p.transferOffsetToElements()
             self.assertEqual(p.lowestOffset, partOffset)
 
-            p.makeRests()
+            p.makeRests(inPlace=True)
 
             # environLocal.printDebug(['first element', p[0], p[0].duration])
             # by default, initial rest should be made
@@ -1907,8 +1907,8 @@ class Test(unittest.TestCase):
         s.insert(0, m1)
         s.insert(4, m2)
         # must connect Measures to Streams before filling gaps
-        m1.makeRests(fillGaps=True, timeRangeFromBarDuration=True)
-        m2.makeRests(fillGaps=True, timeRangeFromBarDuration=True)
+        m1.makeRests(inPlace=True, fillGaps=True, timeRangeFromBarDuration=True)
+        m2.makeRests(inPlace=True, fillGaps=True, timeRangeFromBarDuration=True)
         self.assertTrue(m2.isSorted)
         # m2.sort()
 
@@ -3582,7 +3582,7 @@ class Test(unittest.TestCase):
         self.assertEqual(test, match)
 
         self.assertEqual(len(s), 5)
-        s.makeRests(fillGaps=True)
+        s.makeRests(inPlace=True, fillGaps=True)
         self.assertEqual(len(s), 8)
         self.assertEqual(len(s.getElementsByClass(note.Rest)), 3)
 
@@ -4341,7 +4341,7 @@ class Test(unittest.TestCase):
         s.insert(1, n2)  # overlapping, starting after n1 but finishing before
         s.insert(2, n3)
         s.insert(3, n4)  # overlapping, starting after n3 but finishing before
-        # s.makeRests(fillGaps=True)
+        # s.makeRests(inPlace=True, fillGaps=True)
         # this results in two chords; n2 and n4 are effectively shifted
         # to the start of n1 and n3
         sMod = s.makeChords(inPlace=False)


### PR DESCRIPTION
All but a handful of calls in the test suite set the `inPlace` keyword already, so this was an easy change.

(side note -- the "obvious" problems... have to do with placing rests inside measures, in the last example?)
Update: handled in #922, so removed the TODO line here to avoid a forseeable merge conflict.