### PR TITLE
Run most TestExternal classes on CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,4 +12,5 @@ exclude_lines =
     if self.debug:
     if self.show:
     def x_test
+    def xtest
     pragma: no cover

--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,6 @@ exclude_lines =
     if __name__ == .__main__.:
     if debug:
     if self.debug:
-    class TestExternal(unittest.TestCase):
+    if self.show:
     def x_test
     pragma: no cover

--- a/music21/alpha/analysis/hasher.py
+++ b/music21/alpha/analysis/hasher.py
@@ -754,7 +754,7 @@ class Test(unittest.TestCase):
         unused_hashes = h.hashStream(s)
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     # def testBasicHash(self):

--- a/music21/alpha/analysis/hasher.py
+++ b/music21/alpha/analysis/hasher.py
@@ -755,6 +755,7 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     # def testBasicHash(self):
     #     # from pprint import pprint as pp
@@ -832,10 +833,11 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         hashes2 = h.hashStream(s2)
         hashes3 = h.hashStream(s3)
 
-        print(difflib.SequenceMatcher(a=hashes1, b=hashes2).ratio())
-        print(difflib.SequenceMatcher(a=hashes1, b=hashes3).ratio())
-        print(difflib.SequenceMatcher(a=hashes2, b=hashes3).ratio())
-        s2.show()
+        if self.show:
+            print(difflib.SequenceMatcher(a=hashes1, b=hashes2).ratio())
+            print(difflib.SequenceMatcher(a=hashes1, b=hashes3).ratio())
+            print(difflib.SequenceMatcher(a=hashes2, b=hashes3).ratio())
+            s2.show()
 
         h.hashPitch = False
         h.hashDuration = True
@@ -845,9 +847,10 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         hashes2 = h.hashStream(s2)
         hashes3 = h.hashStream(s3)
 
-        print(difflib.SequenceMatcher(a=hashes1, b=hashes2).ratio())
-        print(difflib.SequenceMatcher(a=hashes1, b=hashes3).ratio())
-        print(difflib.SequenceMatcher(a=hashes2, b=hashes3).ratio())
+        if self.show:
+            print(difflib.SequenceMatcher(a=hashes1, b=hashes2).ratio())
+            print(difflib.SequenceMatcher(a=hashes1, b=hashes3).ratio())
+            print(difflib.SequenceMatcher(a=hashes2, b=hashes3).ratio())
 
     def testInterval(self):
         from music21 import corpus
@@ -858,7 +861,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         hashes3 = h.hashStream(s3)
         hashes4 = h.hashStream(s4)
 
-        print(difflib.SequenceMatcher(a=hashes3, b=hashes4).ratio())
+        if self.show:
+            print(difflib.SequenceMatcher(a=hashes3, b=hashes4).ratio())
 
         h.hashIntervalFromLastNote = True
         h.hashPitch = False
@@ -866,7 +870,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         hashes3 = h.hashStream(s3)
         hashes4 = h.hashStream(s4)
 
-        print(difflib.SequenceMatcher(a=hashes3, b=hashes4).ratio())
+        if self.show:
+            print(difflib.SequenceMatcher(a=hashes3, b=hashes4).ratio())
 
 
 if __name__ == '__main__':

--- a/music21/alpha/analysis/hasher.py
+++ b/music21/alpha/analysis/hasher.py
@@ -754,7 +754,7 @@ class Test(unittest.TestCase):
         unused_hashes = h.hashStream(s)
 
 
-class TestExternal(unittest.TestCase):
+class TestExternal(unittest.TestCase):  # pragma: no cover
 
     # def testBasicHash(self):
     #     # from pprint import pprint as pp

--- a/music21/analysis/metrical.py
+++ b/music21/analysis/metrical.py
@@ -161,6 +161,7 @@ def thomassenMelodicAccent(streamIn):
 
 # ------------------------------------------------------------------------------
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testSingle(self):
         '''Need to test direct meter creation w/o stream
@@ -181,8 +182,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         s = s.makeMeasures()
         s = labelBeatDepth(s)
 
-        s.show()
-
+        if self.show:
+            s.show()
 
 
 class Test(unittest.TestCase):

--- a/music21/analysis/metrical.py
+++ b/music21/analysis/metrical.py
@@ -160,7 +160,7 @@ def thomassenMelodicAccent(streamIn):
 
 
 # ------------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testSingle(self):

--- a/music21/analysis/reduceChords.py
+++ b/music21/analysis/reduceChords.py
@@ -697,6 +697,7 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testTrecentoMadrigal(self):
         from music21 import corpus
@@ -726,7 +727,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         for part in reduction:
             score.insert(0, part)
 
-        score.show()
+        if self.show:
+            score.show()
 
 
 # -----------------------------------------------------------------------------

--- a/music21/analysis/reduceChords.py
+++ b/music21/analysis/reduceChords.py
@@ -696,7 +696,7 @@ class Test(unittest.TestCase):
             s.append(c)
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testTrecentoMadrigal(self):

--- a/music21/analysis/reduceChordsOld.py
+++ b/music21/analysis/reduceChordsOld.py
@@ -339,6 +339,7 @@ class Test(unittest.TestCase):
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
 
+    @unittest.expectedFailure
     def testTrecentoMadrigal(self):
         from music21 import corpus
         # c = corpus.parse('beethoven/opus18no1', 2).measures(1, 19)

--- a/music21/analysis/reduceChordsOld.py
+++ b/music21/analysis/reduceChordsOld.py
@@ -338,6 +338,7 @@ class Test(unittest.TestCase):
             s.append(c)
 
 class TestExternal(unittest.TestCase):
+    show = True
 
     @unittest.expectedFailure
     def testTrecentoMadrigal(self):
@@ -375,7 +376,8 @@ class TestExternal(unittest.TestCase):
 
 
         c.insert(0, p)
-        c.show()
+        if self.show:
+            c.show()
 
 
 # ------------------------------------------------------------------------------

--- a/music21/analysis/reduceChordsOld.py
+++ b/music21/analysis/reduceChordsOld.py
@@ -337,7 +337,7 @@ class Test(unittest.TestCase):
         for c in [c1, c2, c3]:
             s.append(c)
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
 
     @unittest.expectedFailure
     def testTrecentoMadrigal(self):

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -1306,7 +1306,7 @@ class Test(unittest.TestCase):
         unused_target = pr.getGraphHorizontalBarWeightedData()
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testPartReductionB(self):

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -1307,9 +1307,11 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
+
     def testPartReductionB(self):
         t = Test()
-        t.testPartReductionB(show=True)
+        t.testPartReductionB(show=self.show)
 
 
 # ------------------------------------------------------------------------------

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -354,7 +354,7 @@ class WindowedAnalysis:
 
 
 # -----------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     pass
 
 

--- a/music21/audioSearch/recording.py
+++ b/music21/audioSearch/recording.py
@@ -111,7 +111,7 @@ class Test(unittest.TestCase):
     pass
 
 
-class TestExternal(unittest.TestCase):
+class TestExternal(unittest.TestCase):  # pragma: no cover
     try:
         import pygame
         pygame_installed = True

--- a/music21/audioSearch/recording.py
+++ b/music21/audioSearch/recording.py
@@ -111,7 +111,7 @@ class Test(unittest.TestCase):
     pass
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     try:
         import pygame
         pygame_installed = True

--- a/music21/audioSearch/recording.py
+++ b/music21/audioSearch/recording.py
@@ -112,7 +112,13 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    try:
+        import pygame
+        pygame_installed = True
+    except ImportError:
+        pygame_installed = False
 
+    @unittest.skipUnless(pygame_installed, 'pygame must be installed')
     def testRecording(self):
         '''
         record one second of data and print 10 records

--- a/music21/audioSearch/scoreFollower.py
+++ b/music21/audioSearch/scoreFollower.py
@@ -570,7 +570,7 @@ class ScoreFollower:
 # -----------------------------------------------------------------------------
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
 
     def xtestRunScoreFollower(self):
         from music21 import corpus

--- a/music21/audioSearch/transcriber.py
+++ b/music21/audioSearch/transcriber.py
@@ -137,7 +137,7 @@ def monophonicStreamFromFile(fileName, useScale=None):
     return myScore.parts.first()
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
 
     def xtestRunTranscribe(self):
         saveFile = environLocal.getRootTempDir() / 'new_song.wav'

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -892,7 +892,7 @@ class Test(unittest.TestCase):
     pass
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testComplete(self):

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -893,14 +893,15 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
-    pass
+    show = True
 
     def testComplete(self):
         ci = CapellaImporter()
         capellaDirPath = common.getSourceFilePath() / 'capella'
         oswaldPath = capellaDirPath / r'Nu_rue_mit_sorgen.capx'
         partScore = ci.scoreFromFile(oswaldPath)
-        partScore.show()
+        if self.show:
+            partScore.show()
 
     def xtestImportSorgen(self):
         ci = CapellaImporter()
@@ -915,7 +916,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         # scoreElement = ci.mainDom.documentElement.getElementsByTagName('score')[0]
         scoreObj = ci.systemScoreFromScore(ci.mainDom.documentElement)
         partScore = ci.partScoreFromSystemScore(scoreObj)
-        partScore.show()
+        if self.show:
+            partScore.show()
         # ci.walkNodes()
         # print(ci.xmlText)
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -5448,12 +5448,14 @@ def fromIntervalVector(notation, getZRelation=False):
 
 # ------------------------------------------------------------------------------
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testBasic(self):
         for pitchList in [['g2', 'c4', 'c#6'],
                           ['c', 'd-', 'f#', 'g']]:
             a = Chord(pitchList)
-            a.show()
+            if self.show:
+                a.show()
 
     def testPostTonalChords(self):
         import random
@@ -5470,7 +5472,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             c.addLyric(c.forteClass)
             c.addLyric(str(c.primeForm).replace(' ', ''))
             s.append(c)
-        s.show()
+        if self.show:
+            s.show()
 
 
 class Test(unittest.TestCase):

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -5447,7 +5447,7 @@ def fromIntervalVector(notation, getZRelation=False):
 
 
 # ------------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testBasic(self):

--- a/music21/configure.py
+++ b/music21/configure.py
@@ -1596,7 +1596,7 @@ class ConfigurationAssistant:
 _DOC_ORDER = []
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestUserInput(unittest.TestCase):  # pragma: no cover
 
     def testYesOrNo(self):
         print()
@@ -1762,7 +1762,7 @@ if __name__ == '__main__':
     else:
         # only if running tests
         t = Test()
-        te = TestExternal()
+        te = TestUserInput()
 
         if len(sys.argv) < 2 or sys.argv[1] in ['all', 'test']:
             import music21
@@ -1770,7 +1770,7 @@ if __name__ == '__main__':
 
         # arg[1] is test to launch
         elif sys.argv[1] == 'te':
-            # run test external
+            # run test user input
             getattr(te, sys.argv[2])()
         # just run named Test
         elif hasattr(t, sys.argv[1]):

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1306,8 +1306,7 @@ def _osCanLoad(fp: str) -> bool:
 
 
 # ------------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
-    # interpreter loading
+class TestSlow(unittest.TestCase):  # pragma: no cover
 
     def testMusicXMLConversion(self):
         from music21.musicxml import testFiles
@@ -1315,30 +1314,9 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             a = subConverters.ConverterMusicXML()
             a.parseData(mxString)
 
-    def testMusicXMLTabConversion(self):
-        from music21.musicxml import testFiles
 
-        mxString = testFiles.ALL[5]
-        a = subConverters.ConverterMusicXML()
-        a.parseData(mxString)
-
-        b = parseData(mxString)
-        b.show('text')
-
-        # {0.0} <music21.metadata.Metadata object at 0x04501CD0>
-        # {0.0} <music21.stream.Part Electric Guitar>
-        #    {0.0} <music21.instrument.Instrument P0: Electric Guitar: >
-        #    {0.0} <music21.stream.Measure 0 offset=0.0>
-        #        {0.0} <music21.layout.StaffLayout distance None, ...staffLines 6>
-        #        {0.0} <music21.clef.TabClef>
-        #        {0.0} <music21.tempo.MetronomeMark animato Quarter=120.0>
-        #        {0.0} <music21.key.KeySignature of no sharps or flats, mode major>
-        #        {0.0} <music21.meter.TimeSignature 4/4>
-        #        {0.0} <music21.note.Note F>
-        #        {2.0} <music21.note.Note F#>
-
-        b.show()
-        pass
+class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testConversionMusicXml(self):
         c = stream.Score()
@@ -1353,7 +1331,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
 
         c.append(a[0])
         c.append(b[0])
-        c.show()
+        if self.show:
+            c.show()
         # TODO: this is only showing the minimum number of measures
 
     def testParseURL(self):
@@ -1368,7 +1347,32 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         s = corpus.parse('bach/bwv66.6.xml')
         fp = freeze(s)
         s2 = thaw(fp)
-        s2.show()
+        if self.show:
+            s2.show()
+
+    def testMusicXMLTabConversion(self):
+        from music21.musicxml import testFiles
+
+        mxString = testFiles.ALL[5]
+        a = subConverters.ConverterMusicXML()
+        a.parseData(mxString)
+
+        b = parseData(mxString)
+        if self.show:
+            b.show('text')
+            b.show()
+
+        # {0.0} <music21.metadata.Metadata object at 0x04501CD0>
+        # {0.0} <music21.stream.Part Electric Guitar>
+        #    {0.0} <music21.instrument.Instrument P0: Electric Guitar: >
+        #    {0.0} <music21.stream.Measure 0 offset=0.0>
+        #        {0.0} <music21.layout.StaffLayout distance None, ...staffLines 6>
+        #        {0.0} <music21.clef.TabClef>
+        #        {0.0} <music21.tempo.MetronomeMark animato Quarter=120.0>
+        #        {0.0} <music21.key.KeySignature of no sharps or flats, mode major>
+        #        {0.0} <music21.meter.TimeSignature 4/4>
+        #        {0.0} <music21.note.Note F>
+        #        {2.0} <music21.note.Note F#>
 
 
 class Test(unittest.TestCase):

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1315,7 +1315,7 @@ class TestSlow(unittest.TestCase):  # pragma: no cover
             a.parseData(mxString)
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testConversionMusicXml(self):

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1226,7 +1226,7 @@ def freeze(streamObj, fmt=None, fp=None, fastButUnsafe=False, zipType='zlib') ->
 
     OMIT_FROM_DOCS
 
-    >>> import os 
+    >>> import os
     >>> os.remove(fp)
     '''
     from music21 import freezeThaw

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1335,13 +1335,6 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             c.show()
         # TODO: this is only showing the minimum number of measures
 
-    def testParseURL(self):
-        urlBase = 'http://kern.ccarh.org/cgi-bin/ksdata?l=users/craig/classical/'
-        urlB = urlBase + 'schubert/piano/d0576&file=d0576-06.krn&f=kern'
-        urlC = urlBase + 'bach/cello&file=bwv1007-01.krn&f=xml'
-        unused_post = parseURL(urlB)
-        unused_post = parseURL(urlC)
-
     def testFreezer(self):
         from music21 import corpus
         s = corpus.parse('bach/bwv66.6.xml')

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1223,6 +1223,11 @@ def freeze(streamObj, fmt=None, fp=None, fastButUnsafe=False, zipType='zlib') ->
         {2.0} <music21.note.Note E>
         {3.0} <music21.note.Note F>
         {4.0} <music21.bar.Barline type=final>
+
+    OMIT_FROM_DOCS
+
+    >>> import os 
+    >>> os.remove(fp)
     '''
     from music21 import freezeThaw
     v = freezeThaw.StreamFreezer(streamObj, fastButUnsafe=fastButUnsafe)
@@ -1342,6 +1347,7 @@ class TestExternal(unittest.TestCase):
         s2 = thaw(fp)
         if self.show:
             s2.show()
+        os.remove(fp)
 
     def testMusicXMLTabConversion(self):
         from music21.musicxml import testFiles
@@ -1963,6 +1969,8 @@ class Test(unittest.TestCase):
 
         s = parseURL(url, forceSource=True)
         self.assertEqual(len(s.parts), 2)
+
+        os.remove(destFp)
 
 
 # ------------------------------------------------------------------------------

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1496,11 +1496,13 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testXMLShow(self):
         from music21 import corpus
         c = corpus.parse('bwv66.6')
-        c.show()  # musicxml
+        if self.show:
+            c.show()  # musicxml
 
     def testWriteLilypond(self):
         from music21 import note
@@ -1508,8 +1510,9 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         n.duration.type = 'whole'
         s = stream.Stream()
         s.append(n)
-        s.show('lily.png')
-        print(s.write('lily.png'))
+        if self.show:
+            s.show('lily.png')
+            print(s.write('lily.png'))
 
     def testMultiPageXMlShow1(self):
         '''
@@ -1518,8 +1521,9 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         from music21 import omr, converter
         K525 = omr.correctors.K525groundTruthFilePath
         K525 = converter.parse(K525)
-        K525.show('musicxml.png')
-        print(K525.write('musicxml.png'))
+        if self.show:
+            K525.show('musicxml.png')
+            print(K525.write('musicxml.png'))
 
     # def testMultiPageXMlShow2(self):
     #     '''

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1495,7 +1495,7 @@ class Test(unittest.TestCase):
         os.remove(mxlPath)
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testXMLShow(self):

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -1779,7 +1779,7 @@ class BachException(exceptions21.Music21Exception):
 # class Test(unittest.TestCase):
 #     pass
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testGetRiemenschneider1(self):

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -1780,12 +1780,14 @@ class BachException(exceptions21.Music21Exception):
 #     pass
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testGetRiemenschneider1(self):
         from music21 import corpus
         for chorale in corpus.chorales.Iterator(1, 2,
                                                 numberingSystem='riemenschneider', analysis=True):
-            chorale.show()
+            if self.show:
+                chorale.show()
 
 
 if __name__ == '__main__':

--- a/music21/corpus/virtual.py
+++ b/music21/corpus/virtual.py
@@ -183,7 +183,7 @@ class PachelbelCanonD(VirtualWork):
 
 
 # ------------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     # interpreter loading
     pass
 

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -3316,7 +3316,7 @@ class TupletFixer:
 # -------------------------------------------------------------------------------
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testSingle(self):

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -3317,6 +3317,7 @@ class TupletFixer:
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testSingle(self):
         from music21 import note
@@ -3324,7 +3325,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         a.quarterLength = 2.66666
         n = note.Note()
         n.duration = a
-        n.show()
+        if self.show:
+            n.show()
 
     def testBasic(self):
         import random
@@ -3342,7 +3344,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             n.duration = b
             a.append(n)
 
-        a.show()
+        if self.show:
+            a.show()
 
 
 class Test(unittest.TestCase):

--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -391,7 +391,7 @@ class Diminuendo(DynamicWedge):
 # ------------------------------------------------------------------------------
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testSingle(self):

--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -392,10 +392,12 @@ class Diminuendo(DynamicWedge):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testSingle(self):
         a = Dynamic('ffff')
-        a.show()
+        if self.show:
+            a.show()
 
     def testBasic(self):
         '''present each dynamic in a single measure
@@ -407,7 +409,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             b = Dynamic(dynStr)
             a.insert(o, b)
             o += 4  # increment
-        a.show()
+        if self.show:
+            a.show()
 
 
 # ------------------------------------------------------------------------------

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -1111,6 +1111,7 @@ class Environment:
         Returns an xmlReaderType depending on the 'musicxmlPath'
 
         >>> a = environment.Environment()
+        >>> original = a['musicxmlPath']  #_DOCS_HIDE
         >>> a['musicxmlPath'] = '/Applications/Musescore.app'
         >>> a.xmlReaderType()
         'Musescore'
@@ -1130,6 +1131,8 @@ class Environment:
         >>> a['musicxmlPath'] = None
         >>> a.xmlReaderType() is None
         True
+
+        >>> a['musicxmlPath'] = original  #_DOCS_HIDE
         '''
         xp = self['musicxmlPath']
         if common.runningUnderIPython():

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -198,6 +198,10 @@ class StreamFreezer(StreamFreezeThawBase):
     >>> len(s3.parts[0].measure(7).notes) == 6
     True
 
+    OMIT_FROM_DOCS
+
+    >>> import os
+    >>> os.remove(fp2)
     '''
 
     def __init__(self, streamObj=None, fastButUnsafe=False, topLevel=True, streamIds=None):

--- a/music21/graph/__init__.py
+++ b/music21/graph/__init__.py
@@ -129,13 +129,15 @@ def plotStream(
 
 # ------------------------------------------------------------------------------
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testAll(self):
         from music21 import corpus, dynamics
         a = corpus.parse('bach/bwv57.8')
         a.parts[0].insert(0, dynamics.Dynamic('mf'))
         a.parts[0].insert(10, dynamics.Dynamic('f'))
-        plotStream(a, 'all')
+        if self.show:
+            plotStream(a, 'all')
 
 
 class Test(unittest.TestCase):

--- a/music21/graph/__init__.py
+++ b/music21/graph/__init__.py
@@ -128,7 +128,7 @@ def plotStream(
 
 
 # ------------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testAll(self):

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -1441,7 +1441,7 @@ class Features(MultiStream):
 # -----------------------------------------------------------------------------------
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternalManual(unittest.TestCase):  # pragma: no cover
 
     def testHorizontalBarPitchSpaceOffset(self):
         a = corpus.parse('bach/bwv57.8')
@@ -2020,4 +2020,4 @@ _DOC_ORDER = [
 
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test)  # , runTest='test3DPitchSpaceQuarterLengthCount')
+    music21.mainTest(TestExternalManual)  # , runTest='test3DPitchSpaceQuarterLengthCount')

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -162,6 +162,17 @@ class Graph(prebase.ProtoM21Object):
         if hasattr(self, 'figure') and self.figure is not None:
             self.plt.close(self.figure)
 
+    def __getstate__(self):
+        '''
+        The wrapper to matplotlib.pyplot stored as self.plt cannot be pickled/deepcopied.
+        '''
+        state = self.__dict__.copy()
+        del state['plt']
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     @property
     def doneAction(self):
         '''

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -1590,7 +1590,7 @@ class Test(unittest.TestCase):
 
 
 # ------------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testBasic(self):

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -157,7 +157,7 @@ class Graph(prebase.ProtoM21Object):
         '''
         Matplotlib Figure objects need to be explicitly closed when no longer used...
         '''
-        if hasattr(self, 'figure') and self.figure is not None and self.doneAction is None:
+        if hasattr(self, 'figure') and self.figure is not None:
             etm = getExtendedModules()
             etm.plt.close(self.figure)
 
@@ -1599,14 +1599,10 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         a.data = data
         a.process()
 
-        del a
-
         a = GraphHistogram(doneAction=None, title='50 x with random(30) y counts')
         data = [(x, random.choice(range(30))) for x in range(50)]
         a.data = data
         a.process()
-
-        del a
 
         a = Graph3DBars(doneAction=None,
                                title='50 x with random values increase by 10 per x',
@@ -1643,7 +1639,7 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             z = random.choice(range(1, 20))
             data.append([x, y, z])
 
-        a = GraphScatterWeighted()
+        a = GraphScatterWeighted(doneAction=None)
         a.data = data
         a.process()
 

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -104,7 +104,9 @@ class Graph(prebase.ProtoM21Object):
     )
 
     def __init__(self, *args, **keywords):
-        getExtendedModules()
+        extm = getExtendedModules()
+        self.plt = extm.plt  # wrapper to matplotlib.pyplot
+
         self.data = None
         self.figure = None  # a matplotlib.Figure object
         self.subplot = None  # an Axes, AxesSubplot or potentially list of these object
@@ -155,11 +157,10 @@ class Graph(prebase.ProtoM21Object):
 
     def __del__(self):
         '''
-        Matplotlib Figure objects need to be explicitly closed when no longer used...
+        Matplotlib Figure objects need to be explicitly closed when no longer used.
         '''
         if hasattr(self, 'figure') and self.figure is not None:
-            etm = getExtendedModules()
-            etm.plt.close(self.figure)
+            self.plt.close(self.figure)
 
     @property
     def doneAction(self):

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -1639,7 +1639,11 @@ class TestExternal(unittest.TestCase):
             z = random.choice(range(1, 20))
             data.append([x, y, z])
 
-        a = GraphScatterWeighted(doneAction=None)
+        if self.show:
+            doneAction = 'write'
+        else:
+            doneAction = None
+        a = GraphScatterWeighted(doneAction=doneAction)
         a.data = data
         a.process()
 

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -172,6 +172,8 @@ class Graph(prebase.ProtoM21Object):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+        extm = getExtendedModules()
+        self.plt = extm.plt
 
     @property
     def doneAction(self):

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -1591,6 +1591,7 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testBasic(self):
         a = GraphScatter(doneAction=None, title='x to x*x', alpha=1)

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -3079,7 +3079,7 @@ class Test(unittest.TestCase):
         self.runTestOnChord(xmlString, figure, pitches)
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
 
     def testReadInXML(self):
         from music21 import harmony

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -3086,7 +3086,7 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         from music21 import corpus, stream
         testFile = corpus.parse('leadSheet/fosterBrownHair.xml')
 
-        testFile.show('text')
+        # testFile.show('text')
         testFile = harmony.realizeChordSymbolDurations(testFile)
         # testFile.show()
         chordSymbols = testFile.flat.getElementsByClass(harmony.ChordSymbol)

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -3117,7 +3117,7 @@ class Test(unittest.TestCase):
         self.assertEqual(dn.duration.tuplets[0].durationNormal.dots, 0)
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testShowSousa(self):

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -3118,11 +3118,13 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testShowSousa(self):
         hf1 = HumdrumDataCollection(testFiles.sousaStars)
         hf1.parse()
-        hf1.stream.show()
+        if self.show:
+            hf1.stream.show()
 
 
 if __name__ == '__main__':

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -2398,7 +2398,7 @@ def fromString(instrumentString):
 
 
 # ------------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     pass
 
 

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -2609,19 +2609,24 @@ class Test(unittest.TestCase):
         )
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
+
     def xtestConvertNote(self):
         n = note.Note('C5')
-        n.show('lily.png')
+        if self.show:
+            n.show('lily.png')
 
     def xtestConvertChorale(self):
         b = _getCachedCorpusFile('bach/bwv66.6')
         for n in b.flat:
             n.beams = None
-        b.parts[0].show('lily.svg')
+        if self.show:
+            b.parts[0].show('lily.svg')
 
     def xtestSlowConvertOpus(self):
         fifeOpus = corpus.parse('miscFolk/americanfifeopus.abc')
-        fifeOpus.show('lily.png')
+        if self.show:
+            fifeOpus.show('lily.png')
 
     def xtestBreve(self):
         from music21 import stream, meter
@@ -2634,7 +2639,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         p.append(m)
         s = stream.Score()
         s.append(p)
-        s.show('lily.png')
+        if self.show:
+            s.show('lily.png')
 
     def testStaffLines(self):
         from music21 import stream
@@ -2647,7 +2653,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         p2.append(note.Note('B4', type='whole'))
         p2.staffLines = 7
         s.insert(0, p2)
-        s.show('lily.png')
+        if self.show:
+            s.show('lily.png')
 
 
 # ------------------------------------------------------------------------------

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -2608,7 +2608,7 @@ class Test(unittest.TestCase):
             "c' 4  "
         )
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def xtestConvertNote(self):

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -1207,7 +1207,7 @@ class TimeSignature(base.Music21Object):
             weightInts = [0] * accentCount  # weights as integer/depth counts
             for i in range(accentCount):
                 ql = i * divStep
-                weightInts[i] = ms.offsetToDepth(ql, align='quantize')
+                weightInts[i] = ms.offsetToDepth(ql, align='quantize', index=i)
 
             maxInt = max(weightInts)
             weightValues = {}  # reference dictionary

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -15,6 +15,7 @@ This module defines two component objects for defining nested metrical structure
 :class:`~music21.meter.core.MeterTerminal` and :class:`~music21.meter.core.MeterSequence`.
 '''
 import copy
+from typing import Optional
 
 from music21 import prebase
 from music21.common.numberTools import opFrac
@@ -1765,9 +1766,9 @@ class MeterSequence(MeterTerminal):
         iMatch = self.offsetToIndex(qLenPos)
         return opFrac(self[iMatch].weight)
 
-    def offsetToDepth(self, qLenPos, align='quantize'):
+    def offsetToDepth(self, qLenPos, align='quantize', index: Optional[int] = None):
         '''
-        Given a qLenPos, return the maximum available depth at this position
+        Given a qLenPos, return the maximum available depth at this position.
 
         >>> b = meter.MeterSequence('4/4', 4)
         >>> b[1] = b[1].subdivide(2)
@@ -1787,6 +1788,9 @@ class MeterSequence(MeterTerminal):
         >>> b.offsetToDepth(-1)
         Traceback (most recent call last):
         music21.exceptions21.MeterException: cannot access from qLenPos -1.0
+
+        Changed in v.7 -- `index` can be provided, if known, for some long
+        `MeterSequence`s to improve performance.
         '''
         qLenPos = opFrac(qLenPos)
         if qLenPos >= self.duration.quarterLength or qLenPos < 0:
@@ -1797,7 +1801,9 @@ class MeterSequence(MeterTerminal):
         # need to quantize by lowest level
         mapMin = self.getLevelSpan(self.depth - 1)
         msMin = self.getLevel(self.depth - 1)
-        qStart, unused_qEnd = mapMin[msMin.offsetToIndex(qLenPos)]
+        if index is None:
+            index = msMin.offsetToIndex(qLenPos)
+        qStart, unused_qEnd = mapMin[index]
         if align == 'quantize':
             posMatch = opFrac(qStart)
         else:

--- a/music21/meter/tests.py
+++ b/music21/meter/tests.py
@@ -22,11 +22,14 @@ from music21.meter.base import TimeSignature
 from music21.meter.core import MeterSequence, MeterTerminal
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
+
     def testSingle(self):
         '''Need to test direct meter creation w/o stream
         '''
         a = TimeSignature('3/16')
-        a.show()
+        if self.show:
+            a.show()
 
     def testBasic(self):
         a = stream.Stream()
@@ -36,7 +39,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
                 m = stream.Measure()
                 m.timeSignature = ts
                 a.insert(m.timeSignature.barDuration.quarterLength, m)
-        a.show()
+        if self.show:
+            a.show()
 
     def testCompound(self):
         a = stream.Stream()
@@ -52,7 +56,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             m = stream.Measure()
             m.timeSignature = ts
             a.insert(m.timeSignature.barDuration.quarterLength, m)
-        a.show()
+        if self.show:
+            a.show()
 
     def testMeterBeam(self):
         ts = TimeSignature('6/8', 2)
@@ -63,7 +68,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             n = note.Note()
             n.duration = x
             s.append(n)
-        s.show()
+        if self.show:
+            s.show()
 
 
 class Test(unittest.TestCase):

--- a/music21/meter/tests.py
+++ b/music21/meter/tests.py
@@ -21,7 +21,7 @@ from music21 import stream
 from music21.meter.base import TimeSignature
 from music21.meter.core import MeterSequence, MeterTerminal
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testSingle(self):

--- a/music21/meter/tests.py
+++ b/music21/meter/tests.py
@@ -47,7 +47,7 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         meterStrDenominator = [1, 2, 4, 8, 16, 32]
         meterStrNumerator = [2, 3, 4, 5, 6, 7, 9, 11, 12, 13]
 
-        for i in range(30):
+        for i in range(8):
             msg = []
             for j in range(1, random.choice([2, 4])):
                 msg.append('%s/%s' % (random.choice(meterStrNumerator),

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -1653,7 +1653,7 @@ class MidiFile(prebase.ProtoM21Object):
 
 
 # ------------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     '''
     These are tests that open windows and rely on external software
     '''

--- a/music21/midi/realtime.py
+++ b/music21/midi/realtime.py
@@ -177,7 +177,7 @@ class Test(unittest.TestCase):
     pass
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     try:
         import pygame
         pygame_installed = True

--- a/music21/midi/realtime.py
+++ b/music21/midi/realtime.py
@@ -178,7 +178,13 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    try:
+        import pygame
+        pygame_installed = True
+    except (ModuleNotFoundError, ImportError):
+        pygame_installed = False
 
+    @unittest.skipUnless(pygame_installed, 'pygame is not installed')
     def testBachDetune(self):
         from music21 import corpus
         import random

--- a/music21/midi/realtime.py
+++ b/music21/midi/realtime.py
@@ -177,7 +177,7 @@ class Test(unittest.TestCase):
     pass
 
 
-class TestExternal(unittest.TestCase):
+class TestExternal(unittest.TestCase):  # pragma: no cover
     try:
         import pygame
         pygame_installed = True

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6534,7 +6534,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(tree.findall('.//rest')), 1)
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testSimple(self):

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6535,9 +6535,7 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
-
-    def testBasic(self):
-        pass
+    show = True
 
     def testSimple(self):
         from music21 import corpus  # , converter
@@ -6570,7 +6568,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
 
         # b2 = converter.parse(v)
         fp = b.write('musicxml')
-        print(fp)
+        if self.show:
+            print(fp)
 
         with io.open(fp, encoding='utf-8') as f:
             v2 = f.read()
@@ -6579,10 +6578,11 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             if l.startswith('-') or l.startswith('?') or l.startswith('+'):
                 if 'id=' in l:
                     continue
-                print(l)
-                # for j in range(i - 1,i + 1):
-                #    print(differ[j])
-                # print('------------------')
+                if self.show:
+                    print(l)
+                    # for j in range(i - 1,i + 1):
+                    #    print(differ[j])
+                    # print('------------------')
 
 
 if __name__ == '__main__':

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6583,6 +6583,8 @@ class TestExternal(unittest.TestCase):
                     # for j in range(i - 1,i + 1):
                     #    print(differ[j])
                     # print('------------------')
+        import os
+        os.remove(fp)
 
 
 if __name__ == '__main__':

--- a/music21/note.py
+++ b/music21/note.py
@@ -1786,7 +1786,7 @@ class Rest(GeneralNote):
 # ------------------------------------------------------------------------------
 # test methods and classes
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     '''
     These are tests that open windows and rely on external software
     '''

--- a/music21/note.py
+++ b/music21/note.py
@@ -1790,13 +1790,15 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
     '''
     These are tests that open windows and rely on external software
     '''
+    show = True
 
     def testSingle(self):
         '''Need to test direct meter creation w/o stream
         '''
         a = Note('d-3')
         a.quarterLength = 2.25
-        a.show()
+        if self.show:
+            a.show()
 
     def testBasic(self):
         from music21 import stream
@@ -1813,7 +1815,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             b.style.color = '#FF00FF'
             a.append(b)
 
-        a.show()
+        if self.show:
+            a.show()
 
 
 # ------------------------------------------------------------------------------

--- a/music21/noteworthy/translate.py
+++ b/music21/noteworthy/translate.py
@@ -896,6 +896,7 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testComplete(self):
         nwcTranslatePath = common.getSourceFilePath() / 'noteworthy'
@@ -903,7 +904,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         # 'Part_OWeisheit.nwctxt' #
 
         myScore = NoteworthyTranslator().parseFile(complete)
-        myScore.show()
+        if self.show:
+            myScore.show()
 
 
 if __name__ == '__main__':

--- a/music21/noteworthy/translate.py
+++ b/music21/noteworthy/translate.py
@@ -895,7 +895,7 @@ class Test(unittest.TestCase):
         self.assertEqual(n1.pitch.accidental.alter, -1.0)
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testComplete(self):

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -4074,7 +4074,7 @@ class Test(unittest.TestCase):
 
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testFromChordify(self):

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -4075,6 +4075,7 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testFromChordify(self):
         from music21 import corpus
@@ -4092,12 +4093,14 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
                     figuresCache[figure] += 1
                 x.lyric = figure
 
-        sortedList = sorted(figuresCache, key=figuresCache.get, reverse=True)
-        for thisFigure in sortedList:
-            print(thisFigure, figuresCache[thisFigure])
+        if self.show:
+            sortedList = sorted(figuresCache, key=figuresCache.get, reverse=True)
+            for thisFigure in sortedList:
+                print(thisFigure, figuresCache[thisFigure])
 
         b.insert(0, c)
-        b.show()
+        if self.show:
+            b.show()
 
 
 # -----------------------------------------------------------------------------

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -963,7 +963,7 @@ class Test(unittest.TestCase):
     pass
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testB(self):

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -964,12 +964,14 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testB(self):
         from music21.romanText import clercqTemperley
         s = clercqTemperley.CTSong(BlitzkriegBopCT)
         scoreObj = s.toScore()
-        scoreObj.show()
+        if self.show:
+            scoreObj.show()
 
     def x_testA(self):
         pass

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -1133,22 +1133,18 @@ def romanTextToStreamOpus(rtHandler, inputM21=None):
 
 # ------------------------------------------------------------------------------
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
 
+class TestSlow(unittest.TestCase):  # pragma: no cover
+    '''
+    These tests are currently too slow to run every time.
+    '''
     def testExternalA(self):
         from music21.romanText import testFiles
 
         for tf in testFiles.ALL:
             rtf = rtObjects.RTFile()
             rth = rtf.readstr(tf)  # return handler, processes tokens
-            s = romanTextToStreamScore(rth)
-            s.show()
-
-
-class TestSlow(unittest.TestCase):  # pragma: no cover
-    '''
-    These tests are currently too slow to run every time.
-    '''
+            unused_s = romanTextToStreamScore(rth)
 
     # noinspection SpellCheckingInspection
     def testBasicA(self):

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -1154,8 +1154,8 @@ class TestSlow(unittest.TestCase):  # pragma: no cover
             rtf = rtObjects.RTFile()
             rth = rtf.readstr(tf)  # return handler, processes tokens
             # will run romanTextToStreamScore on all but k273
-            unused_s = romanTextToStreamOpus(rth)
-            # s.show()
+            s = romanTextToStreamOpus(rth)
+            s.show()
 
         s = romanTextToStreamScore(testFiles.swv23)
         self.assertEqual(s.metadata.composer, 'Heinrich Schutz')

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -1144,7 +1144,8 @@ class TestSlow(unittest.TestCase):  # pragma: no cover
         for tf in testFiles.ALL:
             rtf = rtObjects.RTFile()
             rth = rtf.readstr(tf)  # return handler, processes tokens
-            unused_s = romanTextToStreamScore(rth)
+            s = romanTextToStreamScore(rth)
+            s.show()
 
     # noinspection SpellCheckingInspection
     def testBasicA(self):

--- a/music21/scale/scala/__init__.py
+++ b/music21/scale/scala/__init__.py
@@ -556,7 +556,7 @@ def search(target):
 
 
 # ------------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     pass
 
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -47,7 +47,7 @@ environLocal = environment.Environment('stream.tests')
 
 
 # ------------------------------------------------------------------------------
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testLilySimple(self):

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -48,6 +48,7 @@ environLocal = environment.Environment('stream.tests')
 
 # ------------------------------------------------------------------------------
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testLilySimple(self):
         a = Stream()
@@ -63,7 +64,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         a.insert(0, ts)
         a.insert(0, b)
 
-        a.show('lily.png')
+        if self.show:
+            a.show('lily.png')
 
     def testLilySemiComplex(self):
         a = Stream()
@@ -94,7 +96,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         a.insert(0, bestC)
         a.insert(0, ts)
         a.insert(0, b)
-        a.show('lily.png')
+        if self.show:
+            a.show('lily.png')
 
     def testScoreLily(self):
         '''
@@ -113,7 +116,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         score1.insert(ts)
         score1.insert(s1)
         score1.insert(s2)
-        score1.show('lily.png')
+        if self.show:
+            score1.show('lily.png')
 
     def testMXOutput(self):
         '''A simple test of adding notes to measures in a stream.
@@ -125,7 +129,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
                 a = note.Note(p)
                 b.append(a)
             c.append(b)
-        c.show()
+        if self.show:
+            c.show()
 
     def testMxMeasures(self):
         '''A test of the automatic partitioning of notes in a measure and the creation of ties.
@@ -142,7 +147,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         a.insert(3, meter.TimeSignature('3/16'))
         a.insert(20, meter.TimeSignature('9/8'))
         a.insert(40, meter.TimeSignature('10/4'))
-        a.show()
+        if self.show:
+            a.show()
 
     def testMultipartStreams(self):
         '''Test the creation of multi-part streams by simply having streams within streams.
@@ -166,7 +172,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         s.insert(3, meter.TimeSignature('5/4'))
         s.insert(8, meter.TimeSignature('3/4'))
 
-        s.show()
+        if self.show:
+            s.show()
 
     def testMultipartMeasures(self):
         '''
@@ -193,7 +200,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         s.append(violin_i_part_slice)
         s.append(violin_ii_part_slice)
         s.append(viola_part_slice)
-        s.show()
+        if self.show:
+            s.show()
 
     def testCanons(self):
         '''
@@ -220,7 +228,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
             s.insert(p)
             partOffset += partOffsetShift
 
-        s.show()
+        if self.show:
+            s.show()
 
     def testBeamsPartial(self):
         '''
@@ -239,7 +248,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         s.insert(3, meter.TimeSignature('5/4'))
         s.insert(8, meter.TimeSignature('4/4'))
 
-        s.show()
+        if self.show:
+            s.show()
 
     def testBeamsStream(self):
         '''A test of beams applied to different time signatures.
@@ -269,7 +279,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         s.insert(8, meter.TimeSignature('4/4'))
         self.assertEqual(len(s.flat.notes), 360)
 
-        s.show()
+        if self.show:
+            s.show()
 
     def testBeamsMeasure(self):
         aMeasure = Measure()
@@ -278,7 +289,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         aNote.quarterLength = 0.25
         aMeasure.repeatAppend(aNote, 16)
         bMeasure = aMeasure.makeBeams()
-        bMeasure.show()
+        if self.show:
+            bMeasure.show()
 
 
 # ------------------------------------------------------------------------------

--- a/music21/test/coverageM21.py
+++ b/music21/test/coverageM21.py
@@ -49,6 +49,9 @@ def getCoverage(overrideVersion=False):
         cov = None
     return cov
 
+def startCoverage(cov):
+    if cov is not None:
+        cov.start()
 
 def stopCoverage(cov):
     if cov is not None:

--- a/music21/test/coverageM21.py
+++ b/music21/test/coverageM21.py
@@ -29,6 +29,7 @@ exclude_lines = [
     r'\s*import music21\s*',
     r'\s*music21.mainTest\(\)\s*',
     r'.*#\s*pragma:\s*no cover.*',
+    r'class TestExternal.*',
 ]
 
 

--- a/music21/test/coverageM21.py
+++ b/music21/test/coverageM21.py
@@ -29,7 +29,6 @@ exclude_lines = [
     r'\s*import music21\s*',
     r'\s*music21.mainTest\(\)\s*',
     r'.*#\s*pragma:\s*no cover.*',
-    r'class TestExternal.*',
 ]
 
 

--- a/music21/test/testSingleCoreAll.py
+++ b/music21/test/testSingleCoreAll.py
@@ -122,7 +122,7 @@ def main(testGroup=('test',), restoreEnvironmentDefaults=False, limit=None, verb
 def ciMain():
     # the main call for ci tests.
     # exits with the returnCode
-    returnCode = main(verbosity=1)
+    returnCode = main(testGroup=('test', 'external'), verbosity=1)
     sys.exit(returnCode)
 
 

--- a/music21/test/testSingleCoreAll.py
+++ b/music21/test/testSingleCoreAll.py
@@ -135,9 +135,8 @@ def ciMain():
     # runs Test classes (including doctests)
     # and TestExternal (without doctests) with show=False
     # exits with the aggregated returnCode
-    # run external first to avoid coverage report issues
-    returnCodeExternal = main(testGroup=('external',), verbosity=1, show=False)
     returnCodeTest = main(testGroup=('test',), verbosity=1)
+    returnCodeExternal = main(testGroup=('external',), verbosity=1, show=False)
     sys.exit(returnCodeTest + returnCodeExternal)
 
 

--- a/music21/test/testSingleCoreAll.py
+++ b/music21/test/testSingleCoreAll.py
@@ -135,8 +135,9 @@ def ciMain():
     # runs Test classes (including doctests)
     # and TestExternal (without doctests) with show=False
     # exits with the aggregated returnCode
-    returnCodeTest = main(testGroup=('test',), verbosity=1)
+    # run external first to avoid coverage report issues
     returnCodeExternal = main(testGroup=('external',), verbosity=1, show=False)
+    returnCodeTest = main(testGroup=('test',), verbosity=1)
     sys.exit(returnCodeTest + returnCodeExternal)
 
 

--- a/music21/test/testSingleCoreAll.py
+++ b/music21/test/testSingleCoreAll.py
@@ -136,6 +136,8 @@ def ciMain():
     # and TestExternal (without doctests) with show=False
     # exits with the aggregated returnCode
     returnCodeTest = main(testGroup=('test',), verbosity=1)
+    # restart coverage if running main() twice
+    coverageM21.startCoverage(cov)
     returnCodeExternal = main(testGroup=('external',), verbosity=1, show=False)
     sys.exit(returnCodeTest + returnCodeExternal)
 

--- a/music21/test/testSingleCoreAll.py
+++ b/music21/test/testSingleCoreAll.py
@@ -36,7 +36,12 @@ environLocal = environment.Environment(_MOD)
 cov = coverageM21.getCoverage()
 
 
-def main(testGroup=('test',), restoreEnvironmentDefaults=False, limit=None, verbosity=2):
+def main(testGroup=('test',),
+         restoreEnvironmentDefaults=False,
+         limit=None,
+         verbosity=2,
+         show: bool = True,
+         ):
     '''
     Run all tests. Group can be test and external
 
@@ -72,6 +77,8 @@ def main(testGroup=('test',), restoreEnvironmentDefaults=False, limit=None, verb
             # environLocal.printDebug(f'{module} has no TestExternal class\n')
         else:
             if 'external' in testGroup or 'testExternal' in testGroup:
+                if not show:
+                    moduleObject.TestExternal.show = False
                 unitTestCases.append(moduleObject.TestExternal)
 
         # for each Test class, load this into a suite
@@ -122,7 +129,7 @@ def main(testGroup=('test',), restoreEnvironmentDefaults=False, limit=None, verb
 def ciMain():
     # the main call for ci tests.
     # exits with the returnCode
-    returnCode = main(testGroup=('test', 'external'), verbosity=1)
+    returnCode = main(testGroup=('test', 'external'), verbosity=1, show=False)
     sys.exit(returnCode)
 
 

--- a/music21/tinyNotation.py
+++ b/music21/tinyNotation.py
@@ -1459,7 +1459,7 @@ class Test(unittest.TestCase):
 
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testOne(self):

--- a/music21/tinyNotation.py
+++ b/music21/tinyNotation.py
@@ -1460,11 +1460,13 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testOne(self):
         c = Converter(Test.parseTest)
         c.parse()
-        c.stream.show('musicxml.png')
+        if self.show:
+            c.stream.show('musicxml.png')
 
 
 # TODO: Chords

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -2635,13 +2635,15 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
+    show = True
 
     def testMergeJacopoVariants(self):
         from music21 import corpus
         j1 = corpus.parse('trecento/PMFC_06-Jacopo-03a')
         j2 = corpus.parse('trecento/PMFC_06-Jacopo-03b')
         jMerged = mergeVariantScores(j1, j2)
-        jMerged.show('musicxml.png')
+        if self.show:
+            jMerged.show('musicxml.png')
 
 
 if __name__ == '__main__':

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -2634,7 +2634,7 @@ class Test(unittest.TestCase):
             '[G4, G4, G4, G4, G4, F#4, A-4, G4, G4]')
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     show = True
 
     def testMergeJacopoVariants(self):

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -2641,7 +2641,7 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         j1 = corpus.parse('trecento/PMFC_06-Jacopo-03a')
         j2 = corpus.parse('trecento/PMFC_06-Jacopo-03b')
         jMerged = mergeVariantScores(j1, j2)
-        jMerged.show('lily.pdf')
+        jMerged.show('musicxml.png')
 
 
 if __name__ == '__main__':

--- a/music21/vexflow/toMusic21j.py
+++ b/music21/vexflow/toMusic21j.py
@@ -278,7 +278,7 @@ class Test(unittest.TestCase):
     pass
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestCuthbert(unittest.TestCase):  # pragma: no cover
 
     def testCuthbertLocal(self):
         '''

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -2426,7 +2426,7 @@ class Test(unittest.TestCase):
         assert d.hiddenInterval(interval.Interval('AA4')) is False
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
+class TestExternal(unittest.TestCase):
     pass
 
 


### PR DESCRIPTION
**Motivation**

Running these on CI should find more bugs going forward. Examples (#953 , #443 - #446, #43 - #47)

**Proposal**

Use a class attribute on the TestExternal classes for whether or not to show files (png, pdf, etc), and use a keyword arg in the test runner so that `ciMain()` can set False without impacting manual tests. Then we don't have to install MuseScore or PNG readers on CI. All of the plot tests involve showing, so just skip them on CI by renaming to `TestExternalManual`.

**Fixes and cleanups found**

- a doctest wasn't setting the musicxml path back (test isolation issue)
- a failure we haven't addressed (will create issue, meanwhile added an @expectedFailure decorator)
- `Graph.__del__()` was hogging memory if doneAction is None
- some slow tests moved to TestSlow or otherwise made faster
- Prevent unraisable `ImportError` when shutting down Python after running a graph
- Improve TimeSignature construction performance

I know it was mentioned to move these over one at a time, but I wanted to demo this approach--rather than have to revisit this one at a time, which sounds possibly too tedious to prioritize, we can get most of it wired up this way. It adds about 40s to the suite (and adds 0.5% coverage).  Let me know what you think.

Fixes #938