### PR TITLE
Create inexpressible durations from tiny durations instead of raising

### DIFF
--- a/music21/duration.py
+++ b/music21/duration.py
@@ -3657,11 +3657,11 @@ class Test(unittest.TestCase):
     def testTinyDuration(self):
         # e.g. delta from chordify: 1/9 - 1/8 = 1/72
         # exercises quarterLengthToNonPowerOf2Tuplet()
-        d = Duration(1/72)
+        d = Duration(1 / 72)
         self.assertEqual(d.type, 'inexpressible')
 
         # this failure happens earlier in quarterConversion()
-        d = Duration(1/2049)
+        d = Duration(1 / 2049)
         self.assertEqual(d.type, 'inexpressible')
 
 

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -2126,7 +2126,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
         For an 'inexpressible' duration, the opposite of consolidate is
         to set the duration's quarterLength to itself.  It won't necessarily
-        return to the original components, but it will (usually? always?)
+        return to the original components, but it will usually
         create something that can be notated.
 
         >>> a.quarterLength = a.quarterLength

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -64,12 +64,18 @@ def typeToMusicXMLType(value):
     'long'
     >>> musicxml.m21ToXml.typeToMusicXMLType('quarter')
     'quarter'
+    >>> musicxml.m21ToXml.typeToMusicXMLType('inexpressible')
+    Traceback (most recent call last):
+    music21.musicxml.xmlObjects.MusicXMLExportException:
+    Cannot convert inexpressible durations to MusicXML.
     '''
     # MusicXML uses long instead of longa
     if value == 'longa':
         return 'long'
     elif value == '2048th':
         raise MusicXMLExportException('Cannot convert "2048th" duration to MusicXML (too short).')
+    elif value == 'inexpressible':
+        raise MusicXMLExportException('Cannot convert inexpressible durations to MusicXML.')
     else:
         return value
 


### PR DESCRIPTION
I had this lying around (not pulling an all-nighter!)

**Motivation**:
Some tiny durations raise exceptions when accessing their types. My real-world case for this was reducing an orchestral score using `chordify()` and ending up with a 1/72 QL from the difference between one violin part with a 9/8/32nd tuplet run and another part with 8 32nd notes. This is how we handle large types, so here I extend it to small types.

MusicXML export should still fail if the type is inexpressible (and in one case they were getting all the way through and exporting invalid musicxml), but better to fail there (seems to me) than when just merely creating the duration and accessing the type.

```
>>> from music21 import *
>>> d = duration.Duration(1/72)
>>> d.type
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jwalls/music21/music21/duration.py", line 2913, in type
    elif len(self.components) == 1:
  File "/Users/jwalls/music21/music21/duration.py", line 2440, in components
    self._updateComponents()
  File "/Users/jwalls/music21/music21/duration.py", line 1732, in _updateComponents
    qlc = quarterConversion(self._qtrLength)
  File "/Users/jwalls/music21/music21/duration.py", line 700, in quarterConversion
    tuplet, component = quarterLengthToNonPowerOf2Tuplet(qLen)
  File "/Users/jwalls/music21/music21/duration.py", line 412, in quarterLengthToNonPowerOf2Tuplet
    closestSmallerType, unused_match = quarterLengthToClosestType(qLen / qFrac.denominator)
  File "/Users/jwalls/music21/music21/duration.py", line 310, in quarterLengthToClosestType
    raise DurationException('Cannot return types smaller than 2048th; '
music21.duration.DurationException: Cannot return types smaller than 2048th; qLen was: 1/576
```

**Now**
- Create inexpressible durations when doing m21 transformations (such as chordify)
- Raise when attempting to export inexpressible durations to musicxml