### PR TITLE
Parse requirements from file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,17 @@ DESCRIPTION_LONG = """A Toolkit for Computer-Aided Musical Analysis.
                         The development of music21 is supported by the
                         generosity of the Seaver Institute and the NEH."""
 
-INSTALL_REQUIRES = [
-    "chardet",
-    "joblib",
-    "more-itertools",
-    "webcolors",
-]
+min_requirements_path = os.path.join(
+    os.path.dirname(__file__), "requirements-minimum.txt"
+)
+with open(min_requirements_path, 'r') as f:
+    INSTALL_REQUIRES = f.read().splitlines()
+all_requirements_path = os.path.join(os.path.dirname(__file__), "requirements.txt")
+with open(all_requirements_path, 'r') as f:
+    extra_requirements = [
+        req for req in f.read().splitlines() if req not in INSTALL_REQUIRES
+    ]
+    EXTRAS_REQUIRE = {"all": extra_requirements}
 
 
 classifiers = [
@@ -79,6 +84,7 @@ if __name__ == '__main__':
         download_url=f'{download_base}v{m21version}/music21-{m21version}.tar.gz',
         packages=setuptools.find_packages(exclude=['ez_setup']),
         install_requires=INSTALL_REQUIRES,
+        extras_require=EXTRAS_REQUIRE,
         include_package_data=True,
         zip_safe=False,
     )

--- a/setup.py
+++ b/setup.py
@@ -31,18 +31,11 @@ DESCRIPTION_LONG = """A Toolkit for Computer-Aided Musical Analysis.
                         The development of music21 is supported by the
                         generosity of the Seaver Institute and the NEH."""
 
-min_requirements_path = os.path.join(
-    os.path.dirname(__file__), "requirements-minimum.txt"
+requirements_path = os.path.join(
+    os.path.dirname(__file__), "requirements.txt"
 )
-with open(min_requirements_path, 'r') as f:
+with open(requirements_path, 'r') as f:
     INSTALL_REQUIRES = f.read().splitlines()
-all_requirements_path = os.path.join(os.path.dirname(__file__), "requirements.txt")
-with open(all_requirements_path, 'r') as f:
-    extra_requirements = [
-        req for req in f.read().splitlines() if req not in INSTALL_REQUIRES
-    ]
-    EXTRAS_REQUIRE = {"all": extra_requirements}
-
 
 classifiers = [
     'Development Status :: 5 - Production/Stable',
@@ -84,7 +77,6 @@ if __name__ == '__main__':
         download_url=f'{download_base}v{m21version}/music21-{m21version}.tar.gz',
         packages=setuptools.find_packages(exclude=['ez_setup']),
         install_requires=INSTALL_REQUIRES,
-        extras_require=EXTRAS_REQUIRE,
         include_package_data=True,
         zip_safe=False,
     )


### PR DESCRIPTION
Reads minimal requirements from the adjacent requirements.txt and uses them to define the install_requires
options for setuptools.

This addresses https://github.com/cuthbertLab/music21/issues/338 and fixes https://github.com/cuthbertLab/music21/issues/1050.

I tested using the following procedure:
```
git_home=~/Downloads
repo_name=music21
repo_path=${git_home}/${repo_name}
repo_url=https://github.com/JamesOwers/music21.git
git clone ${repo_url} ${repo_path}
conda create -n ${repo_name}-dev python=3.8 --yes
conda activate ${repo_name}-dev
pip install ${repo_path}
python -c 'import jsonpickle' && echo 'This succeeded as expected!'
```