### PR TITLE
Refactor catching of OSErrors when finding default temp directories, and improve the naming of fallback temp directories for Linux and Mac platforms

### DIFF
--- a/music21/environment.py
+++ b/music21/environment.py
@@ -30,6 +30,7 @@ import tempfile
 import unittest
 
 from typing import Union
+from typing import Optional
 
 import xml.etree.ElementTree as ET
 from xml.sax import saxutils
@@ -432,7 +433,7 @@ class _EnvironmentCore:
             ]:
                 self.__setitem__(name, value)  # use for key checking
 
-    def _checkAccessibility(self, path: Union[str, pathlib.Path]) -> bool:
+    def _checkAccessibility(self, path: Optional[Union[str, pathlib.Path]]) -> bool:
         '''
         Return True if the path exists, is readable and writable.
         '''


### PR DESCRIPTION
Hi,
I add two checks for read & write permission of the root temp directory.
I also modify the naming rule of alternative temp directory for ~Linux~ Linux and Mac platform with "music21-$UID" (which is "music21-$(8-digit hashed code)" originally). It can avoid music21 creating too many directories while using the alternative temp directory.