### PR TITLE
Remove Ambitus.getPitchRanges()

### DIFF
--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -1064,6 +1064,15 @@ class Ambitus(DiscreteAnalysis):
         >>> s = stream.Stream()
         >>> ambitusAnalyzer.getPitchRanges(s)
         (0, 0)
+
+        OMIT_FROM_DOCS
+
+        >>> s = stream.Stream()
+        >>> for i in range(12, 61):
+        ...    n = note.Note(i)
+        ...    s.repeatAppend(n, 2)
+        >>> ambitusAnalyzer.getPitchRanges(s)
+        (0, 48)
         '''
         ssfn = subStream.flat.notes
 
@@ -1075,15 +1084,19 @@ class Ambitus(DiscreteAnalysis):
             elif 'Note' in n.classes:
                 pitches = [n.pitch]
             for p in pitches:
-                psFound.append(p.ps)
+                # third insertion would be irrelevant
+                # we will sort next, and having two identical
+                # values is enough to produce an interval of 0.
+                if psFound.count(p.ps) < 2:
+                    psFound.append(p.ps)
         psFound.sort()
-        psRange = []
+        psRange = set()
         for i in range(len(psFound) - 1):
             p1 = psFound[i]
             for j in range(i + 1, len(psFound)):
                 p2 = psFound[j]
                 # p2 should always be equal or greater than p1
-                psRange.append(p2 - p1)
+                psRange.add(p2 - p1)
 
         if not psRange:
             return (0, 0)

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -1024,7 +1024,6 @@ class Ambitus(DiscreteAnalysis):
 
         >>> s = stream.Stream(note.Rest())
         >>> p.getPitchSpan(s)
-        None
 
         OMIT_FROM_DOCS
 
@@ -1032,7 +1031,7 @@ class Ambitus(DiscreteAnalysis):
 
         >>> s.insert(4, harmony.ChordSymbol('C6'))
         >>> p.getPitchSpan(s)
-        None
+
         '''
         if subStream is self._referenceStream and self.minPitchObj and self.maxPitchObj:
             return self.minPitchObj, self.maxPitchObj

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -997,10 +997,10 @@ class Ambitus(DiscreteAnalysis):
 
         # environLocal.printDebug([self._pitchSpanColors])
 
-    def getPitchSpan(self, subStream):
+    def getPitchSpan(self, subStream) -> Tuple[Optional[pitch.Pitch], Optional[pitch.Pitch]]:
         '''
-        For a given subStream, return the pitch with the minimum and
-        maximum pitch space value found.
+        For a given subStream, return a tuple consisting of the two pitches
+        with the minimum and maximum pitch space value.
 
         This public method may be used by other classes.
 
@@ -1019,6 +1019,20 @@ class Ambitus(DiscreteAnalysis):
         >>> s.append(c)
         >>> p.getPitchSpan(s)
         (<music21.pitch.Pitch A2>, <music21.pitch.Pitch C8>)
+
+        Returns (None, None) if the stream contains no pitches.
+
+        >>> s = stream.Stream(note.Rest())
+        >>> p.getPitchSpan(s)
+        (None, None)
+
+        OMIT_FROM_DOCS
+
+        And with only ChordSymbols:
+
+        >>> s.insert(4, harmony.ChordSymbol('C6'))
+        >>> p.getPitchSpan(s)
+        (None, None)
         '''
         if subStream is self._referenceStream and self.minPitchObj and self.maxPitchObj:
             return self.minPitchObj, self.maxPitchObj
@@ -1026,7 +1040,7 @@ class Ambitus(DiscreteAnalysis):
         justNotes = subStream.recurse().notes
         if not justNotes:
             # need to handle case of no pitches
-            return None
+            return (None, None)
 
         # find the min and max pitch space value for all pitches
         psFound = []
@@ -1040,9 +1054,9 @@ class Ambitus(DiscreteAnalysis):
                 pitches = [n.pitch]
             psFound += [p.ps for p in pitches]
             pitchesFound.extend(pitches)
-        # in some cases no pitch space values are found due to all rests
+        # in some cases there is stil nothing -- perhaps only ChordSymbols
         if not psFound:
-            return None
+            return (None, None)
         # use built-in functions
         minPitchIndex = psFound.index(min(psFound))
         maxPitchIndex = psFound.index(max(psFound))

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -972,18 +972,18 @@ class Ambitus(DiscreteAnalysis):
         2 #16111d
         3 #16121e
         '''
+        minPitch = 0
         if numColors is None:
             if self._referenceStream is not None:
                 # get total range for entire piece
                 self.minPitchObj, self.maxPitchObj = self.getPitchSpan(self._referenceStream)
-                difference = int(self.maxPitchObj.ps - self.minPitchObj.ps)
-                minPitch, maxPitch = 0, difference
+                maxPitch = int(self.maxPitchObj.ps - self.minPitchObj.ps)
             else:
-                minPitch, maxPitch = 0, 130  # a large default
+                maxPitch = 130  # a large default
         else:  # create minPitch maxPitch
-            minPitch, maxPitch = 0, numColors
+            maxPitch = numColors
 
-        valueRange = maxPitch - minPitch
+        valueRange = maxPitch
         if valueRange == 0:
             valueRange = 1  # avoid float division by zero
         step = 0
@@ -1023,14 +1023,16 @@ class Ambitus(DiscreteAnalysis):
         Returns None if the stream contains no pitches.
 
         >>> s = stream.Stream(note.Rest())
-        >>> p.getPitchSpan(s)
+        >>> p.getPitchSpan(s) is None
+        True
 
         OMIT_FROM_DOCS
 
         And with only ChordSymbols:
 
         >>> s.insert(4, harmony.ChordSymbol('C6'))
-        >>> p.getPitchSpan(s)
+        >>> p.getPitchSpan(s) is None
+        True
 
         '''
         if subStream is self._referenceStream and self.minPitchObj and self.maxPitchObj:
@@ -1060,10 +1062,12 @@ class Ambitus(DiscreteAnalysis):
         minPitchIndex = psFound.index(min(psFound))
         maxPitchIndex = psFound.index(max(psFound))
 
-        minPitchObj, maxPitchObj = pitchesFound[minPitchIndex], pitchesFound[maxPitchIndex]
+        minPitchObj = pitchesFound[minPitchIndex]
+        maxPitchObj = pitchesFound[maxPitchIndex]
 
         if subStream is self._referenceStream:
-            self.minPitchObj, self.maxPitchObj = minPitchObj, maxPitchObj
+            self.minPitchObj = minPitchObj
+            self.maxPitchObj = maxPitchObj
 
         return minPitchObj, maxPitchObj
 

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -997,7 +997,7 @@ class Ambitus(DiscreteAnalysis):
 
         # environLocal.printDebug([self._pitchSpanColors])
 
-    def getPitchSpan(self, subStream) -> Tuple[Optional[pitch.Pitch], Optional[pitch.Pitch]]:
+    def getPitchSpan(self, subStream) -> Optional[Tuple[pitch.Pitch, pitch.Pitch]]:
         '''
         For a given subStream, return a tuple consisting of the two pitches
         with the minimum and maximum pitch space value.
@@ -1020,11 +1020,11 @@ class Ambitus(DiscreteAnalysis):
         >>> p.getPitchSpan(s)
         (<music21.pitch.Pitch A2>, <music21.pitch.Pitch C8>)
 
-        Returns (None, None) if the stream contains no pitches.
+        Returns None if the stream contains no pitches.
 
         >>> s = stream.Stream(note.Rest())
         >>> p.getPitchSpan(s)
-        (None, None)
+        None
 
         OMIT_FROM_DOCS
 
@@ -1032,7 +1032,7 @@ class Ambitus(DiscreteAnalysis):
 
         >>> s.insert(4, harmony.ChordSymbol('C6'))
         >>> p.getPitchSpan(s)
-        (None, None)
+        None
         '''
         if subStream is self._referenceStream and self.minPitchObj and self.maxPitchObj:
             return self.minPitchObj, self.maxPitchObj
@@ -1040,7 +1040,7 @@ class Ambitus(DiscreteAnalysis):
         justNotes = subStream.recurse().notes
         if not justNotes:
             # need to handle case of no pitches
-            return (None, None)
+            return None
 
         # find the min and max pitch space value for all pitches
         psFound = []
@@ -1056,7 +1056,7 @@ class Ambitus(DiscreteAnalysis):
             pitchesFound.extend(pitches)
         # in some cases there is stil nothing -- perhaps only ChordSymbols
         if not psFound:
-            return (None, None)
+            return None
         # use built-in functions
         minPitchIndex = psFound.index(min(psFound))
         maxPitchIndex = psFound.index(max(psFound))

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -1266,12 +1266,11 @@ class RichMetadata(Metadata):
         self.pitchHighest = None
         self.pitchLowest = None
         analysisObject = discrete.Ambitus(streamObj)
-        psRange = analysisObject.getPitchSpan(streamObj)
-        if psRange is not None:
+        if analysisObject.minPitchObj is not None and analysisObject.maxPitchObj is not None:
             # may be none if no pitches are stored
             # presently, these are numbers; convert to pitches later
-            self.pitchLowest = psRange[0].nameWithOctave
-            self.pitchHighest = psRange[1].nameWithOctave
+            self.pitchLowest = analysisObject.minPitchObj.nameWithOctave
+            self.pitchHighest = analysisObject.maxPitchObj.nameWithOctave
         ambitusInterval = analysisObject.getSolution(streamObj)
         self.ambitus = AmbitusShort(semitones=ambitusInterval.semitones,
                                     diatonic=ambitusInterval.diatonic.simpleName,


### PR DESCRIPTION
`s.analyze('range')` is now a synonym for `s.analyze('span')`, which is a much faster algorithm. That means in the rare cases where there were no instances of a repeated note in a stream, the previous nonzero minPitch is now zero.

***

Prevents segfaults I was seeing when trying to cache metadata.

**More information**
This algorithm is O(n^2), so any extra values should be filtered out of `psFound` before running an expensive computation. We don't need more than two instances of any `ps`, because they'll just produce the same interval.

https://github.com/cuthbertLab/music21/blob/ebc47a1fbc9d65981bc52928593b4b564ae96cd5/music21/analysis/discrete.py#L1079-L1091


While debuggging I printed `psRange` being computed for one stream to a file, and it consumed > 500 MB before I interrupted the interpreter.