### PR TITLE
Fix crash when romanNumeralFromChord gets empty chords

### DIFF
--- a/music21/roman.py
+++ b/music21/roman.py
@@ -846,7 +846,7 @@ def romanNumeralFromChord(
     ...     )
     <music21.roman.RomanNumeral #io6b3 in C major>
 
-    :class:`~music21.harmony.NoChord` objects give empty RomanNumerals:
+    Empty chords, including :class:`~music21.harmony.NoChord` objects, give empty RomanNumerals:
 
     >>> roman.romanNumeralFromChord(harmony.NoChord())
     <music21.roman.RomanNumeral>
@@ -1002,7 +1002,7 @@ def romanNumeralFromChord(
 
     noKeyGiven = (keyObj is None)
 
-    if isinstance(chordObj, harmony.NoChord):
+    if not chordObj.pitches:
         return RomanNumeral()
 
     # TODO: Make sure 9 works

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -846,6 +846,10 @@ def romanNumeralFromChord(
     ...     )
     <music21.roman.RomanNumeral #io6b3 in C major>
 
+    :class:`~music21.harmony.NoChord` objects give empty RomanNumerals:
+
+    >>> roman.romanNumeralFromChord(harmony.NoChord())
+    <music21.roman.RomanNumeral>
 
     Augmented 6th chords in other inversions do not currently find correct roman numerals
 
@@ -997,6 +1001,9 @@ def romanNumeralFromChord(
     }
 
     noKeyGiven = (keyObj is None)
+
+    if isinstance(chordObj, harmony.NoChord):
+        return RomanNumeral()
 
     # TODO: Make sure 9 works
     # stepAdjustments = {'minor' : {3: -1, 6: -1, 7: -1},


### PR DESCRIPTION
**Previously**
```
File "/Users/jwalls/music21/music21/roman.py", line 851, in __main__.romanNumeralFromChord
Failed example:
    roman.romanNumeralFromChord(harmony.NoChord())
Exception raised:
    Traceback (most recent call last):
      File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/doctest.py", line 1336, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest __main__.romanNumeralFromChord[27]>", line 1, in <module>
        roman.romanNumeralFromChord(harmony.NoChord())
      File "/Users/jwalls/music21/music21/roman.py", line 1012, in romanNumeralFromChord
        thirdType = chordObj.semitonesFromChordStep(3)
      File "/Users/jwalls/music21/music21/chord/__init__.py", line 3469, in semitonesFromChordStep
        tempInt = self.intervalFromChordStep(chordStep, testRoot=testRoot)
      File "/Users/jwalls/music21/music21/chord/__init__.py", line 1825, in intervalFromChordStep
        raise ChordException("Cannot run intervalFromChordStep without a root")
    music21.chord.ChordException: Cannot run intervalFromChordStep without a root
```