### PR TITLE
Prevent intent boxes from turning into task list

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -22,6 +22,6 @@ Optionally, describe the implementation or the interface, in code or pseudocode.
 **Intent**
 <!-- Please check one or more boxes -->
 
-- [ ] I plan on implementing this myself.
-- [ ] I am willing to pay to have this feature added.
-- [ ] I am starting a discussion with the hope that community members will volunteer their time to create this. I understand that individuals work on features of interest to them and that this feature may never be implemented.
+[ ] I plan on implementing this myself.
+[ ] I am willing to pay to have this feature added.
+[ ] I am starting a discussion with the hope that community members will volunteer their time to create this. I understand that individuals work on features of interest to them and that this feature may never be implemented.


### PR DESCRIPTION
FYI @mscuthbert I don't like how the intent boxes on the feature request template show up as task lists when viewing the rows of the issue board. We don't have to use actual Markdown for this. What do you think?