### PR TITLE
Fix repr() of scales without tonics

### DIFF
--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -1378,7 +1378,7 @@ class ConcreteScale(Scale):
             return ' '.join([self.tonic.name, self.type])
 
     def _reprInternal(self):
-        return f'{self.tonic.name} {self.type}'
+        return self.name
 
     # --------------------------------------------------------------------------
 
@@ -2845,6 +2845,8 @@ class HarmonicMinorScale(DiatonicScale):
     <music21.pitch.Pitch E4>
 
     >>> sc = scale.HarmonicMinorScale()
+    >>> sc
+    <music21.scale.HarmonicMinorScale Abstract harmonic minor>
     >>> sc.deriveRanked(['C', 'E', 'G'], comparisonAttribute='name')
     [(3, <music21.scale.HarmonicMinorScale F harmonic minor>),
      (3, <music21.scale.HarmonicMinorScale E harmonic minor>),


### PR DESCRIPTION
Fixes this issue (and there are tonic-less uses like this in the test suite, for instance, calling `getPitches()` will assume a tonic of C4):

```
>>> sc = scale.MinorScale()
>>> sc
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jwalls/music21/music21/prebase.py", line 236, in __repr__
    strRepr = self._reprInternal()
  File "/Users/jwalls/music21/music21/scale/__init__.py", line 1381, in _reprInternal
    return f'{self.tonic.name} {self.type}'
AttributeError: 'NoneType' object has no attribute 'name'
```

The repr() was simplified in f58395e45b to just be the same as the .name when a tonic exists, so let's just DRY it out and grab the .name.