### PR TITLE
Stop storing id(x) as .id

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (7, 0, 6)  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (7, 0, 7)  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -158,6 +158,8 @@ class Beam(prebase.ProtoM21Object, EqualSlottedObjectMixin, style.StyleMixin):
         # represents which beam line referred to
         # 8th, 16th, etc represented as 1, 2, ...
         self.number = number
+
+        # this should be called something else.
         self.id = id(self)
 
     # PRIVATE METHODS #
@@ -214,6 +216,8 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
         # no need for super() call w/ ProtoM21 and EqualSlottedObject
         self.beamsList = []
         self.feathered = False
+
+        # this should not be called .id.
         self.id = id(self)
 
     # SPECIAL METHODS #

--- a/music21/defaults.py
+++ b/music21/defaults.py
@@ -111,7 +111,7 @@ multiMeasureRestUseSymbols = True
 multiMeasureRestMaxSymbols = 11
 
 # id numbers above this number will be considered memory locations
-# and rewritten on thaw.
+# and rewritten on thaw, etc.
 minIdNumberToConsiderMemoryLocation = 100_000_001
 
 # ----------------------------------------------------------------||||||||||||--

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -758,12 +758,6 @@ class StreamThawer(StreamFreezeThawBase):
         >>> st = freezeThaw.StreamThawer()
         >>> st.teardownSerializationScaffold(a)
         '''
-        def _fixId(innerEl):
-            if (innerEl.id is not None
-                    and common.isNum(innerEl.id)
-                    and innerEl.id > defaults.minIdNumberToConsiderMemoryLocation):
-                innerEl.id = id(innerEl)
-
         if streamObj is None:  # pragma: no cover
             streamObj = self.stream
             if streamObj is None:
@@ -795,12 +789,10 @@ class StreamThawer(StreamFreezeThawBase):
                 self.restoreStreamStatusClient(e)
                 # removing seems to create problems for jsonPickle with Spanners
 
-            _fixId(e)
             # e.wrapWeakref()
 
         # restore to whatever it was
         streamObj.autoSort = storedAutoSort
-        _fixId(streamObj)
 
     def restoreElementsFromTuples(self, streamObj):
         '''

--- a/music21/metadata/bundles.py
+++ b/music21/metadata/bundles.py
@@ -66,7 +66,7 @@ class MetadataEntry(prebase.ProtoM21Object):
     The metadata property contains its :class:`~music21.metadata.RichMetadata` object:
 
     >>> metadataEntry.metadata
-    <music21.metadata.RichMetadata id=0x...>
+    <music21.metadata.RichMetadata object at 0x...>
 
     Note that the id is not necessarily the current memory location.
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1672,7 +1672,7 @@ class PartParser(XMLParserBase):
 
         uniqueStaffKeys: List[int] = self._getUniqueStaffKeys()
         partStaffs: List[stream.PartStaff] = []
-        appendedElementIds: Set[int] = set()  # id = id(el) not el.id
+        appendedElementIds: Set[int] = set()  # id is id(el) not el.id
 
         def copy_into_partStaff(source, target, omitTheseElementIds):
             for sourceElem in source.getElementsByClass(STAFF_SPECIFIC_CLASSES):

--- a/music21/tie.py
+++ b/music21/tie.py
@@ -109,6 +109,7 @@ class Tie(prebase.ProtoM21Object, SlottedObjectMixin):
                 f'Type must be one of {self.VALID_TIE_TYPES}, not {type}')
         # naming this 'type' was a mistake, because cannot create a property of this name.
 
+        # this is not the correct way we want to do this, I don't think...
         self.id = id(self)
         self.type = type
         self.style = 'normal'


### PR DESCRIPTION
The `.id` of the element allows for having the memory location only as a crutch so that it's not required.  It should not be stored but generated dynamically.

This was a mistake in architecture created before music21 v1 release and it's finally time to fix.

TODO: fix in beam and tie also.