### PR TITLE
Preserve value of spellingIsInferred in simplifyMultipleEnharmonics()

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -5876,6 +5876,14 @@ class Test(unittest.TestCase):
         self.assertEqual(unscrambledChord3.pitches[3].name, 'F')
         self.assertEqual(unscrambledChord3.pitches[4].name, 'A-')
 
+    def testEnharmonicSimplification(self):
+        from music21 import chord
+        eFlat = note.Note(63)
+        self.assertEqual(eFlat.pitch.name, 'E-')
+        bMajor = chord.Chord([59, 63, 66])
+        self.assertEqual([p.name for p in bMajor.pitches], ['B', 'D#', 'F#'])
+        self.assertEqual([p.spellingIsInferred for p in bMajor.pitches], [True, True, True])
+
     def testDurations(self):
         from music21 import chord
 

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -5383,22 +5383,23 @@ class Test(unittest.TestCase):
         bm = converter.parse("tinynotation: 4/4 fn1 fn1 e-8 e'-8 fn4 en4 e'n4").flat
         bm.insert(0, key.KeySignature(1))
         bm.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False)
-        assert(bm.flat.notes[0].pitch.accidental.name == 'natural')     # Fn
-        assert(bm.flat.notes[0].pitch.accidental.displayStatus is True)
-        assert(bm.flat.notes[1].pitch.accidental.name == 'natural')     # Fn
-        assert(bm.flat.notes[1].pitch.accidental.displayStatus is True)
-        assert(bm.flat.notes[2].pitch.accidental.name == 'flat')        # E-4
-        assert(bm.flat.notes[2].pitch.accidental.displayStatus is True)
-        assert(bm.flat.notes[3].pitch.accidental.name == 'flat')        # E-5
-        assert(bm.flat.notes[3].pitch.accidental.displayStatus is True)
-        assert(bm.flat.notes[4].pitch.accidental.name == 'natural')     # En4
-        assert(bm.flat.notes[4].pitch.accidental.displayStatus is True)
-        assert(bm.flat.notes[5].pitch.accidental.name == 'natural')     # En4
-        assert(bm.flat.notes[5].pitch.accidental.displayStatus is True)
 
-        assert(bm.flat.notes[6].pitch.accidental is not None)  # En5
-        assert(bm.flat.notes[6].pitch.accidental.name == 'natural')
-        assert(bm.flat.notes[6].pitch.accidental.displayStatus is True)
+        self.assertEqual(bm.flat.notes[0].pitch.accidental.name, 'natural')     # Fn
+        self.assertEqual(bm.flat.notes[0].pitch.accidental.displayStatus, True)
+        self.assertEqual(bm.flat.notes[1].pitch.accidental.name, 'natural')     # Fn
+        self.assertEqual(bm.flat.notes[1].pitch.accidental.displayStatus, True)
+        self.assertEqual(bm.flat.notes[2].pitch.accidental.name, 'flat')        # E-4
+        self.assertEqual(bm.flat.notes[2].pitch.accidental.displayStatus, True)
+        self.assertEqual(bm.flat.notes[3].pitch.accidental.name, 'flat')        # E-5
+        self.assertEqual(bm.flat.notes[3].pitch.accidental.displayStatus, True)
+        self.assertEqual(bm.flat.notes[4].pitch.accidental.name, 'natural')     # En4
+        self.assertEqual(bm.flat.notes[4].pitch.accidental.displayStatus, True)
+        self.assertEqual(bm.flat.notes[5].pitch.accidental.name, 'natural')     # En4
+        self.assertEqual(bm.flat.notes[5].pitch.accidental.displayStatus, True)
+
+        self.assertIsNotNone(bm.flat.notes[6].pitch.accidental)  # En5
+        self.assertEqual(bm.flat.notes[6].pitch.accidental.name, 'natural')
+        self.assertEqual(bm.flat.notes[6].pitch.accidental.displayStatus, True)
 
     def testPitchEquality(self):
         '''

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -547,6 +547,10 @@ def simplifyMultipleEnharmonics(pitches, criterion=_dissonanceScore, keyContext=
     else:
         simplifiedPitches = _greedyEnharmonicsSearch(oldPitches, criterion)
 
+    # Preserve value of spellingIsInferred
+    for oldP, newP in zip(oldPitches, simplifiedPitches):
+        newP.spellingIsInferred = oldP.spellingIsInferred
+
     if remove_first:
         simplifiedPitches = simplifiedPitches[1:]
 


### PR DESCRIPTION
Fixes #929

Also replace some bare asserts in the Chord module tests.