### PR TITLE
Pin pylint==2.8.3

### DIFF
--- a/.github/workflows/pythonpylint.yml
+++ b/.github/workflows/pythonpylint.yml
@@ -23,8 +23,7 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
                   pip install IPython
-                  pip install pylint
-                  pip install astroid==2.5.7
+                  pip install pylint==2.8.3
             - name: Lint with pylint
               run: |
                   pylint -j0 music21

--- a/.github/workflows/pythonpylint.yml
+++ b/.github/workflows/pythonpylint.yml
@@ -24,6 +24,7 @@ jobs:
                   pip install -r requirements.txt
                   pip install IPython
                   pip install pylint
+                  pip install astroid==2.5.7
             - name: Lint with pylint
               run: |
                   pylint -j0 music21


### PR DESCRIPTION
see most recent PR run and https://github.com/PyCQA/astroid/issues/1080

edit: it's probably much simpler to simply disable pylint checks on the one method having trouble in text.py, come to think of it.

edit edit: with limited time before v7, how about we just also pin pylint until after v7