### PR TITLE
Support and recommend `.sorted()` instead of `.sorted`

### DIFF
--- a/documentation/source/usersGuide/usersGuide_55_advancedMeter.ipynb
+++ b/documentation/source/usersGuide/usersGuide_55_advancedMeter.ipynb
@@ -1413,7 +1413,7 @@
     "                mark = articulations.Accent()\n",
     "            n.articulations.append(mark)\n",
     "            lastBeat = beat\n",
-    "        m = m.sorted\n",
+    "        m = m.sorted()\n",
     "        \n",
     "partBass.measures(0, 8).show() "
    ]

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -1198,7 +1198,7 @@ class RichMetadata(Metadata):
 
         environLocal.printDebug(['RichMetadata: update(): start'])
 
-        flat = streamObj.flat.sorted
+        flat = streamObj.flat.sorted()
 
         self.numberOfParts = len(streamObj.parts)
         self.keySignatureFirst = None

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -305,6 +305,21 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         self.coreElementsChanged()
 
+    def __call__(self):
+        '''
+        Temporary workaround to support both prior usage of `.sorted`
+        and new recommended usage of `.sorted()`.
+        During the period where `.sorted` is still supported, even calling `.sorted()`
+        (recommended) will retrieve the property `.sorted` and necessitate
+        this workaround.
+
+        Returns `self` without any changes.
+
+        TODO: manage and emit DeprecationWarnings in v.8
+        TODO: remove in v.9
+        '''
+        return self
+
     def _reprInternal(self):
         if self.id is not None:
             if self.id != id(self) and str(self.id) != str(id(self)):
@@ -7285,7 +7300,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         a Note at offset 0)
 
         if this Stream is not flat, then only the highest elements are sorted.  To sort all,
-        run myStream.flat.sorted
+        run myStream.flat.sorted()
 
         For instance, here is an unsorted Stream
 
@@ -7300,7 +7315,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         But a sorted version of the Stream puts the C first:
 
-        >>> s.sorted.show('text')
+        >>> s.sorted().show('text')
         {0.0} <music21.note.Note C>
         {1.0} <music21.note.Note D>
 
@@ -7324,7 +7339,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         ...    g += '%s: %s; ' % (myElement.offset, myElement.name)
         >>> g
         '0.0: C#; 2.0: C#; 4.0: C#; 1.0: D-; 3.0: D-; 5.0: D-; '
-        >>> y = s.sorted
+        >>> y = s.sorted()
         >>> y.isSorted
         True
         >>> g = ''
@@ -7341,7 +7356,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         ...    g += '%s: %s; ' % (myElement.offset, myElement.name)
         >>> g
         '0.0: C#; 1.0: D-; 2.0: C#; 3.0: D-; 4.0: C#; 5.0: D-; 2.0: E; '
-        >>> z = y.sorted
+        >>> z = y.sorted()
         >>> g = ''
         >>> for myElement in z:
         ...    g += '%s: %s; ' % (myElement.offset, myElement.name)
@@ -7528,7 +7543,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> g
         '0.0: C#; 2.0: C#; 4.0: C#; 1.0: D-; 3.0: D-; 5.0: D-; '
 
-        >>> y = s.sorted
+        >>> y = s.sorted()
         >>> y.isSorted
         True
 
@@ -10013,7 +10028,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         '''
         flatStream = self.flat
         if flatStream.isSorted is False:
-            flatStream = flatStream.sorted
+            flatStream = flatStream.sorted()
         # these may not be sorted
         durSpanSorted = self._getDurSpan(flatStream)
         # According to the above comment, the spans may not be sorted
@@ -10049,7 +10064,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         '''
         flatStream = self.flat
         if flatStream.isSorted is False:
-            flatStream = flatStream.sorted
+            flatStream = flatStream.sorted()
 
         if len(layeringMap) != len(flatStream):
             raise StreamException('layeringMap must be the same length as flatStream')

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -424,7 +424,7 @@ def makeMeasures(
         else:
             srcObj = s.flat
         if not srcObj.isSorted:
-            srcObj = srcObj.sorted
+            srcObj = srcObj.sorted()
         if not inPlace:
             srcObj = copy.deepcopy(srcObj)
         voiceCount = len(srcObj.voices)
@@ -682,7 +682,7 @@ def makeMeasures(
         if post.isSorted:
             postSorted = post
         else:
-            postSorted = post.sorted
+            postSorted = post.sorted()
 
         for e in postSorted:
             # may need to handle spanners; already have s as site

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -307,7 +307,7 @@ class Test(unittest.TestCase):
         s.repeatInsert(note.Note('C#'), [0.0, 2.0, 4.0])
         s.repeatInsert(note.Note('D-'), [1.0, 3.0, 5.0])
         self.assertFalse(s.isSorted)
-        y = s.sorted
+        y = s.sorted()
         self.assertTrue(y.isSorted)
         g = ''
         for myElement in y:
@@ -400,8 +400,8 @@ class Test(unittest.TestCase):
         n1 = note.Note()
         st2.insert(10, n1)
         st1.insert(12, st2)
-        self.assertIs(st1.flat.sorted[0], n1)
-        self.assertEqual(st1.flat.sorted[0].offset, 22.0)
+        self.assertIs(st1.flat.sorted()[0], n1)
+        self.assertEqual(st1.flat.sorted()[0].offset, 22.0)
 
     def testStreamExceptionsOnAssert(self):
         with self.assertRaises(StreamException):
@@ -432,7 +432,7 @@ class Test(unittest.TestCase):
         # environLocal.printDebug(['pre flat of mid stream'])
         self.assertEqual(len(midStream.flat), 24)
 #        self.assertEqual(len(midStream.getOverlaps()), 0)
-        mfs = midStream.flat.sorted
+        mfs = midStream.flat.sorted()
         self.assertEqual(mfs[7].getOffsetBySite(mfs), 11.0)
 
         farStream = Stream()
@@ -473,7 +473,7 @@ class Test(unittest.TestCase):
 
         # get just offset times
         # elementsSorted returns offset, dur, element
-        fs_fs = farStream.flat.sorted
+        fs_fs = farStream.flat.sorted()
         offsets = [a.offset for a in fs_fs]  # safer is a.getOffsetBySite(fs_fs)
         offsetsBrief = offsets[:20]
         self.assertEqual(offsetsBrief,
@@ -4341,7 +4341,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual([x.name for x in s], ['B', 'A'])
         # try getting sorted
-        sSorted = s.sorted
+        sSorted = s.sorted()
         # original unchanged
         self.assertEqual([x.name for x in s], ['B', 'A'])
         # new is changed


### PR DESCRIPTION
As mentioned in v6.7 release notes.