### PR TITLE
Improve Trills and Make sure "methods" are methods

### DIFF
--- a/music21/braille/basic.py
+++ b/music21/braille/basic.py
@@ -1093,7 +1093,7 @@ def showOctaveWithNote(previousNote, currentNote):
 
 
     Of course, these rules cease to apply in quite a few cases, which are not directly reflected
-    in the results of this method:
+    in the results of this function:
 
 
     1) If a braille measure goes to a new line, the first note in the measure carries an
@@ -1109,7 +1109,7 @@ def showOctaveWithNote(previousNote, currentNote):
        those cases needs an octave marking.
 
 
-    If any special case happens, previousNote can be set to None and the method will return
+    If any special case happens, previousNote can be set to None and the function will return
     True.
 
 
@@ -1422,7 +1422,7 @@ def brailleUnicodeToBrailleAscii(brailleUnicode):
     which is the format compatible with most braille embossers.
 
 
-    .. note:: The method works by corresponding braille symbols to ASCII symbols.
+    .. note:: The function works by corresponding braille symbols to ASCII symbols.
         The table which corresponds said values can be found
         `here <http://en.wikipedia.org/wiki/Braille_ASCII#Braille_ASCII_values>`_.
         Because of the way in which the braille symbols translate2, the resulting
@@ -1463,7 +1463,7 @@ def brailleAsciiToBrailleUnicode(brailleAscii):
     can then be displayed on-screen in braille on compatible systems.
 
 
-    .. note:: The method works by corresponding ASCII symbols to braille
+    .. note:: The function works by corresponding ASCII symbols to braille
         symbols in a very direct fashion. It is not a translator from plain
         text to braille, because ASCII symbols may not correspond to their
         equivalents in braille. For example, a literal period is a 4 in

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -8,7 +8,7 @@
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
-Inner classes and methods for transcribing musical segments into braille.
+Inner classes and functions for transcribing musical segments into braille.
 
 This module was made in consultation with the manual "Introduction to Braille
 Music Transcription, Second Edition" by Mary Turner De Garmo, 2005. It is
@@ -1394,10 +1394,10 @@ def findSegments(music21Part, **partKeywords):
 
     Returns a list of :class:`~music21.segment.BrailleSegment` instances.
 
-    Five methods get called in the generation of segments:
+    Five functions or methods get called in the generation of segments:
 
-    * :meth:`~music21.braille.segment.prepareSlurredNotes`
-    * :meth:`~music21.braille.segment.getRawSegments`
+    * :func:`~music21.braille.segment.prepareSlurredNotes`
+    * :func:`~music21.braille.segment.getRawSegments`
     * :meth:`~music21.braille.segment.BrailleSegment.addGroupingAttributes`
     * :meth:`~music21.braille.segment.BrailleSegment.addSegmentAttributes`
     * :meth:`~music21.braille.segment.BrailleSegment.fixArticulations`
@@ -1723,7 +1723,7 @@ def prepareSlurredNotes(music21Part, **keywords):
 def getRawSegments(music21Part, setHand=None):
     '''
     Takes in a :class:`~music21.stream.Part`, divides it up into segments (i.e. instances of
-    :class:`~music21.braille.segment.BrailleSegment`). This method assumes
+    :class:`~music21.braille.segment.BrailleSegment`). This function assumes
     that the Part is already divided up into measures
     (see :class:`~music21.stream.Measure`). An acceptable input is shown below.
 
@@ -1732,10 +1732,10 @@ def getRawSegments(music21Part, setHand=None):
     or :class:`~music21.braille.objects.BrailleOptionalSegmentDivision`
     or after 48 elements if a double bar or repeat sign is encountered.
 
-    Two methods are called on each measure during the creation of segments:
+    Two functions are called for each measure during the creation of segments:
 
-    * :meth:`~music21.braille.segment.prepareBeamedNotes`
-    * :meth:`~music21.braille.segment.extractBrailleElements`
+    * :func:`~music21.braille.segment.prepareBeamedNotes`
+    * :func:`~music21.braille.segment.extractBrailleElements`
 
     >>> tn = converter.parse("tinynotation: 3/4 c4 c c e e e g g g c'2.")
     >>> tn = tn.makeNotation(cautionaryNotImmediateRepeat=False)
@@ -1973,8 +1973,8 @@ def extractBrailleElements(music21Measure):
     {2.0} <music21.bar.Barline type=final>
 
 
-    Spanners are dealt with in :meth:`~music21.braille.segment.prepareSlurredNotes`,
-    so they are not returned by this method, as seen below.
+    Spanners are dealt with in :func:`~music21.braille.segment.prepareSlurredNotes`,
+    so they are not returned by this function, as seen below.
 
     >>> print(segment.extractBrailleElements(measure))
     <music21.meter.TimeSignature 2/4>
@@ -2212,7 +2212,7 @@ def areGroupingsIdentical(noteGroupingA, noteGroupingB):
 
 def splitNoteGrouping(noteGrouping, beatDivisionOffset=0):
     '''
-    Almost identical to :meth:`~music21.braille.segment.splitMeasure`, but
+    Almost identical to :func:`~music21.braille.segment.splitMeasure`, but
     functions on a :class:`~music21.braille.segment.BrailleElementGrouping`
     instead.
 

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -8,7 +8,7 @@
 # License:      BSD, see license.txt
 # -----------------------------------------------------------------------------
 '''
-Methods for exporting music21 data as braille.
+Functions for exporting music21 data as braille.
 
 This module was made in consultation with the manual "Introduction to Braille
 Music Transcription, Second Edition" by Mary Turner De Garmo, 2005. It is
@@ -16,10 +16,10 @@ available from the Library of Congress `here <http://www.loc.gov/nls/music/>`_,
 and will henceforth be referred to as BMTM.
 
 
-The most important method, and the only one that is needed to translate music
-into braille, is :meth:`~music21.braille.translate.objectToBraille`. This method,
-as well as the others, accept keyword arguments that serve to modify the output.
-If no keyword arguments are needed, then using the method is equivalent to
+The most important function, and the only one that is needed to translate music
+into braille, is :func:`~music21.braille.translate.objectToBraille`. This function,
+as well as the others, accepts keyword arguments that serve to modify the output.
+If no keyword arguments are needed, then using the function is equivalent to
 calling :meth:`~music21.base.Music21Object.show` on the music.
 
 

--- a/music21/corpus/__init__.py
+++ b/music21/corpus/__init__.py
@@ -299,8 +299,8 @@ def parse(workName,
     '''
     The most important method call for corpus.
 
-    Similar to the :meth:`~music21.converter.parse` method of converter (which
-    takes in a filepath on the local hard drive), this method searches the
+    Similar to the :func:`~music21.converter.parse` function of converter (which
+    takes in a filepath on the local hard drive), this function searches the
     corpus (including local corpora) for a work fitting the workName
     description and returns a :class:`music21.stream.Stream`.
 

--- a/music21/corpus/manager.py
+++ b/music21/corpus/manager.py
@@ -117,7 +117,7 @@ def getWork(workName,
             fileExtensions=None,
             ):
     '''
-    this parse method is called from `corpus.parse()` and does nothing differently from it.
+    this parse function is called from `corpus.parse()` and does nothing differently from it.
 
     Searches all corpora for a file that matches the name and returns it parsed.
     '''
@@ -218,7 +218,7 @@ def search(query=None, field=None, corpusNames=None, fileExtensions=None, **kwar
     '''
     Search all stored metadata bundles and return a list of file paths.
 
-    This method uses stored metadata and thus, on first usage, will incur a
+    This function uses stored metadata and thus, on first usage, will incur a
     performance penalty during metadata loading.
 
     >>> corpus.search('china')
@@ -244,9 +244,8 @@ def search(query=None, field=None, corpusNames=None, fileExtensions=None, **kwar
     <music21.metadata.bundles.MetadataBundle {368 entries}>
 
 
-
-    This method is implemented in `corpus.manager` but loaded into corpus for
-    ease of use.
+    This function is implemented in `corpus.manager` as a method there but also directly
+    available in the corpus module for ease of use.
 
     The ``corpusNames`` parameter can be used to specify which corpora to search,
     for example:

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -507,7 +507,7 @@ class Mordent(GeneralMordent):
     A normal Mordent -- goes downwards and has a line through it.
 
     Note that some computer terminology calls this one an inverted mordent, but this
-    is a modern term.  See Apel, _Harvard Dictionary of Music_, "Mordent"::
+    is a modern term.  See Apel, *Harvard Dictionary of Music*, "Mordent"::
 
         A musical ornament consisting of the alternation of the written note
         with the note immediately below it.
@@ -565,7 +565,7 @@ class InvertedMordent(GeneralMordent):
     An inverted Mordent -- goes upwards and has no line through it.
 
     Note that some computer terminology calls this one a (normal) mordent, but this
-    is a modern term.    See Apel, _Harvard Dictionary of Music_,
+    is a modern term.    See Apel, *Harvard Dictionary of Music*,
     "Inverted Mordent"::
 
         An 18th-century ornament involving alternation of the

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -965,7 +965,7 @@ class DataSet:
 
     def _processNonParallel(self):
         '''
-        The traditional method: run non-parallel
+        The traditional way: run non-parallel
         '''
         # clear features
         self.features = []

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -48,7 +48,7 @@ environLocal = environment.Environment(_MOD)
 
 
 def _mergeDicts(a, b):
-    '''utility method to merge two dictionaries'''
+    '''utility function to merge two dictionaries'''
     c = a.copy()
     c.update(b)
     return c
@@ -916,7 +916,7 @@ class WindowedAnalysis(primitives.GraphColorGrid, PlotStreamMixin):
 
     def write(self, fp=None):  # pragma: no cover
         '''
-        Process method here overridden to provide legend.
+        Overrides the normal write method here to add a legend.
         '''
         # call the process routine in the base graph
         super().write(fp)

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -284,12 +284,12 @@ class Harmony(chord.Chord):
         When you instantiate a harmony object, if you pass in a figure it
         is stored internally and returned when you access the figure
         property. If you don't instantiate the object with a figure, this
-        property calls :meth:`music21.harmony.findFigure` method which
+        property calls :meth:`music21.harmony.Harmony.findFigure` method which
         deduces the figure provided other information about the object,
         especially the chord.
 
         If the pitches of the harmony object have been modified after being
-        instantiated, call :meth:`music21.harmony.findFigure` to deduce the
+        instantiated, call :meth:`music21.harmony.Harmony.findFigure` to deduce the
         new figure.
 
         >>> h = harmony.ChordSymbol('CM')
@@ -1074,7 +1074,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
        the most thirds above it
        this is not a consistent way to determine the root of 13th chords, for example
     2. a chord vector is extracted from the chord
-        using  :meth:`music21.chord.semitonesFromChordStep`
+        using  :meth:`music21.chord.Chord.semitonesFromChordStep`
         this vector extracts the following degrees: (2, 3, 4, 5, 6, 7, 9, 11, and 13)
     3. this vector is converted to fbNotationString (in the form of chord step,
         and a '-' or '#' to indicate semitone distance)
@@ -1302,7 +1302,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
 def chordSymbolFromChord(inChord):
     '''
     Get the :class:`~music21.harmony.chordSymbol` object from the chord, using
-    :meth:`music21.harmony.chordSymbolFigureFromChord`
+    :meth:`music21.harmony.Harmony.chordSymbolFigureFromChord`
 
     >>> c = chord.Chord(['D3', 'F3', 'A4', 'B-5'])
     >>> symbol = harmony.chordSymbolFromChord(c)
@@ -1390,7 +1390,7 @@ class ChordSymbol(Harmony):
     To obtain the chord representation of the in the score, change the
     :attr:`music21.harmony.ChordSymbol.writeAsChord` to True. Unless otherwise
     specified, the duration of this chord object will become 1.0. If you have a
-    leadsheet, run :meth:`music21.harmony.realizeChordSymbolDurations` on the
+    leadsheet, run :func:`music21.harmony.realizeChordSymbolDurations` on the
     stream to assign the correct (according to offsets) duration to each
     harmony object.)
 

--- a/music21/humdrum/__init__.py
+++ b/music21/humdrum/__init__.py
@@ -37,7 +37,7 @@ extract_      Not needed                                         Use python comm
 fields_       Not needed
 fin2hum_      `music21.converter.parse` (filename)               Enigma Transport Format did not take off and is rarely used. Software to convert Enigma to MusicXML is available from recordare
 freq_         see :meth:`~music21.pitch.Pitch.frequency`
-hint_         see Notes                                          :meth:`~music21.stream.Stream.attachIntervalsBetweenStreams` See alpha.trecento.capua demo to show how it can be done.
+hint_         see Notes                                          :meth:`~music21.stream.Stream.attachIntervalsBetweenStreams` See music21-tools trecento.capua demo to show how it can be done.
 hum2fin_      `.write('musicxml')`                               Writes to musicXML.  A music21 to Enigma converter will not be written (obsolete format)
 humdrum_      Not needed                                         The `spineParser` will report errors when parsing.
 humsed_       Not needed

--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -12,7 +12,7 @@
 These are the public methods for the MEI module by Christopher Antila
 
 To convert a string with MEI markup into music21 objects,
-use :meth:`MeiToM21Converter.convertFromString`.
+use :meth:`~music21.mei.MeiToM21Converter.convertFromString`.
 
 In the future, most of the functions in this module should be moved to a separate, import-only
 module, so that functions for writing music21-to-MEI will fit nicely.
@@ -354,7 +354,9 @@ def safePitch(
     function instead returns a default :class:`~music21.pitch.Pitch` instance.
 
     name: Desired name of the :class:`~music21.pitch.Pitch`.
+
     accidental: (Optional) Symbol for the accidental.
+
     octave: (Optional) Octave number.
 
     Returns A :class:`~music21.pitch.Pitch` with the appropriate properties.

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -282,7 +282,7 @@ def postFigureFromChordAndKey(chordObj, keyObj=None):
     ...     )
     'o6#5b3'
 
-    The method substitutes shorthand (e.g., '6' not '63')
+    The function substitutes shorthand (e.g., '6' not '63')
 
     >>> roman.postFigureFromChordAndKey(
     ...     chord.Chord(['E3', 'C4', 'G4']),
@@ -604,7 +604,7 @@ def identifyAsTonicOrDominant(
 def romanInversionName(inChord, inv=None):
     '''
     Extremely similar to Chord's inversionName() method, but returns string
-    values and allows incomplete triads
+    values and allows incomplete triads.
     '''
     if inv is None:
         inv = inChord.inversion()
@@ -3248,7 +3248,7 @@ class RomanNumeral(harmony.Harmony):
     def isNeapolitan(self,
                      require1stInversion: bool = True):
         '''
-        Music21's Chord module offers methods for identifying chords of a particular type,
+        Music21's Chord class contains methods for identifying chords of a particular type,
         such as :meth:`~music21.chord.Chord.isAugmentedSixth`.
 
         Some similar chord types are defined not only by the structure of a chord but

--- a/music21/search/serial.py
+++ b/music21/search/serial.py
@@ -1351,8 +1351,8 @@ class TransformedSegmentMatcher(SegmentMatcher):
     The convention for serial
     transformations must be specified to either
     'zero' or 'original', as described in
-    :meth:`~music21.search.serial.zeroCenteredTransformation` and
-    :func:`~music21.search.serial.originalCenteredTransformation` - the default setting
+    :meth:`~music21.search.serial.ToneRow.zeroCenteredTransformation` and
+    :func:`~music21.search.serial.ToneRow.originalCenteredTransformation` - the default setting
     is 'original', as to relate found segments
     directly to the given segments, without first transposing the given segment to
     begin on the pitch class 0.
@@ -1716,7 +1716,7 @@ class TransposedMultisetMatcher(SegmentMatcher):
     Finds all instances of given multisets of pitch classes, with transpositions,
     within a :class:`~music21.stream.Stream`. A multiset
     is a generalization of a set, as described in
-    :meth:`~music21.search.serial.findMultisets`.
+    :class:`~music21.search.serial.MultisetSegmentMatcher`.
 
     The inputStream is :class:`~music21.stream.Stream`; as
     in :class:`~music21.search.serial.ContiguousSegmentSearcher`,
@@ -1828,7 +1828,7 @@ class TransposedInvertedMultisetMatcher(TransposedMultisetMatcher):
     Finds all instances of given multisets of pitch classes, with
     transpositions and inversions, within a :class:`~music21.stream.Stream`.
     A multiset is a generalization of a set, as described in
-    :meth:`~music21.search.serial.findMultisets`.
+    :class:`~music21.search.serial.MultisetSegmentMatcher`.
 
     The inputStream is :class:`~music21.stream.Stream`; as
     in :class:`~music21.search.serial.ContiguousSegmentSearcher`,
@@ -2214,13 +2214,13 @@ def labelMultisets(inputStream, multisetDict, reps='skipConsecutive', includeCho
     Labels all instances of a given collection of multisets of pitch classes in a
     :class:`~music21.stream.Stream`. A multiset
     is a generalization of a set, as described in
-    :meth:`~music21.search.serial.findMultisets`.
+    :class:`~music21.search.serial.MultisetSegmentMatcher`.
 
     The multisetDict is a dictionary whose keys are names of
     the multisets to be searched for, and whose
     values are the segments of pitch classes. The values will be
-    turned in to a segmentList, as in :func:`~music21.search.serial.findMultisets`.
-    All other settings are as in :func:`~music21.search.serial.findMultisets` as well.
+    turned in to a segmentList, as in :class:`~music21.search.serial.MultisetSegmentMatcher`.
+    All other settings are as in :class:`~music21.search.serial.MultisetSegmentMatcher` as well.
 
     Returns a deep copy of the inputStream
     with a :class:`~music21.spanner.Line` connecting the first and last notes
@@ -2281,12 +2281,12 @@ def labelTransposedMultisets(inputStream, multisetDict,
     transpositions, of pitch classes in a :class:`~music21.stream.Stream`.
 
     A multiset is a generalization of a set, as described in
-    :meth:`~music21.search.serial.findMultisets`.
+    :class:`~music21.search.serial.MultisetSegmentMatcher`.
 
     The multisetDict is a dictionary whose keys are names of the multisets to
     be searched for, and whose values are the segments of pitch classes. The
     values will be turned in to a segmentList, as in
-    :func:`~music21.search.serial.findMultisets`.
+    :class:`~music21.search.serial.MultisetSegmentMatcher`.
 
     All other settings are as in
     :func:`~music21.search.serial.findTransposedMultisets` as well.
@@ -2345,12 +2345,12 @@ def labelTransposedAndInvertedMultisets(inputStream,
     :class:`~music21.stream.Stream`.
 
     A multiset is a generalization of a set, as described in
-    :meth:`~music21.search.serial.findMultisets`.
+    :class:`~music21.search.serial.MultisetSegmentMatcher`.
 
     The multisetDict is a dictionary whose keys are names of the multisets to
     be searched for, and whose values are the segments of pitch classes. The
     values will be turned in to a segmentList, as in
-    :func:`~music21.search.serial.findMultisets`.
+    :class:`~music21.search.serial.MultisetSegmentMatcher`.
 
     All other settings are as in
     :func:`~music21.search.serial.findTransposedMultisets` as well.

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -49,7 +49,7 @@ class TwelveToneMatrix(stream.Stream):
 
     This object is commonly used by calling the
     :meth:`~music21.stream.TwelveToneRow.matrix` method of
-    :meth:`~music21.stream.TwelveToneRow` (or a subclass).
+    :class:`~music21.stream.TwelveToneRow` (or a subclass).
 
     >>> ttr = serial.TwelveToneRow([0, 2, 11, 7, 8, 3, 9, 1, 4, 10, 6, 5])
     >>> aMatrix = ttr.matrix()
@@ -563,7 +563,7 @@ class ToneRow(stream.Stream):
         to another, the second specified in the argument. Each transformation is given as a
         tuple of the transformation type and index.
 
-        See :meth:`~music21.serial.zeroCenteredTransformation` for
+        See :meth:`~music21.serial.ToneRow.zeroCenteredTransformation` for
         an explanation of this convention.
 
 
@@ -766,8 +766,8 @@ class TwelveToneRow(ToneRow):
 
         The convention for serial transformations must also be specified as 'zero' or
         'original', as explained
-        in :meth:`~music21.serial.findZeroCenteredTransformations` and
-        :meth:`~music21.serial.findOriginalCenteredTransformations`.
+        in :meth:`~music21.serial.ToneRow.findZeroCenteredTransformations` and
+        :meth:`~music21.serial.ToneRow.findOriginalCenteredTransformations`.
 
         >>> row = serial.pcToToneRow([5, 9, 11, 3, 6, 7, 4, 10, 0, 8, 2, 1])
         >>> row.findTransformedHistorical('original')
@@ -1045,8 +1045,8 @@ class TwelveToneRow(ToneRow):
         The first and second arguments describe one transformation, while the third and fourth
         describe another. One of the zero-centered or original-centered conventions for tone row
         transformations must be specified in the last argument; see
-        :meth:`~music21.serial.zeroCenteredTransformation` and
-        :meth:`~music21.serial.originalCenteredTransformation` explanations of these conventions.
+        :meth:`~music21.serial.ToneRow.zeroCenteredTransformation` and
+        :meth:`~music21.serial.ToneRow.originalCenteredTransformation` explanations of these conventions.
 
         >>> moses = serial.getHistoricalRowByName('SchoenbergMosesAron')
         >>> moses.pitchClasses()

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -1046,7 +1046,8 @@ class TwelveToneRow(ToneRow):
         describe another. One of the zero-centered or original-centered conventions for tone row
         transformations must be specified in the last argument; see
         :meth:`~music21.serial.ToneRow.zeroCenteredTransformation` and
-        :meth:`~music21.serial.ToneRow.originalCenteredTransformation` explanations of these conventions.
+        :meth:`~music21.serial.ToneRow.originalCenteredTransformation` explanations
+        of these conventions.
 
         >>> moses = serial.getHistoricalRowByName('SchoenbergMosesAron')
         >>> moses.pitchClasses()


### PR DESCRIPTION
A lot of early documentation did not make a strong distinction between functions and methods.  Went through some places and clarified.

Noticed during review of #962