### PR TITLE
New `Stream.getContextByClass()` in order to search itself at 0.0 before searching context

### DIFF
--- a/music21/base.py
+++ b/music21/base.py
@@ -4662,6 +4662,10 @@ class Test(unittest.TestCase):
         c = b.getContextByClass('Note', getElementMethod='getElementAfterOffset')
         self.assertEqual(c.name, 'C')
 
+        # And in 2021...
+        m = p.measure(1)
+        self.assertIsNotNone(m.getContextByClass('Clef'))
+
     def testGetContextByClassB(self):
         from music21 import stream, note, meter
 

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -2113,7 +2113,8 @@ class LilypondConverter:
         ['london']
 
         '''
-        replacedElementsClef = replacedElements[0].getContextByClass('Clef')
+        replacedElementsClef = replacedElements[0].getContextByClass(
+            'Clef', getElementMethod='getElementBefore')
 
         variantContainerStream = variantObject.getContextByClass('Part')
         if variantContainerStream is None:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -3737,7 +3737,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> p = converter.parse('tinyNotation: c1 d1')
         >>> m = p.measure(2)
         >>> m.insert(0, clef.BassClef())
-        >>> m.getContextByClass(clef.Clef, getElementMethod='getElementAtOrBefore')
+        >>> m.getContextByClass(clef.Clef)
         <music21.clef.BassClef>
 
         Searching before yields the clef in m. 1:

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1790,11 +1790,13 @@ class Test(unittest.TestCase):
         self.assertEqual(s2.elementOffset(s1), 0.0)
         self.assertRaises(sites.SitesException, s2.elementOffset, s1.flat)
 
-        # getContextByClass will not work; the clef is in s2; its not in a context of s2
+        # getContextByClass now finds this as of v7
+        # it performs what getClefs() used to do
+        # by searching a stream at 0.0 before searching the context
         post = s2.getContextByClass(clef.Clef)
-        self.assertIsNone(post)
+        self.assertIsInstance(post, clef.AltoClef)
 
-        # but s2.clef works...
+        # s2.clef works fine
         self.assertIsInstance(s2.clef, clef.AltoClef)
 
         # we can find the clef from the flat version of s1 also:


### PR DESCRIPTION
Fixes #1028

Debatable whether this was supposed to be supported already, but I think this will line up with user expectations.

Needed for deprecations of `getClefs()` etc