### PR TITLE
v7 SpannerBundle.replaceSpannedElement() only takes elements, not ids

### DIFF
--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -788,7 +788,7 @@ class Expander:
         for m in srcStream:
             # processes uses the spanner bundle stored on this Stream
             self._repeatBrackets.spannerBundle.replaceSpannedElement(
-                id(m.derivation.origin), m)
+                m.derivation.origin, m)
 
         # srcStream = self._srcMeasureStream
         # post = copy.deepcopy(self._srcMeasureStream)

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -8858,7 +8858,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                     origin = e.derivation.origin
                     if (origin is not None
                             and e.derivation.method == '__deepcopy__'):
-                        spannerBundle.replaceSpannedElement(id(origin), e)
+                        spannerBundle.replaceSpannedElement(origin, e)
 
         return post
 
@@ -13339,7 +13339,7 @@ class Score(Stream):
             if e.sites.hasSpannerSite():
                 origin = e.derivation.origin
                 if origin is not None and e.derivation.method == '__deepcopy__':
-                    spannerBundle.replaceSpannedElement(id(origin), e)
+                    spannerBundle.replaceSpannedElement(origin, e)
         return post
 
     def measureOffsetMap(self, classFilterList=None):

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -1549,13 +1549,14 @@ class RecursiveIterator(StreamIterator):
             else:
                 self.sectionIndex = self.index
 
-            self.index += 1  # increment early in case of an error in the next try.
-
             try:
-                e = self.srcStreamElements[self.index - 1]
+                e = self.srcStreamElements[self.index]
             except IndexError:
-                # this may happen in the number of elements has changed
+                self.index += 1
+                # this may happen if the number of elements has changed
                 continue
+
+            self.index += 1
 
             # in a recursive filter, the stream does not need to match the filter,
             # only the internal elements.


### PR DESCRIPTION
One last PR for spanners.

After the last few PRs there remains only one use of `getSpannedElementIds()`, which inefficiently builds the entire list before providing it to the caller to search, in `SpannerBundle.replaceSpannedElement()`, which alternatively takes an element, and which could be tested for spanner membership with the faster `Spanner.__contains__()` pattern we just optimized in 839c7e5.

- commit 1: sends elements, not ids, to `SpannerBundle.replaceSpannedElement()`, since we just optimized that, and raises an exception if you try to do it the slow way by passing an id.
- <s>commit 2: instead of raising an exception, provide backwards compatibility by checking if the input is `int`, so as to treat as an id and pass to new function `replaceSpannedElementSlow` with a deprecation warning. </s> dropped from the branch
- commit 3: unrelated optimization -- make a similar change to `RecursiveIterator.__next__()` for speed as in 113929c for consistency.

If you think we don't need to bother with backwards compatibility for this power usage -- (wouldn't a power user want to know they were doing it the slow way?) -- I can drop commit 2 and force-push.  I don't think we really need to go to the effort of having the shim, but it was fast to just code it up and push it. Your call.