### PR TITLE
Improve `Stream.__getitem__()`

### DIFF
--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -908,15 +908,20 @@ class Test(unittest.TestCase):
         self.assertEqual(len(post.parts[0].flat.notes), 3)
         # post.parts[0].show('t')
 
-        found = post.parts.first().measures(0, 2)[note.GeneralNote]
-        match = [(repr(e), e.offset, e.duration.quarterLength) for e in found]
+        three_measures = post.parts.first()[stream.Measure][:3]
+        new_stream = stream.Stream()
+        for m in three_measures:
+            new_stream.append(m)
+        flat_stream = new_stream.flat
+        match = [(repr(e), e.offset, e.duration.quarterLength) for e in flat_stream.notesAndRests]
+        self.maxDiff = None
         self.assertEqual(match,
                          [('<music21.note.Rest rest>', 0.0, 1.0),
                           ('<music21.note.Note F#>', 1.0, 1.0),
                           ('<music21.note.Rest rest>', 2.0, 1.0),
                           ('<music21.note.Note C#>', 3.0, 1.0),
-                          ('<music21.note.Rest rest>', 5.0, 1.0),
-                          ('<music21.note.Note G#>', 6.0, 1.0)])
+                          ('<music21.note.Rest rest>', 4.0, 1.0),
+                          ('<music21.note.Note G#>', 5.0, 1.0)])
 
         # test that lyric is found
         self.assertEqual(post.parts[0].flat.notes[0].lyric, 'fromBass')

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -908,8 +908,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(post.parts[0].flat.notes), 3)
         # post.parts[0].show('t')
 
-        match = [(repr(e), e.offset, e.duration.quarterLength)
-            for e in post.parts[0].getElementsByClass('Measure').stream()[0:3].flat.notesAndRests]
+        found = post.parts.first().measures(0, 2)[note.GeneralNote]
+        match = [(repr(e), e.offset, e.duration.quarterLength) for e in found]
         self.assertEqual(match,
                          [('<music21.note.Rest rest>', 0.0, 1.0),
                           ('<music21.note.Note F#>', 1.0, 1.0),

--- a/music21/audioSearch/__init__.py
+++ b/music21/audioSearch/__init__.py
@@ -920,7 +920,8 @@ def decisionProcess(
     >>> beginningData = []
     >>> lengthData = []
     >>> for i in range(4):
-    ...     scNotes = scoreStream[i * hop + 1:i * hop + tn_recording + 1]
+    ...     excerpt = scoreStream[i * hop + 1:i * hop + tn_recording + 1]
+    ...     scNotes = stream.Part(excerpt)
     ...     name = str(i)
     ...     beginningData.append(i * hop + 1)
     ...     lengthData.append(tn_recording)

--- a/music21/audioSearch/scoreFollower.py
+++ b/music21/audioSearch/scoreFollower.py
@@ -161,7 +161,8 @@ class ScoreFollower:
             detectedPitchObjects)
         self.silencePeriodDetection(notesList)
         environLocal.printDebug('made it to here...')
-        scNotes = stream.Stream(self.scoreStream[self.lastNotePosition:self.lastNotePosition + len(notesList)])
+        excerpt = self.scoreStream[self.lastNotePosition:self.lastNotePosition + len(notesList)]
+        scNotes = stream.Part(excerpt)
         # print('1')
         transcribedScore, self.qle = audioSearch.notesAndDurationsToStream(
             notesList,
@@ -502,7 +503,8 @@ class ScoreFollower:
                              - math.ceil(tn_window / hop))
 
         for i in range(iterations):
-            scNotes = scoreStream[i * hop + 1:i * hop + tn_recording + 1]
+            excerpt = scoreStream[i * hop + 1:i * hop + tn_recording + 1]
+            scNotes = stream.Part(excerpt)
             name = str(i)
             beginningData.append(i * hop + 1)
             lengthData.append(tn_recording)

--- a/music21/audioSearch/scoreFollower.py
+++ b/music21/audioSearch/scoreFollower.py
@@ -17,6 +17,7 @@ from time import time
 
 from music21 import scale
 from music21 import search
+from music21 import stream
 
 from music21 import environment
 _MOD = 'audioSearch.scoreFollower'
@@ -160,7 +161,7 @@ class ScoreFollower:
             detectedPitchObjects)
         self.silencePeriodDetection(notesList)
         environLocal.printDebug('made it to here...')
-        scNotes = self.scoreStream[self.lastNotePosition:self.lastNotePosition + len(notesList)]
+        scNotes = stream.Stream(self.scoreStream[self.lastNotePosition:self.lastNotePosition + len(notesList)])
         # print('1')
         transcribedScore, self.qle = audioSearch.notesAndDurationsToStream(
             notesList,

--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -263,7 +263,7 @@ class FiguredBassLine:
 
         >>> from music21 import corpus
         >>> sBach = corpus.parse('bach/bwv307')
-        >>> sBach['bass'].measure(0).show('text')
+        >>> sBach.parts.last().measure(0).show('text')
         {0.0} ...
         {0.0} <music21.clef.BassClef>
         {0.0} <music21.key.Key of B- major>
@@ -271,7 +271,7 @@ class FiguredBassLine:
         {0.0} <music21.note.Note B->
         {0.5} <music21.note.Note C>
 
-        >>> fbLine = realizer.figuredBassFromStream(sBach['bass'])
+        >>> fbLine = realizer.figuredBassFromStream(sBach.parts.last())
         >>> fbLine.generateBassLine().measure(1).show('text')
         {0.0} <music21.clef.BassClef>
         {0.0} <music21.key.KeySignature of 2 flats>

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -411,7 +411,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         3.0
 
 
-        If a class (or a list of classes) is given then an iterator of elements
+        If a class is given then an iterator of elements
         that match the requested class(es) is returned, similar
         to `Stream().recurse().getElementsByClass()`.
 
@@ -421,8 +421,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         2
         >>> len(s[note.Note])
         6
-        >>> len(s[[note.Note, note.Rest]])
-        8
 
         >>> for n in s[note.Note]:
         ...     print(n.name, end=' ')
@@ -487,7 +485,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         Any other query raises a TypeError:
 
         >>> s[0.5]
-
+        Traceback (most recent call last):
+        TypeError: Streams can get items by int, slice, class, or string query; got <class 'float'>
 
 
         Changed in v7:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -413,8 +413,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             return searchElements[k]
 
         elif isinstance(k, type):
-            # shouldn't this have been equivalent? might have revealed a bug.
-            # classIter = iterator.RecursiveIterator(self, filterList=(k,))
             classIter = self.recurse().getElementsByClass(k)
             if classIter:
                 return classIter

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -366,21 +366,20 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         Get items by groups:
 
         >>> violinGroup = a['violin']
-        >>> violinGroup
-        <music21.stream.iterator.StreamIterator for Part:hello @:1>
-        >>> violinGroup.first() is b
-        True
+        >>> violinGroup #_DOCS_SHOW
+        <music21.stream.iterator.StreamIterator for Part:hello @:1> #_DOCS_SHOW
+        >>> violinGroup.first() is b #_DOCS_SHOW
+        True #_DOCS_SHOW
 
         If a string or class is not found, a KeyError will be raised:
 
         >>> a['purple']
         Traceback (most recent call last):
-        KeyError: 'provided key (purple) does not match any class or group'
+        KeyError: 'provided key (purple) was not found in query results'
 
         >>> a[layout.StaffLayout]
         Traceback (most recent call last):
-        KeyError: "provided key (<class 'music21.layout.StaffLayout'>) does
-        not match any class or group"
+        KeyError: "provided key (<class 'music21.layout.StaffLayout'>) does not match any class"
 
         Changed in v7:
           - out of range indexes now raise an IndexError, not StreamException
@@ -425,7 +424,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         elif isinstance(k, type):
             # shouldn't this have been equivalent? might have revealed a bug.
-            # classIter = iterator.RecursiveIterator(self, filterList=(k))
+            # classIter = iterator.RecursiveIterator(self, filterList=(k,))
             classIter = self.recurse().getElementsByClass(k)
             if classIter:
                 return classIter

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -316,11 +316,12 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         '''
         Get a Music21Object from the Stream using a variety of keys or indices.
 
-        If an int is given, the Music21Object at the index is returned. If the Stream is sorted
-        (if isSorted is True), the elements are returned in order.
+        If an int is given, the Music21Object at the index is returned.
+        If the Stream is sorted (isSorted is True), the elements are returned in order.
 
-        If a string is given, :meth:`~music21.stream.Stream.getElementsByGroup` is used to
-        select items. If that search yields nothing, the string is treated as a class, described next.
+        If a string is given, :meth:`~music21.stream.Stream.getElementsByGroup`
+        is used to select items. If that search yields nothing, the string is
+        treated as a class, described next.
 
         If a class name is given (as a string or name),
         :meth:`~music21.stream.Stream.getElementsByClass` is used to return a

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -363,19 +363,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> allNotes.first() is b
         True
 
-        Get items by groups:
-
-        >>> violinGroup = a['violin']
-        >>> violinGroup #_DOCS_SHOW
-        <music21.stream.iterator.StreamIterator for Part:hello @:1> #_DOCS_SHOW
-        >>> violinGroup.first() is b #_DOCS_SHOW
-        True #_DOCS_SHOW
+        TODO: demo string query search
 
         If a string or class is not found, a KeyError will be raised:
-
-        >>> a['purple']
-        Traceback (most recent call last):
-        KeyError: 'provided key (purple) was not found in query results'
 
         >>> a[layout.StaffLayout]
         Traceback (most recent call last):

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -417,9 +417,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # manually inserting elements is critical to setting the element
             # locations
             searchElements = self._elements
-            if k.start < 0 or k.stop < 0:
+            if (k.start is not None and k.start < 0) or (k.stop is not None and k.stop < 0):
                 # Must use .elements property to incorporate end elements
-                searchElements = k.elements
+                searchElements = self.elements
 
             return searchElements[k]
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -466,7 +466,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         ...     print(n.name, end=' ')
         C C# D E F G A
 
-        '.ghost', because it begins with is treated as a class name and returns a `RecursiveIterator`:
+        '.ghost', because it begins with is treated as a class name and
+        returns a `RecursiveIterator`:
 
 
         >>> for n in s['.ghost']:

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -89,6 +89,16 @@ class StreamIterator(prebase.ProtoM21Object):
     * For `activeInformation` see above.
 
     Changed in v.5.2 -- all arguments except srcStream are keyword only.
+
+    OMIT_FROM_DOCS
+
+    Informative exception for user error:
+
+    >>> s = stream.Stream()
+    >>> sIter = stream.iterator.StreamIterator(s, filterList=[note.Note])
+    Traceback (most recent call last):
+    TypeError: filterList expects Filters or callables,
+    not types themselves; got <class 'music21.note.Note'>
     '''
     def __init__(self,
                  srcStream: 'music21.stream.Stream',
@@ -122,6 +132,10 @@ class StreamIterator(prebase.ProtoM21Object):
             filterList = [filterList]
         elif isinstance(filterList, (set, tuple)):
             filterList = list(filterList)  # mutable....
+        for x in filterList:
+            if isinstance(x, type):
+                raise TypeError(
+                    f'filterList expects Filters or callables, not types themselves; got {x}')
         # self.filters is a list of expressions that
         # return True or False for an element for
         # whether it should be yielded.

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -957,19 +957,24 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s = converter.parse('tinyNotation: 4/4 GG4 AA4 BB4 r4 C4 D4 E4 F4 r1')
         >>> s[note.Note].last().id = 'last'
         >>> for n in s[note.Note]:
-        ...     if n.octave == 4:
-        ...         n.groups.append('high')
+        ...     if n.octave == 3:
+        ...         n.groups.append('tenor')
 
-        >>> s.recurse().getElementsByQuerySelector('#last').first()
-        <music21.note.Note F>
-        >>> list(s.recurse().getElementsByQuerySelector('.high'))
+        >>> list(s.recurse().getElementsByQuerySelector('.tenor'))
         [<music21.note.Note C>,
          <music21.note.Note D>,
          <music21.note.Note E>,
          <music21.note.Note F>]
+
         >>> list(s.recurse().getElementsByQuerySelector('Rest'))
-        [<music21.note.Rest quarter>,
-         <music21.note.Rest whole>]
+        [<music21.note.Rest rest>,
+         <music21.note.Rest rest>]
+
+        Note that unlike with stream slices, the querySelector does not do anything special
+        for id searches.  `.first()` will need to be called to find the element (if any)
+
+        >>> s.recurse().getElementsByQuerySelector('#last').first()
+        <music21.note.Note F>
 
         New in v.7
         '''

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -938,6 +938,48 @@ class StreamIterator(prebase.ProtoM21Object):
         '''
         return self.addFilter(filters.ClassFilter(classFilterList), returnClone=returnClone)
 
+    def getElementsByQuerySelector(self, querySelector: str, *, returnClone=True):
+        '''
+        First implementation of a query selector, similar to CSS QuerySelectors used in
+        HTML DOM:
+
+        * A leading `#` indicates the id of an element, so '#hello' will find elements
+          with `el.id=='hello'` (should only be one)
+        * A leading `.` indicates the group of an element, so '.high' will find elements
+          with `'high' in el.groups`
+        * Any other string is considered to be the type/class of the element.  So `Note`
+          will find all Note elements.  Can be fully qualified like `note.Note`
+
+        Eventually, more complex query selectors will be implemented.  This is just a start.
+
+        Setting up an example:
+
+        >>> s = converter.parse('tinyNotation: 4/4 GG4 AA4 BB4 r4 C4 D4 E4 F4 r1')
+        >>> s[note.Note].last().id = 'last'
+        >>> for n in s[note.Note]:
+        ...     if n.octave == 4:
+        ...         n.groups.append('high')
+
+        >>> s.recurse().getElementsByQuerySelector('#last').first()
+        <music21.note.Note F>
+        >>> list(s.recurse().getElementsByQuerySelector('.high'))
+        [<music21.note.Note C>,
+         <music21.note.Note D>,
+         <music21.note.Note E>,
+         <music21.note.Note F>]
+        >>> list(s.recurse().getElementsByQuerySelector('Rest'))
+        [<music21.note.Rest quarter>,
+         <music21.note.Rest whole>]
+
+        New in v.7
+        '''
+        if querySelector.startswith('#'):
+            return self.addFilter(filters.IdFilter(querySelector[1:]), returnClone=returnClone)
+        if querySelector.startswith('.'):
+            return self.addFilter(filters.GroupFilter(querySelector[1:]), returnClone=returnClone)
+        return self.addFilter(filters.ClassFilter(querySelector), returnClone=returnClone)
+
+
     def getElementsNotOfClass(self, classFilterList, *, returnClone=True):
         '''
         Adds a filter, removing all Elements that do not

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -337,6 +337,9 @@ class StreamIterator(prebase.ProtoM21Object):
 
         (nothing is printed)
         '''
+        if isinstance(k, type):
+            self.addFilter(k)
+            return self
         fe = self.matchingElements()
         try:
             e = fe[k]

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -351,9 +351,6 @@ class StreamIterator(prebase.ProtoM21Object):
 
         (nothing is printed)
         '''
-        if isinstance(k, type):
-            self.addFilter(k)
-            return self
         fe = self.matchingElements()
         try:
             e = fe[k]

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -619,18 +619,18 @@ class Test(unittest.TestCase):
         a = converter.parse(thisWork)
 
         b = a[7][5:10]
-        environLocal.printDebug(['b', b, b.sites.getSiteIds()])
+        #environLocal.printDebug(['b', b, b.sites.getSiteIds()])
         c = a[7][10:15]
-        environLocal.printDebug(['c', c, c.sites.getSiteIds()])
+        #environLocal.printDebug(['c', c, c.sites.getSiteIds()])
         d = a[7][15:20]
-        environLocal.printDebug(['d', d, d.sites.getSiteIds()])
+        #environLocal.printDebug(['d', d, d.sites.getSiteIds()])
 
         s2 = Stream()
-        environLocal.printDebug(['s2', s2, id(s2)])
+        #environLocal.printDebug(['s2', s2, id(s2)])
 
-        s2.insert(b)
-        s2.insert(c)
-        s2.insert(d)
+        for stream_case in (b, c, d):
+            for e in stream_case:
+                s2.insert(e.offset, e)
 
     def testActiveSites(self):
         '''
@@ -2929,7 +2929,8 @@ class Test(unittest.TestCase):
         '''
         src = corpus.parse('bach/bwv324.xml')
         # get some measures of the soprano; just get the notes
-        ex = src.parts[0].flat.notesAndRests.stream()[0:30]
+        found = src.parts.first().flat.notesAndRests[0:30]
+        ex = Part(found)
 
         self.assertEqual(ex.highestOffset, 38.0)
         self.assertEqual(ex.highestTime, 42.0)
@@ -2957,7 +2958,8 @@ class Test(unittest.TestCase):
         src = corpus.parse('bach/bwv324.xml')
         # get some measures of the soprano; just get the notes
         # environLocal.printDebug(['testAugmentOrDiminishCorpus()', 'extracting notes:'])
-        ex = src.parts[0].flat.notesAndRests.stream()[0:30]
+        found = src.parts.first().flat.notesAndRests[0:30]
+        ex = Part(found)
         # attach a couple of transformations
         s = Score()
         for scalar in [0.5, 1.5, 2, 0.25]:

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -619,14 +619,14 @@ class Test(unittest.TestCase):
         a = converter.parse(thisWork)
 
         b = a[7][5:10]
-        #environLocal.printDebug(['b', b, b.sites.getSiteIds()])
+        # environLocal.printDebug(['b', b, b.sites.getSiteIds()])
         c = a[7][10:15]
-        #environLocal.printDebug(['c', c, c.sites.getSiteIds()])
+        # environLocal.printDebug(['c', c, c.sites.getSiteIds()])
         d = a[7][15:20]
-        #environLocal.printDebug(['d', d, d.sites.getSiteIds()])
+        # environLocal.printDebug(['d', d, d.sites.getSiteIds()])
 
         s2 = Stream()
-        #environLocal.printDebug(['s2', s2, id(s2)])
+        # environLocal.printDebug(['s2', s2, id(s2)])
 
         for stream_case in (b, c, d):
             for e in stream_case:
@@ -6548,11 +6548,11 @@ class Test(unittest.TestCase):
         self.assertEqual(match, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 25.0])
 
         # s.elements = s1
-        s3 = s1[:]
+        s3 = Stream(s1[:])
         match = []
         for e in s3.elements:
             match.append(e.getOffsetBySite(s3))
-        self.assertEqual(match, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+        self.assertEqual(match, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 25.0])
 
         # this resets active site, so we get the right offsets on element
         # assignment


### PR DESCRIPTION
Fixes #947 

Changed in v7:
  - [earlier PR:] out of range indexes now raise an IndexError, not StreamException
  - class searches now recursive
  - negative slice indices now work
  -  Unsupported types now raise TypeError
  - Class and string searches now return a `StreamIterator` rather than a `Stream`
  - slice searches return a list, not a `Stream`