### PR TITLE
Give more info in Rest __repr__

### DIFF
--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -911,11 +911,11 @@ class Test(unittest.TestCase):
         match = [(repr(e), e.offset, e.duration.quarterLength)
             for e in post.parts[0].getElementsByClass('Measure').stream()[0:3].flat.notesAndRests]
         self.assertEqual(match,
-                         [('<music21.note.Rest rest>', 0.0, 1.0),
+                         [('<music21.note.Rest quarter>', 0.0, 1.0),
                           ('<music21.note.Note F#>', 1.0, 1.0),
-                          ('<music21.note.Rest rest>', 2.0, 1.0),
+                          ('<music21.note.Rest quarter>', 2.0, 1.0),
                           ('<music21.note.Note C#>', 3.0, 1.0),
-                          ('<music21.note.Rest rest>', 5.0, 1.0),
+                          ('<music21.note.Rest quarter>', 5.0, 1.0),
                           ('<music21.note.Note G#>', 6.0, 1.0)])
 
         # test that lyric is found

--- a/music21/audioSearch/__init__.py
+++ b/music21/audioSearch/__init__.py
@@ -668,7 +668,7 @@ def joinConsecutiveIdenticalPitches(detectedPitchObjects):
     >>> len(notesList)
     24
     >>> print(notesList)
-    [<music21.note.Rest rest>, <music21.note.Note C>, <music21.note.Note C>,
+    [<music21.note.Rest quarter>, <music21.note.Note C>, <music21.note.Note C>,
      <music21.note.Note D>, <music21.note.Note E>, <music21.note.Note F>,
      <music21.note.Note G>, <music21.note.Note A>, <music21.note.Note B>,
      <music21.note.Note C>, ...]
@@ -836,7 +836,7 @@ def notesAndDurationsToStream(
         {2.0} <music21.note.Note B>
         {2.5} <music21.note.Note F#>
         {4.0} <music21.note.Note C>
-        {4.25} <music21.note.Rest rest>
+        {4.25} <music21.note.Rest quarter>
     '''
     # rounding lengths
     p2 = stream.Part()

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -196,11 +196,11 @@ class BrailleElementGrouping(ProtoM21Object):
         >>> bg.append(note.Note('F4'))
         >>> bg
         <music21.braille.segment.BrailleElementGrouping [<music21.note.Note C>,
-            <music21.note.Note D>, <music21.note.Rest rest>, <music21.note.Note F>]>
+            <music21.note.Note D>, <music21.note.Rest quarter>, <music21.note.Note F>]>
         >>> print(bg)
         <music21.note.Note C>
         <music21.note.Note D>
-        <music21.note.Rest rest>
+        <music21.note.Rest quarter>
         <music21.note.Note F>
 
         These are the defaults and they are shared across all objects...
@@ -1504,9 +1504,9 @@ def findSegments(music21Part, **partKeywords):
     ===
     Measure 15, Note Grouping 1:
     <music21.note.Note C>
-    <music21.note.Rest rest>
+    <music21.note.Rest quarter>
     <music21.note.Note F>
-    <music21.note.Rest rest>
+    <music21.note.Rest quarter>
     ===
     Measure 16, Note Grouping 1:
     <music21.note.Note A->
@@ -2233,7 +2233,7 @@ def splitNoteGrouping(noteGrouping, beatDivisionOffset=0):
 
     >>> right
     <music21.braille.segment.BrailleElementGrouping
-        [<music21.note.Rest rest>, <music21.note.Note E>]>
+        [<music21.note.Rest quarter>, <music21.note.Note E>]>
 
 
     Now split one beat division earlier than it should be.  For 2/2 that means
@@ -2245,7 +2245,7 @@ def splitNoteGrouping(noteGrouping, beatDivisionOffset=0):
         [<music21.note.Note C>]>
     >>> right
     <music21.braille.segment.BrailleElementGrouping
-        [<music21.note.Note D>, <music21.note.Rest rest>, <music21.note.Note E>]>
+        [<music21.note.Note D>, <music21.note.Rest quarter>, <music21.note.Note E>]>
     '''
     music21Measure = stream.Measure()
     for brailleElement in noteGrouping:

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -414,7 +414,7 @@ class CapellaImporter:
         >>> restElement = ci.domElementFromText('<rest><duration base="1/2"/></rest>')
         >>> r = ci.restFromRest(restElement)
         >>> r
-        <music21.note.Rest rest>
+        <music21.note.Rest half>
         >>> r.duration.type
         'half'
         '''

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -658,13 +658,13 @@ class ConverterHumdrum(SubConverter):
             {0.0} <music21.humdrum.spineParser.MiscTandem **kern>
             {0.0} <music21.stream.Measure 1 offset=0.0>
                 {0.0} <music21.meter.TimeSignature 2/4>
-                {0.0} <music21.note.Rest rest>
+                {0.0} <music21.note.Rest 1/6ql>
                 {0.1667} <music21.note.Note G#>
                 {0.3333} <music21.note.Note F#>
                 {0.5} <music21.note.Note E>
                 {0.6667} <music21.note.Note C#>
                 {0.8333} <music21.note.Note F>
-                {1.0} <music21.note.Rest rest>
+                {1.0} <music21.note.Rest 1/6ql>
                 {1.1667} <music21.note.Note D>
                 {1.3333} <music21.note.Note E->
                 {1.5} <music21.note.Note G>
@@ -727,7 +727,7 @@ class ConverterTinyNotation(SubConverter):
             {0.0} <music21.clef.TrebleClef>
             {0.0} <music21.meter.TimeSignature 3/4>
             {0.0} <music21.note.Note E>
-            {1.0} <music21.note.Rest rest>
+            {1.0} <music21.note.Rest quarter>
             {2.0} <music21.note.Note F#>
         {3.0} <music21.stream.Measure 2 offset=3.0>
             {0.0} <music21.note.Note G>

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -2123,11 +2123,11 @@ def partitionByInstrument(streamObj):
             {0.0} <music21.meter.TimeSignature 4/4>
             {0.0} <music21.note.Note C>
             {1.0} <music21.note.Note D>
-            {2.0} <music21.note.Rest rest>
+            {2.0} <music21.note.Rest quarter>
             {3.0} <music21.note.Note F#>
         {4.0} <music21.stream.Measure 2 offset=4.0>
             {0.0} <music21.note.Note G#>
-            {1.0} <music21.note.Rest rest>
+            {1.0} <music21.note.Rest half>
             {3.0} <music21.note.Note C>
         {8.0} <music21.stream.Measure 3 offset=8.0>
             {0.0} <music21.note.Note C>
@@ -2137,7 +2137,7 @@ def partitionByInstrument(streamObj):
             {0.0} <music21.instrument.AltoSaxophone 'Alto Saxophone'>
             {0.0} <music21.clef.TrebleClef>
             {0.0} <music21.meter.TimeSignature 4/4>
-            {0.0} <music21.note.Rest rest>
+            {0.0} <music21.note.Rest half>
             {2.0} <music21.note.Note E>
             {3.0} <music21.note.Note F>
         {4.0} <music21.stream.Measure 2 offset=4.0>
@@ -2153,9 +2153,9 @@ def partitionByInstrument(streamObj):
             {0.0} <music21.note.Note C#>
             {1.0} <music21.note.Note D#>
             {2.0} <music21.note.Note E#>
-            {3.0} <music21.note.Rest rest>
+            {3.0} <music21.note.Rest quarter>
         {4.0} <music21.stream.Measure 2 offset=4.0>
-            {0.0} <music21.note.Rest rest>
+            {0.0} <music21.note.Rest quarter>
             {1.0} <music21.note.Note A#>
             {2.0} <music21.note.Note B#>
             {3.0} <music21.note.Note C#>
@@ -2165,6 +2165,7 @@ def partitionByInstrument(streamObj):
 
     TODO: parts should be in Score Order. Coincidence that this almost works.
     TODO: use proper recursion to make a copy of the stream.
+    TODO: final barlines should be aligned.
     '''
     from music21 import stream
 

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1796,22 +1796,22 @@ def midiTrackToStream(
         {0.0} <music21.clef.TrebleClef>
         {0.0} <music21.meter.TimeSignature 4/4>
         {0.0} <music21.note.Note C>
-        {1.0} <music21.note.Rest rest>
+        {1.0} <music21.note.Rest quarter>
         {2.0} <music21.chord.Chord F3 G#4 C5>
-        {3.0} <music21.note.Rest rest>
+        {3.0} <music21.note.Rest quarter>
     {4.0} <music21.stream.Measure 2 offset=4.0>
-        {0.0} <music21.note.Rest rest>
+        {0.0} <music21.note.Rest eighth>
         {0.5} <music21.note.Note B->
-        {1.5} <music21.note.Rest rest>
+        {1.5} <music21.note.Rest half>
         {3.5} <music21.chord.Chord D2 A4>
     {8.0} <music21.stream.Measure 3 offset=8.0>
-        {0.0} <music21.note.Rest rest>
+        {0.0} <music21.note.Rest eighth>
         {0.5} <music21.chord.Chord C#2 B-3 G#6>
-        {1.0} <music21.note.Rest rest>
+        {1.0} <music21.note.Rest dotted-quarter>
         {2.5} <music21.chord.Chord F#3 A4 C#5>
     {12.0} <music21.stream.Measure 4 offset=12.0>
         {0.0} <music21.chord.Chord F#3 A4 C#5>
-        {2.5} <music21.note.Rest rest>
+        {2.5} <music21.note.Rest dotted-quarter>
         {4.0} <music21.bar.Barline type=final>
     '''
     # environLocal.printDebug(['midiTrackToStream(): got midi track: events',
@@ -2669,7 +2669,7 @@ def midiStringToStream(strData, **keywords):
             {0.0} <music21.clef.TrebleClef>
             {0.0} <music21.meter.TimeSignature 4/4>
             {0.0} <music21.note.Note G>
-            {1.0} <music21.note.Rest rest>
+            {1.0} <music21.note.Rest dotted-half>
             {4.0} <music21.bar.Barline type=final>
     '''
     from music21 import midi as midiModule

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1800,7 +1800,7 @@ class PartParser(XMLParserBase):
 
         >>> measureRest = m.notesAndRests[0]
         >>> measureRest
-        <music21.note.Rest rest>
+        <music21.note.Rest dotted-half>
         >>> measureRest.duration.type
         'half'
         >>> measureRest.duration.quarterLength
@@ -3051,7 +3051,7 @@ class MeasureParser(XMLParserBase):
         >>> mxr = EL('<note><rest/><duration>5040</duration><type>eighth</type></note>')
         >>> r = MP.xmlToRest(mxr)
         >>> r
-        <music21.note.Rest rest>
+        <music21.note.Rest eighth>
         >>> r.duration.quarterLength
         0.5
 
@@ -3060,7 +3060,7 @@ class MeasureParser(XMLParserBase):
         ...              '</rest><duration>5040</duration><type>eighth</type></note>')
         >>> r = MP.xmlToRest(mxr)
         >>> r
-        <music21.note.Rest rest>
+        <music21.note.Rest eighth>
 
         A rest normally lies at B4 in treble clef, but here we have put it at
         G4, so we'll shift it down two steps.

--- a/music21/note.py
+++ b/music21/note.py
@@ -1733,7 +1733,15 @@ class Rest(GeneralNote):
         self.fullMeasure = 'auto'  # see docs; True, False, 'always',
 
     def _reprInternal(self):
-        return self.name
+        duration_name = self.duration.fullName.lower()
+        if len(duration_name) < 15:  # dotted quarter = 14
+            return duration_name.replace(' ', '-')
+        else:
+            ql = self.duration.quarterLength
+            if ql == int(ql):
+                ql = int(ql)
+            ql_string = str(ql)
+            return f'{ql_string}ql'
 
     def __eq__(self, other):
         '''

--- a/music21/noteworthy/translate.py
+++ b/music21/noteworthy/translate.py
@@ -519,8 +519,8 @@ class NoteworthyTranslator:
         >>> nwt.translateRest({'Dur': '4th'})
         >>> measureIn.show('text')
         {0.0} <music21.note.Note C#>
-        {2.0} <music21.note.Rest rest>
-        {2.75} <music21.note.Rest rest>
+        {2.0} <music21.note.Rest dotted-eighth>
+        {2.75} <music21.note.Rest quarter>
 
         '''
         durationInfo = attributes['Dur']
@@ -628,7 +628,7 @@ class NoteworthyTranslator:
         >>> nwt.currentKey.sharps
         4
         >>> measureIn.show('text')
-        {0.0} <music21.note.Rest rest>
+        {0.0} <music21.note.Rest dotted-half>
         {3.0} <music21.key.KeySignature of 4 sharps>
         '''
         ke = attributes['Signature']

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -343,7 +343,7 @@ def rhythmicSearch(thisStreamOrIterator, searchList):
         {2.0} <music21.note.Note F>
     {6.0} <music21.stream.Measure 3 offset=6.0>
         {0.5} <music21.note.Note C>
-        {2.0} <music21.note.Rest rest>
+        {2.0} <music21.note.Rest quarter>
         {3.0} <music21.bar.Barline type=final>
 
     Now we will search for all dotted-quarter/eighth elements in the Stream:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -157,7 +157,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
     >>> s2.show('text')
     {0.0} <music21.clef.TrebleClef>
     {0.0} <music21.stream.Part embeddedPart>
-        {0.0} <music21.note.Rest rest>
+        {0.0} <music21.note.Rest quarter>
     {1.0} <music21.note.Note E->
 
     New in v7 -- providing a single element now works:
@@ -184,7 +184,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
     {0.0} <music21.stream.Measure 1 offset=0.0>
         {1.0} <music21.note.Note E->
     {1.5} <music21.stream.Measure 2 offset=1.5>
-        {0.0} <music21.note.Rest rest>
+        {0.0} <music21.note.Rest quarter>
 
     Here, every element is a Stream that's not a Measure, so we instead insert:
 
@@ -193,7 +193,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
     {0.0} <music21.stream.PartStaff 0x...>
         {1.0} <music21.note.Note E->
     {0.0} <music21.stream.PartStaff 0x...>
-        {0.0} <music21.note.Rest rest>
+        {0.0} <music21.note.Rest quarter>
     '''
     # this static attributes offer a performance boost over other
     # forms of checking class
@@ -2065,7 +2065,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> s.append(c1)
         >>> s.show('text')
         {0.0} <music21.note.Note D>
-        {2.0} <music21.note.Rest rest>
+        {2.0} <music21.note.Rest half>
         {4.0} <music21.chord.Chord C4 E4>
 
         Save the original Streams for later
@@ -2110,7 +2110,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         Chords can also be inserted into rests:
 
         >>> s3.getElementsByOffset(2.0).first()
-        <music21.note.Rest rest>
+        <music21.note.Rest half>
         >>> s3.insertIntoNoteOrChord(2.0, chord.Chord('C4 E4 G#4'))
         >>> s3.show('text')
         {0.0} <music21.note.Note D>
@@ -2123,7 +2123,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         >>> s4.show('text', addEndTimes=True)
         {0.0 - 2.0} <music21.note.Note D>
-        {2.0 - 4.0} <music21.note.Rest rest>
+        {2.0 - 4.0} <music21.note.Rest half>
         {4.0 - 5.0} <music21.chord.Chord C4 E4>
 
         >>> for i in [0.0, 4.0, 6.0]:  # skipping 2.0 for now
@@ -2133,9 +2133,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> s4.insertIntoNoteOrChord(2.0, r)
         >>> s4.show('text', addEndTimes=True)
         {0.0 - 2.0} <music21.note.Note D>
-        {2.0 - 4.0} <music21.note.Rest rest>
+        {2.0 - 4.0} <music21.note.Rest half>
         {4.0 - 5.0} <music21.chord.Chord C4 E4>
-        {6.0 - 7.0} <music21.note.Rest rest>
+        {6.0 - 7.0} <music21.note.Rest quarter>
 
         Notice that (1) the original duration and not the new duration is used, unless
         there is no element at that place, and (2) if an element is put into a place where
@@ -3872,7 +3872,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         >>> t5 = st1.getElementAfterElement(n1, [note.Rest])
         >>> t5
-        <music21.note.Rest rest>
+        <music21.note.Rest quarter>
         >>> t5 is r3
         True
         >>> t6 = st1.getElementAfterElement(n1, [note.Rest, note.Note])
@@ -4323,14 +4323,14 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             {0.0} <music21.clef.TrebleClef>
             {0.0} <music21.key.Key of f# minor>
             {0.0} <music21.meter.TimeSignature 4/4>
-            {0.0} <music21.note.Rest rest>
+            {0.0} <music21.note.Rest quarter>
         {1.0} <music21.stream.Measure 1 offset=1.0>
-            {0.0} <music21.note.Rest rest>
+            {0.0} <music21.note.Rest whole>
         {5.0} <music21.stream.Measure 2 offset=5.0>
-            {0.0} <music21.note.Rest rest>
+            {0.0} <music21.note.Rest whole>
         {9.0} <music21.stream.Measure 3 offset=9.0>
             {0.0} <music21.layout.SystemLayout>
-            {0.0} <music21.note.Rest rest>
+            {0.0} <music21.note.Rest whole>
         {13.0} <music21.stream.Measure 4 offset=13.0>
         ...
 
@@ -4399,12 +4399,12 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 {0.0} <music21.clef.TrebleClef>
                 {0.0} <music21.key.Key of f# minor>
                 {0.0} <music21.meter.TimeSignature 4/4>
-                {0.0} <music21.note.Rest rest>
+                {0.0} <music21.note.Rest quarter>
             {1.0} <music21.stream.Measure 1 offset=1.0>
-                {0.0} <music21.note.Rest rest>
+                {0.0} <music21.note.Rest whole>
                 ...
             {33.0} <music21.stream.Measure 9 offset=33.0>
-                {0.0} <music21.note.Rest rest>
+                {0.0} <music21.note.Rest dotted-half>
                 {3.0} <music21.bar.Barline type=final>
         {0.0} <music21.stream.Part Alto>
             {0.0} <music21.instrument.Instrument 'P2: Alto: Instrument 2'>
@@ -4412,12 +4412,12 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 {0.0} <music21.clef.TrebleClef>
                 {0.0} <music21.key.Key of f# minor>
                 {0.0} <music21.meter.TimeSignature 4/4>
-                {0.0} <music21.note.Rest rest>
+                {0.0} <music21.note.Rest quarter>
             {1.0} <music21.stream.Measure 1 offset=1.0>
-                {0.0} <music21.note.Rest rest>
+                {0.0} <music21.note.Rest whole>
             ...
             {33.0} <music21.stream.Measure 9 offset=33.0>
-                {0.0} <music21.note.Rest rest>
+                {0.0} <music21.note.Rest dotted-half>
                 {3.0} <music21.bar.Barline type=final>
         {0.0} <music21.layout.StaffGroup ...>
 
@@ -4440,9 +4440,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> pt = p.template(retainVoices=False)
         >>> pt.show('text')
         {0.0} <music21.stream.Measure 1 offset=0.0>
-            {0.0} <music21.note.Rest rest>
+            {0.0} <music21.note.Rest whole>
         {4.0} <music21.stream.Measure 2 offset=4.0>
-            {0.0} <music21.note.Rest rest>
+            {0.0} <music21.note.Rest whole>
         >>> pt[0][0].quarterLength
         4.0
 
@@ -5952,10 +5952,10 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> s.show('text', addEndTimes=True)
         {0.0 - 6.3} <music21.stream.Part part1>
             {4.0 - 5.0} <music21.note.Note C#>
-            {5.3 - 6.3} <music21.note.Rest rest>
+            {5.3 - 6.3} <music21.note.Rest quarter>
         {0.0 - 6.5} <music21.stream.Part part2>
             {2.12 - 4.12} <music21.note.Note D->
-            {5.5 - 6.5} <music21.note.Rest rest>
+            {5.5 - 6.5} <music21.note.Rest quarter>
 
         >>> cc = s.chordify()
 
@@ -5965,11 +5965,11 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         Fraction(22, 25)
 
         >>> cc.show('text', addEndTimes=True)
-        {0.0 - 2.12} <music21.note.Rest rest>
+        {0.0 - 2.12} <music21.note.Rest 53/25ql>
         {2.12 - 4.0} <music21.chord.Chord D-4>
         {4.0 - 4.12} <music21.chord.Chord C#4 D-4>
         {4.12 - 5.0} <music21.chord.Chord C#4>
-        {5.0 - 6.5} <music21.note.Rest rest>
+        {5.0 - 6.5} <music21.note.Rest dotted-quarter>
 
         Here's how addPartIdAsGroup works:
 
@@ -9427,7 +9427,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> s1.show('text')
         {0.0} <music21.key.KeySignature of no sharps or flats>
         {0.0} <music21.note.Note B>
-        {1.0} <music21.note.Rest rest>
+        {1.0} <music21.note.Rest quarter>
         {2.0} <music21.chord.Chord A B->
 
         `.notesAndRests` removes the `KeySignature` object but keeps the `Rest`.
@@ -9435,7 +9435,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> notes1 = s1.notesAndRests.stream()
         >>> notes1.show('text')
         {0.0} <music21.note.Note B>
-        {1.0} <music21.note.Rest rest>
+        {1.0} <music21.note.Rest quarter>
         {2.0} <music21.chord.Chord A B->
 
         The same caveats about `Stream` classes and `.flat` in `.notes` apply here.
@@ -9471,7 +9471,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> p1.show('text')
         {0.0} <music21.key.KeySignature of no sharps or flats>
         {0.0} <music21.note.Note B>
-        {1.0} <music21.note.Rest rest>
+        {1.0} <music21.note.Rest quarter>
         {2.0} <music21.chord.Chord A B->
 
         >>> noteStream = p1.notes.stream()
@@ -10008,8 +10008,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> s.storeAtEnd(bar.Barline('final'))
         >>> gapStream = s.findGaps()
         >>> gapStream.show('text', addEndTimes=True)
-        {0.0 - 1.0} <music21.note.Rest rest>
-        {3.0 - 5.0} <music21.note.Rest rest>
+        {0.0 - 1.0} <music21.note.Rest quarter>
+        {3.0 - 5.0} <music21.note.Rest half>
 
         Returns None if not gaps:
 
@@ -10660,7 +10660,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 {0.0} <music21.stream.Voice 3>
                     {0.0} <music21.note.Note E>
                     ...
-                    {3.0} <music21.note.Rest rest>
+                    {3.0} <music21.note.Rest quarter>
                 {0.0} <music21.stream.Voice 4>
                     {0.0} <music21.note.Note F#>
                     ...
@@ -10669,13 +10669,13 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 {0.0} <music21.stream.Voice 3>
                     {0.0} <music21.note.Note E>
                     ...
-                    {3.0} <music21.note.Rest rest>
+                    {3.0} <music21.note.Rest quarter>
                 {0.0} <music21.stream.Voice 4>
                     {0.0} <music21.note.Note E>
                     ...
                     {3.5} <music21.note.Note A>
             {8.0} <music21.stream.Measure 3 offset=8.0>
-                {0.0} <music21.note.Rest rest>
+                {0.0} <music21.note.Rest whole>
                 {4.0} <music21.bar.Barline type=final>
         {0.0} <music21.layout.ScoreLayout>
 
@@ -10689,13 +10689,13 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 {0.0} <music21.meter.TimeSignature 4/4>
                 {0.0} <music21.note.Note E>
                 ...
-                {3.0} <music21.note.Rest rest>
+                {3.0} <music21.note.Rest quarter>
             {4.0} <music21.stream.Measure 2 offset=4.0>
                 {0.0} <music21.note.Note E>
                 ...
-                {3.0} <music21.note.Rest rest>
+                {3.0} <music21.note.Rest quarter>
             {8.0} <music21.stream.Measure 3 offset=8.0>
-                {0.0} <music21.note.Rest rest>
+                {0.0} <music21.note.Rest whole>
                 {4.0} <music21.bar.Barline type=final>
         {0.0} <music21.stream.Part Piano-v1>
             {0.0} <music21.instrument.Instrument 'P1: Piano: '>
@@ -12674,10 +12674,10 @@ class Measure(Stream):
         >>> m.append(note.Note('D4', type='eighth'))
         >>> m.show('text')
         {0.0} <music21.meter.TimeSignature 3/4>
-        {0.0} <music21.note.Rest rest>
-        {0.5} <music21.note.Rest rest>
+        {0.0} <music21.note.Rest eighth>
+        {0.5} <music21.note.Rest eighth>
         {1.0} <music21.note.Note C>
-        {2.0} <music21.note.Rest rest>
+        {2.0} <music21.note.Rest eighth>
         {2.5} <music21.note.Note D>
         >>> m.padAsAnacrusis(useInitialRests=True)
         >>> m.paddingLeft
@@ -12685,7 +12685,7 @@ class Measure(Stream):
         >>> m.show('text')
         {0.0} <music21.meter.TimeSignature 3/4>
         {0.0} <music21.note.Note C>
-        {1.0} <music21.note.Rest rest>
+        {1.0} <music21.note.Rest eighth>
         {1.5} <music21.note.Note D>
         '''
         if useInitialRests:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -402,7 +402,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         >>> subslice = s[2:5]
         >>> subslice
-        [<music21.note.Note E>, <music21.note.Rest rest>, <music21.note.Note F>]
+        [<music21.note.Note E>, <music21.note.Rest quarter>, <music21.note.Note F>]
         >>> len(subslice)
         3
         >>> s[1].offset

--- a/music21/stream/filters.py
+++ b/music21/stream/filters.py
@@ -112,7 +112,7 @@ class IsFilter(StreamFilter):
     >>> for el in s.iter.addFilter(isFilter2):
     ...     print(el)
     <music21.note.Note C#>
-    <music21.note.Rest rest>
+    <music21.note.Rest quarter>
 
     '''
     derivationStr = 'is'
@@ -151,14 +151,14 @@ class IsNotFilter(IsFilter):
     >>> for el in s.iter.addFilter(stream.filters.IsNotFilter(n)):
     ...     el
     <music21.key.KeySignature of 3 flats>
-    <music21.note.Rest rest>
+    <music21.note.Rest quarter>
 
     test that resetting works...
 
     >>> for el in s.iter.addFilter(stream.filters.IsNotFilter(n)):
     ...     el
     <music21.key.KeySignature of 3 flats>
-    <music21.note.Rest rest>
+    <music21.note.Rest quarter>
 
 
     multiple...
@@ -229,7 +229,7 @@ class ClassFilter(StreamFilter):
     >>> for x in sI:
     ...     print(x)
     <music21.note.Note C>
-    <music21.note.Rest rest>
+    <music21.note.Rest quarter>
     <music21.note.Note D>
 
     >>> sI.filters.append(stream.filters.ClassFilter('Note'))
@@ -285,7 +285,7 @@ class ClassNotFilter(ClassFilter):
 
     >>> for x in sI:
     ...     print(x)
-    <music21.note.Rest rest>
+    <music21.note.Rest quarter>
     '''
     derivationStr = 'getElementsNotOfClass'
 

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -964,8 +964,8 @@ class StreamIterator(prebase.ProtoM21Object):
          <music21.note.Note F>]
 
         >>> list(s.recurse().getElementsByQuerySelector('Rest'))
-        [<music21.note.Rest rest>,
-         <music21.note.Rest rest>]
+        [<music21.note.Rest quarter>,
+         <music21.note.Rest whole>]
 
         Note that unlike with stream slices, the querySelector does not do anything special
         for id searches.  `.first()` will need to be called to find the element (if any)

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -448,7 +448,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s.recurse().notes.first()
         <music21.note.Note D>
         >>> s.recurse().getElementsByClass('Rest').first()
-        <music21.note.Rest rest>
+        <music21.note.Rest half>
 
         If no elements match, returns None:
 
@@ -499,7 +499,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s.recurse().notes.last()
         <music21.note.Note G>
         >>> s.recurse().getElementsByClass('Rest').last()
-        <music21.note.Rest rest>
+        <music21.note.Rest quarter>
 
         New in v7.
 
@@ -727,7 +727,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s3 = s.iter.stream()
         >>> s3.show('t')
         {0.0} <music21.note.Note C>
-        {1.0} <music21.note.Rest rest>
+        {1.0} <music21.note.Rest quarter>
         {2.0} <music21.note.Note D>
         {3.0} <music21.bar.Barline type=regular>
 
@@ -897,7 +897,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s.append(note.Note('D'))
         >>> for el in s.iter.getElementsByClass('Rest'):
         ...     print(el)
-        <music21.note.Rest rest>
+        <music21.note.Rest quarter>
 
 
         ActiveSite is restored...
@@ -916,7 +916,7 @@ class StreamIterator(prebase.ProtoM21Object):
 
         >>> for el in s.iter.getElementsByClass(note.Rest):
         ...     print(el)
-        <music21.note.Rest rest>
+        <music21.note.Rest quarter>
 
         '''
         return self.addFilter(filters.ClassFilter(classFilterList), returnClone=returnClone)
@@ -1280,7 +1280,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> for el in s.iter.notesAndRests:
         ...     print(el)
         <music21.note.Note C>
-        <music21.note.Rest rest>
+        <music21.note.Rest quarter>
         <music21.note.Note D>
 
         chained filters... (this makes no sense since notes is a subset of notesAndRests)

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -726,7 +726,7 @@ def makeRests(
     >>> b.lowestOffset
     0.0
     >>> b.show('text')
-    {0.0} <music21.note.Rest rest>
+    {0.0} <music21.note.Rest 20ql>
     {20.0} <music21.note.Note C>
     >>> b[0].duration.quarterLength
     20.0
@@ -749,9 +749,9 @@ def makeRests(
     >>> b.lowestOffset
     0.0
     >>> b.show('text')
-    {0.0} <music21.note.Rest rest>
+    {0.0} <music21.note.Rest 20ql>
     {20.0} <music21.note.Note C>
-    {21.0} <music21.note.Rest rest>
+    {21.0} <music21.note.Rest 9ql>
     {30.0} <music21.note.Note D>
     >>> b[0].style.hideObjectOnPrint
     True
@@ -781,13 +781,13 @@ def makeRests(
     {0.0 - 4.0} <music21.stream.Measure 1 offset=0.0>
         {0.0 - 0.0} <music21.clef.TrebleClef>
         {0.0 - 0.0} <music21.meter.TimeSignature 4/4>
-        {0.0 - 4.0} <music21.note.Rest rest>
+        {0.0 - 4.0} <music21.note.Rest whole>
     {4.0 - 8.0} <music21.stream.Measure 2 offset=4.0>
         {0.0 - 1.0} <music21.note.Note C>
-        {1.0 - 4.0} <music21.note.Rest rest>
+        {1.0 - 4.0} <music21.note.Rest dotted-half>
     {8.0 - 12.0} <music21.stream.Measure 3 offset=8.0>
         {0.0 - 1.0} <music21.note.Note D>
-        {1.0 - 4.0} <music21.note.Rest rest>
+        {1.0 - 4.0} <music21.note.Rest dotted-half>
         {4.0 - 4.0} <music21.bar.Barline type=final>
 
     Changed in v6 -- all but first attribute are keyword only
@@ -988,11 +988,11 @@ def makeTies(
     {0.0} <music21.stream.Measure 1 offset=0.0>
         {0.0} <music21.clef.TrebleClef>
         {0.0} <music21.meter.TimeSignature 4/4>
-        {0.0} <music21.note.Rest rest>
+        {0.0} <music21.note.Rest whole>
     {4.0} <music21.stream.Measure 2 offset=4.0>
-        {0.0} <music21.note.Rest rest>
+        {0.0} <music21.note.Rest whole>
     {8.0} <music21.stream.Measure 3 offset=8.0>
-        {0.0} <music21.note.Rest rest>
+        {0.0} <music21.note.Rest whole>
         {4.0} <music21.bar.Barline type=final>
 
     Notes: uses base.Music21Object.splitAtQuarterLength() once it has figured out
@@ -1019,7 +1019,7 @@ def makeTies(
     {0.0 - 3.0} <music21.stream.Measure 1 offset=0.0>
         {0.0 - 0.0} <music21.clef.TrebleClef>
         {0.0 - 0.0} <music21.meter.TimeSignature 2/4>
-        {0.0 - 3.0} <music21.note.Rest rest>
+        {0.0 - 3.0} <music21.note.Rest dotted-half>
     {2.0 - 4.0} <music21.stream.Measure 2 offset=2.0>
         {1.0 - 2.0} <music21.note.Note C>
     {4.0 - 6.0} <music21.stream.Measure 3 offset=4.0>

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1933,29 +1933,29 @@ class Test(unittest.TestCase):
 
         match = str([(n.offset, n, n.duration) for n in m2.flat.notesAndRests])
         self.assertEqual(match,
-                         '[(0.0, <music21.note.Rest rest>, <music21.duration.Duration 1.0>), '
+                         '[(0.0, <music21.note.Rest quarter>, <music21.duration.Duration 1.0>), '
                          + '(1.0, <music21.note.Note C>, <music21.duration.Duration 1.0>), '
-                         + '(2.0, <music21.note.Rest rest>, <music21.duration.Duration 2.0>)]')
+                         + '(2.0, <music21.note.Rest half>, <music21.duration.Duration 2.0>)]')
 
         match = str([(n.offset, n, n.duration) for n in m2.flat])
         self.assertEqual(match,
-                         '[(0.0, <music21.note.Rest rest>, <music21.duration.Duration 1.0>), '
+                         '[(0.0, <music21.note.Rest quarter>, <music21.duration.Duration 1.0>), '
                          + '(1.0, <music21.note.Note C>, <music21.duration.Duration 1.0>), '
-                         + '(2.0, <music21.note.Rest rest>, <music21.duration.Duration 2.0>)]')
+                         + '(2.0, <music21.note.Rest half>, <music21.duration.Duration 2.0>)]')
 
         # m2.show()
 
         match = str(list(s.flat.notesAndRests))
-        self.assertEqual(match, '[<music21.note.Rest rest>, <music21.note.Note C>, '
-                                  + '<music21.note.Rest rest>, <music21.note.Rest rest>, '
-                                  + '<music21.note.Note C>, <music21.note.Rest rest>]')
+        self.assertEqual(match, '[<music21.note.Rest half>, <music21.note.Note C>, '
+                                  + '<music21.note.Rest quarter>, <music21.note.Rest quarter>, '
+                                  + '<music21.note.Note C>, <music21.note.Rest half>]')
         match = str([(n, n.duration) for n in s.flat.notesAndRests])
-        self.assertEqual(match, '[(<music21.note.Rest rest>, <music21.duration.Duration 2.0>), '
+        self.assertEqual(match, '[(<music21.note.Rest half>, <music21.duration.Duration 2.0>), '
                                   + '(<music21.note.Note C>, <music21.duration.Duration 1.0>), '
-                                  + '(<music21.note.Rest rest>, <music21.duration.Duration 1.0>), '
-                                  + '(<music21.note.Rest rest>, <music21.duration.Duration 1.0>), '
+                                  + '(<music21.note.Rest quarter>, <music21.duration.Duration 1.0>), '
+                                  + '(<music21.note.Rest quarter>, <music21.duration.Duration 1.0>), '
                                   + '(<music21.note.Note C>, <music21.duration.Duration 1.0>), '
-                                  + '(<music21.note.Rest rest>, <music21.duration.Duration 2.0>)]')
+                                  + '(<music21.note.Rest half>, <music21.duration.Duration 2.0>)]')
 
         GEX = m21ToXml.GeneralObjectExporter()
         unused_mx = GEX.parse(s).decode('utf-8')
@@ -5455,16 +5455,20 @@ class Test(unittest.TestCase):
 
         sPost = s.makeRests(fillGaps=True, inPlace=False)
         self.assertEqual(str(list(sPost.voices[0].notesAndRests)),
-                         '[<music21.note.Rest rest>, <music21.note.Note C>, '
-                         + '<music21.note.Rest rest>, <music21.note.Note C>, '
-                         + '<music21.note.Rest rest>, <music21.note.Note C>, '
-                         + '<music21.note.Rest rest>, <music21.note.Note C>, '
-                         + '<music21.note.Rest rest>]')
+                         '[<music21.note.Rest half>, <music21.note.Note C>, '
+                         + '<music21.note.Rest 2.25ql>, '
+                         + '<music21.note.Note C>, '
+                         + '<music21.note.Rest 2.5ql>, '
+                         + '<music21.note.Note C>, '
+                         + '<music21.note.Rest 4.25ql>, '
+                         + '<music21.note.Note C>, '
+                         + '<music21.note.Rest half>]')
         self.assertEqual(str(list(sPost.voices[1].notesAndRests)),
-                         '[<music21.note.Rest rest>, <music21.note.Note C>, '
-                         + '<music21.note.Rest rest>, <music21.note.Note C>, '
-                         + '<music21.note.Rest rest>, <music21.note.Note C>, '
-                         + '<music21.note.Rest rest>, <music21.note.Note C>]')
+                         '[<music21.note.Rest 16th>, <music21.note.Note C>, '
+                         + '<music21.note.Rest 3.25ql>, '
+                         + '<music21.note.Note C>, '
+                         + '<music21.note.Rest dotted-quarter>, <music21.note.Note C>, '
+                         + '<music21.note.Rest breve>, <music21.note.Note C>]')
 
         # sPost.show()
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1950,12 +1950,13 @@ class Test(unittest.TestCase):
                                   + '<music21.note.Rest quarter>, <music21.note.Rest quarter>, '
                                   + '<music21.note.Note C>, <music21.note.Rest half>]')
         match = str([(n, n.duration) for n in s.flat.notesAndRests])
-        self.assertEqual(match, '[(<music21.note.Rest half>, <music21.duration.Duration 2.0>), '
-                                  + '(<music21.note.Note C>, <music21.duration.Duration 1.0>), '
-                                  + '(<music21.note.Rest quarter>, <music21.duration.Duration 1.0>), '
-                                  + '(<music21.note.Rest quarter>, <music21.duration.Duration 1.0>), '
-                                  + '(<music21.note.Note C>, <music21.duration.Duration 1.0>), '
-                                  + '(<music21.note.Rest half>, <music21.duration.Duration 2.0>)]')
+        self.assertEqual(match,
+                         '[(<music21.note.Rest half>, <music21.duration.Duration 2.0>), '
+                          + '(<music21.note.Note C>, <music21.duration.Duration 1.0>), '
+                          + '(<music21.note.Rest quarter>, <music21.duration.Duration 1.0>), '
+                          + '(<music21.note.Rest quarter>, <music21.duration.Duration 1.0>), '
+                          + '(<music21.note.Note C>, <music21.duration.Duration 1.0>), '
+                          + '(<music21.note.Rest half>, <music21.duration.Duration 2.0>)]')
 
         GEX = m21ToXml.GeneralObjectExporter()
         unused_mx = GEX.parse(s).decode('utf-8')

--- a/music21/tinyNotation.py
+++ b/music21/tinyNotation.py
@@ -58,7 +58,7 @@ Here is an example of TinyNotation in action.
     {0.0} <music21.clef.TrebleClef>
     {0.0} <music21.meter.TimeSignature 3/4>
     {0.0} <music21.note.Note E>
-    {1.0} <music21.note.Rest rest>
+    {1.0} <music21.note.Rest quarter>
     {2.0} <music21.note.Note F#>
 {3.0} <music21.stream.Measure 2 offset=3.0>
     {0.0} <music21.note.Note G>

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -570,7 +570,7 @@ class Verticality(prebase.ProtoM21Object):
         <music21.tree.verticality.Verticality 400.0 {}>
         >>> el = verticality.makeElement(1/3)
         >>> el
-        <music21.note.Rest rest>
+        <music21.note.Rest 1/3ql>
         >>> el.duration.fullName
         'Eighth Triplet (1/3 QL)'
 


### PR DESCRIPTION
Give the type/duration-fullName of the rest or something useful if type is too long.

Wanted since v3 or so but finally got around to implementing.