### PR TITLE
Ignore grace notes when beaming

### DIFF
--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -157,6 +157,7 @@ def makeBeams(
             for n in noteStream:
                 if n.duration.isGrace:
                     noteStream.remove(n)
+                    continue
                 durList.append(n.duration)
             # environLocal.printDebug([
             #    'beaming with ts', lastTimeSignature, 'measure', m, durList,

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -90,6 +90,22 @@ def makeBeams(
     4 <music21.beam.Beams <music21.beam.Beam 1/continue>/<music21.beam.Beam 2/continue>>
     5 <music21.beam.Beams <music21.beam.Beam 1/stop>/<music21.beam.Beam 2/stop>>
 
+    Grace notes no longer interfere with beaming:
+
+    >>> m = stream.Measure()
+    >>> m.timeSignature = meter.TimeSignature('3/4')
+    >>> m.repeatAppend(note.Note(quarterLength=0.25), 4)
+    >>> m.repeatAppend(note.Rest(), 2)
+    >>> gn = note.Note(duration=duration.GraceDuration())
+    >>> m.insert(0.25, gn)
+    >>> m.makeBeams(inPlace=True)
+    >>> [n.beams for n in m.notes]
+    [<music21.beam.Beams <music21.beam.Beam 1/start>/<music21.beam.Beam 2/start>>,
+    <music21.beam.Beams>,
+    <music21.beam.Beams <music21.beam.Beam 1/continue>/<music21.beam.Beam 2/stop>>,
+    <music21.beam.Beams <music21.beam.Beam 1/continue>/<music21.beam.Beam 2/start>>,
+    <music21.beam.Beams <music21.beam.Beam 1/stop>/<music21.beam.Beam 2/stop>>]
+
     OMIT_FROM_DOCS
     TODO: inPlace=False does not work in many cases  ?? still an issue? 2017
     '''
@@ -139,6 +155,8 @@ def makeBeams(
                 continue  # nothing to beam
             durList = []
             for n in noteStream:
+                if n.duration.isGrace:
+                    noteStream.remove(n)
                 durList.append(n.duration)
             # environLocal.printDebug([
             #    'beaming with ts', lastTimeSignature, 'measure', m, durList,


### PR DESCRIPTION
Fixes #345 

Applied equally with or without tuplets -- just an issue with makeBeams() in general.

**Before**
![Screen Shot 2021-04-28 at 2 16 41 PM](https://user-images.githubusercontent.com/38668450/116453091-7206ae80-a82c-11eb-831d-827dcff02ee1.png)

**Patch**
![Screen Shot 2021-04-28 at 2 16 45 PM](https://user-images.githubusercontent.com/38668450/116453073-6c10cd80-a82c-11eb-801b-33e861ac10b4.png)

The variables `noteStream` and `noteGroups` are temp streams, so it's safe to edit.
