### PR TITLE
getGraceDuration() now sets type on GraceDuration

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (7, 0, 4)  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (7, 0, 5)  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'7.0.4'
+'7.0.5'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -2172,7 +2172,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
         >>> gd = d.getGraceDuration()
         >>> gd
-        <music21.duration.GraceDuration unlinked type:zero quarterLength:0.0>
+        <music21.duration.GraceDuration unlinked type:complex quarterLength:0.0>
         >>> gd.quarterLength
         0.0
         >>> gd.components
@@ -2198,6 +2198,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             newComponents.append(DurationTuple(c.type, c.dots, 0.0))
         gd.components = newComponents  # set new components
         gd.linked = False
+        gd.type = self.type
         gd.quarterLength = 0.0
         return gd
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -68,6 +68,10 @@ def typeToMusicXMLType(value):
     Traceback (most recent call last):
     music21.musicxml.xmlObjects.MusicXMLExportException:
     Cannot convert inexpressible durations to MusicXML.
+    >>> musicxml.m21ToXml.typeToMusicXMLType('zero')
+    Traceback (most recent call last):
+    music21.musicxml.xmlObjects.MusicXMLExportException:
+    Cannot convert durations without types to MusicXML.
     '''
     # MusicXML uses long instead of longa
     if value == 'longa':
@@ -76,6 +80,8 @@ def typeToMusicXMLType(value):
         raise MusicXMLExportException('Cannot convert "2048th" duration to MusicXML (too short).')
     elif value == 'inexpressible':
         raise MusicXMLExportException('Cannot convert inexpressible durations to MusicXML.')
+    elif value == 'zero':
+        raise MusicXMLExportException('Cannot convert durations without types to MusicXML.')
     else:
         return value
 
@@ -3383,27 +3389,13 @@ class MeasureExporter(XMLExporterBase):
             mxVoice = SubElement(mxNote, 'voice')
             mxVoice.text = str(self.currentVoiceId)
 
-        if d.type != 'zero':
-            mxType = Element('type')
-            mxType.text = typeToMusicXMLType(d.type)
-            self.setStyleAttributes(mxType, n, 'size', 'noteSize')
-            mxNote.append(mxType)
-            for unused_dotCounter in range(d.dots):
-                SubElement(mxNote, 'dot')
-                # TODO: dot placement...
-
-        elif d.components:
-            mxType = Element('type')
-            mxType.text = typeToMusicXMLType(d.components[0].type)
-            self.setStyleAttributes(mxType, n, 'size', 'noteSize')
-            if (n.hasStyleInformation
-                    and hasattr(n.style, 'noteSize')
-                    and n.style.noteSize is not None):
-                mxType.set('size', n.style.noteSize)
-
-            mxNote.append(mxType)
-            for unused_dotCounter in range(d.components[0].dots):
-                SubElement(mxNote, 'dot')
+        mxType = Element('type')
+        mxType.text = typeToMusicXMLType(d.type)
+        self.setStyleAttributes(mxType, n, 'size', 'noteSize')
+        mxNote.append(mxType)
+        for unused_dotCounter in range(d.dots):
+            SubElement(mxNote, 'dot')
+            # TODO: dot placement...
 
         if (hasattr(n, 'pitch')
                 and n.pitch.accidental is not None

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3269,7 +3269,7 @@ class MeasureParser(XMLParserBase):
         >>> gn1 = note.Note(duration=c2)
         >>> gn2 = MP.xmlGraceToGrace(mxGrace, gn1)
         >>> gn2.duration
-        <music21.duration.GraceDuration unlinked type:zero quarterLength:0.0>
+        <music21.duration.GraceDuration unlinked type:eighth quarterLength:0.0>
         '''
         numDots = 0
         tuplets = ()

--- a/music21/note.py
+++ b/music21/note.py
@@ -839,9 +839,9 @@ class GeneralNote(base.Music21Object):
         >>> ng.duration.isGrace
         True
         >>> ng.duration
-        <music21.duration.GraceDuration unlinked type:zero quarterLength:0.0>
+        <music21.duration.GraceDuration unlinked type:half quarterLength:0.0>
         >>> ng.duration.type
-        'zero'
+        'half'
         >>> ng.duration.components
         (DurationTuple(type='half', dots=0, quarterLength=0.0),)
 
@@ -850,7 +850,7 @@ class GeneralNote(base.Music21Object):
 
         >>> ng2 = n.getGrace(appoggiatura=True)
         >>> ng2.duration
-        <music21.duration.AppoggiaturaDuration unlinked type:zero quarterLength:0.0>
+        <music21.duration.AppoggiaturaDuration unlinked type:half quarterLength:0.0>
         >>> ng2.duration.slash
         False
 
@@ -860,7 +860,7 @@ class GeneralNote(base.Music21Object):
         >>> r = note.Rest(quarterLength=0.5)
         >>> r.getGrace(inPlace=True)
         >>> r.duration
-        <music21.duration.GraceDuration unlinked type:zero quarterLength:0.0>
+        <music21.duration.GraceDuration unlinked type:eighth quarterLength:0.0>
         '''
         if inPlace is False:
             e = copy.deepcopy(self)


### PR DESCRIPTION
Fixes #968 

Reproduced the bug on 3.1.0, actually!

The issue was that you can't derive type from components once the duration is unlinked. And the constructor for a GraceDuration sets .linked = False shortly after calling the superclass constructor. So the GraceDuration constructor is your only chance to get a type set automatically. Figured this fix, deliberately setting type, was cleaner than some sort of (`if not self.components: self.linked = True`) logic in the GraceDuration constructor that might just cause bugs later.