### PR TITLE
Add StreamPlayer2 to master

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (6, 7, 0)  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (6, 7, 1)  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'6.7.0'
+'6.7.1'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -1564,6 +1564,10 @@ class Test(unittest.TestCase):
         os.access(Environment().getDefaultRootTempDir(), stat.S_IRWXU),
         'test will programmatically set read/write/exec permissions on this dir'
     )
+    @unittest.skipIf(
+        common.getPlatform() == 'win',
+        'os.chmod does not have the intended effect on Windows'
+    )
     def testGetTempFile(self):
         import getpass
         import stat

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -794,6 +794,7 @@ class LilypondConverter:
             text = ' _ '
         else:
             text = '"' + el.text + '"'
+            # TODO: composite
             if el.syllabic == 'end':
                 text = text + '__'
                 inWord = False

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -18,6 +18,7 @@ import unittest
 import xml.etree.ElementTree as ET
 from xml.etree.ElementTree import Element, SubElement
 
+from music21.key import KeySignature  # for typing
 from music21.layout import StaffGroup
 from music21 import stream  # for typing
 from music21.musicxml import helpers
@@ -397,8 +398,8 @@ class PartStaffExporterMixin:
 
     def setEarliestAttributesAndClefsPartStaff(self, group: StaffGroup):
         '''
-        Set the <staff> and <clef> information on the earliest measure <attributes> tag
-        in the <part> representing the joined PartStaffs.
+        Set the <staff>, <key>, and <clef> information on the earliest measure <attributes>
+        tag in the <part> representing the joined PartStaffs.
 
         Need the earliest <attributes> tag, which may not exist in the merged <part>
         until moved there by movePartStaffMeasureContents() --
@@ -408,7 +409,8 @@ class PartStaffExporterMixin:
         Called by :meth:`~music21.musicxml.partStaffExporter.PartStaffExporterMixin.joinPartStaffs`
 
         >>> from music21.musicxml import testPrimitive
-        >>> s = converter.parse(testPrimitive.pianoStaff43a)
+        >>> xmlDir = common.getSourceFilePath() / 'musicxml' / 'lilypondTestSuite'
+        >>> s = converter.parse(xmlDir / '43b-MultiStaff-DifferentKeys.xml')
         >>> SX = musicxml.m21ToXml.ScoreExporter(s)
         >>> root = SX.parse()
         >>> m1 = root.find('part/measure')
@@ -416,9 +418,12 @@ class PartStaffExporterMixin:
         <measure number="1">
           <attributes>
             <divisions>10080</divisions>
-            <key>
+            <key number="1">
               <fifths>0</fifths>
-              </key>
+            </key>
+            <key number="2">
+              <fifths>2</fifths>
+            </key>
             <time>
               <beats>4</beats>
               <beat-type>4</beat-type>
@@ -436,6 +441,23 @@ class PartStaffExporterMixin:
         ...
         </measure>
         '''
+        # Is this source multi-key?
+        initialM21Key: Optional[KeySignature] = None
+        multiKey: bool = False
+        for ps in group:
+            if initialM21Key is None:
+                for ks in ps.recurse().getElementsByClass(KeySignature):
+                    initialM21Key = ks
+                    break
+            else:
+                firstKeySubsequentStaff = None
+                for ks in ps.recurse().getElementsByClass(KeySignature):
+                    firstKeySubsequentStaff = ks
+                    break
+                if firstKeySubsequentStaff != initialM21Key:
+                    multiKey = True
+                    break
+
         initialPartStaffRoot: Optional[Element] = None
         mxAttributes: Optional[Element] = None
         for i, ps in enumerate(group):
@@ -457,6 +479,11 @@ class PartStaffExporterMixin:
                     tagList=['part-symbol', 'instruments', 'clef', 'staff-details',
                                 'transpose', 'directive', 'measure-style']
                 )
+
+                if multiKey:
+                    key1 = mxAttributes.find('key')
+                    if key1:
+                        key1.set('number', '1')
 
             # Subsequent PartStaffs in group: set additional clefs on mxAttributes
             else:
@@ -481,6 +508,16 @@ class PartStaffExporterMixin:
                         newClef,
                         tagList=['staff-details', 'transpose', 'directive', 'measure-style']
                     )
+
+                if multiKey:
+                    oldKey: Optional[Element] = thisPartStaffRoot.find('measure/attributes/key')
+                    if oldKey:
+                        oldKey.set('number', str(staffNumber))
+                        helpers.insertBeforeElements(
+                            mxAttributes,
+                            oldKey,
+                            tagList=['time', 'staves']
+                        )
 
     def cleanUpSubsequentPartStaffs(self, group: StaffGroup):
         '''

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1661,6 +1661,7 @@ class PartParser(XMLParserBase):
             'Dynamic',
             'Expression',
             'GeneralNote',
+            'KeySignature',
             'StaffLayout',
         ]
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -18,7 +18,7 @@ import re
 # import sys
 # import traceback
 import unittest
-from typing import List, Optional, Dict, Tuple
+from typing import List, Optional, Dict, Tuple, Set
 
 import xml.etree.ElementTree as ET
 
@@ -1506,7 +1506,7 @@ class PartParser(XMLParserBase):
         if self.maxStaves > 1:
             self.separateOutPartStaves()
         else:
-            self.stream.addGroupForElements(self.partId)  # set group for components
+            self.stream.addGroupForElements(self.partId)  # set group for components (recurse?)
             self.stream.groups.append(self.partId)  # set group for stream itself
 
     def parseXmlScorePart(self):
@@ -1653,6 +1653,8 @@ class PartParser(XMLParserBase):
     def separateOutPartStaves(self):
         '''
         Take a `Part` with multiple staves and make them a set of `PartStaff` objects.
+
+        There must be more than one staff to do this.
         '''
         # Elements in these classes appear only on the staff to which they are assigned.
         # All other classes appear on every staff, except for spanners, which remain on the first.
@@ -1665,61 +1667,71 @@ class PartParser(XMLParserBase):
             'StaffLayout',
         ]
 
-        def separateOneStaff(streamPartStaff: stream.PartStaff, staffNumber: int):
-            partStaffId = f'{self.partId}-Staff{staffNumber}'
-            streamPartStaff.id = partStaffId
+        uniqueStaffKeys: List[int] = self._getUniqueStaffKeys()
+        partStaffs: List[stream.PartStaff] = []
+        appendedElementIds: Set[int] = set()  # id = id(el) not el.id
 
-            # remove all elements that are not part of this staff
-            mStream = list(streamPartStaff.getElementsByClass('Measure'))
-            for i, staffReference in enumerate(self.staffReferenceList):
-                staffExclude = self._getStaffExclude(staffReference, staffNumber)
-                if not staffExclude:
+        def copy_into_partStaff(source, target, omitTheseElementIds):
+            for sourceElem in source.getElementsByClass(STAFF_SPECIFIC_CLASSES):
+                idSource = id(sourceElem)
+                if idSource in omitTheseElementIds:
                     continue
+                if idSource in appendedElementIds:
+                    targetElem = copy.deepcopy(sourceElem)
+                else:
+                    targetElem = sourceElem  # do not make a copy if not yet in staff.
+                    appendedElementIds.add(idSource)
+                sourceOffset = source.elementOffset(sourceElem, stringReturns=True)
+                if sourceOffset != 'highestTime':
+                    target.coreInsert(sourceElem.offset, targetElem)
+                else:
+                    target.coreStoreAtEnd(targetElem)
+            target.coreElementsChanged()
 
-                m = mStream[i]
-                for eRemove in staffExclude:
-                    m.remove(eRemove, recurse=True)
-                # after adjusting voices see if voices can be reduced or
-                # removed
-                # environLocal.printDebug(['calling flattenUnnecessaryVoices: voices before:',
-                #     len(m.voices)])
-                m.flattenUnnecessaryVoices(force=False, inPlace=True)
-                # environLocal.printDebug(['calling flattenUnnecessaryVoices: voices after:',
-                #    len(m.voices)])
+        for staffIndex, staffKey in enumerate(uniqueStaffKeys):
+            # staffIndex should be staffKey - 1, but you never know...
+            removeClasses = STAFF_SPECIFIC_CLASSES[:]
+            if staffIndex != 0:  # spanners only on the first staff.
+                removeClasses.append('Spanner')
+            newPartStaff = self.stream.template(removeClasses=removeClasses, fillWithRests=False)
+            partStaffId = f'{self.partId}-Staff{staffKey}'
+            newPartStaff.id = partStaffId
+            newPartStaff.addGroupForElements(partStaffId)  # set group for components (recurse?)
+            newPartStaff.groups.append(partStaffId)
+            partStaffs.append(newPartStaff)
+            self.parent.m21PartObjectsById[partStaffId] = newPartStaff
+            elementsIdsNotToGoInThisStaff: Set[int] = set()
+            for staffReference in self.staffReferenceList:
+                excludeOneMeasure = self._getStaffExclude(
+                    staffReference,
+                    staffKey
+                )
+                for el in excludeOneMeasure:
+                    elementsIdsNotToGoInThisStaff.add(id(el))
 
-            streamPartStaff.addGroupForElements(partStaffId)
-            streamPartStaff.groups.append(partStaffId)
-            self.parent.stream.insert(0, streamPartStaff)
-            self.parent.m21PartObjectsById[partStaffId] = streamPartStaff
-
-        uniqueStaffKeys = self._getUniqueStaffKeys()
-        templates = []
-        for unused_key in uniqueStaffKeys[1:]:
-            # Add Spanner to the list of removeClasses; leave them in first staff only
-            template = self.stream.template(
-                removeClasses=STAFF_SPECIFIC_CLASSES + ['Spanner'], fillWithRests=False)
-            templates.append(template)
-
-            # Populate elements from source into copy (template)
             for sourceMeasure, copyMeasure in zip(
                 self.stream.getElementsByClass('Measure'),
-                template.getElementsByClass('Measure')
+                newPartStaff.getElementsByClass('Measure')
             ):
-                for elem in sourceMeasure.getElementsByClass(STAFF_SPECIFIC_CLASSES):
-                    copyMeasure.insert(elem.offset, elem)
+                copy_into_partStaff(sourceMeasure, copyMeasure, elementsIdsNotToGoInThisStaff)
                 for sourceVoice, copyVoice in zip(sourceMeasure.voices, copyMeasure.voices):
-                    for elem in sourceVoice.getElementsByClass(STAFF_SPECIFIC_CLASSES):
-                        copyVoice.insert(elem.offset, elem)
+                    copy_into_partStaff(sourceVoice, copyVoice, elementsIdsNotToGoInThisStaff)
+                copyMeasure.flattenUnnecessaryVoices(force=False, inPlace=True)
 
-        modelAndCopies = [self.stream] + templates
-        for staff, outerStaffNumber in zip(modelAndCopies, uniqueStaffKeys):
-            separateOneStaff(staff, outerStaffNumber)
+        score = self.parent.stream
+        for partStaff in partStaffs:
+            score.coreInsert(0, partStaff)
+        score.coreElementsChanged()
 
-        staffGroup = layout.StaffGroup(modelAndCopies, name=self.stream.partName, symbol='brace')
+        self.appendToScoreAfterParse = False  # ensures that the original stream is not appended.
+        # and thus that these next two lines are not needed:
+        # score.remove(originalPartStaff)
+        # del self.parent.m21PartObjectsById[originalPartStaff.id]
+
+        staffGroup = layout.StaffGroup(partStaffs, name=self.stream.partName, symbol='brace')
         staffGroup.style.hideObjectOnPrint = True  # in truth, hide the name, not the brace
         self.parent.stream.insert(0, staffGroup)
 
-        self.appendToScoreAfterParse = False
 
     def _getStaffExclude(
         self,
@@ -5706,11 +5718,17 @@ class Test(unittest.TestCase):
         self.assertIsInstance(s.parts[0], stream.PartStaff)
         self.assertIsInstance(s.parts[1], stream.PartStaff)
 
+        # make sure both staves get identical key signatures, but not the same object
+        keySigs = s.recurse().getElementsByClass('KeySignature')
+        self.assertEqual(len(keySigs), 2)
+        self.assertEqual(keySigs[0], keySigs[1])
+        self.assertIsNot(keySigs[0], keySigs[1])
+
     def testMultipleStavesPerPartB(self):
         from music21 import converter
         from music21.musicxml import testFiles
 
-        s = converter.parse(testFiles.moussorgskyPromenade)  # @UndefinedVariable
+        s = converter.parse(testFiles.moussorgskyPromenade)
         self.assertEqual(len(s.parts), 2)
 
         self.assertEqual(len(s.parts[0].flat.getElementsByClass('Note')), 19)
@@ -5726,11 +5744,25 @@ class Test(unittest.TestCase):
         from music21 import corpus
         s = corpus.parse('schoenberg/opus19/movement2')
         self.assertEqual(len(s.parts), 2)
+        self.assertEqual(len(s.getElementsByClass('PartStaff')), 2)
 
-        s = corpus.parse('schoenberg/opus19/movement6')
-        self.assertEqual(len(s.parts), 2)
+        # test that all elements are unique
+        setElementIds = set()
+        for el in s.recurse():
+            setElementIds.add(id(el))
+        self.assertEqual(len(setElementIds), len(s.recurse()))
 
-        # s.show()
+
+    def testMultipleStavesInPartWithBarline(self):
+        from music21 import converter
+        from music21.musicxml import testPrimitive
+        s = converter.parse(testPrimitive.mixedVoices1a)
+        self.assertEqual(len(s.getElementsByClass('PartStaff')), 2)
+        self.assertEqual(len(s.recurse().getElementsByClass('Barline')), 2)
+        lastMeasure = s.parts[0].getElementsByClass('Measure')[-1]
+        lastElement = lastMeasure[-1]
+        lastOffset = lastMeasure.elementOffset(lastElement, stringReturns=True)
+        self.assertEqual(lastOffset, 'highestTime')
 
     def testSpannersA(self):
         from music21 import converter

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -271,6 +271,23 @@ class LyricSearcher:
                         identifier=1)]
         >>> sm[0].mStart, sm[0].mEnd
         (49, 55)
+
+        OMIT_FROM_DOCS
+
+        Make sure that regexp characters are not interpreted as such in plaintext:
+
+        This should only match Amen.
+
+        >>> ls.search('en.')
+        [SearchMatch(mStart=125, mEnd=125, matchText='en.', ...)]
+
+        This should match 'ene', 'eni', and 'en.'
+
+        >>> ls.search(re.compile('en.'))
+        [SearchMatch(mStart=13, mEnd=13, matchText='ene', ...),
+         SearchMatch(mStart=38, mEnd=38, matchText='ens', ...),
+         SearchMatch(mStart=42, mEnd=42, matchText='eni', ...),
+         SearchMatch(mStart=125, mEnd=125, matchText='en.', ...)]
         '''
         if s is None:
             s = self.stream
@@ -287,7 +304,7 @@ class LyricSearcher:
                 f'{textOrRe} is not a string or RE with the finditer() function')
 
         if plainText is True:
-            return self._reSearch(re.compile(textOrRe))
+            return self._reSearch(re.compile(re.escape(textOrRe)))
         else:
             return self._reSearch(textOrRe)
 

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -261,6 +261,7 @@ class StreamIterator(prebase.ProtoM21Object):
         True
         '''
         # Prevent infinite loop in feature extractor task serialization
+        # TODO: investigate if this can be removed once iter becomes iter()
         if attr == 'srcStream':
             return None
 

--- a/music21/text.py
+++ b/music21/text.py
@@ -59,7 +59,9 @@ def assembleLyrics(streamIn, lineNumber=1):
     '''
     Concatenate text from a stream. The Stream is automatically flattened.
 
-    The `lineNumber` parameter determines which line of text is assembled.
+    The `lineNumber` parameter determines which line of text is assembled,
+    as an index in the .lyrics array.  (To be changed in v7 to go with an
+    identifier.)
 
 
     >>> s = stream.Stream()
@@ -71,6 +73,17 @@ def assembleLyrics(streamIn, lineNumber=1):
     >>> s.append(n2)
     >>> text.assembleLyrics(s)
     'Hi there'
+
+    Composite lyrics can also be assembled.
+
+    >>> composite = note.Lyric()
+    >>> composite0 = note.Lyric(text="He'", syllabic='begin')
+    >>> composite1 = note.Lyric(text="ya", syllabic='end')
+    >>> composite1.elisionBefore = '_'
+    >>> composite.components = [composite0, composite1]
+    >>> n1.lyrics[0] = composite
+    >>> text.assembleLyrics(s)
+    "He'_ya there"
     '''
     word = []
     words = []
@@ -95,6 +108,12 @@ def assembleLyrics(streamIn, lineNumber=1):
                 # environLocal.printDebug(['word pre-join', word])
                 words.append(''.join(word))
                 word = []
+            elif lyricObj.syllabic == 'composite':
+                if lyricObj.text is not None:
+                    word.append(lyricObj.text)
+                if lyricObj.components[-1].syllabic in ('end', 'single', None):
+                    words.append(''.join(word))
+                    word = []
             else:
                 raise Exception(f'no known Text syllabic setting: {lyricObj.syllabic}')
     return ' '.join(words)


### PR DESCRIPTION
Hi,

Based on _pyGame_ **StreamPlayer** api don't manage _soundfont_.
To achieve the addon [music21drums](http://github.com/jbigdata-git/music21drums) _soundfont_ managing is required, that's why I dev **StreamPlayer2** class.
It's a kind of _StreamPlayer_ V2, full based on _fluidsynth_, no more _pyGame_. 
The tuto snippet is:
> player = StreamPlayer2(driver='alsa', soundfont='../_soundfont/PNS_Drum_Kit.SF2')
> player.setMidiFile('../_midi/tuto_drumsnotes.mid')
> player.play()
> player.stop()

StreamPlayer2 added values are : 
-  _StreamPlayer_ api like: simple and easy to use.
-  _soundfont_ managing in python dev.
-  _fluidsynth_ features embeded via _pyFluidSynth_ package.

Devs are [here](http://github.com/jbigdata-git/music21drums/tree/main/music21drums), test cases in _player.py_.

JB.