### PR TITLE
v7 Write `.musicxml` files instead of `.xml` if `fp` not given

### DIFF
--- a/documentation/source/usersGuide/usersGuide_11_corpusSearching.ipynb
+++ b/documentation/source/usersGuide/usersGuide_11_corpusSearching.ipynb
@@ -48,7 +48,7 @@
     "durations, ambitus (range) and so forth.\n",
     "\n",
     "This metadata is collected in *metadata bundles* for each corpus. The *corpus*\n",
-    "module has tools to search these bundles and persist them disk for later\n",
+    "module has tools to search these bundles and persist them on disk for later\n",
     "research.\n",
     "\n",
     "## Types of corpora\n",

--- a/music21/common/formats.py
+++ b/music21/common/formats.py
@@ -94,11 +94,11 @@ def findFormat(fmt):
     Note that .mxl and .mx are only considered MusicXML input formats.
 
     >>> common.findFormat('mx')
-    ('musicxml', '.xml')
+    ('musicxml', '.musicxml')
     >>> common.findFormat('.mxl')
-    ('musicxml', '.xml')
+    ('musicxml', '.musicxml')
     >>> common.findFormat('musicxml')
-    ('musicxml', '.xml')
+    ('musicxml', '.musicxml')
     >>> common.findFormat('lily')
     ('lilypond', '.ly')
     >>> common.findFormat('lily.png')
@@ -121,9 +121,6 @@ def findFormat(fmt):
     ('vexflow', '.html')
     >>> common.findFormat('capx')
     ('capella', '.capx')
-
-    >>> common.findFormat('mx')
-    ('musicxml', '.xml')
 
 
     Works the same whether you have a leading dot or not:

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -838,7 +838,7 @@ class ConverterMusicXML(SubConverter):
     '''
     registerFormats = ('musicxml', 'xml')
     registerInputExtensions = ('xml', 'mxl', 'mx', 'musicxml')
-    registerOutputExtensions = ('xml', 'mxl')
+    registerOutputExtensions = ('musicxml', 'xml', 'mxl')
     registerOutputSubformatExtensions = {'png': 'png',
                                          'pdf': 'pdf',
                                          }
@@ -850,7 +850,7 @@ class ConverterMusicXML(SubConverter):
         then return appropriate fp. Raises an exception if png fp does not exist.
         '''
         xmlFilePath = str(xmlFilePath)  # not pathlib.
-        path_without_extension = xmlFilePath[:-4]
+        path_without_extension = xmlFilePath[:-1 * len('.musicxml')]
 
         for search_extension in ('1', '01', '001', '0001', '00001'):
             search_path = path_without_extension + '-' + search_extension + '.png'
@@ -923,7 +923,9 @@ class ConverterMusicXML(SubConverter):
         else:
             subformatExtension = subformats[0]
 
-        fpOut = str(fp)[:-3]
+        if not str(fp).endswith('.musicxml'):
+            raise ValueError('fp must end with the extension .musicxml')
+        fpOut = str(fp)[:-1 * len('musicxml')]
         fpOut += subformatExtension
 
         musescoreRun = [str(musescorePath), fp, '-o', fpOut, '-T', '0']
@@ -963,7 +965,7 @@ class ConverterMusicXML(SubConverter):
     def write(self, obj, fmt, fp=None, subformats=None,
               compress=False, **keywords):  # pragma: no cover
         '''
-        Write to a .xml file.
+        Write to a .musicxml file.
         Set `compress=True` to immediately compress the output to a .mxl file.
         '''
         from music21.musicxml import archiveTools, m21ToXml
@@ -984,7 +986,7 @@ class ConverterMusicXML(SubConverter):
         if fp is not None and subformats is not None:
             fpStr = str(fp)
             noExtFpStr = os.path.splitext(fpStr)[0]
-            writeDataStreamFp = noExtFpStr + '.xml'
+            writeDataStreamFp = noExtFpStr + '.musicxml'
 
         xmlFp = self.writeDataStream(writeDataStreamFp, dataBytes)
 
@@ -1429,7 +1431,7 @@ class Test(unittest.TestCase):
             png_ext = '-' + ext_base + '.png'
 
             tempFp1 = str(env.getTempFile())
-            xmlFp1 = tempFp1 + '.xml'
+            xmlFp1 = tempFp1 + '.musicxml'
             os.rename(tempFp1, tempFp1 + png_ext)
             tempFp1 += png_ext
             xmlConverter1 = ConverterMusicXML()
@@ -1443,7 +1445,7 @@ class Test(unittest.TestCase):
         '''
         env = environment.Environment()
         tempFp = str(env.getTempFile())
-        xmlFp = tempFp + '.xml'
+        xmlFp = tempFp + '.musicxml'
         os.rename(tempFp, tempFp + '-0000001.png')
         tempFp += '-0000001.png'
         xmlConverter = ConverterMusicXML()

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -849,8 +849,9 @@ class ConverterMusicXML(SubConverter):
         Check whether total number of pngs is in 1-9, 10-99, or 100-999 range,
         then return appropriate fp. Raises an exception if png fp does not exist.
         '''
+        # TODO: xmlFilePath is misleading, since we're passing in a .png path
         xmlFilePath = str(xmlFilePath)  # not pathlib.
-        path_without_extension = xmlFilePath[:-1 * len('.musicxml')]
+        path_without_extension = xmlFilePath[:-1 * len('.png')]
 
         for search_extension in ('1', '01', '001', '0001', '00001'):
             search_path = path_without_extension + '-' + search_extension + '.png'

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -843,8 +843,8 @@ class ConverterMusicXML(SubConverter):
                                          'pdf': 'pdf',
                                          }
 
-    # --------------------------------------------------------------------------
-    def findNumberedPNGPath(self, inputFp: Union[str, pathlib.Path]) -> str:
+    @staticmethod
+    def findNumberedPNGPath(inputFp: Union[str, pathlib.Path]) -> str:
         '''
         Find the first numbered file path corresponding to the provided unnumbered file path
         ending in ".png". Raises an exception if no file can be found.
@@ -948,7 +948,7 @@ class ConverterMusicXML(SubConverter):
         sys.stderr = storedStrErr
 
         if subformatExtension == 'png':
-            return self.findNumberedPNGPath(fpOut)
+            return ConverterMusicXML.findNumberedPNGPath(fpOut)
         else:
             return fpOut
         # common.cropImageFromPath(fp)
@@ -1438,7 +1438,7 @@ class Test(unittest.TestCase):
             tmp = env.getTempFile(suffix='.png', returnPathlib=False)
             tmpNumbered = tmp.replace('.png', png_ext)
             os.rename(tmp, tmpNumbered)
-            pngFp1 = ConverterMusicXML().findNumberedPNGPath(tmp)
+            pngFp1 = ConverterMusicXML.findNumberedPNGPath(tmp)
             self.assertEqual(pngFp1, tmpNumbered)
             os.remove(tmpNumbered)
 
@@ -1447,7 +1447,7 @@ class Test(unittest.TestCase):
         tmpNumbered = tmp.replace('.png', '-0000001.png')
         os.rename(tmp, tmpNumbered)
         with self.assertRaises(SubConverterFileIOException):
-            ConverterMusicXML().findNumberedPNGPath(tmpNumbered)
+            ConverterMusicXML.findNumberedPNGPath(tmpNumbered)
         os.remove(tmpNumbered)
 
     def testWriteMXL(self):

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -953,10 +953,12 @@ class ConverterMusicXML(SubConverter):
             return fpOut
         # common.cropImageFromPath(fp)
 
-    def writeDataStream(self, fp, dataBytes: bytes):  # pragma: no cover
+    def writeDataStream(self, fp, dataBytes: bytes) -> pathlib.Path:  # pragma: no cover
         '''
         Writes `dataBytes` to `fp`.
         Adds `.musicxml` suffix to `fp` if it does not already contain some suffix.
+
+        Changed in v7 -- returns a pathlib.Path
 
         OMIT_FROM_DOCS
 
@@ -1017,7 +1019,7 @@ class ConverterMusicXML(SubConverter):
             noExtFpStr = os.path.splitext(fpStr)[0]
             writeDataStreamFp = noExtFpStr + '.musicxml'
 
-        xmlFp = self.writeDataStream(writeDataStreamFp, dataBytes)
+        xmlFp: pathlib.Path = self.writeDataStream(writeDataStreamFp, dataBytes)
 
         if subformats is not None and 'png' in subformats:
             defaults.title = savedDefaultTitle

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -954,10 +954,17 @@ class ConverterMusicXML(SubConverter):
         # common.cropImageFromPath(fp)
 
     def writeDataStream(self, fp, dataBytes: bytes):  # pragma: no cover
+        '''
+        Writes `dataBytes` to `fp`.
+        Adds `.musicxml` suffix to `fp` if it does not already contain some suffix.
+        '''
         if fp is None:
             fp = self.getTemporaryFile()
         else:
-            fp = common.cleanpath(fp)
+            fp = common.cleanpath(fp, returnPathlib=True)
+
+        if not fp.suffix:
+            fp = fp.with_suffix('.musicxml')
 
         writeFlags = 'wb'
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -963,7 +963,7 @@ class ConverterMusicXML(SubConverter):
         return fp
 
     def write(self, obj, fmt, fp=None, subformats=None,
-              compress=False, **keywords):  # pragma: no cover
+              compress=False, **keywords):
         '''
         Write to a .musicxml file.
         Set `compress=True` to immediately compress the output to a .mxl file.
@@ -983,7 +983,7 @@ class ConverterMusicXML(SubConverter):
         dataBytes: bytes = generalExporter.parse()
 
         writeDataStreamFp = fp
-        if fp is not None and subformats is not None:
+        if fp is not None and subformats:  # could be empty list
             fpStr = str(fp)
             noExtFpStr = os.path.splitext(fpStr)[0]
             writeDataStreamFp = noExtFpStr + '.musicxml'

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -963,7 +963,7 @@ class ConverterMusicXML(SubConverter):
         return fp
 
     def write(self, obj, fmt, fp=None, subformats=None,
-              compress=False, **keywords):
+              compress=False, **keywords):  # pragma: no cover
         '''
         Write to a .musicxml file.
         Set `compress=True` to immediately compress the output to a .mxl file.

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -957,6 +957,23 @@ class ConverterMusicXML(SubConverter):
         '''
         Writes `dataBytes` to `fp`.
         Adds `.musicxml` suffix to `fp` if it does not already contain some suffix.
+
+        OMIT_FROM_DOCS
+
+        >>> import os
+        >>> from music21.converter.subConverters import ConverterMusicXML
+        >>> fp = 'nosuffix'
+        >>> sub = ConverterMusicXML()
+        >>> outFp = sub.writeDataStream(fp, b'')
+        >>> str(outFp).endswith('.musicxml')
+        True
+
+        >>> os.remove(outFp)
+        >>> fp = 'other.suffix'
+        >>> outFp = sub.writeDataStream(fp, b'')
+        >>> str(outFp).endswith('.suffix')
+        True
+        >>> os.remove(outFp)
         '''
         if fp is None:
             fp = self.getTemporaryFile()

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1422,10 +1422,13 @@ class Test(unittest.TestCase):
             testConverter.parseFile(testPath)
             self.assertEqual(1, mockConv.call_count)
 
-    def testXMLtoPNG(self):
+    def x_testXMLtoPNG(self):
         '''
         testing the findPNGfpFromXMLfp method with three different files of lengths
         that create .png files with -1, -01, and -001 in the fp
+
+        Doesn't work. Was mocking wrong behavior.
+        TODO: fix up
         '''
         env = environment.Environment()
         for ext_base in '1', '01', '001':

--- a/music21/defaults.py
+++ b/music21/defaults.py
@@ -34,7 +34,7 @@ class DefaultsException(Exception):
 title = 'Music21 Fragment'
 author = 'Music21'
 software = 'music21 v.' + _version.__version__  # used in xml encoding source software
-musicxmlVersion = '3.0'
+musicxmlVersion = '3.1'
 
 meterNumerator = 4
 meterDenominator = 'quarter'

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -8133,10 +8133,10 @@ class Test(unittest.TestCase):
         os.remove(otherFile)
 
         # test giving fp
-        tmp = environLocal.getTempFile(suffix='musicxml')
+        tmp = environLocal.getTempFile(suffix='xml')
         out = o.write(fp=tmp)
         otherFile = str(out).replace('-2', '-1')
-        self.assertTrue(str(out).endswith('-2.musicxml'))
+        self.assertTrue(str(out).endswith('-2.xml'))
         self.assertTrue(os.path.exists(otherFile))
         os.remove(tmp)
         os.remove(out)

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -8092,7 +8092,7 @@ class Test(unittest.TestCase):
         tmp = environLocal.getTempFile()
         out = o.write(fp=tmp)
         otherFile = str(out).replace('-2', '-1')
-        self.assertTrue(str(out).endswith('-2.xml'))
+        self.assertTrue(str(out).endswith('-2.musicxml'))
         self.assertTrue(os.path.exists(otherFile))
         os.remove(tmp)
         os.remove(out)

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -8075,6 +8075,41 @@ class Test(unittest.TestCase):
         self.assertEqual(beams[3], continue_beam)  # fourth should be continue
         self.assertEqual(beams[4], stop_beam)  # last should be stop
 
+    def testWrite(self):
+        import os
+
+        s = Stream([note.Note()])
+        tmpMusicxml = environLocal.getTempFile(suffix='musicxml')
+        tmpXml = environLocal.getTempFile(suffix='xml')
+        tmpNoSuffix = environLocal.getTempFile()
+
+        # Default: .musicxml
+        out1 = s.write()
+        # .musicxml pathlib.Path
+        out2 = s.write(fp=tmpMusicxml)
+        # .xml pathlib.Path
+        out3 = s.write(fp=tmpXml)
+        # .musicxml string
+        out4 = s.write(fp=str(tmpMusicxml))
+        # .xml string
+        out5 = s.write(fp=str(tmpXml))
+        # no suffix
+        out6 = s.write(fp=tmpNoSuffix)
+
+        self.assertTrue(str(out1).endswith('.musicxml'))
+        self.assertTrue(str(out2).endswith('.musicxml'))
+        self.assertTrue(str(out3).endswith('.xml'))
+        self.assertTrue(out4.endswith('.musicxml'))
+        self.assertTrue(out5.endswith('.xml'))
+        # in v7, we no longer coerce fp to end in .xml
+        self.assertNotIn('.xml', str(out6))
+
+        self.assertEqual(str(out2), out4)
+        self.assertEqual(str(out3), out5)
+
+        for fp in (out1, tmpMusicxml, tmpXml, tmpNoSuffix):
+            os.remove(fp)
+
     def testOpusWrite(self):
         import os
 
@@ -8089,7 +8124,16 @@ class Test(unittest.TestCase):
         os.remove(out)
         os.remove(otherFile)
 
-        tmp = environLocal.getTempFile()
+        # test no fp
+        out = o.write()
+        otherFile = str(out).replace('-2', '-1')
+        self.assertTrue(str(out).endswith('-2.musicxml'))
+        self.assertTrue(os.path.exists(otherFile))
+        os.remove(out)
+        os.remove(otherFile)
+
+        # test giving fp
+        tmp = environLocal.getTempFile(suffix='musicxml')
         out = o.write(fp=tmp)
         otherFile = str(out).replace('-2', '-1')
         self.assertTrue(str(out).endswith('-2.musicxml'))
@@ -8098,6 +8142,7 @@ class Test(unittest.TestCase):
         os.remove(out)
         os.remove(otherFile)
 
+        # test another format
         out = o.write(fmt='midi')
         otherFile = str(out).replace('-2', '-1')
         self.assertTrue(str(out).endswith('-2.mid'))

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -8096,18 +8096,18 @@ class Test(unittest.TestCase):
         # no suffix
         out6 = s.write(fp=tmpNoSuffix)
 
-        self.assertTrue(str(out1).endswith('.musicxml'))
-        self.assertTrue(str(out2).endswith('.musicxml'))
-        self.assertTrue(str(out3).endswith('.xml'))
-        self.assertTrue(out4.endswith('.musicxml'))
-        self.assertTrue(out5.endswith('.xml'))
-        # in v7, we no longer coerce fp to end in .xml
-        self.assertNotIn('.xml', str(out6))
+        self.assertEqual(out1.suffix, '.musicxml')
+        self.assertEqual(out2.suffix, '.musicxml')
+        self.assertEqual(out3.suffix, '.xml')
+        self.assertEqual(out4.suffix, '.musicxml')
+        self.assertEqual(out5.suffix, '.xml')
+        # Provide suffix if user didn't provide one
+        self.assertEqual(out6.suffix, '.musicxml')
 
-        self.assertEqual(str(out2), out4)
-        self.assertEqual(str(out3), out5)
+        self.assertEqual(str(out2), str(out4))
+        self.assertEqual(str(out3), str(out5))
 
-        for fp in (out1, tmpMusicxml, tmpXml, tmpNoSuffix):
+        for fp in (out1, tmpMusicxml, tmpXml, tmpNoSuffix, out6):
             os.remove(fp)
 
     def testOpusWrite(self):


### PR DESCRIPTION
There was a [comment](https://github.com/cuthbertLab/music21/issues/456#issuecomment-544558681) a while ago about doing this for v6, so when I saw `.endswith('-2.xml')` in the temp files cleanup patch, I thought "let's cross this off now".

(Let me know if I've severely misunderstood the point of the comment!)