### PR TITLE
Import musicxml measures containing only ChordSymbols

### DIFF
--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1387,8 +1387,8 @@ class ChordSymbol(Harmony):
     chords, by default appear as chord symbols in a score and have duration of
     0.
 
-    To obtain the chord representation of the in the score, change the
-    :attr:`music21.harmony.ChordSymbol.writeAsChord` to True. Unless otherwise
+    To obtain the chord representation of the `ChordSymbol` in the score, change
+    :attr:`~music21.harmony.ChordSymbol.writeAsChord` to True. Unless otherwise
     specified, the duration of this chord object will become 1.0. If you have a
     leadsheet, run :meth:`music21.harmony.realizeChordSymbolDurations` on the
     stream to assign the correct (according to offsets) duration to each

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1388,7 +1388,7 @@ class ChordSymbol(Harmony):
     0.
 
     To obtain the chord representation of the `ChordSymbol` in the score, change
-    :attr:`~music21.harmony.ChordSymbol.writeAsChord` to True. Unless otherwise
+    :attr:`~music21.harmony.Harmony.writeAsChord` to True. Unless otherwise
     specified, the duration of this chord object will become 1.0. If you have a
     leadsheet, run :meth:`music21.harmony.realizeChordSymbolDurations` on the
     stream to assign the correct (according to offsets) duration to each

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1430,7 +1430,7 @@ class PartParser(XMLParserBase):
         self.mxScorePart = mxScorePart
 
         if mxPart is not None:
-            self.partId = mxPart.get('id', None)
+            self.partId = mxPart.get('id')
             if self.partId is None and parent is not None:
                 self.partId = list(parent.mxScorePartDict.keys())[0]
         else:

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1430,7 +1430,7 @@ class PartParser(XMLParserBase):
         self.mxScorePart = mxScorePart
 
         if mxPart is not None:
-            self.partId = mxPart.get('id')
+            self.partId = mxPart.get('id', None)
             if self.partId is None and parent is not None:
                 self.partId = list(parent.mxScorePartDict.keys())[0]
         else:
@@ -1984,6 +1984,17 @@ class PartParser(XMLParserBase):
 
         sets self.lastMeasureWasShort to True or False if it is an incomplete measure
         that is not a pickup.
+
+        >>> m = stream.Measure([meter.TimeSignature('4/4'), harmony.ChordSymbol('C7')])
+        >>> m.highestTime
+        0.0
+        >>> PP = musicxml.xmlToM21.PartParser()
+        >>> PP.setLastMeasureInfo(m)
+        >>> PP.adjustTimeAttributesFromMeasure(m)
+        >>> m.highestTime
+        4.0
+        >>> PP.lastMeasureWasShort
+        False
         '''
         # note: we cannot assume that the time signature properly
         # describes the offsets w/n this bar. need to look at
@@ -1999,7 +2010,9 @@ class PartParser(XMLParserBase):
         if mHighestTime >= lastTimeSignatureQuarterLength:
             mOffsetShift = mHighestTime
 
-        elif mHighestTime == 0.0 and not m.recurse().notesAndRests:
+        elif (mHighestTime == 0.0
+              and not m.recurse().notesAndRests.getElementsNotOfClass('Harmony')
+              ):
             # this routine fixes a bug in PDFtoMusic and other MusicXML writers
             # that omit empty rests in a Measure.  It is a very quick test if
             # the measure has any notes.  Slower if it does not.
@@ -2007,6 +2020,7 @@ class PartParser(XMLParserBase):
             r.duration.quarterLength = lastTimeSignatureQuarterLength
             m.insert(0.0, r)
             mOffsetShift = lastTimeSignatureQuarterLength
+            self.lastMeasureWasShort = False
 
         else:  # use time signature
             # for the first measure, this may be a pickup


### PR DESCRIPTION
A sequence of two such measures previously raised `ZeroDivisionError`.

**Example source:**
```
    <measure number="4" width="289.46">
      <harmony print-frame="no">
        <root>
          <root-step>G</root-step>
          </root>
        <kind text="m">minor</kind>
        </harmony>
      <harmony print-frame="no">
        <root>
          <root-step>E</root-step>
          <root-alter>-1</root-alter>
          </root>
        <kind>major</kind>
        <offset>24</offset>
        </harmony>
      <forward>
        <duration>48</duration>
        </forward>
      </measure>
    <measure number="5" width="357.54">
      <harmony print-frame="no">
        <root>
          <root-step>D</root-step>
          </root>
        <kind>major</kind>
        </harmony>
      <forward>
        <duration>48</duration>
        </forward>
      </measure>
```

Because m.4 was treated as "short", in the next measure we executed the last-measure-was-short branch and then crashed on a `ZeroDivisionError`:

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/musicxml/xmlToM21.py", line 2028, in adjustTimeAttributesFromMeasure
    barDurationProportion = m.barDurationProportion()
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/stream/base.py", line 12538, in barDurationProportion
    return opFrac(self.highestTime / barDuration.quarterLength)
ZeroDivisionError: float division by zero
```
