### PR TITLE
`stripTies()` now sets StreamStatus.beams = False

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ http://web.mit.edu/music21 or http://music21.readthedocs.org/en/latest/index.htm
 And to install, see:
 http://web.mit.edu/music21/doc/usersGuide/usersGuide_01_installing.html
 
-Music21 runs on Python 3.6+.  Use version 4 on Python 2 or Py3.4, version 5
-on Py3.5.
+Music21 runs on Python 3.7+.  Use version 4 on Python 2 or Py3.4, version 5
+on Py3.5, version 6 on Py3.6.
 
 Released under the BSD (3-clause) license. Music21 may also be used
 under the LGPL license.  See LICENSE.

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2528,26 +2528,29 @@ class PartExporter(XMLExporterBase):
         '''
         part = self.stream
         measures = part.getElementsByClass(stream.Measure)
+        first_measure = measures.first()
+        if not first_measure:
+            return
         # check that first measure has any attributes in outer Stream
         # this is for non-standard Stream formations (some kern imports)
         # that place key/clef information in the containing stream
-        if hasattr(measures.first(), 'clef') and measures[0].clef is None:
-            measures.first().makeMutable()  # must mutate
+        if hasattr(first_measure, 'clef') and first_measure.clef is None:
+            first_measure.makeMutable()  # must mutate
             outerClefs = part.getElementsByClass('Clef')
             if outerClefs:
-                measures.first().clef = outerClefs.first()
+                first_measure.clef = outerClefs.first()
 
-        if hasattr(measures.first(), 'keySignature') and measures.first().keySignature is None:
-            measures.first().makeMutable()  # must mutate
+        if hasattr(first_measure, 'keySignature') and first_measure.keySignature is None:
+            first_measure.makeMutable()  # must mutate
             outerKeySignatures = part.getElementsByClass('KeySignature')
             if outerKeySignatures:
-                measures.first().keySignature = outerKeySignatures.first()
+                first_measure.keySignature = outerKeySignatures.first()
 
-        if hasattr(measures.first(), 'timeSignature') and measures.first().timeSignature is None:
-            measures.first().makeMutable()  # must mutate
+        if hasattr(first_measure, 'timeSignature') and first_measure.timeSignature is None:
+            first_measure.makeMutable()  # must mutate
             outerTimeSignatures = part.getElementsByClass('TimeSignature')
             if outerTimeSignatures:
-                measures.first().timeSignature = outerTimeSignatures.first()
+                first_measure.timeSignature = outerTimeSignatures.first()
 
         # see if accidentals/beams can be processed
         if not part.streamStatus.haveAccidentalsBeenMade():

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2411,7 +2411,7 @@ class PartExporter(XMLExporterBase):
             self.fixupNotationMeasured()
         # make sure that all instances of the same class have unique ids
         self.spannerBundle.setIdLocals()
-        for m in self.stream[stream.Measure]:
+        for m in self.stream.getElementsByClass(stream.Measure):
             self.addDividerComment('Measure ' + str(m.number))
             measureExporter = MeasureExporter(m, parent=self)
             measureExporter.spannerBundle = self.spannerBundle

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1479,6 +1479,13 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         [0.0, 36.0]
         >>> len(SX.parts)
         4
+
+        >>> b.insert(stream.Score())
+        >>> SX = musicxml.m21ToXml.ScoreExporter(b)
+        >>> SX.setPartsAndRefStream()
+        Traceback (most recent call last):
+        music21.musicxml.xmlObjects.MusicXMLExportException:
+        Exporting scores nested inside scores is not supported
         '''
         s = self.stream
         # environLocal.printDebug('streamToMx(): interpreting multipart')
@@ -1490,6 +1497,9 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
             # https://github.com/cuthbertLab/music21/issues/580
             if isinstance(innerStream, stream.Measure):
                 ht = innerStream.offset + innerStream.highestTime
+            elif isinstance(innerStream, (stream.Score, stream.Opus)):
+                raise MusicXMLExportException(
+                    'Exporting scores nested inside scores is not supported')
             else:
                 innerStream.transferOffsetToElements()
                 ht = innerStream.highestTime

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2877,16 +2877,21 @@ class MeasureExporter(XMLExporterBase):
         # turn inexpressible durations into complex durations (unless unlinked)
         if obj.duration.type == 'inexpressible':
             obj.duration.quarterLength = obj.duration.quarterLength
-
+            objList = obj.splitAtDurations()
         # make dotGroups into normal notes
-        if len(obj.duration.dotGroups) > 1:
+        elif len(obj.duration.dotGroups) > 1:
             obj.duration.splitDotGroups(inPlace=True)
+            objList = obj.splitAtDurations()
+        # otherwise, splitAtDurations() was already called by parse(), no need to repeat
+        else:
+            objList = [obj]
 
         parsedObject = False
         for className, methName in self.classesToMethods.items():
             if className in classes:
                 meth = getattr(self, methName)
-                meth(obj)
+                for o in objList:
+                    meth(o)
                 parsedObject = True
                 break
 
@@ -2895,7 +2900,8 @@ class MeasureExporter(XMLExporterBase):
         for className, methName in self.wrapAttributeMethodClasses.items():
             if className in classes:
                 meth = getattr(self, methName)
-                self.wrapObjectInAttributes(obj, meth)
+                for o in objList:
+                    self.wrapObjectInAttributes(o, meth)
                 parsedObject = True
                 break
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1226,6 +1226,25 @@ class Test(unittest.TestCase):
         self.assertTrue(s.spanners[1].isFirst(n1))
         self.assertTrue(s.spanners[1].isLast(n3))
 
+    def testStripTiesClearBeaming(self):
+        from music21 import converter
+
+        p = converter.parse('tinyNotation: c2~ c8 c8 c8 c8')
+        p.makeNotation(inPlace=True)
+        self.assertEqual(p.streamStatus.beams, True)
+        p.stripTies(inPlace=True)
+        self.assertEqual(p.streamStatus.beams, False)
+        p = p.splitAtDurations(recurse=True)[0]
+        p.makeBeams(inPlace=True)
+        self.assertEqual([repr(el.beams) for el in p[note.Note]],
+            ['<music21.beam.Beams>',
+             '<music21.beam.Beams <music21.beam.Beam 1/start>>',
+             '<music21.beam.Beams <music21.beam.Beam 1/stop>>',
+             '<music21.beam.Beams <music21.beam.Beam 1/start>>',
+             '<music21.beam.Beams <music21.beam.Beam 1/stop>>'
+             ]
+        )
+
     def testGetElementsByOffsetZeroLength(self):
         '''
         Testing multiple zero-length elements with mustBeginInSpan:


### PR DESCRIPTION
- Fixes #994: `stripTies()` sets StreamStatus.beams = False
- for that to have effect, refactored `fixupNotationMeasured()` in musicxml export so that it doesn't use a dummy stream as an iterator and then query that dummy stream for its beam status
- called `splitAtDurations()` earlier in musicxml export so that it happens before fixupNotationMeasured remakes beams
- moved full-measure rest splitting logic out of musicxml exporter and into `splitAtDurations()`
