### PR TITLE
Delete unnecessary temp files in `Opus.write()` and test suite; return `fp` from `DataSet.write()`

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1459,6 +1459,7 @@ class Test(unittest.TestCase):
         self.assertTrue(str(mxlPath).endswith('.mxl'))
         os.remove(mxlPath)
 
+
 class TestExternal(unittest.TestCase):  # pragma: no cover
 
     def testXMLShow(self):

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -236,8 +236,8 @@ class SubConverter:
         >>> tf = str(lpConverter.getTemporaryFile(subformats=['png']))
         >>> tf.endswith('.png')
         True
-        >>> import os
-        >>> os.remove(tf)
+        >>> import os  #_DOCS_HIDE
+        >>> os.remove(tf)  #_DOCS_HIDE
 
         Changed in v.6 -- returns pathlib.Path
         '''
@@ -1436,8 +1436,7 @@ class Test(unittest.TestCase):
             try:
                 pngFp1 = xmlConverter1.findPNGfpFromXMLfp(xmlFp1)
                 self.assertEqual(pngFp1, tempFp1)
-            finally:
-                os.remove(tempFp1)
+            os.remove(tempFp1)
 
     def testXMLtoPNGTooLong(self):
         '''
@@ -1449,21 +1448,17 @@ class Test(unittest.TestCase):
         os.rename(tempFp, tempFp + '-0000001.png')
         tempFp += '-0000001.png'
         xmlConverter = ConverterMusicXML()
-        try:
-            self.assertRaises(SubConverterFileIOException, xmlConverter.findPNGfpFromXMLfp, xmlFp)
-        finally:
-            os.remove(tempFp)
+        self.assertRaises(SubConverterFileIOException, xmlConverter.findPNGfpFromXMLfp, xmlFp)
+        os.remove(tempFp)
 
     def testWriteMXL(self):
         from music21 import converter
         from music21.musicxml import testPrimitive
 
         s = converter.parseData(testPrimitive.multiDigitEnding)
-        try:
-            mxlPath = s.write('mxl')
-            self.assertTrue(str(mxlPath).endswith('.mxl'))
-        finally:
-            os.remove(mxlPath)
+        mxlPath = s.write('mxl')
+        self.assertTrue(str(mxlPath).endswith('.mxl'))
+        os.remove(mxlPath)
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1433,9 +1433,8 @@ class Test(unittest.TestCase):
             os.rename(tempFp1, tempFp1 + png_ext)
             tempFp1 += png_ext
             xmlConverter1 = ConverterMusicXML()
-            try:
-                pngFp1 = xmlConverter1.findPNGfpFromXMLfp(xmlFp1)
-                self.assertEqual(pngFp1, tempFp1)
+            pngFp1 = xmlConverter1.findPNGfpFromXMLfp(xmlFp1)
+            self.assertEqual(pngFp1, tempFp1)
             os.remove(tempFp1)
 
     def testXMLtoPNGTooLong(self):

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -622,11 +622,16 @@ class _EnvironmentCore:
 
         OMIT_FROM_DOCS
         >>> e = environment.Environment()
-        >>> isinstance(e.getTempFile(returnPathlib=False), str)
+        >>> tmp1 = e.getTempFile(returnPathlib=False)
+        >>> isinstance(tmp1, str)
         True
         >>> import pathlib
-        >>> isinstance(e.getTempFile(), pathlib.Path)
+        >>> tmp2 = e.getTempFile()
+        >>> isinstance(tmp2, pathlib.Path)
         True
+        >>> import os
+        >>> os.remove(tmp1)
+        >>> os.remove(tmp2)
         '''
         # get the root dir, which may be the user-specified dir
         rootDir = self.getRootTempDir()
@@ -1579,11 +1584,13 @@ class Test(unittest.TestCase):
             # Wipe out write, exec permissions on the default root dir
             os.chmod(e.getDefaultRootTempDir(), stat.S_IREAD)
             # Was the PermissionError caught and a new "music21-{user}" dir created?
-            self.assertIn('music21-' + getpass.getuser(), e.getTempFile(returnPathlib=False))
+            tmp = e.getTempFile(returnPathlib=False)
+            self.assertIn('music21-' + getpass.getuser(), tmp)
         finally:
             # Restore owner read/write/exec permissions and original path
             os.chmod(e.getDefaultRootTempDir(), stat.S_IRWXU)
             e['directoryScratch'] = oldScratchDir
+            os.remove(tmp)
 
 
 # -----------------------------------------------------------------------------

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -1590,7 +1590,7 @@ class Test(unittest.TestCase):
             # Restore owner read/write/exec permissions and original path
             os.chmod(e.getDefaultRootTempDir(), stat.S_IRWXU)
             e['directoryScratch'] = oldScratchDir
-            os.remove(tmp)
+        os.remove(tmp)
 
 
 # -----------------------------------------------------------------------------

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -1083,7 +1083,7 @@ class DataSet:
             raise DataSetException('no output format could be defined from file path '
                                    + f'{fp} or format {format}')
 
-        outputFormat.write(fp=fp, includeClassLabel=includeClassLabel)
+        return outputFormat.write(fp=fp, includeClassLabel=includeClassLabel)
 
 
 def _dataSetParallelSubprocess(dataInstance, failFast):
@@ -1424,9 +1424,14 @@ class Test(unittest.TestCase):
             'Unique_Note_Quarter_Lengths,Most_Common_Note_Quarter_Length,'
             'Range_of_Note_Quarter_Lengths,Composer//3,1.0,1.5,Bach//8,0.5,3.75,Corelli')
 
-        ds.write(format='tab')
-        ds.write(format='csv')
-        ds.write(format='arff')
+        fp1 = ds.write(format='tab')
+        fp2 = ds.write(format='csv')
+        # Also test providing fp
+        fp3 = environLocal.getTempFile(suffix='.arff')
+        ds.write(fp=fp3, format='arff')
+
+        for fp in (fp1, fp2, fp3):
+            os.remove(fp)
 
     def testFeatureFail(self):
         from music21 import features

--- a/music21/metadata/bundles.py
+++ b/music21/metadata/bundles.py
@@ -1347,8 +1347,9 @@ class MetadataBundle(prebase.ProtoM21Object):
         True
 
         >>> import os
-        >>> import tempfile
-        >>> tempFilePath = tempfile.mkstemp()[1]
+        >>> from music21 import environment
+        >>> e = environment.Environment()
+        >>> tempFilePath = e.getTempFile()
         >>> bachBundle.write(filePath=tempFilePath)
         <music21.metadata.bundles.MetadataBundle {363 entries}>
         >>> os.remove(tempFilePath)

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -720,6 +720,7 @@ class Test(unittest.TestCase):
         self.assertEqual(out_stream.parts[0].measure(1)[0].figure, 'I')  # First item in measure 1
 
     def testM21ToTsv(self):
+        import os
         from music21 import corpus
 
         bachHarmony = corpus.parse('bach/choraleAnalyses/riemenschneider001.rntxt')
@@ -731,9 +732,12 @@ class Test(unittest.TestCase):
         # Test .write
         envLocal = environment.Environment()
         tempF = envLocal.getTempFile()
-        initial.write(tempF)
-        handler = TsvHandler(tempF)
-        self.assertEqual(handler.tsvData[0][0], 'I')
+        try:
+            initial.write(tempF)
+            handler = TsvHandler(tempF)
+            self.assertEqual(handler.tsvData[0][0], 'I')
+        finally:
+            os.remove(tempF)
 
     def testIsMinor(self):
         self.assertTrue(is_minor('f'))

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -732,12 +732,10 @@ class Test(unittest.TestCase):
         # Test .write
         envLocal = environment.Environment()
         tempF = envLocal.getTempFile()
-        try:
-            initial.write(tempF)
-            handler = TsvHandler(tempF)
-            self.assertEqual(handler.tsvData[0][0], 'I')
-        finally:
-            os.remove(tempF)
+        initial.write(tempF)
+        handler = TsvHandler(tempF)
+        self.assertEqual(handler.tsvData[0][0], 'I')
+        os.remove(tempF)
 
     def testIsMinor(self):
         self.assertTrue(is_minor('f'))

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -24,6 +24,7 @@ import collections
 import copy
 import itertools
 import math
+import os
 import pathlib
 import unittest
 import sys
@@ -13799,12 +13800,15 @@ class Opus(Stream):
         elif common.runningUnderIPython():
             return Stream.write(self, fmt, fp, **keywords)
 
+        delete = False
         if fp is None:
             if fmt is None:
                 suffix = '.' + environLocal['writeFormat']
             else:
                 unused_format, suffix = common.findFormat(fmt)
-            fp = environLocal.getTempFile(returnPathlib=False) + suffix
+            fp = environLocal.getTempFile(suffix=suffix, returnPathlib=False)
+            # Mark for deletion, because it won't actually be used
+            delete = True
         if isinstance(fp, str):
             fp = pathlib.Path(fp)
 
@@ -13824,6 +13828,10 @@ class Opus(Stream):
             fpReturned = s.write(fmt=fmt, fp=fpToUse, **keywords)
             environLocal.printDebug(f'Component {s} written to {fpReturned}')
             post.append(fpReturned)
+
+        if delete:
+            os.remove(fp)
+
         return post[-1] if post else None
 
     def show(self, fmt=None, app=None, **keywords):

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -8076,19 +8076,40 @@ class Test(unittest.TestCase):
         self.assertEqual(beams[4], stop_beam)  # last should be stop
 
     def testOpusWrite(self):
+        import os
+
         o = Opus()
         s1 = Score()
         s2 = Score()
         o.append([s1, s2])
 
         out = o.write()
-        self.assertIsNotNone(out)
+        otherFile = str(out).replace('-2', '-1')
+        try:
+            self.assertIsNotNone(out)
+        finally:
+            os.remove(out)
+            os.remove(otherFile)
 
-        out = o.write(fp=environLocal.getTempFile())
-        self.assertTrue(str(out).endswith('-2.xml'))
+        tmp = environLocal.getTempFile()
+        out = o.write(fp=tmp)
+        otherFile = str(out).replace('-2', '-1')
+        try:
+            self.assertTrue(str(out).endswith('-2.xml'))
+            self.assertTrue(os.path.exists(otherFile))
+        finally:
+            os.remove(tmp)
+            os.remove(out)
+            os.remove(otherFile)
 
         out = o.write(fmt='midi')
-        self.assertTrue(str(out).endswith('-2.mid'))
+        otherFile = str(out).replace('-2', '-1')
+        try:
+            self.assertTrue(str(out).endswith('-2.mid'))
+            self.assertTrue(os.path.exists(otherFile))
+        finally:
+            os.remove(out)
+            os.remove(otherFile)
 
 
 # -----------------------------------------------------------------------------

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -8085,31 +8085,25 @@ class Test(unittest.TestCase):
 
         out = o.write()
         otherFile = str(out).replace('-2', '-1')
-        try:
-            self.assertIsNotNone(out)
-        finally:
-            os.remove(out)
-            os.remove(otherFile)
+        self.assertIsNotNone(out)
+        os.remove(out)
+        os.remove(otherFile)
 
         tmp = environLocal.getTempFile()
         out = o.write(fp=tmp)
         otherFile = str(out).replace('-2', '-1')
-        try:
-            self.assertTrue(str(out).endswith('-2.xml'))
-            self.assertTrue(os.path.exists(otherFile))
-        finally:
-            os.remove(tmp)
-            os.remove(out)
-            os.remove(otherFile)
+        self.assertTrue(str(out).endswith('-2.xml'))
+        self.assertTrue(os.path.exists(otherFile))
+        os.remove(tmp)
+        os.remove(out)
+        os.remove(otherFile)
 
         out = o.write(fmt='midi')
         otherFile = str(out).replace('-2', '-1')
-        try:
-            self.assertTrue(str(out).endswith('-2.mid'))
-            self.assertTrue(os.path.exists(otherFile))
-        finally:
-            os.remove(out)
-            os.remove(otherFile)
+        self.assertTrue(str(out).endswith('-2.mid'))
+        self.assertTrue(os.path.exists(otherFile))
+        os.remove(out)
+        os.remove(otherFile)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Noticed yesterday that a number of temp files are not cleaned up by the test suite. (I authored about half of these tests.) Not a showstopper, but going to the minimal effort to clean them up revealed a couple of bugs/functional changes to fix/make:

Functional changes:

- `Opus.write(fp=None)` now deletes the temp file that it creates and doesn't use
- `DataSet.write()` now returns `fp` (`OutputFormat.write()` returns `fp` to `DataSet.write()`, which returns nothing)

Documentation:

- replace use of `mkstemp()` in a metadata doctest