### PR TITLE
Use `requests_html` to implement `ComposerPopularityFeature`

### DIFF
--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -890,6 +890,8 @@ class ComposerPopularity(featuresModule.FeatureExtractor):
         session = HTMLSession()
         response = session.get(urlStr)
         resultsDiv = response.html.find('div[@id="result-stats"]', first=True)
+        if resultsDiv is None:  # pragma: no cover
+            return 0
         m = self.googleResultsRE.search(resultsDiv.text)
         if m is not None and m.group(0):
             totalRes = int(m.group(1).replace(',', ''))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ jsonpickle
 matplotlib
 more_itertools
 numpy
+requests_html
 webcolors>=1.5


### PR DESCRIPTION
Fixes #907 
This had stopped working because Google's response to the static UserAgent we were giving lacked result counts.

I was looking into this package for another reason today and realized it would solve this problem. It rotates user agents. It's owned by PSF. If you don't want to add it to requirements.txt then we can fiddle with the CI script to still have the test run on CI, or we can just deprecate the feature.