### PR TITLE
v7 Stream constructor improvements

### DIFF
--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1358,12 +1358,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         urlBase = 'http://kern.ccarh.org/cgi-bin/ksdata?l=users/craig/classical/'
         urlB = urlBase + 'schubert/piano/d0576&file=d0576-06.krn&f=kern'
         urlC = urlBase + 'bach/cello&file=bwv1007-01.krn&f=xml'
-        for url in [urlB, urlC]:
-            try:
-                unused_post = parseURL(url)
-            except:
-                print(url)
-                raise
+        unused_post = parseURL(urlB)
+        unused_post = parseURL(urlC)
 
     def testFreezer(self):
         from music21 import corpus
@@ -1949,8 +1945,8 @@ class Test(unittest.TestCase):
     def testParseURL(self):
         from music21.humdrum.spineParser import HumdrumException
 
-        urlBase = 'http://kern.ccarh.org/cgi-bin/ksdata?l=users/craig/classical/'
-        url = urlBase + 'chopin/prelude&file=prelude28-20.krn&format=kern'
+        urlBase = 'https://raw.githubusercontent.com/craigsapp/chopin-preludes/'
+        url = urlBase + 'f8fb01f09d717e84929fb8b2950f96dd6bc05686/kern/prelude28-20.krn'
 
         e = environment.Environment()
         e['autoDownload'] = 'allow'

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -115,9 +115,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
     The duration, however, can be "unlinked" and explicitly
     set independent of the Stream's contents.
 
-    The first element passed to the Stream is an optional list,
-    tuple, or other Stream of music21 objects which is used to
-    populate the Stream by inserting each object at
+    The first element passed to the Stream is an optional single
+    Music21Object or a list, tuple, or other Stream of Music21Objects
+    which is used to populate the Stream by inserting each object at
     its :attr:`~music21.base.Music21Object.offset`
     property. Other arguments and keywords are ignored, but are
     allowed so that subclassing the Stream is easier.
@@ -154,6 +154,12 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
     {0.0} <music21.stream.Part embeddedPart>
         {0.0} <music21.note.Rest rest>
     {1.0} <music21.note.Note E->
+
+    New in v7 -- providing a single element now works:
+
+    >>> s = stream.Stream(meter.TimeSignature())
+    >>> s.first()
+    <music21.meter.TimeSignature 4/4>
     '''
     # this static attributes offer a performance boost over other
     # forms of checking class
@@ -227,8 +233,10 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         # experimental
         self._mutable = True
 
-        if givenElements and common.isIterable(givenElements):
-            # TODO: perhaps convert a single element into a list?
+        if givenElements and not common.isIterable(givenElements):
+            givenElements = [givenElements]
+
+        if givenElements:
             for e in givenElements:
                 try:
                     self.coreGuardBeforeAddElement(e)

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -281,9 +281,12 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             append = all(e.offset == 0.0 for e in givenElements)
         except AttributeError:
             pass  # appropriate failure will be raised by coreGuardBeforeAddElement()
-        if append and all(e.isStream for e in givenElements):
-            if all(not e.isMeasure for e in givenElements):
-                append = False
+        if (
+            append
+            and all(e.isStream for e in givenElements)
+            and all(not e.isMeasure for e in givenElements)
+        ):
+            append = False
 
         for e in givenElements:
             self.coreGuardBeforeAddElement(e)

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -231,6 +231,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # TODO: perhaps convert a single element into a list?
             for e in givenElements:
                 try:
+                    self.coreGuardBeforeAddElement(e)
                     self.coreInsert(e.offset, e)
                 except (AttributeError, TypeError):
                     raise StreamException(f'Unable to insert {e}')

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1973,12 +1973,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         except (ValueError, TypeError):
             raise StreamException(f'Offset {offset!r} must be a number.')
 
-        if not isinstance(item, base.Music21Object):
-            raise StreamException('to put a non Music21Object in a stream, '
-                                  + 'create a music21.ElementWrapper for the item')
         element = item
 
-        # checks if element is self; possibly performs additional checks
+        # checks if element is self, among other checks
         self.coreGuardBeforeAddElement(element)
         # main insert procedure here
 
@@ -2350,20 +2347,15 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         else:
             item = itemOrList
 
-        try:
-            unused = item.isStream  # will raise attribute error
-            element = item
-        except AttributeError:  # need to wrap
-            # element = music21.ElementWrapper(item)
-            raise StreamException('to put a non Music21Object in a stream, '
-                                  + 'create a music21.ElementWrapper for the item')
+        element = item
+        # checks if element is self, among other checks
+        self.coreGuardBeforeAddElement(element)
+
         # cannot support elements with Durations in the highest time list
         if element.duration.quarterLength != 0:
             raise StreamException('cannot insert an object with a non-zero '
                                   + 'Duration into the highest time elements list')
 
-        # checks of element is self; possibly performs additional checks
-        self.coreGuardBeforeAddElement(element)
         self.coreStoreAtEnd(element)
         # Streams cannot reside in end elements, thus do not update is flat
         self.coreElementsChanged(updateIsFlat=False)

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -281,11 +281,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             append = all(e.offset == 0.0 for e in givenElements)
         except AttributeError:
             pass  # appropriate failure will be raised by coreGuardBeforeAddElement()
-        if (
-            append
-            and all(e.isStream for e in givenElements)
-            and all(not e.isMeasure for e in givenElements)
-        ):
+        if append and all((e.isStream and not e.isMeasure) for e in givenElements):
             append = False
 
         for e in givenElements:

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -384,7 +384,7 @@ class StreamCoreMixin:
         Before adding an element, this method provides
         important checks to that element.
 
-        Used by both insert() and append()
+        Used by insert() and append() and Stream.__init__()
 
         Returns None or raises a StreamException
 

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -392,10 +392,18 @@ class StreamCoreMixin:
         >>> s.coreGuardBeforeAddElement(s)
         Traceback (most recent call last):
         music21.exceptions21.StreamException: this Stream cannot be contained within itself
+
+        >>> s.append(s.iter)
+        Traceback (most recent call last):
+        music21.exceptions21.StreamException: cannot insert StreamIterator into a Stream
+        Iterate over it instead (Users Guide chs. 6 and 26)
         '''
         # using id() here b/c we do not want to get __eq__ comparisons
         if element is self:  # cannot add this Stream into itself
             raise StreamException('this Stream cannot be contained within itself')
+        if 'StreamIterator' in element.classes:
+            raise StreamException('cannot insert StreamIterator into a Stream\n'
+            'Iterate over it instead (Users Guide chs. 6 and 26)')
         if checkRedundancy:
             idElement = id(element)
             if idElement in self._offsetDict:

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -32,6 +32,7 @@ from music21.common.numberTools import opFrac
 from music21 import spanner
 from music21 import tree
 from music21.exceptions21 import StreamException, ImmutableStreamException
+from music21.stream.iterator import StreamIterator
 
 # pylint: disable=attribute-defined-outside-init
 class StreamCoreMixin:
@@ -381,10 +382,15 @@ class StreamCoreMixin:
     # --------------------------------------------------------------------------
     def coreGuardBeforeAddElement(self, element, *, checkRedundancy=True):
         '''
-        Before adding an element, this method provides
-        important checks to that element.
+        Before adding an element, this method performs
+        important checks on that element.
 
-        Used by insert() and append() and Stream.__init__()
+        Used by:
+
+          - :meth:`~music21.stream.Stream.insert`
+          - :meth:`~music21.stream.Stream.append`
+          - :meth:`~music21.stream.Stream.storeAtEnd`
+          - `Stream.__init__()`
 
         Returns None or raises a StreamException
 
@@ -396,15 +402,23 @@ class StreamCoreMixin:
         >>> s.append(s.iter)
         Traceback (most recent call last):
         music21.exceptions21.StreamException: cannot insert StreamIterator into a Stream
-        Iterate over it instead (Users Guide chs. 6 and 26)
+        Iterate over it instead (User's Guide chs. 6 and 26)
+
+        >>> s.insert(4, 3.14159)
+        Traceback (most recent call last):
+        music21.exceptions21.StreamException: to put a non Music21Object in a stream,
+        create a music21.ElementWrapper for the item
         '''
-        # using id() here b/c we do not want to get __eq__ comparisons
         if element is self:  # cannot add this Stream into itself
             raise StreamException('this Stream cannot be contained within itself')
-        if 'StreamIterator' in element.classes:
-            raise StreamException('cannot insert StreamIterator into a Stream\n'
-            'Iterate over it instead (Users Guide chs. 6 and 26)')
+        if not isinstance(element, Music21Object):
+            if isinstance(element, StreamIterator):
+                raise StreamException('cannot insert StreamIterator into a Stream\n'
+                    "Iterate over it instead (User's Guide chs. 6 and 26)")
+            raise StreamException('to put a non Music21Object in a stream, '
+                                  'create a music21.ElementWrapper for the item')
         if checkRedundancy:
+            # using id() here b/c we do not want to get __eq__ comparisons
             idElement = id(element)
             if idElement in self._offsetDict:
                 # now go slow for safety -- maybe something is amiss in the index.

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -7929,8 +7929,11 @@ class Test(unittest.TestCase):
 
     def testCoreGuardBeforeAddElement(self):
         n = note.Note()
+        s = Stream()
         with self.assertRaises(StreamException):
             Stream([n, n])
+        with self.assertRaises(StreamException):
+            Stream([n, None, s.iter])
 
     # REMOVED: Turns out that it DOES have fermata on every note!
     # def testSchoenbergChordifyFermatas(self):

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -7927,6 +7927,11 @@ class Test(unittest.TestCase):
             # print(note1.id, note2.id, note3.id, note4.id)
         # TEST???
 
+    def testCoreGuardBeforeAddElement(self):
+        n = note.Note()
+        with self.assertRaises(StreamException):
+            Stream([n, n])
+
     # REMOVED: Turns out that it DOES have fermata on every note!
     # def testSchoenbergChordifyFermatas(self):
     #     '''

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -926,7 +926,7 @@ def addVariant(
     {0.0} <music21.note.Note E>
     {1.0} <music21.note.Note E>
     {2.0} <music21.note.Note E>
-    {3.0} <music21.variant.Variant object of length 0.0>
+    {3.0} <music21.variant.Variant object of length 6.0>
     {3.0} <music21.note.Note E>
     {4.0} <music21.note.Note E>
     {5.0} <music21.note.Note E>
@@ -947,12 +947,7 @@ def addVariant(
             tempVariant.append(sVariant)
         else:  # sVariant is not a measure
             sVariantMeasures = sVariant.getElementsByClass('Measure')
-            # apparently expression cannot be simplified. -- this is a mistake
-            # since sVariantMeasures will never == [] even if there are no measures.
-            # yet switching this to `if not sVariantMeasures` breaks things.
-            # TODO(msc) -- figure this out and fix it.
-            # noinspection PySimplifyBooleanCheck
-            if sVariantMeasures == []:  # If there are no measures, work element-wise
+            if not sVariantMeasures:  # If there are no measures, work element-wise
                 for e in sVariant:
                     offset = e.getOffsetBySite(sVariant) + startOffset
                     tempVariant.insert(offset, e)

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -2584,7 +2584,9 @@ class Test(unittest.TestCase):
         vn1 = note.Note('F#4')
         vn2 = note.Note('A-4')
 
-        v1 = Variant([vn1, vn2])
+        v1 = Variant()
+        v1.insert(0, vn1)
+        v1.insert(0, vn2)
         v1Copy = copy.deepcopy(v1)
         # copies stored objects; they point to the different Notes vn1/vn2
         self.assertIsNot(v1Copy[0], v1[0])
@@ -2614,7 +2616,9 @@ class Test(unittest.TestCase):
         s.repeatAppend(note.Note('G4'), 8)
         vn1 = note.Note('F#4')
         vn2 = note.Note('A-4')
-        v1 = Variant([vn1, vn2])
+        v1 = Variant()
+        v1.insert(0, vn1)
+        v1.insert(0, vn2)
         s.insert(5, v1)
 
         # as we deepcopy the elements in the variants, we have new Notes


### PR DESCRIPTION
Inspired by mailing list 4/2/21

This would be the error if someone tried to follow my advice to `.show('text')` on a stream where iterators were inserted (user error!). Easy improvement.

**Update: ** also add `coreGuard...` check to Stream constructor.

```
>>> src = stream.Stream()
>>> otherStream.append(src.iter)
>>> otherStream.show('t')
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/stream/base.py", line 1844, in elementOffset
    o = self._offsetDict[id(element)][0]
KeyError: 4469622288

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/base.py", line 894, in getOffsetBySite
    raise e
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/base.py", line 880, in getOffsetBySite
    a = site.elementOffset(tryOrigin, returnSpecial=returnSpecial)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/stream/base.py", line 1855, in elementOffset
    raise base.SitesException(
music21.sites.SitesException: an entry for this object 0x10a690610 is not stored in stream <music21.stream.Stream 0x109ffcd90>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/stream/base.py", line 258, in show
    return super().show(fmt=fmt, app=app, **keywords)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/base.py", line 2647, in show
    return formatWriter.show(self,
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/converter/subConverters.py", line 552, in show
    print(obj._reprText(**keywords))
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/stream/base.py", line 2985, in _reprText
    return self.recurseRepr(addEndTimes=addEndTimes,
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/stream/base.py", line 2962, in recurseRepr
    msg.append(singleElement(element, indent))
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/stream/base.py", line 2937, in singleElement
    offGet = in_element.getOffsetBySite(self)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/base.py", line 901, in getOffsetBySite
    raise SitesException(
music21.sites.SitesException: an entry for this object <music21.stream.Score 0x10a2cb7c0> is not stored in stream <music21.stream.Stream 0x109ffcd90>
```