### PR TITLE
`findConsecutiveNotes()` no longer evaluates a flat version

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -254,7 +254,7 @@ class Chord(note.NotRest):
 
     def __eq__(self, other):
         '''
-        True if the it passes all `super()`
+        True if the Chord passes all `super()`
         equality tests and the pitches are the same
         (possibly in a different order)
 


### PR DESCRIPTION
Fixes #1000

Also changed `findConsecutiveNotes()` to scan each Voice of Measure or Part of Score separately rather than flattening. Used existing `noNone=False` functionality to insert None when backing up to scan another Voice or Part.


Previously, notes in Voices could be accessed with getOverlaps=True (not default), but the results were likely unwanted:
```
>>> from music21 import stream
>>> m = stream.Measure()
>>> m.repeatAppend(note.Note(), 4)
>>> m.repeatInsert(note.Note(), [0, 1, 2, 3])
>>> m.makeVoices(inPlace=True)
>>> for i, elem in enumerate(list(m.recurse().notes)):
...     elem.transpose(i, inPlace=True)
... 
>>> p = stream.Part(m)
>>> p.show('t')
{0.0} <music21.stream.Measure 0 offset=0.0>
    {0.0} <music21.stream.Voice 0x105077880>
        {0.0} <music21.note.Note C>
        {1.0} <music21.note.Note C#>
        {2.0} <music21.note.Note D>
        {3.0} <music21.note.Note E->
    {0.0} <music21.stream.Voice 0x1050779a0>
        {0.0} <music21.note.Note E>
        {1.0} <music21.note.Note F>
        {2.0} <music21.note.Note F#>
        {3.0} <music21.note.Note G>
>>> p.findConsecutiveNotes(getOverlaps=True)
[<music21.note.Note C>, 
<music21.note.Note E>, 
<music21.note.Note C#>, 
<music21.note.Note F>, 
<music21.note.Note D>, 
<music21.note.Note F#>, 
<music21.note.Note E->, 
<music21.note.Note G>]
```