### PR TITLE
Support and recommend `.iter()` instead of `.iter`

### DIFF
--- a/music21/analysis/floatingKey.py
+++ b/music21/analysis/floatingKey.py
@@ -86,7 +86,7 @@ class KeyAnalyzer:
 
         self.weightAlgorithm = divide
         if s.hasPartLikeStreams():
-            p = s.iter.parts.first()
+            p = s.iter().parts.first()
         else:
             p = s
         self.numMeasures = len(p.getElementsByClass('Measure'))  # could be wrong for endings, etc.

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -585,7 +585,7 @@ class PartReduction:
                     # check for activity in any part in the part group
                     for p in partMeasures:  # iter of parts containing measures
                         # print(p, i, p[i], len(p[i].flat.notes))
-                        if p[i].iter.notes:
+                        if p[i].iter().notes:
                             active = True
                             break
                     # environLocal.printDebug([i, 'active', active])

--- a/music21/base.py
+++ b/music21/base.py
@@ -1988,8 +1988,8 @@ class Music21Object(prebase.ProtoM21Object):
         The `className` can be used to specify one or more classes to match.
 
         >>> s = corpus.parse('bwv66.6')
-        >>> m2 = s.parts[0].iter().getElementsByClass('Measure')[2]  # pickup measure
-        >>> m3 = s.parts[0].iter().getElementsByClass('Measure')[3]
+        >>> m2 = s.parts[0].getElementsByClass('Measure')[2]  # pickup measure
+        >>> m3 = s.parts[0].getElementsByClass('Measure')[3]
         >>> m3
         <music21.stream.Measure 3 offset=9.0>
         >>> m3prev = m3.previous()
@@ -2002,7 +2002,7 @@ class Music21Object(prebase.ProtoM21Object):
 
         We'll iterate backwards from the first note of the second measure of the Alto part.
 
-        >>> o = s.parts[1].iter().getElementsByClass('Measure')[2][0]
+        >>> o = s.parts[1].getElementsByClass('Measure')[2][0]
         >>> while o:
         ...    print(o)
         ...    o = o.previous()
@@ -4957,7 +4957,7 @@ class Test(unittest.TestCase):
 #     def testPreviousA(self):
 #         from music21 import corpus
 #         s = corpus.parse('bwv66.6')
-#         o = s.parts[0].iter().getElementsByClass('Measure')[2][1]
+#         o = s.parts[0].getElementsByClass('Measure')[2][1]
 #         i = 20
 #         while o and i:
 #             print(o)

--- a/music21/base.py
+++ b/music21/base.py
@@ -1988,8 +1988,8 @@ class Music21Object(prebase.ProtoM21Object):
         The `className` can be used to specify one or more classes to match.
 
         >>> s = corpus.parse('bwv66.6')
-        >>> m2 = s.parts[0].iter.getElementsByClass('Measure')[2]  # pickup measure
-        >>> m3 = s.parts[0].iter.getElementsByClass('Measure')[3]
+        >>> m2 = s.parts[0].iter().getElementsByClass('Measure')[2]  # pickup measure
+        >>> m3 = s.parts[0].iter().getElementsByClass('Measure')[3]
         >>> m3
         <music21.stream.Measure 3 offset=9.0>
         >>> m3prev = m3.previous()
@@ -2002,7 +2002,7 @@ class Music21Object(prebase.ProtoM21Object):
 
         We'll iterate backwards from the first note of the second measure of the Alto part.
 
-        >>> o = s.parts[1].iter.getElementsByClass('Measure')[2][0]
+        >>> o = s.parts[1].iter().getElementsByClass('Measure')[2][0]
         >>> while o:
         ...    print(o)
         ...    o = o.previous()
@@ -4957,7 +4957,7 @@ class Test(unittest.TestCase):
 #     def testPreviousA(self):
 #         from music21 import corpus
 #         s = corpus.parse('bwv66.6')
-#         o = s.parts[0].iter.getElementsByClass('Measure')[2][1]
+#         o = s.parts[0].iter().getElementsByClass('Measure')[2][1]
 #         i = 20
 #         while o and i:
 #             print(o)

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -2066,8 +2066,8 @@ def prepareBeamedNotes(music21Measure):
     def beamStopFilter(el, unused):
         return el.beams.getByNumber(1).type == 'stop'
 
-    allStartIter = allNotes.iter.addFilter(withBeamFilter).addFilter(beamStartFilter)
-    allStopIter = allNotes.iter.addFilter(withBeamFilter).addFilter(beamStopFilter)
+    allStartIter = allNotes.iter().addFilter(withBeamFilter).addFilter(beamStartFilter)
+    allStopIter = allNotes.iter().addFilter(withBeamFilter).addFilter(beamStopFilter)
 
     if len(allStartIter) != len(allStopIter):
         environRules.warn('Incorrect beaming: number of start notes != to number of stop notes.')

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -934,7 +934,7 @@ def bestClef(streamObj: 'music21.stream.Stream',
     totalNotes = 0
     totalHeight = 0
 
-    sIter = streamObj.recurse() if recurse else streamObj.iter
+    sIter = streamObj.recurse() if recurse else streamObj.iter()
 
     notes = sIter.getElementsByClass('GeneralNote')
 

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -250,7 +250,7 @@ def checkSinglePossibilities(music21Stream, functionToApply, color="#FF0000", de
         for partNumberTuple in vlm_violations:
             for partNumber in partNumberTuple:
                 if color is not None:
-                    noteA = allParts[partNumber - 1].iter().getElementsByOffset(
+                    noteA = allParts[partNumber - 1].getElementsByOffset(
                         initOffset,
                         initOffset,
                         mustBeginInSpan=False)[0]
@@ -320,9 +320,9 @@ def checkConsecutivePossibilities(music21Stream, functionToApply, color="#FF0000
         for partNumberTuple in vlm_violations:
             for partNumber in partNumberTuple:
                 if color is not None:
-                    noteA = allParts[partNumber - 1].iter().getElementsByOffset(
+                    noteA = allParts[partNumber - 1].getElementsByOffset(
                         initOffsetA, initOffsetA, mustBeginInSpan=False).first()
-                    noteB = allParts[partNumber - 1].iter().getElementsByOffset(
+                    noteB = allParts[partNumber - 1].getElementsByOffset(
                         initOffsetB, initOffsetB, mustBeginInSpan=False).first()
                     noteA.style.color = color
                     noteB.style.color = color

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -179,7 +179,7 @@ def correlateHarmonies(currentMapping, music21Part):
 
     for offsets in sorted(currentMapping.keys()):
         (initOffset, endTime) = offsets
-        notesInRange = music21Part.flat.iter().getElementsByClass('GeneralNote').getElementsByOffset(
+        notesInRange = music21Part.flat.getElementsByClass('GeneralNote').getElementsByOffset(
             initOffset, offsetEnd=endTime,
             includeEndBoundary=False, mustFinishInSpan=False,
             mustBeginInSpan=False, includeElementsThatEndAtStart=False)

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -179,7 +179,7 @@ def correlateHarmonies(currentMapping, music21Part):
 
     for offsets in sorted(currentMapping.keys()):
         (initOffset, endTime) = offsets
-        notesInRange = music21Part.flat.iter.getElementsByClass('GeneralNote').getElementsByOffset(
+        notesInRange = music21Part.flat.iter().getElementsByClass('GeneralNote').getElementsByOffset(
             initOffset, offsetEnd=endTime,
             includeEndBoundary=False, mustFinishInSpan=False,
             mustBeginInSpan=False, includeElementsThatEndAtStart=False)
@@ -250,7 +250,7 @@ def checkSinglePossibilities(music21Stream, functionToApply, color="#FF0000", de
         for partNumberTuple in vlm_violations:
             for partNumber in partNumberTuple:
                 if color is not None:
-                    noteA = allParts[partNumber - 1].iter.getElementsByOffset(
+                    noteA = allParts[partNumber - 1].iter().getElementsByOffset(
                         initOffset,
                         initOffset,
                         mustBeginInSpan=False)[0]
@@ -320,9 +320,9 @@ def checkConsecutivePossibilities(music21Stream, functionToApply, color="#FF0000
         for partNumberTuple in vlm_violations:
             for partNumber in partNumberTuple:
                 if color is not None:
-                    noteA = allParts[partNumber - 1].iter.getElementsByOffset(
+                    noteA = allParts[partNumber - 1].iter().getElementsByOffset(
                         initOffsetA, initOffsetA, mustBeginInSpan=False).first()
-                    noteB = allParts[partNumber - 1].iter.getElementsByOffset(
+                    noteB = allParts[partNumber - 1].iter().getElementsByOffset(
                         initOffsetB, initOffsetB, mustBeginInSpan=False).first()
                     noteA.style.color = color
                     noteB.style.color = color

--- a/music21/graph/axis.py
+++ b/music21/graph/axis.py
@@ -1107,7 +1107,7 @@ class QuarterLengthAxis(PositionAxis):
         elif self.client.recurse:
             sSrc = s.recurse()
         else:
-            sSrc = s.iter
+            sSrc = s.iter()
 
         sSrc = sSrc.getElementsByClass(self.client.classFilterList)
         # get all quarter lengths

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -195,7 +195,7 @@ class PlotStreamMixin(prebase.ProtoM21Object):
         if self.recurse:
             sIter = self.streamObj.recurse()
         else:
-            sIter = self.streamObj.iter
+            sIter = self.streamObj.iter()
 
         if self.classFilterList:
             sIter = sIter.getElementsByClass(self.classFilterList)

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -861,7 +861,7 @@ class LayoutScore(stream.Opus):
 
 
         >>> #_DOCS_SHOW g = corpus.parse('luca/gloria')
-        >>> #_DOCS_SHOW m22 = g.parts[0].iter.getElementsByClass('Measure')[22]
+        >>> #_DOCS_SHOW m22 = g.parts[0].iter().getElementsByClass('Measure')[22]
         >>> #_DOCS_SHOW m22.getElementsByClass('PageLayout').first().leftMargin = 204.0
         >>> #_DOCS_SHOW gl = layout.divideByPages(g)
         >>> #_DOCS_SHOW gl.getMarginsAndSizeForPageId(1)
@@ -1196,7 +1196,7 @@ class LayoutScore(stream.Opus):
                 f'No measures found in pageId {pageId}, systemId {systemId}, staffId {staffId}'
             )
 
-        allStaffLayouts = firstMeasureOfStaff.iter.getElementsByClass('StaffLayout')
+        allStaffLayouts = firstMeasureOfStaff.iter().getElementsByClass('StaffLayout')
         if allStaffLayouts:
             # print('Got staffLayouts: ')
             for slTemp in allStaffLayouts:
@@ -1252,7 +1252,7 @@ class LayoutScore(stream.Opus):
 
         staffSize = staffSizeBase
 
-        allStaffLayouts = list(firstMeasureOfStaff.iter.getElementsByClass('StaffLayout'))
+        allStaffLayouts = list(firstMeasureOfStaff.iter().getElementsByClass('StaffLayout'))
         if allStaffLayouts:
             # print('Got staffLayouts: ')
             staffLayoutObj = allStaffLayouts[0]
@@ -1302,7 +1302,7 @@ class LayoutScore(stream.Opus):
         thisStaff = self.pages[pageId].systems[systemId].staves[staffId]
 
         staffLayoutObject = None
-        allStaffLayoutObjects = list(thisStaff.flat.iter.getElementsByClass('StaffLayout'))
+        allStaffLayoutObjects = list(thisStaff.flat.iter().getElementsByClass('StaffLayout'))
         if allStaffLayoutObjects:
             staffLayoutObject = allStaffLayoutObjects[0]
         if staffLayoutObject is None or staffLayoutObject.hidden is None:
@@ -1477,7 +1477,7 @@ class LayoutScore(stream.Opus):
                 # first system is hidden, thus has no width information
                 for j in range(1, len(thisSystemStaves)):
                     searchOtherStaffForWidth = thisSystemStaves[j]
-                    searchIter = searchOtherStaffForWidth.iter
+                    searchIter = searchOtherStaffForWidth.iter()
                     searchOtherStaffMeasure = searchIter.getElementsByClass('Measure')[i]
                     if searchOtherStaffMeasure.layoutWidth is not None:
                         currentWidth = searchOtherStaffMeasure.layoutWidth

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -861,7 +861,7 @@ class LayoutScore(stream.Opus):
 
 
         >>> #_DOCS_SHOW g = corpus.parse('luca/gloria')
-        >>> #_DOCS_SHOW m22 = g.parts[0].iter().getElementsByClass('Measure')[22]
+        >>> #_DOCS_SHOW m22 = g.parts[0].getElementsByClass('Measure')[22]
         >>> #_DOCS_SHOW m22.getElementsByClass('PageLayout').first().leftMargin = 204.0
         >>> #_DOCS_SHOW gl = layout.divideByPages(g)
         >>> #_DOCS_SHOW gl.getMarginsAndSizeForPageId(1)
@@ -1196,7 +1196,7 @@ class LayoutScore(stream.Opus):
                 f'No measures found in pageId {pageId}, systemId {systemId}, staffId {staffId}'
             )
 
-        allStaffLayouts = firstMeasureOfStaff.iter().getElementsByClass('StaffLayout')
+        allStaffLayouts = firstMeasureOfStaff.getElementsByClass('StaffLayout')
         if allStaffLayouts:
             # print('Got staffLayouts: ')
             for slTemp in allStaffLayouts:
@@ -1252,7 +1252,7 @@ class LayoutScore(stream.Opus):
 
         staffSize = staffSizeBase
 
-        allStaffLayouts = list(firstMeasureOfStaff.iter().getElementsByClass('StaffLayout'))
+        allStaffLayouts = list(firstMeasureOfStaff.getElementsByClass('StaffLayout'))
         if allStaffLayouts:
             # print('Got staffLayouts: ')
             staffLayoutObj = allStaffLayouts[0]
@@ -1302,7 +1302,7 @@ class LayoutScore(stream.Opus):
         thisStaff = self.pages[pageId].systems[systemId].staves[staffId]
 
         staffLayoutObject = None
-        allStaffLayoutObjects = list(thisStaff.flat.iter().getElementsByClass('StaffLayout'))
+        allStaffLayoutObjects = list(thisStaff.flat.getElementsByClass('StaffLayout'))
         if allStaffLayoutObjects:
             staffLayoutObject = allStaffLayoutObjects[0]
         if staffLayoutObject is None or staffLayoutObject.hidden is None:

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -396,7 +396,7 @@ class LilypondConverter:
 
         # Also get the variants, and the total number of measures here and make start each
         # staff context with { \stopStaff s1*n} where n is the number of measures.
-        if hasattr(scoreIn, 'parts') and scoreIn.iter.parts:  # or has variants
+        if hasattr(scoreIn, 'parts') and scoreIn.iter().parts:  # or has variants
             if scoreIn.recurse().variants:
                 lpPartsAndOssiaInit = self.lyPartsAndOssiaInitFromScore(scoreIn)
                 lpGroupedMusicList = self.lyGroupedMusicListFromScoreWithParts(

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2318,7 +2318,7 @@ def packetStorageFromSubstreamList(
         subs = subs.flat
 
         # get a first instrument; iterate over rest
-        instrumentStream = subs.iter().getElementsByClass('Instrument')
+        instrumentStream = subs.getElementsByClass('Instrument')
 
         # if there is an Instrument object at the start, make instObj that instrument
         # this may be a Conductor object if prepareStreamForMidi() was run

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2318,7 +2318,7 @@ def packetStorageFromSubstreamList(
         subs = subs.flat
 
         # get a first instrument; iterate over rest
-        instrumentStream = subs.iter.getElementsByClass('Instrument')
+        instrumentStream = subs.iter().getElementsByClass('Instrument')
 
         # if there is an Instrument object at the start, make instObj that instrument
         # this may be a Conductor object if prepareStreamForMidi() was run

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2385,7 +2385,7 @@ class MeasureParser(XMLParserBase):
                     meth(mxObj)
 
         if self.useVoices is True:
-            for v in self.stream.iter.voices:
+            for v in self.stream.iter().voices:
                 if v:  # do not bother with empty voices
                     # the musicDataMethods use insertCore, thus the voices need to run
                     # coreElementsChanged

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -53,7 +53,7 @@ class RepeatMark:
     >>> s = stream.Stream()
     >>> s.append(note.Note())
     >>> s.append(PartialRepeat())
-    >>> repeats = s.iter.getElementsByClass(repeat.RepeatMark)
+    >>> repeats = s.iter().getElementsByClass(repeat.RepeatMark)
     >>> if repeats:
     ...    print('Stream has %s repeat(s) in it' % (len(repeats)))
     Stream has 1 repeat(s) in it
@@ -1715,7 +1715,7 @@ class Expander:
         '''
         post = []
         for i, m in enumerate(streamObj):
-            for e in m.iter.getElementsByClass('RepeatExpression'):
+            for e in m.iter().getElementsByClass('RepeatExpression'):
                 if (target in e.classes
                         or (not isinstance(target, str) and isinstance(e, target))):
                     post.append(i)

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -53,7 +53,7 @@ class RepeatMark:
     >>> s = stream.Stream()
     >>> s.append(note.Note())
     >>> s.append(PartialRepeat())
-    >>> repeats = s.iter().getElementsByClass(repeat.RepeatMark)
+    >>> repeats = s.getElementsByClass(repeat.RepeatMark)
     >>> if repeats:
     ...    print('Stream has %s repeat(s) in it' % (len(repeats)))
     Stream has 1 repeat(s) in it
@@ -1715,7 +1715,7 @@ class Expander:
         '''
         post = []
         for i, m in enumerate(streamObj):
-            for e in m.iter().getElementsByClass('RepeatExpression'):
+            for e in m.getElementsByClass('RepeatExpression'):
                 if (target in e.classes
                         or (not isinstance(target, str) and isinstance(e, target))):
                     post.append(i)

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -208,7 +208,7 @@ class StreamSearcher:
             if self.recurse:
                 thisStreamIterator = self.streamSearch.recurse()
             else:
-                thisStreamIterator = self.streamSearch.iter
+                thisStreamIterator = self.streamSearch.iter()
 
             if self.filterNotesAndRests:
                 thisStreamIterator = thisStreamIterator.addFilter(

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1596,11 +1596,11 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 shiftDur += matchDuration
                 if shiftDur != 0.0:
                     # can this be done with recurse???
-                    for e in self.iter().getElementsByOffset(shiftedRegionStart,
-                                                           shiftedRegionEnd,
-                                                           includeEndBoundary=False,
-                                                           mustFinishInSpan=False,
-                                                           mustBeginInSpan=True):
+                    for e in self.getElementsByOffset(shiftedRegionStart,
+                                                        shiftedRegionEnd,
+                                                        includeEndBoundary=False,
+                                                        mustFinishInSpan=False,
+                                                        mustBeginInSpan=True):
 
                         elementOffset = self.elementOffset(e)
                         self.coreSetElementOffset(e, elementOffset - shiftDur)
@@ -2204,7 +2204,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         '''
         # could use duration of Note to get end offset span
         targets = list(
-            self.iter().getElementsByOffset(
+            self.getElementsByOffset(
                 offset,
                 offset + noteOrChord.quarterLength,  # set end to dur of supplied
                 includeEndBoundary=False,
@@ -11562,7 +11562,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 # get target offset relative to Stream
                 oInStream = vStart + e.getOffsetBySite(v.containedSite)
                 # get all elements at this offset, force a class match
-                targets = self.iter().getElementsByOffset(oInStream).getElementsByClass(e.classes[0])
+                targets = self.getElementsByOffset(oInStream).getElementsByClass(e.classes[0])
                 # only replace if we match the start
                 if targets:
                     targetsMatched += 1

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -938,7 +938,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         {0.0} <music21.clef.BassClef>
         {0.0} <music21.note.Note D#>
         '''
-        clefList = self.iter().getElementsByClass('Clef').getElementsByOffset(0)
+        clefList = self.getElementsByClass('Clef').getElementsByOffset(0)
         # casting to list added 20microseconds...
         return clefList.first()
 
@@ -1001,7 +1001,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         True
         '''
         # there could be more than one
-        tsList = self.iter().getElementsByClass('TimeSignature').getElementsByOffset(0)
+        tsList = self.getElementsByClass('TimeSignature').getElementsByOffset(0)
         # environLocal.printDebug([
         #    'matched Measure classes of type TimeSignature', tsList, len(tsList)])
         # only return timeSignatures at offset = 0.0
@@ -10686,7 +10686,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         voiceIds = []
 
         if self.hasMeasures():
-            for m in self.iter().getElementsByClass('Measure'):
+            for m in self.getElementsByClass('Measure'):
                 mVoices = m.voices
                 mVCount = len(mVoices)
                 if not countById:
@@ -10915,7 +10915,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             p.mergeElements(self, classFilterList=('Instrument',))
 
         if self.hasMeasures():
-            for m in self.iter().getElementsByClass('Measure'):
+            for m in self.getElementsByClass('Measure'):
                 if m.hasVoices():
                     doOneMeasureWithVoices(m)
                 # if a measure does not have voices, simply populate
@@ -13474,7 +13474,7 @@ class Score(Stream):
             eNew = copy.deepcopy(e)  # assume that this is needed
             post.insert(self.elementOffset(e), eNew)
 
-        for p in self.iter().getElementsByClass('Part'):
+        for p in self.getElementsByClass('Part'):
             # get spanners at highest level, not by Part
             post.insert(0, p.expandRepeats(copySpanners=False))
 
@@ -13775,7 +13775,7 @@ class Score(Stream):
 
         # do not assume that we have parts here
         if self.hasPartLikeStreams():
-            for s in returnStream.iter().getElementsByClass('Stream'):
+            for s in returnStream.getElementsByClass('Stream'):
                 # process all component Streams inPlace
                 s.makeNotation(meterStream=meterStream,
                                refStreamOrTimeRange=refStreamOrTimeRange,
@@ -13823,7 +13823,7 @@ class Opus(Stream):
         ['1', '2', '3']
         '''
         post = []
-        for s in self.iter().getElementsByClass('Score'):
+        for s in self.getElementsByClass('Score'):
             post.append(s.metadata.number)
         return post
 
@@ -13844,7 +13844,7 @@ class Opus(Stream):
         >>> s.metadata.alternativeTitle
         'Tenor'
         '''
-        for s in self.iter().getElementsByClass('Score'):
+        for s in self.getElementsByClass('Score'):
             match, unused_field = s.metadata.search(opusMatch, 'number')
             if match:
                 return s

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -564,7 +564,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         Return the first element of a Stream.  (Added for compatibility with StreamIterator)
         Or None if the Stream is empty.
 
-        Unlike s.iter.first(), which is a significant performance gain, s.first() is the
+        Unlike s.iter().first(), which is a significant performance gain, s.first() is the
         same speed as s[0], except for not raising an IndexError.
 
         >>> nC = note.Note('C4')
@@ -938,7 +938,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         {0.0} <music21.clef.BassClef>
         {0.0} <music21.note.Note D#>
         '''
-        clefList = self.iter.getElementsByClass('Clef').getElementsByOffset(0)
+        clefList = self.iter().getElementsByClass('Clef').getElementsByOffset(0)
         # casting to list added 20microseconds...
         return clefList.first()
 
@@ -1001,7 +1001,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         True
         '''
         # there could be more than one
-        tsList = self.iter.getElementsByClass('TimeSignature').getElementsByOffset(0)
+        tsList = self.iter().getElementsByClass('TimeSignature').getElementsByOffset(0)
         # environLocal.printDebug([
         #    'matched Measure classes of type TimeSignature', tsList, len(tsList)])
         # only return timeSignatures at offset = 0.0
@@ -1052,7 +1052,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         True
         '''
         try:
-            return next(self.iter.getElementsByClass('KeySignature').getElementsByOffset(0))
+            return next(self.iter().getElementsByClass('KeySignature').getElementsByOffset(0))
         except StopIteration:
             return None
 
@@ -1596,7 +1596,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 shiftDur += matchDuration
                 if shiftDur != 0.0:
                     # can this be done with recurse???
-                    for e in self.iter.getElementsByOffset(shiftedRegionStart,
+                    for e in self.iter().getElementsByOffset(shiftedRegionStart,
                                                            shiftedRegionEnd,
                                                            includeEndBoundary=False,
                                                            mustFinishInSpan=False,
@@ -1697,7 +1697,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> len(s)
         5
         '''
-        elFilter = self.iter.getElementsByClass(classFilterList)
+        elFilter = self.iter().getElementsByClass(classFilterList)
         self._removeIteration(elFilter)
 
     def removeByNotOfClass(self, classFilterList):
@@ -1716,7 +1716,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> len(s.notes)
         0
         '''
-        elFilter = self.iter.getElementsNotOfClass(classFilterList)
+        elFilter = self.iter().getElementsNotOfClass(classFilterList)
         return self._removeIteration(elFilter)
 
     def _deepcopySubclassable(self, memo=None, ignoreAttributes=None, removeFromIgnore=None):
@@ -2204,7 +2204,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         '''
         # could use duration of Note to get end offset span
         targets = list(
-            self.iter.getElementsByOffset(
+            self.iter().getElementsByOffset(
                 offset,
                 offset + noteOrChord.quarterLength,  # set end to dur of supplied
                 includeEndBoundary=False,
@@ -2677,7 +2677,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         if recurse:
             sIter = self.recurse()
         else:
-            sIter = self.iter
+            sIter = self.iter()
 
         for el in sIter:
             if el.derivation is not None:
@@ -3274,7 +3274,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         Added in v6.7.1 -- recurse
         '''
-        sIterator = self.iter if not recurse else self.recurse()
+        sIterator = self.iter() if not recurse else self.recurse()
         if classFilter is not None:
             sIterator = sIterator.addFilter(filters.ClassFilter(classFilter))
         for el in sIterator:
@@ -3359,7 +3359,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> len(foundList)
         25
         '''
-        return self.iter.getElementsByClass(classFilterList, returnClone=False)
+        return self.iter().getElementsByClass(classFilterList, returnClone=False)
 
     def getElementsNotOfClass(self, classFilterList) -> iterator.StreamIterator:
         '''
@@ -3392,7 +3392,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> len(found)
         25
         '''
-        return self.iter.getElementsNotOfClass(classFilterList, returnClone=False)
+        return self.iter().getElementsNotOfClass(classFilterList, returnClone=False)
 
     def getElementsByGroup(self, groupFilterList) -> iterator.StreamIterator:
         '''
@@ -3421,7 +3421,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         OMIT_FROM_DOCS
         # TODO: group comparisons are not YET case insensitive.
         '''
-        return self.iter.getElementsByGroup(groupFilterList, returnClone=False)
+        return self.iter().getElementsByGroup(groupFilterList, returnClone=False)
 
     def getElementById(self, elementId) -> Optional[base.Music21Object]:
         '''
@@ -3456,7 +3456,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         Changed in v7. -- remove classFilter.
         '''
-        sIterator = self.iter.addFilter(filters.IdFilter(elementId))
+        sIterator = self.iter().addFilter(filters.IdFilter(elementId))
         for e in sIterator:
             return e
         return None
@@ -3698,7 +3698,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         Changed in v5.5: all arguments changing behavior are keyword only.
         '''
-        sIterator = self.iter.getElementsByOffset(
+        sIterator = self.iter().getElementsByOffset(
             offsetStart=offsetStart,
             offsetEnd=offsetEnd,
             includeEndBoundary=includeEndBoundary,
@@ -3801,7 +3801,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         offset = opFrac(offset)
         nearestTrailSpan = offset  # start with max time
 
-        sIterator = self.iter
+        sIterator = self.iter()
         if classList:
             sIterator = sIterator.getElementsByClass(classList)
 
@@ -3889,7 +3889,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         offset = opFrac(offset)
         nearestTrailSpan = offset  # start with max time
 
-        sIterator = self.iter
+        sIterator = self.iter()
         if classList:
             sIterator = sIterator.getElementsByClass(classList)
 
@@ -5168,7 +5168,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         if recurse:
             sIter = self.recurse()
         else:
-            sIter = self.iter
+            sIter = self.iter()
 
         post = sIter.getElementsByClass('Instrument').stream()
         if post:
@@ -10686,7 +10686,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         voiceIds = []
 
         if self.hasMeasures():
-            for m in self.iter.getElementsByClass('Measure'):
+            for m in self.iter().getElementsByClass('Measure'):
                 mVoices = m.voices
                 mVCount = len(mVoices)
                 if not countById:
@@ -10915,7 +10915,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             p.mergeElements(self, classFilterList=('Instrument',))
 
         if self.hasMeasures():
-            for m in self.iter.getElementsByClass('Measure'):
+            for m in self.iter().getElementsByClass('Measure'):
                 if m.hasVoices():
                     doOneMeasureWithVoices(m)
                 # if a measure does not have voices, simply populate
@@ -11562,7 +11562,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 # get target offset relative to Stream
                 oInStream = vStart + e.getOffsetBySite(v.containedSite)
                 # get all elements at this offset, force a class match
-                targets = self.iter.getElementsByOffset(oInStream).getElementsByClass(e.classes[0])
+                targets = self.iter().getElementsByOffset(oInStream).getElementsByClass(e.classes[0])
                 # only replace if we match the start
                 if targets:
                     targetsMatched += 1
@@ -13470,11 +13470,11 @@ class Score(Stream):
         post.mergeAttributes(self)
 
         # get all things in the score that are not Parts
-        for e in self.iter.getElementsNotOfClass('Part'):
+        for e in self.iter().getElementsNotOfClass('Part'):
             eNew = copy.deepcopy(e)  # assume that this is needed
             post.insert(self.elementOffset(e), eNew)
 
-        for p in self.iter.getElementsByClass('Part'):
+        for p in self.iter().getElementsByClass('Part'):
             # get spanners at highest level, not by Part
             post.insert(0, p.expandRepeats(copySpanners=False))
 
@@ -13504,7 +13504,7 @@ class Score(Stream):
         This method is smart and does not assume that all Parts
         have measures with identical offsets.
         '''
-        parts = self.iter.parts
+        parts = self.iter().parts
         if not parts:
             return Stream.measureOffsetMap(self, classFilterList)
         # else:
@@ -13775,7 +13775,7 @@ class Score(Stream):
 
         # do not assume that we have parts here
         if self.hasPartLikeStreams():
-            for s in returnStream.iter.getElementsByClass('Stream'):
+            for s in returnStream.iter().getElementsByClass('Stream'):
                 # process all component Streams inPlace
                 s.makeNotation(meterStream=meterStream,
                                refStreamOrTimeRange=refStreamOrTimeRange,
@@ -13823,7 +13823,7 @@ class Opus(Stream):
         ['1', '2', '3']
         '''
         post = []
-        for s in self.iter.getElementsByClass('Score'):
+        for s in self.iter().getElementsByClass('Score'):
             post.append(s.metadata.number)
         return post
 
@@ -13844,7 +13844,7 @@ class Opus(Stream):
         >>> s.metadata.alternativeTitle
         'Tenor'
         '''
-        for s in self.iter.getElementsByClass('Score'):
+        for s in self.iter().getElementsByClass('Score'):
             match, unused_field = s.metadata.search(opusMatch, 'number')
             if match:
                 return s

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -399,7 +399,7 @@ class StreamCoreMixin:
         Traceback (most recent call last):
         music21.exceptions21.StreamException: this Stream cannot be contained within itself
 
-        >>> s.append(s.iter)
+        >>> s.append(s.iter())
         Traceback (most recent call last):
         music21.exceptions21.StreamException: cannot insert StreamIterator into a Stream
         Iterate over it instead (User's Guide chs. 6 and 26)
@@ -694,7 +694,7 @@ class StreamCoreMixin:
         if recurse is True:
             sIter = self.recurse()
         else:
-            sIter = self.iter
+            sIter = self.iter()
 
         collectList = []
         for el in list(sIter):

--- a/music21/stream/filters.py
+++ b/music21/stream/filters.py
@@ -93,7 +93,7 @@ class IsFilter(StreamFilter):
     `.numToFind` is used so that once all elements are found, the iterator can short circuit.
 
 
-    >>> for el in s.iter.addFilter(isFilter):
+    >>> for el in s.iter().addFilter(isFilter):
     ...     print(el is n)
     True
 
@@ -109,7 +109,7 @@ class IsFilter(StreamFilter):
     >>> isFilter2.numToFind
     2
 
-    >>> for el in s.iter.addFilter(isFilter2):
+    >>> for el in s.iter().addFilter(isFilter2):
     ...     print(el)
     <music21.note.Note C#>
     <music21.note.Rest quarter>
@@ -148,14 +148,14 @@ class IsNotFilter(IsFilter):
     >>> n = note.Note('C#')
     >>> s.append(n)
     >>> s.append(note.Rest())
-    >>> for el in s.iter.addFilter(stream.filters.IsNotFilter(n)):
+    >>> for el in s.iter().addFilter(stream.filters.IsNotFilter(n)):
     ...     el
     <music21.key.KeySignature of 3 flats>
     <music21.note.Rest quarter>
 
     test that resetting works...
 
-    >>> for el in s.iter.addFilter(stream.filters.IsNotFilter(n)):
+    >>> for el in s.iter().addFilter(stream.filters.IsNotFilter(n)):
     ...     el
     <music21.key.KeySignature of 3 flats>
     <music21.note.Rest quarter>
@@ -169,7 +169,7 @@ class IsNotFilter(IsFilter):
     >>> s.append(n)
     >>> r = note.Rest()
     >>> s.append(r)
-    >>> for el in s.iter.addFilter(stream.filters.IsNotFilter([n, r])):
+    >>> for el in s.iter().addFilter(stream.filters.IsNotFilter([n, r])):
     ...     print(el)
     <music21.key.KeySignature of 3 flats>
     '''

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -317,7 +317,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s = stream.Stream()
         >>> s.insert(0, note.Note('F#'))
         >>> s.repeatAppend(note.Note('C'), 2)
-        >>> sI = s.iter
+        >>> sI = s.iter()
         >>> sI
         <music21.stream.iterator.StreamIterator for Stream:0x104743be0 @:0>
 
@@ -346,7 +346,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s.insert(0, clef.TrebleClef())
         >>> s[0]
         <music21.clef.TrebleClef>
-        >>> s.iter.notes[0]
+        >>> s.iter().notes[0]
         <music21.note.Note F#>
 
         Demo of cleanupOnStop = True
@@ -386,11 +386,11 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s = converter.parse('tinynotation: 3/4 c4 d e f g a', makeNotation=False)
         >>> len(s)
         7
-        >>> len(s.iter)
+        >>> len(s.iter())
         7
-        >>> len(s.iter.notes)
+        >>> len(s.iter().notes)
         6
-        >>> [n.name for n in s.iter.notes]
+        >>> [n.name for n in s.iter().notes]
         ['C', 'D', 'E', 'F', 'G', 'A']
         '''
         if self._len is not None:
@@ -507,7 +507,7 @@ class StreamIterator(prebase.ProtoM21Object):
         An Empty stream:
 
         >>> s = stream.Stream()
-        >>> s.iter.notes.first() is None
+        >>> s.iter().notes.first() is None
         True
         '''
         iter(self)
@@ -537,7 +537,7 @@ class StreamIterator(prebase.ProtoM21Object):
         Check on empty Stream:
 
         >>> s2 = stream.Stream()
-        >>> s2.iter.notes.last() is None
+        >>> s2.iter().notes.last() is None
         True
 
         Next has a different feature from first(), will start again from beginning.
@@ -622,7 +622,7 @@ class StreamIterator(prebase.ProtoM21Object):
 
         >>> s = converter.parse('tinynotation: 3/4 c4 d e f g a', makeNotation=False)
         >>> s.id = 'tn3/4'
-        >>> sI = s.iter
+        >>> sI = s.iter()
         >>> sI
         <music21.stream.iterator.StreamIterator for Part:tn3/4 @:0>
 
@@ -704,7 +704,7 @@ class StreamIterator(prebase.ProtoM21Object):
         cannot just call `type(StreamIterator.srcStream)()`
 
         >>> p = stream.Part()
-        >>> pi = p.iter
+        >>> pi = p.iter()
         >>> s = pi._newBaseStream()
         >>> s
         <music21.stream.Stream 0x1047eb2e8>
@@ -735,7 +735,7 @@ class StreamIterator(prebase.ProtoM21Object):
 
         In other words:
 
-        `s.getElementsByClass()` == `s.iter.getElementsByClass().stream()`
+        `s.getElementsByClass()` == `s.iter().getElementsByClass().stream()`
 
         >>> s = stream.Part()
         >>> s.insert(0, note.Note('C'))
@@ -744,7 +744,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> b = bar.Barline()
         >>> s.storeAtEnd(b)
 
-        >>> s2 = s.iter.getElementsByClass('Note').stream()
+        >>> s2 = s.iter().getElementsByClass('Note').stream()
         >>> s2.show('t')
         {0.0} <music21.note.Note C>
         {2.0} <music21.note.Note D>
@@ -753,7 +753,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s2
         <music21.stream.Part ...>
 
-        >>> s3 = s.iter.stream()
+        >>> s3 = s.iter().stream()
         >>> s3.show('t')
         {0.0} <music21.note.Note C>
         {1.0} <music21.note.Rest quarter>
@@ -763,7 +763,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s3.elementOffset(b, returnSpecial=True)
         <OffsetSpecial.AT_END>
 
-        >>> s4 = s.iter.getElementsByClass('Barline').stream()
+        >>> s4 = s.iter().getElementsByClass('Barline').stream()
         >>> s4.show('t')
         {0.0} <music21.bar.Barline type=regular>
 
@@ -924,7 +924,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> r = note.Rest()
         >>> s.append(r)
         >>> s.append(note.Note('D'))
-        >>> for el in s.iter.getElementsByClass('Rest'):
+        >>> for el in s.iter().getElementsByClass('Rest'):
         ...     print(el)
         <music21.note.Rest quarter>
 
@@ -936,14 +936,14 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> r.activeSite.id
         's2'
 
-        >>> for el in s.iter.getElementsByClass('Rest'):
+        >>> for el in s.iter().getElementsByClass('Rest'):
         ...     print(el.activeSite.id)
         s1
 
 
         Classes work in addition to strings...
 
-        >>> for el in s.iter.getElementsByClass(note.Rest):
+        >>> for el in s.iter().getElementsByClass(note.Rest):
         ...     print(el)
         <music21.note.Rest quarter>
 
@@ -1010,13 +1010,13 @@ class StreamIterator(prebase.ProtoM21Object):
         ...     n = note.Note('G#')
         ...     n.offset = x * 3
         ...     a.insert(n)
-        >>> found = a.iter.getElementsNotOfClass(note.Note)
+        >>> found = a.iter().getElementsNotOfClass(note.Note)
         >>> len(found)
         10
-        >>> found = a.iter.getElementsNotOfClass('Rest')
+        >>> found = a.iter().getElementsNotOfClass('Rest')
         >>> len(found)
         4
-        >>> found = a.iter.getElementsNotOfClass(['Note', 'Rest'])
+        >>> found = a.iter().getElementsNotOfClass(['Note', 'Rest'])
         >>> len(found)
         0
 
@@ -1047,12 +1047,12 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s1.append(n2)
         >>> s1.append(n3)
 
-        >>> tboneSubStream = s1.iter.getElementsByGroup('trombone')
+        >>> tboneSubStream = s1.iter().getElementsByGroup('trombone')
         >>> for thisNote in tboneSubStream:
         ...     print(thisNote.name)
         C
         D
-        >>> tubaSubStream = s1.iter.getElementsByGroup('tuba')
+        >>> tubaSubStream = s1.iter().getElementsByGroup('tuba')
         >>> for thisNote in tubaSubStream:
         ...     print(thisNote.name)
         D
@@ -1134,34 +1134,34 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> n2.duration.type = 'half'
         >>> n2.offset = 2
         >>> st1.insert(n2)
-        >>> out1 = list(st1.iter.getElementsByOffset(2))
+        >>> out1 = list(st1.iter().getElementsByOffset(2))
         >>> len(out1)
         1
         >>> out1[0].step
         'D'
-        >>> out2 = list(st1.iter.getElementsByOffset(1, 3))
+        >>> out2 = list(st1.iter().getElementsByOffset(1, 3))
         >>> len(out2)
         1
         >>> out2[0].step
         'D'
-        >>> out3 = list(st1.iter.getElementsByOffset(1, 3, mustFinishInSpan=True))
+        >>> out3 = list(st1.iter().getElementsByOffset(1, 3, mustFinishInSpan=True))
         >>> len(out3)
         0
-        >>> out4 = list(st1.iter.getElementsByOffset(1, 2))
+        >>> out4 = list(st1.iter().getElementsByOffset(1, 2))
         >>> len(out4)
         1
         >>> out4[0].step
         'D'
-        >>> out5 = list(st1.iter.getElementsByOffset(1, 2, includeEndBoundary=False))
+        >>> out5 = list(st1.iter().getElementsByOffset(1, 2, includeEndBoundary=False))
         >>> len(out5)
         0
-        >>> out6 = list(st1.iter.getElementsByOffset(1, 2, includeEndBoundary=False,
+        >>> out6 = list(st1.iter().getElementsByOffset(1, 2, includeEndBoundary=False,
         ...                                          mustBeginInSpan=False))
         >>> len(out6)
         1
         >>> out6[0].step
         'C'
-        >>> out7 = list(st1.iter.getElementsByOffset(1, 3, mustBeginInSpan=False))
+        >>> out7 = list(st1.iter().getElementsByOffset(1, 3, mustBeginInSpan=False))
         >>> len(out7)
         2
         >>> [el.step for el in out7]
@@ -1169,7 +1169,7 @@ class StreamIterator(prebase.ProtoM21Object):
 
         Note, that elements that end at the start offset are included if mustBeginInSpan is False
 
-        >>> out8 = list(st1.iter.getElementsByOffset(2, 4, mustBeginInSpan=False))
+        >>> out8 = list(st1.iter().getElementsByOffset(2, 4, mustBeginInSpan=False))
         >>> len(out8)
         2
         >>> [el.step for el in out8]
@@ -1177,7 +1177,7 @@ class StreamIterator(prebase.ProtoM21Object):
 
         To change this behavior set includeElementsThatEndAtStart=False
 
-        >>> out9 = list(st1.iter.getElementsByOffset(2, 4, mustBeginInSpan=False,
+        >>> out9 = list(st1.iter().getElementsByOffset(2, 4, mustBeginInSpan=False,
         ...                                          includeElementsThatEndAtStart=False))
         >>> len(out9)
         1
@@ -1190,10 +1190,10 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> a.repeatInsert(n, list(range(8)))
         >>> b = stream.Stream(id='b')
         >>> b.repeatInsert(a, [0, 3, 6])
-        >>> c = list(b.iter.getElementsByOffset(2, 6.9))
+        >>> c = list(b.iter().getElementsByOffset(2, 6.9))
         >>> len(c)
         2
-        >>> c = list(b.flat.iter.getElementsByOffset(2, 6.9))
+        >>> c = list(b.flat.iter().getElementsByOffset(2, 6.9))
         >>> len(c)
         10
 
@@ -1206,9 +1206,9 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s.insert(0.0, c)
         >>> s.insert(0.0, ts)
         >>> s.insert(0.0, ks)
-        >>> len(list(s.iter.getElementsByOffset(0.0, mustBeginInSpan=True)))
+        >>> len(list(s.iter().getElementsByOffset(0.0, mustBeginInSpan=True)))
         3
-        >>> len(list(s.iter.getElementsByOffset(0.0, mustBeginInSpan=False)))
+        >>> len(list(s.iter().getElementsByOffset(0.0, mustBeginInSpan=False)))
         3
 
         On a :class:`~music21.stream.iterator.RecursiveIterator`,
@@ -1264,46 +1264,46 @@ class StreamIterator(prebase.ProtoM21Object):
 
         Same test as above, but with floats
 
-        >>> out1 = list(st1.iter.getElementsByOffset(2.0))
+        >>> out1 = list(st1.iter().getElementsByOffset(2.0))
         >>> len(out1)
         1
         >>> out1[0].step
         'D'
-        >>> out2 = list(st1.iter.getElementsByOffset(1.0, 3.0))
+        >>> out2 = list(st1.iter().getElementsByOffset(1.0, 3.0))
         >>> len(out2)
         1
         >>> out2[0].step
         'D'
-        >>> out3 = list(st1.iter.getElementsByOffset(1.0, 3.0, mustFinishInSpan=True))
+        >>> out3 = list(st1.iter().getElementsByOffset(1.0, 3.0, mustFinishInSpan=True))
         >>> len(out3)
         0
-        >>> out3b = list(st1.iter.getElementsByOffset(0.0, 3.001, mustFinishInSpan=True))
+        >>> out3b = list(st1.iter().getElementsByOffset(0.0, 3.001, mustFinishInSpan=True))
         >>> len(out3b)
         1
         >>> out3b[0].step
         'C'
-        >>> out3b = list(st1.iter.getElementsByOffset(1.0, 3.001, mustFinishInSpan=True,
+        >>> out3b = list(st1.iter().getElementsByOffset(1.0, 3.001, mustFinishInSpan=True,
         ...                                           mustBeginInSpan=False))
         >>> len(out3b)
         1
         >>> out3b[0].step
         'C'
 
-        >>> out4 = list(st1.iter.getElementsByOffset(1.0, 2.0))
+        >>> out4 = list(st1.iter().getElementsByOffset(1.0, 2.0))
         >>> len(out4)
         1
         >>> out4[0].step
         'D'
-        >>> out5 = list(st1.iter.getElementsByOffset(1.0, 2.0, includeEndBoundary=False))
+        >>> out5 = list(st1.iter().getElementsByOffset(1.0, 2.0, includeEndBoundary=False))
         >>> len(out5)
         0
-        >>> out6 = list(st1.iter.getElementsByOffset(1.0, 2.0, includeEndBoundary=False,
+        >>> out6 = list(st1.iter().getElementsByOffset(1.0, 2.0, includeEndBoundary=False,
         ...                                          mustBeginInSpan=False))
         >>> len(out6)
         1
         >>> out6[0].step
         'C'
-        >>> out7 = list(st1.iter.getElementsByOffset(1.0, 3.0, mustBeginInSpan=False))
+        >>> out7 = list(st1.iter().getElementsByOffset(1.0, 3.0, mustBeginInSpan=False))
         >>> len(out7)
         2
         >>> [el.step for el in out7]
@@ -1336,7 +1336,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s.append(note.Note('C'))
         >>> s.append(note.Rest())
         >>> s.append(note.Note('D'))
-        >>> for el in s.iter.notes:
+        >>> for el in s.iter().notes:
         ...     print(el)
         <music21.note.Note C>
         <music21.note.Note D>
@@ -1353,7 +1353,7 @@ class StreamIterator(prebase.ProtoM21Object):
         >>> s.append(note.Note('C'))
         >>> s.append(note.Rest())
         >>> s.append(note.Note('D'))
-        >>> for el in s.iter.notesAndRests:
+        >>> for el in s.iter().notesAndRests:
         ...     print(el)
         <music21.note.Note C>
         <music21.note.Rest quarter>
@@ -1361,7 +1361,7 @@ class StreamIterator(prebase.ProtoM21Object):
 
         chained filters... (this makes no sense since notes is a subset of notesAndRests)
 
-        >>> for el in s.iter.notesAndRests.notes:
+        >>> for el in s.iter().notesAndRests.notes:
         ...     print(el)
         <music21.note.Note C>
         <music21.note.Note D>
@@ -1858,11 +1858,11 @@ class Test(unittest.TestCase):
         r = note.Rest()
         n = note.Note()
         s.append([r, n])
-        all_s = list(s.iter)
+        all_s = list(s.iter())
         self.assertEqual(len(all_s), 2)
         self.assertIs(all_s[0], r)
         self.assertIs(all_s[1], n)
-        s_notes = list(s.iter.notes)
+        s_notes = list(s.iter().notes)
         self.assertEqual(len(s_notes), 1)
         self.assertIs(s_notes[0], n)
 
@@ -1872,7 +1872,7 @@ class Test(unittest.TestCase):
         r = note.Rest()
         n = note.Note()
         s.append([r, n])
-        sIter = s.iter
+        sIter = s.iter()
         r0 = next(sIter)
         self.assertIs(r0, r)
 

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -164,6 +164,21 @@ class StreamIterator(prebase.ProtoM21Object):
 
         return f'for {streamClass}:{srcStreamId} @:{self.index}'
 
+    def __call__(self) -> _SIter:
+        '''
+        Temporary workaround to support both prior usage of `.iter`
+        and new recommended usage of `.iter()`.
+        During the period where `.iter` is still supported, even calling `.iter()`
+        (recommended) will retrieve the property `.iter` and necessitate
+        this workaround.
+
+        Returns `self` without any changes.
+
+        TODO: manage and emit DeprecationWarnings in v.8
+        TODO: remove in v.9
+        '''
+        return self
+
     def __iter__(self):
         self.reset()
         return self

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -123,7 +123,7 @@ def makeBeams(
         returnObj: stream.Measure
         mColl = [returnObj]  # store a list of measures for processing
     else:
-        mColl = list(returnObj.iter().getElementsByClass('Measure'))  # a list of measures
+        mColl = list(returnObj.getElementsByClass('Measure'))  # a list of measures
         if not mColl:
             raise stream.StreamException(
                 'cannot process a stream that is neither a Measure nor has no Measures')
@@ -476,7 +476,7 @@ def makeMeasures(
     # del clefList
     clefObj = srcObj.clef or srcObj.getContextByClass('Clef')
     if clefObj is None:
-        clefObj = srcObj.iter().getElementsByClass('Clef').getElementsByOffset(0).first()
+        clefObj = srcObj.getElementsByClass('Clef').getElementsByOffset(0).first()
         # only return clefs that have offset = 0.0
         if not clefObj:
             clefObj = clef.bestClef(srcObj, recurse=True)
@@ -1543,7 +1543,7 @@ def moveNotesToVoices(source, classFilterList=('GeneralNote',)):
     dst = Voice()
 
     # cast to list so source can be edited.
-    affectedElements = list(source.iter().getElementsByClass(classFilterList))
+    affectedElements = list(source.getElementsByClass(classFilterList))
 
     for e in affectedElements:
         dst.insert(source.elementOffset(e), e)

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -123,7 +123,7 @@ def makeBeams(
         returnObj: stream.Measure
         mColl = [returnObj]  # store a list of measures for processing
     else:
-        mColl = list(returnObj.iter.getElementsByClass('Measure'))  # a list of measures
+        mColl = list(returnObj.iter().getElementsByClass('Measure'))  # a list of measures
         if not mColl:
             raise stream.StreamException(
                 'cannot process a stream that is neither a Measure nor has no Measures')
@@ -476,7 +476,7 @@ def makeMeasures(
     # del clefList
     clefObj = srcObj.clef or srcObj.getContextByClass('Clef')
     if clefObj is None:
-        clefObj = srcObj.iter.getElementsByClass('Clef').getElementsByOffset(0).first()
+        clefObj = srcObj.iter().getElementsByClass('Clef').getElementsByOffset(0).first()
         # only return clefs that have offset = 0.0
         if not clefObj:
             clefObj = clef.bestClef(srcObj, recurse=True)
@@ -826,8 +826,8 @@ def makeRests(
     else:
         returnObj = s
 
-    if returnObj.iter.parts:
-        for inner_part in returnObj.iter.parts:
+    if returnObj.iter().parts:
+        for inner_part in returnObj.iter().parts:
             inner_part.makeRests(
                 inPlace=True,
                 fillGaps=fillGaps,
@@ -1543,7 +1543,7 @@ def moveNotesToVoices(source, classFilterList=('GeneralNote',)):
     dst = Voice()
 
     # cast to list so source can be edited.
-    affectedElements = list(source.iter.getElementsByClass(classFilterList))
+    affectedElements = list(source.iter().getElementsByClass(classFilterList))
 
     for e in affectedElements:
         dst.insert(source.elementOffset(e), e)
@@ -1653,7 +1653,7 @@ def iterateBeamGroups(
 
     New in v6.7.
     '''
-    iterator: 'music21.stream.iterator.StreamIterator' = s.recurse() if recurse else s.iter
+    iterator: 'music21.stream.iterator.StreamIterator' = s.recurse() if recurse else s.iter()
     current_beam_group: List[note.NotRest] = []
     in_beam_group: bool = False
     for el in iterator.getElementsByClass('NotRest'):

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -6126,8 +6126,8 @@ class Test(unittest.TestCase):
 
         # try imported
         s = corpus.parse('bwv66.6')
-        p = s.iter().getElementsByClass('Part').first()  # for test, not .parts, use .iter()
-        m = p.iter().getElementsByClass('Measure')[2]  # for test, not .getElementsByClass('Measure')
+        p = s.getElementsByClass('Part').first()  # for test, not .parts, use .iter()
+        m = p.iter().getElementsByClass(Measure)[2]  # for test, not .getElementsByClass('Measure')
         rn = m[2]
 
         self.assertEqual(id(rn.activeSite), id(m))

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -6126,8 +6126,8 @@ class Test(unittest.TestCase):
 
         # try imported
         s = corpus.parse('bwv66.6')
-        p = s.iter.getElementsByClass('Part').first()  # for test, not .parts, use .iter
-        m = p.iter.getElementsByClass('Measure')[2]  # for test, not .getElementsByClass('Measure')
+        p = s.iter().getElementsByClass('Part').first()  # for test, not .parts, use .iter()
+        m = p.iter().getElementsByClass('Measure')[2]  # for test, not .getElementsByClass('Measure')
         rn = m[2]
 
         self.assertEqual(id(rn.activeSite), id(m))
@@ -8019,7 +8019,7 @@ class Test(unittest.TestCase):
         with self.assertRaises(StreamException):
             Stream([n, n])
         with self.assertRaises(StreamException):
-            Stream([n, None, s.iter])
+            Stream([n, None, s.iter()])
 
     # REMOVED: Turns out that it DOES have fermata on every note!
     # def testSchoenbergChordifyFermatas(self):

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -1245,7 +1245,7 @@ def interpolateElements(element1, element2, sourceStream,
 
     scaleAmount = ((endOffsetDest - startOffsetDest) / (endOffsetSrc - startOffsetSrc))
 
-    interpolatedElements = sourceStream.iter().getElementsByOffset(
+    interpolatedElements = sourceStream.getElementsByOffset(
         offsetStart=startOffsetSrc,
         offsetEnd=endOffsetSrc
     )

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -1245,7 +1245,7 @@ def interpolateElements(element1, element2, sourceStream,
 
     scaleAmount = ((endOffsetDest - startOffsetDest) / (endOffsetSrc - startOffsetSrc))
 
-    interpolatedElements = sourceStream.iter.getElementsByOffset(
+    interpolatedElements = sourceStream.iter().getElementsByOffset(
         offsetStart=startOffsetSrc,
         offsetEnd=endOffsetSrc
     )

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -824,7 +824,7 @@ def mergePartAsOssia(mainPart, ossiaPart, ossiaName,
             if ossiaMeasure.notes:  # If the measure is not just rests
                 ossiaOffset = ossiaMeasure.getOffsetBySite(ossiaPart)
                 if recurseInMeasures is True:
-                    returnMeasure = returnObj.iter().getElementsByOffset(
+                    returnMeasure = returnObj.getElementsByOffset(
                         ossiaOffset
                     ).getElementsByClass(stream.Measure).first()
                     mergeVariantsEqualDuration(
@@ -1964,7 +1964,7 @@ def _getPreviousElement(s, v):
 
     # Get next element in s after v which is of type vClass
     variantOffset = v.getOffsetBySite(s)
-    potentialTargets = s.iter().getElementsByOffset(
+    potentialTargets = s.getElementsByOffset(
         0.0,
         offsetEnd=variantOffset,
         includeEndBoundary=False,

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -153,7 +153,7 @@ def mergeVariants(streamX, streamY, variantName='variant', *, inPlace=False):
     classesX = streamX.classes
     if 'Score' in classesX:
         return mergeVariantScores(streamX, streamY, variantName, inPlace=inPlace)
-    elif streamX.iter().getElementsByClass('Measure'):
+    elif streamX.getElementsByClass('Measure'):
         return mergeVariantMeasureStreams(streamX, streamY, variantName, inPlace=inPlace)
     elif (streamX.iter().notesAndRests
             and streamX.duration.quarterLength == streamY.duration.quarterLength):
@@ -1952,9 +1952,9 @@ def _getPreviousElement(s, v):
     # Get class of elements in variant or replaced Region
     foundStream = None
     if lengthType == 'elongation':
-        foundStream = v.iter().getElementsByClass(['Measure', 'Note', 'Rest'])
+        foundStream = v.getElementsByClass(['Measure', 'Note', 'Rest'])
     else:
-        foundStream = replacedElements.iter().getElementsByClass(['Measure', 'Note', 'Rest'])
+        foundStream = replacedElements.getElementsByClass(['Measure', 'Note', 'Rest'])
 
     if not foundStream:
         raise VariantException('Cannot find any Measures, Notes, or Rests in variant')

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -153,9 +153,9 @@ def mergeVariants(streamX, streamY, variantName='variant', *, inPlace=False):
     classesX = streamX.classes
     if 'Score' in classesX:
         return mergeVariantScores(streamX, streamY, variantName, inPlace=inPlace)
-    elif streamX.iter.getElementsByClass('Measure'):
+    elif streamX.iter().getElementsByClass('Measure'):
         return mergeVariantMeasureStreams(streamX, streamY, variantName, inPlace=inPlace)
-    elif (streamX.iter.notesAndRests
+    elif (streamX.iter().notesAndRests
             and streamX.duration.quarterLength == streamY.duration.quarterLength):
         return mergeVariantsEqualDuration([streamX, streamY], [variantName], inPlace=inPlace)
     else:
@@ -221,7 +221,7 @@ def mergeVariantScores(aScore, vScore, variantName='variant', *, inPlace=False):
             {3.0} <music21.note.Note F>
             {4.0} <music21.bar.Barline type=final>
     '''
-    if len(aScore.iter.parts) != len(vScore.iter.parts):
+    if len(aScore.iter().parts) != len(vScore.iter().parts):
         raise VariantException(
             'These scores do not have the same number of parts and cannot be merged.')
 
@@ -824,7 +824,7 @@ def mergePartAsOssia(mainPart, ossiaPart, ossiaName,
             if ossiaMeasure.notes:  # If the measure is not just rests
                 ossiaOffset = ossiaMeasure.getOffsetBySite(ossiaPart)
                 if recurseInMeasures is True:
-                    returnMeasure = returnObj.iter.getElementsByOffset(
+                    returnMeasure = returnObj.iter().getElementsByOffset(
                         ossiaOffset
                     ).getElementsByClass(stream.Measure).first()
                     mergeVariantsEqualDuration(
@@ -1952,9 +1952,9 @@ def _getPreviousElement(s, v):
     # Get class of elements in variant or replaced Region
     foundStream = None
     if lengthType == 'elongation':
-        foundStream = v.iter.getElementsByClass(['Measure', 'Note', 'Rest'])
+        foundStream = v.iter().getElementsByClass(['Measure', 'Note', 'Rest'])
     else:
-        foundStream = replacedElements.iter.getElementsByClass(['Measure', 'Note', 'Rest'])
+        foundStream = replacedElements.iter().getElementsByClass(['Measure', 'Note', 'Rest'])
 
     if not foundStream:
         raise VariantException('Cannot find any Measures, Notes, or Rests in variant')
@@ -1964,7 +1964,7 @@ def _getPreviousElement(s, v):
 
     # Get next element in s after v which is of type vClass
     variantOffset = v.getOffsetBySite(s)
-    potentialTargets = s.iter.getElementsByOffset(
+    potentialTargets = s.iter().getElementsByOffset(
         0.0,
         offsetEnd=variantOffset,
         includeEndBoundary=False,

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -447,7 +447,7 @@ def realizeVolume(srcStream,
 
     # check for any dynamics
     dynamicsAvailable = False
-    if flatSrc.iter().getElementsByClass('Dynamic'):
+    if flatSrc.getElementsByClass('Dynamic'):
         dynamicsAvailable = True
     else:  # no dynamics available
         if useDynamicContext is True:  # only if True, and non avail, override

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -447,7 +447,7 @@ def realizeVolume(srcStream,
 
     # check for any dynamics
     dynamicsAvailable = False
-    if flatSrc.iter.getElementsByClass('Dynamic'):
+    if flatSrc.iter().getElementsByClass('Dynamic'):
         dynamicsAvailable = True
     else:  # no dynamics available
         if useDynamicContext is True:  # only if True, and non avail, override


### PR DESCRIPTION
Fixes #1025 

I had this lying around from when I wrote up the issue. Just tweaked the doc string on the `__call__()` method a bit and it was ready to go.

On second glance, some of these existing calls to `.iter` look unnecessary, <s>but I didn't stop to audit them all.</s> so I spruced them up to get Pylint to pass (two extra characters knocked a couple of these over the line limit!)