### PR TITLE
Generalize exceptions in duration module and remove try block in `xmlToDuration()`

### DIFF
--- a/music21/duration.py
+++ b/music21/duration.py
@@ -1178,6 +1178,10 @@ class Tuplet(prebase.ProtoM21Object):
         Fraction(1, 3)
 
         Raises ValueError if `amountToScale` is negative.
+
+        >>> a.augmentOrDiminish(-1)
+        Traceback (most recent call last):
+        ValueError: amountToScale must be greater than zero
         '''
         if not amountToScale > 0:
             raise ValueError('amountToScale must be greater than zero')
@@ -1914,6 +1918,12 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> gRetain.components
         (DurationTuple(type='eighth', dots=0, quarterLength=0.5),
          DurationTuple(type='eighth', dots=0, quarterLength=0.5))
+
+        Negative values raise ValueError:
+
+        >>> fDur.augmentOrDiminish(-1)
+        Traceback (most recent call last):
+        ValueError: amountToScale must be greater than zero
         '''
         if not amountToScale > 0:
             raise ValueError('amountToScale must be greater than zero')
@@ -3667,6 +3677,30 @@ class Test(unittest.TestCase):
         # this failure happens earlier in quarterConversion()
         d = Duration(1 / 2049)
         self.assertEqual(d.type, 'inexpressible')
+
+    def testExceptions(self):
+        with self.assertRaises(TypeError):
+            unused = Duration('redundant type', type='eighth')
+
+        d = Duration(1 / 3)
+        with self.assertRaises(TypeError):
+            d.linked = 'do not link'
+        with self.assertRaises(ValueError):
+            d.componentIndexAtQtrPosition(400)
+        with self.assertRaises(ValueError):
+            d.componentIndexAtQtrPosition(-0.001)
+        with self.assertRaises(TypeError):
+            d.dotGroups = None
+        with self.assertRaises(TypeError):
+            d.dots = None
+        with self.assertRaises(ValueError):
+            d.type = 'custom'
+
+        gd = GraceDuration()
+        with self.assertRaises(ValueError):
+            gd.makeTime = 'True'
+        with self.assertRaises(ValueError):
+            gd.slash = 'none'
 
 
 # -------------------------------------------------------------------------------

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -1176,9 +1176,11 @@ class Tuplet(prebase.ProtoM21Object):
 
         >>> c.tupletMultiplier()
         Fraction(1, 3)
+
+        Raises ValueError if `amountToScale` is negative.
         '''
         if not amountToScale > 0:
-            raise DurationException('amountToScale must be greater than zero')
+            raise ValueError('amountToScale must be greater than zero')
         # TODO: scale the triplet in the same manner as Durations
 
         post = copy.deepcopy(self)
@@ -1588,7 +1590,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             elif isinstance(a, DurationTuple):
                 self.addDurationTuple(a)
             else:
-                raise DurationException(f'Cannot parse argument {a}')
+                raise TypeError(f'Cannot parse argument {a}')
 
         if 'durationTuple' in keywords:
             self.addDurationTuple(keywords['durationTuple'])
@@ -1768,7 +1770,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
     def _setLinked(self, value: bool):
         if value not in (True, False):
-            raise DurationException(f'Linked can only be True or False, not {value}')
+            raise TypeError(f'Linked can only be True or False, not {value}')
         if self._quarterLengthNeedsUpdating:
             self._updateQuarterLength()
         if value is False:
@@ -1914,7 +1916,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
          DurationTuple(type='eighth', dots=0, quarterLength=0.5))
         '''
         if not amountToScale > 0:
-            raise DurationException('amountToScale must be greater than zero')
+            raise ValueError('amountToScale must be greater than zero')
 
         post = copy.deepcopy(self)
 
@@ -2004,12 +2006,12 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             raise DurationException(
                 'Need components to run getComponentIndexAtQtrPosition')
         if quarterPosition > self.quarterLength:
-            raise DurationException(
+            raise ValueError(
                 'position is after the end of the duration')
 
         if quarterPosition < 0:
             # values might wrap around from the other side
-            raise DurationException(
+            raise ValueError(
                 'position is before the start of the duration')
 
         # it seems very odd that these return objects
@@ -2054,11 +2056,11 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         1.0
         >>> a.componentStartTime(3)
         Traceback (most recent call last):
-        music21.duration.DurationException: invalid component index value 3 submitted;
-                                            value must be an integer between 0 and 2
+        IndexError: invalid component index value 3 submitted;
+                    value must be an integer between 0 and 2
         '''
         if componentIndex not in range(len(self.components)):
-            raise DurationException(
+            raise IndexError(
                 f'invalid component index value {componentIndex} '
                 + f'submitted; value must be an integer between 0 and {len(self.components) - 1}')
 
@@ -2490,7 +2492,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
     @dotGroups.setter
     def dotGroups(self, value: Tuple[int, ...]):
         if not isinstance(value, tuple):
-            raise DurationException('only tuple dotGroups values can be used with this method.')
+            raise TypeError('only tuple dotGroups values can be used with this method.')
         # removes dots from all components...
         for i in range(len(self._components)):
             self._components[i] = durationTupleFromTypeDots(self._components[i].type, 0)
@@ -2582,7 +2584,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         if self._componentsNeedUpdating:
             self._updateComponents()
         if not common.isNum(value):
-            raise DurationException('only numeric dot values can be used with this method.')
+            raise TypeError('only numeric dot values can be used with this method.')
 
         # easter egg...
         if value == inf:
@@ -2929,7 +2931,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
     def type(self, value: str):
         # need to check that type is valid
         if value not in ordinalTypeFromNum and value not in ('inexpressible', 'complex'):
-            raise DurationException(f'no such type exists: {value}')
+            raise ValueError(f'no such type exists: {value}')
 
         if self.linked is True:
             nt = durationTupleFromTypeDots(value, self.dots)
@@ -3040,7 +3042,7 @@ class GraceDuration(Duration):
     @makeTime.setter
     def makeTime(self, expr):
         if expr not in (True, False, None):
-            raise DurationException('expr must be True, False, or None')
+            raise ValueError('expr must be True, False, or None')
         self._makeTime = bool(expr)
 
     @property
@@ -3054,7 +3056,7 @@ class GraceDuration(Duration):
     @slash.setter
     def slash(self, expr):
         if expr not in (True, False, None):
-            raise DurationException('expr must be True, False, or None')
+            raise ValueError('expr must be True, False, or None')
         self._slash = bool(expr)
 
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -12,7 +12,6 @@
 import copy
 import fractions
 import io
-import math
 # import pprint
 import re
 # import sys
@@ -3312,23 +3311,12 @@ class MeasureParser(XMLParserBase):
 
         # two ways to create durations, raw (from qLen) and cooked (from type, time-mod, dots)
         if d is not None:
+            # N.B. this branch currently executes just for grace note corrections
             durRaw = duration.Duration(quarterLength=qLen)  # raw just uses qLen
-            # the qLen set here may not be computable, but is not immediately
-            # computed until setting components
-            try:
-                d.components = durRaw.components
-            except duration.DurationException:  # TODO: Test
-                if qLen:
-                    qLenRounded = 2.0 ** round(math.log2(qLen))
-                else:
-                    qLenRounded = 0.0
-                environLocal.printDebug(
-                    ['mxToDuration',
-                        f'rounding duration to {qLenRounded} as type is not'
-                        + 'defined and raw quarterLength '
-                        + f'({qLen}) is not a computable duration'])
-                durRaw.quarterLength = qLen = qLenRounded
+            d.components = durRaw.components
+            d.tuplets = durRaw.tuplets
         else:
+            # N.B. this branch executes most of the time
             d = duration.Duration(quarterLength=qLen)
         # can't do this unless we have a type, so if not forceRaw
         if not forceRaw:  # a cooked version builds up from pieces
@@ -3340,7 +3328,7 @@ class MeasureParser(XMLParserBase):
                 return d if inputM21 is None else None
             if d is not None:
                 d.clear()
-                d.tuplets = []
+                d.tuplets = ()
                 d.addDurationTuple(dt)
             else:
                 d = duration.Duration(durationTuple=dt)
@@ -6946,6 +6934,19 @@ class Test(unittest.TestCase):
         s = converter.parse(testFiles.tabTest)
         metro = s.recurse().getElementsByClass('MetronomeMark').first()
         self.assertEqual(metro.style.absoluteY, 40)
+
+    def testClearingTuplets(self):
+        from xml.etree.ElementTree import fromstring as EL
+
+        MP = MeasureParser()
+        MP.divisions = 4
+        d = duration.Duration(2 / 3)
+        self.assertEqual(len(d.tuplets), 1)
+        mxNoteNoType = EL('<note><pitch><step>D</step><octave>6</octave></pitch>'
+                            '<duration>3</duration></note>')
+        MP.xmlToDuration(mxNoteNoType, inputM21=d)
+        self.assertEqual(len(d.tuplets), 0)
+        self.assertEqual(d.linked, True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Fixes #967: Remove unneeded `try` block in `xmlToDuration()`
- Investigating this revealed there was a bug with tuplets not being cleared in that branch. Fixed and added a regression test. Luckily, since #941, we only execute that branch for grace notes, so the likelihood of a grace-note tuplet hitting this was vanishingly low. But adding some future-proofing.
- While investigating the exceptions, noticed that we should raise `ValueError` or `IndexError` instead of `DurationException` in cases of user error to distinguish from the inability to calculate durations. We would expect users to have wide catches for `DurationException`, but it would be shame for user errors to be caught. Added test coverage for these exceptions.