### PR TITLE
Prevent unnecessary deepcopies in `makeRests()`

### DIFF
--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -878,7 +878,7 @@ def makeRests(
 
     if returnObj.hasMeasures():
         # split rests at measure boundaries
-        returnObj.makeTies(classFilterList=(note.Rest,))
+        returnObj.makeTies(classFilterList=(note.Rest,), inPlace=True)
 
         # reposition measures
         accumulatedTime = 0.0


### PR DESCRIPTION
Missed in #922.

`returnObj` is already a deepcopy if need be, so just like the branch below for voices, we should just edit inPlace instead of doing more copies.