### PR TITLE
Check if `Instrument.midiProgram` is None in feature extractors

### DIFF
--- a/music21/features/jSymbolic.py
+++ b/music21/features/jSymbolic.py
@@ -24,6 +24,7 @@ from math import isclose
 from music21 import base
 from music21 import exceptions21
 from music21.features import base as featuresModule
+from music21.instrument import Instrument
 
 from music21 import environment
 _MOD = 'features.jSymbolic'
@@ -3360,7 +3361,7 @@ class PitchedInstrumentsPresentFeature(featuresModule.FeatureExtractor):
             raise JSymbolicFeatureException('input lacks instruments')
         for p in s.parts:
             # always one instrument
-            i = p.getElementsByClass('Instrument').first()
+            i = p.getElementsByClass(Instrument).first()
             if p.recurse().notes:
                 if i.midiProgram is None:
                     iStr = str(i) or repr(i)
@@ -3453,7 +3454,7 @@ class NotePrevalenceOfPitchedInstrumentsFeature(
             raise JSymbolicFeatureException('input lacks notes')
         for p in s.parts:
             # always one instrument
-            i = p.getElementsByClass('Instrument').first()
+            i = p.getElementsByClass(Instrument).first()
             pNotes = p.recurse().notes
             if pNotes:
                 if i.midiProgram is None:
@@ -3561,7 +3562,7 @@ class VariabilityOfNotePrevalenceOfPitchedInstrumentsFeature(
         coll = []
         for p in s.parts:
             # always one instrument
-            i = p.getElementsByClass('Instrument').first()
+            i = p.getElementsByClass(Instrument).first()
             pNotes = p.recurse().notes
             if pNotes:
                 coll.append(len(pNotes) / total)
@@ -3711,7 +3712,7 @@ class InstrumentFractionFeature(featuresModule.FeatureExtractor):
         if not total:
             raise JSymbolicFeatureException('input lacks notes')
         for p in s.parts:
-            i = p.getElementsByClass('Instrument').first()
+            i = p.getElementsByClass(Instrument).first()
             if i.midiProgram in self._targetPrograms:
                 count += len(p.flat.notes)
         self.feature.vector[0] = count / total


### PR DESCRIPTION
Generic `Instrument` objects (the fall back for several file parsers) have a `.midiProgram` of None, so we can't use that value as an index in the feature extractors.

```
>>> i = instrument.Instrument()
>>> s = stream.Stream()
>>> s.append(i)
>>> s.append(note.Note())
>>> fe2 = features.jSymbolic.PitchedInstrumentsPresentFeature(s)
>>> fe2.extract()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/features/base.py", line 249, in extract
    self.process()  # will set Feature object to _feature
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/music21/features/jSymbolic.py", line 3354, in process
    self.feature.vector[i.midiProgram] = 1
TypeError: list indices must be integers or slices, not NoneType
```

Since #571 we still want this to fail, just with a more informative error so that users can assess whether to fix up their data.

Happened to notice there was an old issue for this #150 (and mentioned also in #223).