### PR TITLE
Add safety to `Stream._getDuration()`

### DIFF
--- a/music21/duration.py
+++ b/music21/duration.py
@@ -2845,7 +2845,10 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
     @property
     def tuplets(self) -> Tuple[Tuplet, ...]:
         '''
-        return a tuple of Tuplet objects
+        Return a tuple of Tuplet objects.
+        May leave a stream containing objects having this duration
+        in an unusable state, requiring :meth:`~music21.stream.core.coreElementsChanged`
+        to be called. For this reason, prefer using :meth:`appendTuplet` to add tuplets.
         '''
         if self._componentsNeedUpdating:
             self._updateComponents()

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -7882,8 +7882,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             return self._cache['Duration']
         else:
             # environLocal.printDebug(['creating new duration based on highest time'])
-            self._cache['Duration'] = duration.Duration()
-            self._cache['Duration'].quarterLength = self.highestTime
+            self._cache['Duration'] = duration.Duration(quarterLength=self.highestTime)
             return self._cache['Duration']
 
     def _setDuration(self, durationObj):

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -545,6 +545,23 @@ class Test(unittest.TestCase):
         self.assertEqual(a.duration.quarterLength, 2.0)
         self.assertEqual(a.highestTime, 4)
 
+    def testStreamDurationRecalculated(self):
+        from fractions import Fraction
+
+        a = Stream()
+        n = note.Note(quarterLength=1.0)
+        a.append(n)
+        self.assertEqual(a.duration.quarterLength, 1.0)
+
+        # Alter the note's duration in a nonstandard way
+        # Normally, one would call Duration.appendTuplet()
+        tup = duration.Tuplet()
+        n.duration.tuplets = (tup,)
+        # Nonstandard workflow requires coreElementsChanged() to be called
+        # https://github.com/cuthbertLab/music21/issues/957
+        a.coreElementsChanged()
+        self.assertEqual(a.duration.quarterLength, Fraction(2,3))
+
     def testMeasureStream(self):
         '''An approach to setting TimeSignature measures in offsets and durations
         '''

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -560,7 +560,7 @@ class Test(unittest.TestCase):
         # Nonstandard workflow requires coreElementsChanged() to be called
         # https://github.com/cuthbertLab/music21/issues/957
         a.coreElementsChanged()
-        self.assertEqual(a.duration.quarterLength, Fraction(2,3))
+        self.assertEqual(a.duration.quarterLength, Fraction(2, 3))
 
     def testMeasureStream(self):
         '''An approach to setting TimeSignature measures in offsets and durations


### PR DESCRIPTION
Fixes #957 

(few days, few minutes, what is a Duration anyway?)

Thanks again to @gregchapman-dev for tracking down the interaction with `coreElementsChanged()` so that we could get a reproducer.