### PR TITLE
Fix LilyPond crash where Lyric.text is None

### DIFF
--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -791,6 +791,8 @@ class LilypondConverter:
             text = ' _ '
         elif el.text == '':
             text = ' _ '
+        elif el.text is None:
+            text = ''
         else:
             text = '"' + el.text + '"'
             # TODO: composite
@@ -2571,6 +2573,13 @@ class Test(unittest.TestCase):
         # print(lpc.topLevelObject)
         # lpc.showPNG()
         # s.show('lily.png')
+
+    def testCompositeLyrics(self):
+        from music21 import corpus
+        s = corpus.parse('theoryExercises/checker_demo.xml')
+        lpc = LilypondConverter()
+        # previously this choked where .text is None on Lyric object
+        lpc.loadObjectFromScore(s)
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -2575,7 +2575,6 @@ class Test(unittest.TestCase):
         # s.show('lily.png')
 
     def testCompositeLyrics(self):
-        from music21 import corpus
         s = corpus.parse('theoryExercises/checker_demo.xml')
         lpc = LilypondConverter()
         # previously this choked where .text is None on Lyric object


### PR DESCRIPTION
Spotted when testing #1001 but doesn't address the reporter's issue.