### PR TITLE
Provide default type when exporting grace durations to musicxml

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -3390,7 +3390,12 @@ class MeasureExporter(XMLExporterBase):
             mxVoice.text = str(self.currentVoiceId)
 
         mxType = Element('type')
-        mxType.text = typeToMusicXMLType(d.type)
+        if d.isGrace is True and d.type == 'zero':
+            # Default type-less grace durations to eighths
+            mxType.text = 'eighth'
+        else:
+            mxType.text = typeToMusicXMLType(d.type)
+
         self.setStyleAttributes(mxType, n, 'size', 'noteSize')
         mxNote.append(mxType)
         for unused_dotCounter in range(d.dots):

--- a/music21/note.py
+++ b/music21/note.py
@@ -494,7 +494,7 @@ class GeneralNote(base.Music21Object):
     double-dotted sixteenth note.
 
     In almost every circumstance, you should
-    create note.Note() or note.Rest() or note.Chord()
+    create note.Note() or note.Rest() or chord.Chord()
     objects directly, and not use this underlying
     structure.
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -466,7 +466,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         ...     print(n.name, end=' ')
         C C# D E F G A
 
-        '.ghost', because it begins with is treated as a class name and
+        '.ghost', because it begins with `.`, is treated as a class name and
         returns a `RecursiveIterator`:
 
 
@@ -474,7 +474,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         ...     print(n.name, end=' ')
         C E
 
-        A query selector with a `#`
+        A query selector with a `#`:
 
         >>> s['#last_a']
         <music21.note.Note A>


### PR DESCRIPTION
#982 was a little too strict when defining the new error condition for 'zero' duration.

If a user creates a vanilla GraceDuration() (i.e. without calling `getGrace()` to get a grace duration with a type), and it makes it to the MusicXML exporter, it seems harmless to give them a default of an eighth.