### PR TITLE
Set `Interval.noteStart` when `melodicIntervals()` encounters Chords

### DIFF
--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9798,7 +9798,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         findConsecutiveNotes.
 
 
-
         >>> s1 = converter.parse("tinynotation: 3/4 c4 d' r b b'", makeNotation=False)
         >>> #_DOCS_SHOW s1.show()
 
@@ -9834,33 +9833,22 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         for i in range(len(returnList) - 1):
             firstNote = returnList[i]
             secondNote = returnList[i + 1]
-            firstPitch = None
-            secondPitch = None
-            if firstNote is not None and secondNote is not None:
-                startIsChord = False
-                endIsChord = False
-                if hasattr(firstNote, 'pitch') and firstNote.pitch is not None:
-                    firstPitch = firstNote.pitch
-                elif hasattr(firstNote, 'pitches') and firstNote.pitches:
-                    firstPitch = firstNote.pitches[0]
-                    startIsChord = True
-                if hasattr(secondNote, 'pitch') and secondNote.pitch is not None:
-                    secondPitch = secondNote.pitch
-                elif hasattr(secondNote, 'pitches') and secondNote.pitches:
-                    secondPitch = secondNote.pitches[0]
-                    endIsChord = True
-                if firstPitch is not None and secondPitch is not None:
-                    returnInterval = interval.notesToInterval(firstPitch,
-                                                              secondPitch)
-                    if startIsChord is False:
-                        returnInterval.noteStart = firstNote
-                    if endIsChord is False:
-                        returnInterval.noteEnd = secondNote
-                    returnInterval.offset = opFrac(firstNote.offset
-                                                   + firstNote.duration.quarterLength)
-                    returnInterval.duration = duration.Duration(opFrac(
-                        secondNote.offset - returnInterval.offset))
-                    returnStream.insert(returnInterval)
+            # Protect against empty chords
+            if firstNote.pitches and secondNote.pitches:
+                if chord.Chord in firstNote.classSet:
+                    noteStart = firstNote.notes[0]
+                else:
+                    noteStart = firstNote
+                if chord.Chord in secondNote.classSet:
+                    noteEnd = secondNote.notes[0]
+                else:
+                    noteEnd = secondNote
+                # Prefer Note objects over Pitch objects so that noteStart is set correctly
+                returnInterval = interval.Interval(noteStart, noteEnd)
+                returnInterval.offset = opFrac(firstNote.offset + firstNote.quarterLength)
+                returnInterval.duration = duration.Duration(opFrac(
+                    secondNote.offset - returnInterval.offset))
+                returnStream.insert(returnInterval)
 
         return returnStream
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9833,22 +9833,26 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         for i in range(len(returnList) - 1):
             firstNote = returnList[i]
             secondNote = returnList[i + 1]
+            # returnList could contain None to represent a rest
+            if firstNote is None or secondNote is None:
+                continue
             # Protect against empty chords
-            if firstNote.pitches and secondNote.pitches:
-                if chord.Chord in firstNote.classSet:
-                    noteStart = firstNote.notes[0]
-                else:
-                    noteStart = firstNote
-                if chord.Chord in secondNote.classSet:
-                    noteEnd = secondNote.notes[0]
-                else:
-                    noteEnd = secondNote
-                # Prefer Note objects over Pitch objects so that noteStart is set correctly
-                returnInterval = interval.Interval(noteStart, noteEnd)
-                returnInterval.offset = opFrac(firstNote.offset + firstNote.quarterLength)
-                returnInterval.duration = duration.Duration(opFrac(
-                    secondNote.offset - returnInterval.offset))
-                returnStream.insert(returnInterval)
+            if not (firstNote.pitches and secondNote.pitches):
+                continue
+            if chord.Chord in firstNote.classSet:
+                noteStart = firstNote.notes[0]
+            else:
+                noteStart = firstNote
+            if chord.Chord in secondNote.classSet:
+                noteEnd = secondNote.notes[0]
+            else:
+                noteEnd = secondNote
+            # Prefer Note objects over Pitch objects so that noteStart is set correctly
+            returnInterval = interval.Interval(noteStart, noteEnd)
+            returnInterval.offset = opFrac(firstNote.offset + firstNote.quarterLength)
+            returnInterval.duration = duration.Duration(opFrac(
+                secondNote.offset - returnInterval.offset))
+            returnStream.insert(returnInterval)
 
         return returnStream
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -994,6 +994,18 @@ class Test(unittest.TestCase):
         self.assertEqual(len(intS1), 2)
         M9 = intS1[0]
         self.assertEqual(M9.niceName, 'Major Ninth')
+
+        # Simple chord example
+        ch1 = chord.Chord('C4 E4 G4')
+        ch2 = chord.Chord('D4 F4 A4')
+        s2 = Stream([ch1, ch2])
+        intS2 = s2.melodicIntervals()
+        self.assertEqual(len(intS2), 1)
+        major_second = intS2.first()
+        self.assertEqual(major_second.niceName, 'Major Second')
+        self.assertIs(major_second.noteStart, ch1.notes[0])
+        self.assertIs(major_second.noteEnd, ch2.notes[0])
+
         # TODO: Many more tests
 
     def testMelodicIntervalsB(self):


### PR DESCRIPTION
I was using `melodicIntervals()` with the intent to find desired intervals and then extract the measure context by accessing .noteStart and then .derivation.origin, but I was encountering broken derivation chains because of the way `.noteStart` is set *after* the interval is created from `Pitch` objects:

```
>>> n = note.Note()
>>> n2 = note.Note()
>>> i = interval.notesToInterval(n.pitch, n2.pitch) # from pitches
>>> i.noteStart = n  # set the note afterward
>>> i.noteEnd = n2
>>> i.noteStart is n
False
>>> i.noteEnd is n2
True
```

The above example only happens in `melodicIntervals()` if chords are involved, so this PR just has melodicIntervals handle chords as it does notes and create intervals from Note objects, not Pitch objects. Took the opportunity to simplify a little bit, also.
