### PR TITLE
Check literal duration from MusicXML against notated type and create unlinked durations

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (7, 0, 3)  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (7, 0, 4)  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'7.0.3'
+'7.0.4'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/musicxml/testTab.xml
+++ b/music21/musicxml/testTab.xml
@@ -9,6 +9,12 @@
     </part-list>
     <part id="P1">
         <measure number="0">
+            <attributes>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+            </attributes>
             <note>
                 <type>quarter</type>
                 <notations>

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3199,8 +3199,7 @@ class MeasureParser(XMLParserBase):
 
         If the `<duration>` doesn't match the `<type>` and `<dots>`,
         an unlinked duration is created so that `.quarterLength` agrees with
-        `<duration>` but the notated types can still be represented by
-        `.components`.
+        `<duration>` but the notated types can still be represented.
 
         Create a second dot on `mxNote` and parse again, observing the identical
         `quarterLength`:

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -6515,7 +6515,7 @@ class Test(unittest.TestCase):
           <step>D</step>
           <octave>5</octave>
         </pitch>
-        <duration>{defaults.divisionsPerQuarter * 0.5}</duration>
+        <duration>{defaults.divisionsPerQuarter * 0.5 * (2/3) * (2/3)}</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3259,8 +3259,9 @@ class MeasureParser(XMLParserBase):
         # can't do this unless we have a type, so if not forceRaw
         if not forceRaw:  # a cooked version builds up from pieces
             dt = duration.durationTupleFromTypeDots(durationType, numDots)
-            if dt.quarterLength == qLen:
+            if dt.quarterLength == qLen and not tuplets:
                 # raw == cooked, so we're done
+                # but this comparison gives false positives if tuplets are involved
                 return d if inputM21 is None else None
             if d is not None:
                 d.clear()
@@ -3271,6 +3272,7 @@ class MeasureParser(XMLParserBase):
 
             for tup in tuplets:
                 d.appendTuplet(tup)
+                qLen = common.opFrac(qLen * tup.tupletMultiplier())
 
             # Second check against qLen (raw), now with tuplets
             # if != , create unlinked Duration and set raw qLen
@@ -6506,13 +6508,13 @@ class Test(unittest.TestCase):
         '''
         test that a note with nested tuplets gets converted properly.
         '''
-        mxN = '''
+        mxN = f'''
         <note default-x="347">
         <pitch>
           <step>D</step>
           <octave>5</octave>
         </pitch>
-        <duration>4</duration>
+        <duration>{defaults.divisionsPerQuarter * 0.5}</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3257,10 +3257,9 @@ class MeasureParser(XMLParserBase):
 
         # two ways to create durations, raw (from qLen) and cooked (from type, time-mod, dots)
         if d is not None:
-            durRaw = duration.Duration()  # raw just uses qLen
+            durRaw = duration.Duration(quarterLength=qLen)  # raw just uses qLen
             # the qLen set here may not be computable, but is not immediately
             # computed until setting components
-            durRaw.quarterLength = qLen
             try:
                 d.components = durRaw.components
             except duration.DurationException:  # TODO: Test

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3196,6 +3196,26 @@ class MeasureParser(XMLParserBase):
         'eighth'
         >>> c.dots
         1
+
+        If the `<duration>` doesn't match the `<type>` and `<dots>`,
+        an unlinked duration is created so that `.quarterLength` agrees with
+        `<duration>` but the notated types can still be represented by
+        `.components`.
+
+        Create a second dot on `mxNote` and parse again, observing the identical
+        `quarterLength`:
+
+        >>> from xml.etree.ElementTree import SubElement
+        >>> unused = SubElement(mxNote, 'dot')
+        >>> c2 = MP.xmlToDuration(mxNote)
+        >>> c2
+        <music21.duration.Duration unlinked type:eighth quarterLength:0.75>
+        >>> c2.quarterLength
+        0.75
+        >>> c2.type
+        'eighth'
+        >>> c2.dots
+        2
         '''
         numDots = 0
         tuplets = ()
@@ -3238,7 +3258,6 @@ class MeasureParser(XMLParserBase):
 
         # two ways to create durations, raw (from qLen) and cooked (from type, time-mod, dots)
         if d is not None:
-            # environLocal.printDebug(['forced to use raw duration', durRaw])
             durRaw = duration.Duration()  # raw just uses qLen
             # the qLen set here may not be computable, but is not immediately
             # computed until setting components

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3274,7 +3274,6 @@ class MeasureParser(XMLParserBase):
 
             for tup in tuplets:
                 d.appendTuplet(tup)
-                qLen = common.opFrac(qLen * tup.tupletMultiplier())
 
             # Second check against qLen (raw), now with tuplets
             # if not isclose , create unlinked Duration and set raw qLen

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3279,7 +3279,7 @@ class MeasureParser(XMLParserBase):
         # can't do this unless we have a type, so if not forceRaw
         if not forceRaw:  # a cooked version builds up from pieces
             dt = duration.durationTupleFromTypeDots(durationType, numDots)
-            if not tuplets and (dt.quarterLength == qLen):
+            if (dt.quarterLength == qLen) and not tuplets:
                 # raw == cooked, so we're done
                 # but this comparison gives false positives if tuplets are involved
                 # don't bother with isclose; merely trying to short-circuit

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2577,6 +2577,8 @@ class MeasureParser(XMLParserBase):
         <music21.pitch.Pitch A3>
         >>> c.pitches[1]
         <music21.pitch.Pitch B3>
+        >>> c.duration
+        <music21.duration.Duration unlinked type:quarter quarterLength:0.75>
 
         >>> a = EL('<note><pitch><step>A</step><octave>3</octave></pitch>'
         ...        + qnDuration
@@ -3215,6 +3217,19 @@ class MeasureParser(XMLParserBase):
         'eighth'
         >>> c2.dots
         2
+
+        Grace note durations will be converted later to GraceDurations:
+
+        >>> mxDuration = mxNote.find('duration')
+        >>> mxNote.remove(mxDuration)
+        >>> mxGrace = SubElement(mxNote, 'grace')
+        >>> MP.xmlToDuration(mxNote, inputM21=c2)
+        >>> c2
+        <music21.duration.Duration unlinked type:eighth quarterLength:0.0>
+        >>> gn1 = note.Note(duration=c2)
+        >>> gn2 = MP.xmlGraceToGrace(mxGrace, gn1)
+        >>> gn2.duration
+        <music21.duration.GraceDuration unlinked type:zero quarterLength:0.0>
         '''
         numDots = 0
         tuplets = ()

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3261,9 +3261,10 @@ class MeasureParser(XMLParserBase):
         # can't do this unless we have a type, so if not forceRaw
         if not forceRaw:  # a cooked version builds up from pieces
             dt = duration.durationTupleFromTypeDots(durationType, numDots)
-            if isclose(dt.quarterLength, qLen, abs_tol=1e-7) and not tuplets:
-                # raw ~= cooked, so we're done
+            if not tuplets and (dt.quarterLength == qLen):
+                # raw == cooked, so we're done
                 # but this comparison gives false positives if tuplets are involved
+                # don't bother with isclose; merely trying to short-circuit
                 return d if inputM21 is None else None
             if d is not None:
                 d.clear()
@@ -3276,7 +3277,7 @@ class MeasureParser(XMLParserBase):
                 d.appendTuplet(tup)
 
             # Second check against qLen (raw), now with tuplets
-            # if not isclose , create unlinked Duration and set raw qLen
+            # if not almost equal, create unlinked Duration and set raw qLen
             if not isclose(d.quarterLength, qLen, abs_tol=1e-7):
                 d.linked = False
                 d.quarterLength = qLen

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -18,6 +18,8 @@ import re
 # import sys
 # import traceback
 import unittest
+
+from math import isclose
 from typing import List, Optional, Dict, Tuple, Set
 
 import xml.etree.ElementTree as ET
@@ -3259,8 +3261,8 @@ class MeasureParser(XMLParserBase):
         # can't do this unless we have a type, so if not forceRaw
         if not forceRaw:  # a cooked version builds up from pieces
             dt = duration.durationTupleFromTypeDots(durationType, numDots)
-            if dt.quarterLength == qLen and not tuplets:
-                # raw == cooked, so we're done
+            if isclose(dt.quarterLength, qLen, abs_tol=1e-7) and not tuplets:
+                # raw ~= cooked, so we're done
                 # but this comparison gives false positives if tuplets are involved
                 return d if inputM21 is None else None
             if d is not None:
@@ -3275,8 +3277,8 @@ class MeasureParser(XMLParserBase):
                 qLen = common.opFrac(qLen * tup.tupletMultiplier())
 
             # Second check against qLen (raw), now with tuplets
-            # if != , create unlinked Duration and set raw qLen
-            if d.quarterLength != qLen:
+            # if not isclose , create unlinked Duration and set raw qLen
+            if not isclose(d.quarterLength, qLen, abs_tol=1e-7):
                 d.linked = False
                 d.quarterLength = qLen
 


### PR DESCRIPTION
... and create unlinked durations if discrepancies.

Fixes #779 

<s>I say I'm not going to jump on these and then it turns out to be just one more line to add. Needs tests before it's ready. </s> (Added one test.) And verify this is the direction we want to go.