### PR TITLE
Implemented jazz minor scale and relative key functionality on harmonic, melodic, and jazz minors

### DIFF
--- a/music21/key.py
+++ b/music21/key.py
@@ -1078,7 +1078,7 @@ class Key(KeySignature, scale.DiatonicScale):
         To use the harmonic form, change `.abstract` on the key to
         another abstract scale:
 
-        >>> minorKey.abstract = scale.AbstractHarmonicMinorScale()
+        >>> minorKey.abstract = key.Key(mode='harmonic minor').abstract
         >>> minorKey.deriveByDegree(7, 'E')
         <music21.key.Key of f minor>
         >>> minorKey.deriveByDegree(6, 'G')

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -752,7 +752,7 @@ class AbstractDiatonicScale(AbstractScale):
             self.relativeMajorDegree = 3
             self.relativeMinorDegree = 1
         elif mode == 'harmonic minor':
-            intervalList = srcList[5:] + srcList[:5]  # a to A
+            intervalList = ['M2', 'm2', 'M2', 'M2', 'm2', 'A2', 'm2']  # a to A
             self.relativeMajorDegree = 3
             self.relativeMinorDegree = 1
         elif mode == 'melodic minor':

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -882,6 +882,35 @@ class AbstractHarmonicMinorScale(AbstractScale):
         return MinorScale(self.tonic)
 
 
+class AbstractMelodicMinorScale(AbstractScale):
+    '''
+    A directional scale.
+    '''
+
+    def __init__(self, mode=None):
+        super().__init__()
+        self.type = 'Abstract Melodic Minor'
+        self.octaveDuplicating = True
+        self.relativeMinorDegree = 1
+        self.relativeMajorDegree = 3
+        self.dominantDegree: int = -1
+        self.buildNetwork()
+
+    def buildNetwork(self):
+        self.tonicDegree = 1
+        self.dominantDegree = 5
+        self._net = intervalNetwork.IntervalNetwork(
+            octaveDuplicating=self.octaveDuplicating,
+            pitchSimplification=None)
+        self._net.fillMelodicMinor()
+
+    def getRelativeMajor(self):
+        return MajorScale(self.tonic)
+
+    def getRelativeMinor(self):
+        return MinorScale(self.tonic)
+    
+    
 class AbstractJazzMinorScale(AbstractScale):
     '''
     A true bi-directional scale containing the raised
@@ -926,35 +955,7 @@ class AbstractJazzMinorScale(AbstractScale):
     def getRelativeMinor(self):
         return MinorScale(self.tonic)
 
-
-class AbstractMelodicMinorScale(AbstractScale):
-    '''
-    A directional scale.
-    '''
-
-    def __init__(self, mode=None):
-        super().__init__()
-        self.type = 'Abstract Melodic Minor'
-        self.octaveDuplicating = True
-        self.relativeMinorDegree = 1
-        self.relativeMajorDegree = 3
-        self.dominantDegree: int = -1
-        self.buildNetwork()
-
-    def buildNetwork(self):
-        self.tonicDegree = 1
-        self.dominantDegree = 5
-        self._net = intervalNetwork.IntervalNetwork(
-            octaveDuplicating=self.octaveDuplicating,
-            pitchSimplification=None)
-        self._net.fillMelodicMinor()
-
-    def getRelativeMajor(self):
-        return MajorScale(self.tonic)
-
-    def getRelativeMinor(self):
-        return MinorScale(self.tonic)
-
+    
 class AbstractCyclicalScale(AbstractScale):
     '''
     A scale of any size built with an interval list of any form.
@@ -2925,9 +2926,28 @@ class HarmonicMinorScale(DiatonicScale):
         # self._abstract.buildNetwork()
 
 
+class MelodicMinorScale(DiatonicScale):
+    '''
+    A melodic minor scale, which is not the same ascending or descending
+
+    >>> sc = scale.MelodicMinorScale('e4')
+    '''
+
+    def __init__(self, tonic=None):
+        super().__init__(tonic=tonic)
+        self.type = 'melodic minor'
+
+        # note: this changes the previously assigned AbstractDiatonicScale
+        # from the DiatonicScale base class
+        self._abstract = AbstractMelodicMinorScale()
+        
+        
 class JazzMinorScale(DiatonicScale):
     '''
     The jazz minor scale.
+    
+    A synthetic scale identical to the ascending melodic minor. Useful in
+    jazz, especially over harmonies that employ minor-major seventh chords.
     >>> sc = scale.JazzMinorScale('e4')
     >>> [str(p) for p in sc.pitches]
     ['E4', 'F#4', 'G4', 'A4', 'B4', 'C#5', 'D#5', 'E5']
@@ -2949,28 +2969,7 @@ class JazzMinorScale(DiatonicScale):
         super().__init__(tonic=tonic)
         self.type = 'jazz minor'
 
-        # note: this changes the previously assigned AbstractDiatonicScale
-        # from the DiatonicScale base class
-
         self._abstract = AbstractJazzMinorScale()
-        # network building happens on object creation
-        # self._abstract.buildNetwork()
-
-
-class MelodicMinorScale(DiatonicScale):
-    '''
-    A melodic minor scale, which is not the same ascending or descending
-
-    >>> sc = scale.MelodicMinorScale('e4')
-    '''
-
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
-        self.type = 'melodic minor'
-
-        # note: this changes the previously assigned AbstractDiatonicScale
-        # from the DiatonicScale base class
-        self._abstract = AbstractMelodicMinorScale()
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #955 and also allows getRelativeMinor/getRelativeMajor functions to be used on minor scales other than natural minor, as per the [documentation](http://web.mit.edu/music21/doc/moduleReference/moduleScale.html).