### PR TITLE
Don't flatten Stream containers when passing to Stream()

### DIFF
--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -553,7 +553,7 @@ class StreamFreezer(StreamFreezeThawBase):
         >>> n2.duration.type = 'whole'
         >>> m2.append(n2)
         >>> s2.append(m2)
-        >>> v = variant.Variant(s2)
+        >>> v = variant.Variant(s2.elements)
         >>> s.insert(0, v)
         >>> sf = freezeThaw.StreamFreezer(s, fastButUnsafe=True)
         >>> allIds = sf.findActiveStreamIdsInHierarchy()

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -1857,7 +1857,7 @@ class LilypondConverter:
         >>> for s in [ s1, s2, s3, s4, s5]:
         ...     s.makeMeasures(inPlace=True)
 
-        >>> activeSite = stream.Part(s5)
+        >>> activeSite = stream.Part(s5.elements)
 
         >>> v1 = variant.Variant()
         >>> for el in s1:
@@ -2070,11 +2070,11 @@ class LilypondConverter:
 
         >>> pStream = converter.parse('tinynotation: 4/4 a4 b c d   e4 f g a')
         >>> pStream.makeMeasures(inPlace=True)
-        >>> p = stream.Part(pStream)
+        >>> p = stream.Part(pStream.elements)
         >>> p.id = 'p1'
         >>> vStream = converter.parse('tinynotation: 4/4 a4. b8 c4 d')
         >>> vStream.makeMeasures(inPlace=True)
-        >>> v = variant.Variant(vStream)
+        >>> v = variant.Variant(vStream.elements)
         >>> v.groups = ['london']
         >>> p.insert(0.0, v)
         >>> lpc = lily.translate.LilypondConverter()
@@ -2221,7 +2221,7 @@ class LilypondConverter:
 
 
         >>> c = converter.parse('tinynotation: 3/4 C4 D E F2.')
-        >>> v = variant.Variant(c)
+        >>> v = variant.Variant(c.elements)
         >>> lpc = lily.translate.LilypondConverter()
         >>> lySequentialMusicOut = lpc.lySequentialMusicFromStream(v)
         >>> lySequentialMusicOut

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -11037,9 +11037,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         Note that streams which do not contain any instance of a lyric number will not
         appear anywhere in the final list (not as a [] or otherwise).
 
-        >>> p = stream.Part(s)
-        >>> scr = stream.Score()
-        >>> scr.append(p)
+        >>> scr = stream.Score(s)
 
         >>> scr.lyrics(ignoreBarlines=False, recurse=True)[1]
         [[[<music21.note.Lyric number=1 syllabic=single text='this'>, <...'is'>, <...'a'>, None],

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -278,7 +278,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         if givenElements is None:
             return
 
-        if not common.isIterable(givenElements) or isinstance(givenElements, Stream):
+        if isinstance(givenElements, Stream) or not common.isIterable(givenElements):
             givenElements = [givenElements]
 
         # Append rather than insert if every offset is 0.0

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -194,6 +194,14 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         {1.0} <music21.note.Note E->
     {0.0} <music21.stream.PartStaff 0x...>
         {0.0} <music21.note.Rest quarter>
+
+    Create nested streams in one fell swoop:
+
+    >>> s5 = stream.Score(stream.Part(stream.Measure(note.Note())))
+    >>> s5.show('text')
+    {0.0} <music21.stream.Part 0x...>
+        {0.0} <music21.stream.Measure 0 offset=0.0>
+            {0.0} <music21.note.Note C>
     '''
     # this static attributes offer a performance boost over other
     # forms of checking class
@@ -270,7 +278,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         if givenElements is None:
             return
 
-        if not common.isIterable(givenElements):
+        if not common.isIterable(givenElements) or isinstance(givenElements, Stream):
             givenElements = [givenElements]
 
         # Append rather than insert if every offset is 0.0

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -171,15 +171,15 @@ def mergeVariantScores(aScore, vScore, variantName='variant', *, inPlace=False):
 
     >>> aScore, vScore = stream.Score(), stream.Score()
 
-    >>> ap1 = stream.Part(converter.parse('tinynotation: 4/4   a4 b c d    e2 f2   g2 f4 g4 '
-    ...                                   ).makeMeasures())
-    >>> vp1 = stream.Part(converter.parse('tinynotation: 4/4   a4 b c e    e2 f2   g2 f4 a4 '
-    ...                                   ).makeMeasures())
+    >>> ap1 = converter.parse('tinynotation: 4/4   a4 b c d    e2 f2   g2 f4 g4 '
+    ...                                   ).makeMeasures()
+    >>> vp1 = converter.parse('tinynotation: 4/4   a4 b c e    e2 f2   g2 f4 a4 '
+    ...                                   ).makeMeasures()
 
-    >>> ap2 = stream.Part(converter.parse('tinynotation: 4/4   a4 g f e    f2 e2   d2 g4 f4 '
-    ...                                   ).makeMeasures())
-    >>> vp2 = stream.Part(converter.parse('tinynotation: 4/4   a4 g f e    f2 g2   f2 g4 d4 '
-    ...                                   ).makeMeasures())
+    >>> ap2 = converter.parse('tinynotation: 4/4   a4 g f e    f2 e2   d2 g4 f4 '
+    ...                                   ).makeMeasures()
+    >>> vp2 = converter.parse('tinynotation: 4/4   a4 g f e    f2 g2   f2 g4 d4 '
+    ...                                   ).makeMeasures()
 
     >>> aScore.insert(0.0, ap1)
     >>> aScore.insert(0.0, ap2)
@@ -1659,9 +1659,7 @@ def makeAllVariantsReplacements(streamWithVariants,
     >>> s2.makeMeasures(inPlace=True)
     >>> variant.mergeVariants(s, s2, variantName='london', inPlace=True)
 
-    >>> newPart = stream.Part(s)
-    >>> newStream = stream.Score()
-    >>> newStream.append(newPart)
+    >>> newStream = stream.Score(s)
 
     >>> returnStream = variant.makeAllVariantsReplacements(newStream, recurse=False)
     >>> for v in returnStream.parts[0].variants:

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -171,15 +171,11 @@ def mergeVariantScores(aScore, vScore, variantName='variant', *, inPlace=False):
 
     >>> aScore, vScore = stream.Score(), stream.Score()
 
-    >>> ap1 = converter.parse('tinynotation: 4/4   a4 b c d    e2 f2   g2 f4 g4 '
-    ...                                   ).makeMeasures()
-    >>> vp1 = converter.parse('tinynotation: 4/4   a4 b c e    e2 f2   g2 f4 a4 '
-    ...                                   ).makeMeasures()
+    >>> ap1 = converter.parse('tinynotation: 4/4   a4 b c d    e2 f2   g2 f4 g4 ')
+    >>> vp1 = converter.parse('tinynotation: 4/4   a4 b c e    e2 f2   g2 f4 a4 ')
 
-    >>> ap2 = converter.parse('tinynotation: 4/4   a4 g f e    f2 e2   d2 g4 f4 '
-    ...                                   ).makeMeasures()
-    >>> vp2 = converter.parse('tinynotation: 4/4   a4 g f e    f2 g2   f2 g4 d4 '
-    ...                                   ).makeMeasures()
+    >>> ap2 = converter.parse('tinynotation: 4/4   a4 g f e    f2 e2   d2 g4 f4 ')
+    >>> vp2 = converter.parse('tinynotation: 4/4   a4 g f e    f2 g2   f2 g4 d4 ')
 
     >>> aScore.insert(0.0, ap1)
     >>> aScore.insert(0.0, ap2)


### PR DESCRIPTION
**Before**
`Score(Part(Measure(Note())))` gave Score > Measure > Note, because `common.isIterable(myPart)` evaluated True and we just took the `.elements` of `myPart`, effectively flattening the provided container away.

#946 didn't make this any worse, as far as I can tell, but by providing additional support for single elements, we would have nudged people toward this banana peel by encouraging them to send single elements to the constructor. So this is another case we should handle.

**Now**
We don't flatten the provided container when sending that single Stream container to `Stream()`, i.e. we wrap it in a list.

Spruced up some doctests that were previously demonstrating the antipattern.

There are some **very** deep problems with this previous antipattern in LilyPond and Variant that I'm not volunteering to resolve ATM, but I was able to get the tests to pass by deliberately asking for the result of the old antipattern--i.e. flattening the provided container--by sending `.elements` to `Stream()`.

