### PR TITLE
Add classFilterList to makeTies and allow makeRests to put rests in Measures

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (7, 0, 3)  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (7, 0, 4)  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'7.0.3'
+'7.0.4'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1678,7 +1678,7 @@ class Test(unittest.TestCase):
         # environLocal.printDebug(['\n' + 'opening fp', fp])
 
         self.assertEqual(len(s.flat.getElementsByClass(note.Note)), 2)
-        self.assertEqual(len(s.flat.getElementsByClass(chord.Chord)), 4)
+        self.assertEqual(len(s.flat.getElementsByClass(chord.Chord)), 5)
 
         # MIDI import makes measures, so we will have one 4/4 time sig
         self.assertEqual(len(s.flat.getElementsByClass(meter.TimeSignature)), 1)

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1742,7 +1742,7 @@ def midiTrackToStream(
     >>> p
     <music21.stream.Part ...>
     >>> len(p.flat.notesAndRests)
-    13
+    14
     >>> p.flat.notes[0].pitch.midi
     36
     >>> p.flat.notes[0].volume.velocity
@@ -1770,7 +1770,8 @@ def midiTrackToStream(
         {1.0} <music21.note.Rest rest>
         {2.5} <music21.chord.Chord F#3 A4 C#5>
     {12.0} <music21.stream.Measure 4 offset=12.0>
-        {0.0} <music21.note.Rest rest>
+        {0.0} <music21.chord.Chord F#3 A4 C#5>
+        {2.5} <music21.note.Rest rest>
         {4.0} <music21.bar.Barline type=final>
     '''
     # environLocal.printDebug(['midiTrackToStream(): got midi track: events',
@@ -1921,8 +1922,9 @@ def midiTrackToStream(
     for m in s.getElementsByClass(stream.Measure):
         if voicesRequired:
             m.makeVoices(inPlace=True, fillGaps=True)
-        # always need to fill gaps, as rests are not found in any other way
-        m.makeRests(inPlace=True, fillGaps=True, timeRangeFromBarDuration=True)
+    s.makeTies(inPlace=True)
+    # always need to fill gaps, as rests are not found in any other way
+    s.makeRests(inPlace=True, fillGaps=True, timeRangeFromBarDuration=True)
     return s
 
 
@@ -2614,7 +2616,7 @@ def midiFileToStream(
     >>> s
     <music21.stream.Score ...>
     >>> len(s.flat.notesAndRests)
-    13
+    14
     '''
     # environLocal.printDebug(['got midi file: tracks:', len(mf.tracks)])
     if inputM21 is None:
@@ -3534,7 +3536,7 @@ class Test(unittest.TestCase):
         # a simple file created in athenacl
         s = converter.parse(fp)
         # s.show('t')
-        self.assertEqual(len(s.flat.getElementsByClass('Chord')), 4)
+        self.assertEqual(len(s.flat.getElementsByClass('Chord')), 5)
 
     def testMidiEventsImported(self):
         self.maxDiff = None
@@ -3684,6 +3686,28 @@ class Test(unittest.TestCase):
 
         self.assertEqual(
             len(inn.parts[1].measure(3).voices.last().getElementsByClass('Rest')), 1)
+
+    def testRestsMadeInMeasures(self):
+        from music21 import converter
+
+        fp = common.getSourceFilePath() / 'midi' / 'testPrimitive' / 'test17.mid'
+        inn = converter.parse(fp)
+        pianoLH = inn.parts.last()
+        m1 = pianoLH.measure(1)  # quarter note, quarter note, quarter rest
+        m2 = pianoLH.measure(2)
+        self.assertEqual(len(m1.notesAndRests), 3)
+        self.assertEqual(len(m1.notes), 2)
+        self.assertEqual(m1.duration.quarterLength, 3.0)
+        self.assertEqual(pianoLH.elementOffset(m2), 3.0)
+
+        for part in inn.parts:
+            with self.subTest(part=part):
+                self.assertEqual(
+                    sum(m.barDuration.quarterLength for m in part.getElementsByClass(
+                        stream.Measure)
+                    ),
+                    part.duration.quarterLength
+                )
 
 
 # ------------------------------------------------------------------------------

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3705,7 +3705,7 @@ class Test(unittest.TestCase):
                 self.assertEqual(
                     sum(m.barDuration.quarterLength for m in part.getElementsByClass(
                         stream.Measure)
-                    ),
+                        ),
                     part.duration.quarterLength
                 )
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -6286,17 +6286,20 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                  meterStream=None,
                  inPlace=False,
                  displayTiedAccidentals=False,
+                 classFilterList=(note.GeneralNote,),
                  ):
         '''
         Calls :py:func:`~music21.stream.makeNotation.makeTies`.
 
         Changed in v.4., inPlace=False by default.
+        Added in v.7, `classFilterList`.
         '''
         return makeNotation.makeTies(
             self,
             meterStream=meterStream,
             inPlace=inPlace,
             displayTiedAccidentals=displayTiedAccidentals,
+            classFilterList=classFilterList,
         )
 
     def makeBeams(self, *, inPlace=False, setStemDirections=True):

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -809,6 +809,10 @@ def makeRests(
         if timeRangeFromBarDuration and returnObj.isMeasure:
             # NOTE: this will raise an exception if no meter can be found
             oHighTarget = returnObj.barDuration.quarterLength
+        elif timeRangeFromBarDuration and returnObj.hasMeasures():
+            oHighTarget = sum(
+                m.barDuration.quarterLength for m in returnObj.getElementsByClass(stream.Measure)
+            )
         else:
             oHighTarget = returnObj.highestTime
     elif isinstance(refStreamOrTimeRange, stream.Stream):
@@ -879,6 +883,14 @@ def makeRests(
             returnObj.setElementOffset(m, accumulatedTime)
             accumulatedTime += m.highestTime
 
+            # process voices
+            for v in m.voices:
+                v.makeRests(inPlace=True,
+                            fillGaps=fillGaps,
+                            hideRests=hideRests,
+                            refStreamOrTimeRange=m,
+                            )
+
     if inPlace is not True:
         return returnObj
 
@@ -894,7 +906,7 @@ def makeTies(
     # noinspection PyShadowingNames
     '''
     Given a stream containing measures, examine each element in the
-    Stream. If the elements duration extends beyond the measure's boundary,
+    Stream. If the element's duration extends beyond the measure's boundary,
     create a tied entity, placing the split Note in the next Measure.
 
     Note that this method assumes that there is appropriate space in the

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -870,7 +870,14 @@ def makeRests(
         # environLocal.printDebug(['post makeRests show()', v])
 
     if returnObj.hasMeasures():
+        # split rests at measure boundaries
         returnObj.makeTies(classFilterList=(note.Rest,))
+
+        # reposition measures
+        accumulatedTime = 0.0
+        for m in returnObj.getElementsByClass(stream.Measure):
+            returnObj.setElementOffset(m, accumulatedTime)
+            accumulatedTime += m.highestTime
 
     if inPlace is not True:
         return returnObj

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -835,10 +835,9 @@ def makeRests(
     for v in bundle:
         oLow = v.lowestOffset
         oHigh = v.highestTime
-        # adjust oHigh to not exceed measure
-        oHighTargetAdjusted = oHighTarget
-        if v.isMeasure:
-            oHighTargetAdjusted = min(v.barDuration.quarterLength, oHighTarget)
+        if returnObj.hasMeasures():
+            # adjust oHigh to not exceed measure
+            oHighTarget = min(v.barDuration.quarterLength, oHighTarget)
 
         # create rest from start to end
         qLen = oLow - oLowTarget
@@ -851,7 +850,7 @@ def makeRests(
             v.insert(oLowTarget, r)
 
         # create rest from end to highest
-        qLen = oHighTargetAdjusted - oHigh
+        qLen = oHighTarget - oHigh
         # environLocal.printDebug(['v', v, oHigh, oHighTarget, 'qLen', qLen])
         if qLen > 0:
             r = note.Rest()
@@ -859,7 +858,6 @@ def makeRests(
             r.style.hideObjectOnPrint = hideRests
             # place at oHigh to reach to oHighTarget
             v.insert(oHigh, r)
-
 
         if fillGaps:
             gapStream = v.findGaps()

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1907,8 +1907,7 @@ class Test(unittest.TestCase):
         s.insert(0, m1)
         s.insert(4, m2)
         # must connect Measures to Streams before filling gaps
-        m1.makeRests(inPlace=True, fillGaps=True, timeRangeFromBarDuration=True)
-        m2.makeRests(inPlace=True, fillGaps=True, timeRangeFromBarDuration=True)
+        s.makeRests(inPlace=True, fillGaps=True, timeRangeFromBarDuration=True)
         self.assertTrue(m2.isSorted)
         # m2.sort()
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1906,7 +1906,6 @@ class Test(unittest.TestCase):
 
         s.insert(0, m1)
         s.insert(4, m2)
-        # must connect Measures to Streams before filling gaps
         s.makeRests(inPlace=True, fillGaps=True, timeRangeFromBarDuration=True)
         self.assertTrue(m2.isSorted)
         # m2.sort()
@@ -1941,6 +1940,32 @@ class Test(unittest.TestCase):
         unused_mx = GEX.parse(s).decode('utf-8')
         # s.show('text')
         # s.show()
+
+    def testMakeRestsInMeasures(self):
+        p = Part()
+        m1 = Measure()
+        m1.timeSignature = meter.TimeSignature('4/4')
+        m1.insert(2, note.Note())
+        m2 = Measure()
+        m2.insert(1, note.Note())
+        p.append(m1)
+        p.append(m2)
+
+        self.assertEqual(m1.duration.quarterLength, 3.0)
+        self.assertEqual(m2.duration.quarterLength, 2.0)
+        self.assertEqual(p.duration.quarterLength, 5.0)
+
+        for m in (m1, m2):
+            m.makeRests(inPlace=True, timeRangeFromBarDuration=True)
+
+        self.assertEqual(m1.duration.quarterLength, 4.0)
+        self.assertEqual(m2.duration.quarterLength, 4.0)
+
+        # m2 was never repositioned in p
+        self.assertEqual(p.duration.quarterLength, 7.0)
+
+        p.makeRests(inPlace=True)
+        self.assertEqual(p.duration.quarterLength, 8.0)
 
     def testMakeMeasuresInPlace(self):
         sScr = Stream()


### PR DESCRIPTION
Noticed that we can solve 2 TODOs at once: 

- `makeRests()` makes rests inside Measures now
- in order to do that, we need to split rests at measure boundaries, which is what `makeTies()` does, but we don't want to touch the notes, therefore it was convenient to just handle the TODO declared there to create a class filter list.
- Update: now this also fixes some issues with MIDI notation making:
-- measures are now repositioned in the stream if they were enlarged due to gap-filling
-- ties are now made on notes and chords across barlines (vs. just rests, by virtue of this PR's new feature in makeRests())