### PR TITLE
Let `asKey()` solve for mode from tonic and sharps

### DIFF
--- a/music21/key.py
+++ b/music21/key.py
@@ -408,6 +408,14 @@ class KeySignature(base.Music21Object):
         Traceback (most recent call last):
         music21.key.KeyException: Could not solve for mode from sharps=2, tonic=D#
 
+        Ionian and Aeolian are supplied instead of major or minor when deriving mode in this way:
+
+        >>> ks2 = key.KeySignature()
+        >>> ks2.asKey()
+        <music21.key.Key of C major>
+        >>> ks2.asKey(tonic='C')
+        <music21.key.Key of C ionian>
+
         New in v7 -- `tonic` argument to solve for mode.
         '''
         if mode is not None and tonic is not None:

--- a/music21/key.py
+++ b/music21/key.py
@@ -1339,14 +1339,15 @@ class Test(unittest.TestCase):
         self.assertEqual(k.mode, 'dorian')
         self.assertEqual(k.tonicPitchNameWithCase, 'E')
 
-        with self.assertWarns(KeyWarning):
+        expected = 'ignoring provided tonic: E'
+        with self.assertWarnsRegex(KeyWarning, expected) as cm:
             # warn user we ignored their tonic
             k = ks.asKey(mode='minor', tonic='E')
         self.assertEqual(k.mode, 'minor')
         self.assertEqual(k.tonicPitchNameWithCase, 'b')
 
-        msg = 'Could not solve for mode from sharps=2, tonic=A-'
-        with self.assertRaises(KeyException, msg=msg) as cm:
+        expected = 'Could not solve for mode from sharps=2, tonic=A-'
+        with self.assertRaisesRegex(KeyException, expected) as cm:
             k = ks.asKey(mode=None, tonic='A-')
         # test exception chained from KeyError
         self.assertIsInstance(cm.exception.__cause__, KeyError)

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2946,10 +2946,10 @@ class Test(unittest.TestCase):
 
         # User error
         iObjs[0].midiChannel = 100
-        msg = 'Harpsichord specified 1-indexed MIDI channel 101 but '
-        msg += 'acceptable channels were [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16].'
-        msg += 'Defaulting to channel 1.'
-        with self.assertWarns(TranslateWarning, msg=msg):
+        want = 'Harpsichord specified 1-indexed MIDI channel 101 but '
+        want += r'acceptable channels were \[1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16\]. '
+        want += 'Defaulting to channel 1.'
+        with self.assertWarnsRegex(TranslateWarning, want):
             channelByInstrument, channelsDynamic = channelInstrumentData(s)
         self.assertEqual(channelByInstrument.keys(), set(inst.midiProgram for inst in iObjs))
         self.assertSetEqual(set(channelByInstrument.values()), {1, 11, 12, 13, 14, 15})
@@ -3823,9 +3823,9 @@ class Test(unittest.TestCase):
         event.channel = 10
         event.type = midiModule.ChannelVoiceMessages.PROGRAM_CHANGE
 
-        msg = 'Unable to determine instrument from '
-        msg += '<music21.midi.MidiEvent PROGRAM_CHANGE, track=0, channel=10, data=0>'
-        with self.assertWarns(TranslateWarning, msg=msg):
+        expected = 'Unable to determine instrument from '
+        expected += '<music21.midi.MidiEvent PROGRAM_CHANGE, track=None, channel=10, data=0>'
+        with self.assertWarnsRegex(TranslateWarning, expected):
             i = midiEventsToInstrument(event)
             self.assertIsNone(i.instrumentName)
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -2220,8 +2220,8 @@ class Test(unittest.TestCase):
         s.replace(n4, n1)
         self.assertEqual([s[0], s[1]], [n3, n1])
 
-        error_msg = f'{n3} already in {s}'
-        with self.assertRaises(StreamException, msg=error_msg):
+        expected = f'{n3} already in {s}'
+        with self.assertRaisesRegex(StreamException, expected):
             s.replace(n4, n3)
 
     def testReplaceA1(self):


### PR DESCRIPTION
I built this for someone, and I'm offering it back upstream. It's what I had suggested in reviewing #781.