### PR TITLE
Fix LilyPond color statements

### DIFF
--- a/.github/scripts/install_ubuntu_deps.sh
+++ b/.github/scripts/install_ubuntu_deps.sh
@@ -6,8 +6,8 @@ mkdir ~/Desktop
 
 sudo apt-get install -y libpng-dev
 # sudo apt-get install -y python3-pyqt5
-wget -q https://lilypond.org/download/binaries/linux-64/lilypond-2.22.0-1.linux-64.sh
-sh lilypond-2.22.0-1.linux-64.sh --batch
+wget -q https://lilypond.org/download/binaries/linux-64/lilypond-2.22.1-1.linux-64.sh
+sh lilypond-2.22.1-1.linux-64.sh --batch
 export PATH=/home/runner/bin:$PATH
 pip3 install -r requirements.txt
 pip3 install coveralls


### PR DESCRIPTION
Turns out LilyPond started supporting hex colors this year. Simpler than using `webcolors` to convert to RGB.

Fixes #1001 and fixes #541 (duplicates)

"#FF0000"
![tmpmapd4pqj ly](https://user-images.githubusercontent.com/38668450/117395604-43d93c80-aec6-11eb-8343-200aca96b476.png)

"darkgreen"
![tmpuqgf0jf4 ly](https://user-images.githubusercontent.com/38668450/117395643-50f62b80-aec6-11eb-9a9c-f2c202c25f77.png)
