### PR TITLE
Fix documentation order in serial module

### DIFF
--- a/documentation/docbuild/documenters.py
+++ b/documentation/docbuild/documenters.py
@@ -1375,11 +1375,10 @@ class ModuleDocumenter(ObjectDocumenter):
         >>> for classDocumenter in modDocumenter.classDocumenters:
         ...     print(classDocumenter.referentPackageSystemPath)
         ...
-        music21.serial.HistoricalTwelveToneRow
         music21.serial.ToneRow
-        music21.serial.TwelveToneMatrix
         music21.serial.TwelveToneRow
-
+        music21.serial.HistoricalTwelveToneRow
+        music21.serial.TwelveToneMatrix
         '''
         result = []
         classDocumenters = {}

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -1452,9 +1452,8 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER = ['ToneRow', 'TwelveToneRow', 'HistoricalTwelveToneRow', 'ContiguousSegmentOfNotes',
-              'historicalDict',
-              'pcToToneRow', 'TwelveToneMatrix', 'rowToMatrix', 'getHistoricalRowByName',
+_DOC_ORDER = [ToneRow, TwelveToneRow, HistoricalTwelveToneRow,
+              pcToToneRow, TwelveToneMatrix, rowToMatrix, getHistoricalRowByName,
               ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
h/t @MarkGotham for noticing a stray item in `_DOC_ORDER` -- harmless by itself, but led me to discover that the entire order was being ignored.


Now, in the correct order!

![new-order](https://user-images.githubusercontent.com/38668450/111910045-1a5b7300-8a36-11eb-8506-071935a67ad2.png)


PS -- `historicalDict` had to be removed from the order, b/c dicts aren't hashable (deep in the ModuleDocumenter), but it wasn't displaying anyway. There's another doctest that prints the keys, so it's visible in one way/shape/form.