### PR TITLE
Add deprecation warning for .sorted and some Pylint fixes

### DIFF
--- a/.github/workflows/pythonpylint.yml
+++ b/.github/workflows/pythonpylint.yml
@@ -23,7 +23,7 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
                   pip install IPython
-                  pip install pylint==2.8.3
+                  pip install pylint
             - name: Lint with pylint
               run: |
                   pylint -j0 music21

--- a/.pylintrc
+++ b/.pylintrc
@@ -97,7 +97,9 @@ disable=
     no-else-continue,  # not so bad...
     no-else-break,  # same...
     consider-using-enumerate,  # sometimes parallelism is better than enumerate.
+    consider-using-dict-items,  # readability improvement depends on excellent variable names
     arguments-differ,  # we are not purists.
+    arguments-renamed,  # same
     simplifiable-if-statement,  # simpler to a computer maybe...
     unsubscriptable-object,  # too many errors
     import-outside-toplevel,  # allow for import music21, etc.

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (7, 0, 7)  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (7, 0, 7, 'b1')  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -1556,7 +1556,7 @@ class ABCNote(ABCToken):
             ql = activeDefaultQuarterLength / int(numStr.split('/')[1])
         # uncommon usage: 3/ short for 3/2
         elif numStr.endswith('/'):
-            n = int(numStr.split('/')[0].strip())
+            n = int(numStr.split('/', maxsplit=1)[0].strip())
             d = 2
             ql = activeDefaultQuarterLength * n / d
         # if we have two, this is usually an error

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'7.0.7'
+'7.0.7b1'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/chord/tables.py
+++ b/music21/chord/tables.py
@@ -2944,7 +2944,7 @@ class Test(unittest.TestCase):
 
         for key, value in partition.items():
             # the length of the list should be the max value stored
-            self.assertEqual(max(value), len(partition[key]))
+            self.assertEqual(max(value), len(value))
 
     def testScDict(self):
         for key, value in SCDICT.items():

--- a/music21/common/classTools.py
+++ b/music21/common/classTools.py
@@ -123,7 +123,7 @@ def classToClassStr(classObj: Type) -> str:
     'Chord'
     '''
     # remove closing quotes
-    return str(classObj).split('.')[-1][:-2]
+    return str(classObj).rsplit('.', maxsplit=1)[-1][:-2]
 
 
 def getClassSet(instance, classNameTuple=None):

--- a/music21/ipython21/objects.py
+++ b/music21/ipython21/objects.py
@@ -15,6 +15,7 @@ class IPythonPNGObject:
 
     def getData(self):
         fp = self.fp
-        data = open(fp, 'rb').read()
+        with open(fp, 'rb') as f:
+            data = f.read()
         os.remove(fp)
         return data

--- a/music21/lily/lilyObjects.py
+++ b/music21/lily/lilyObjects.py
@@ -2043,7 +2043,7 @@ class LyNumberTerm(LyObject):
 
 
 class LyLyricMarkup(LyObject):
-    def __init_(self, lyricMarkupOrIdentifier=None, markupTop=None):
+    def __init__(self, lyricMarkupOrIdentifier=None, markupTop=None):
         super().__init__()
         self.lyricMarkupOrIdentifier = lyricMarkupOrIdentifier
         self.markupTop = markupTop
@@ -2056,7 +2056,7 @@ class LyLyricMarkup(LyObject):
 
 
 class LyFullMarkupList(LyObject):
-    def __init_(self, markupListOrIdentifier=None):
+    def __init__(self, markupListOrIdentifier=None):
         super().__init__()
         self.markupListOrIdentifier = markupListOrIdentifier
 
@@ -2069,7 +2069,7 @@ class LyFullMarkupList(LyObject):
 
 
 class LyFullMarkup(LyObject):
-    def __init_(self, markupTopOrIdentifier=None):
+    def __init__(self, markupTopOrIdentifier=None):
         super().__init__()
         self.markupTopOrIdentifier = markupTopOrIdentifier
 

--- a/music21/mei/test_base.py
+++ b/music21/mei/test_base.py
@@ -1940,7 +1940,7 @@ class Test(unittest.TestCase):
     @mock.patch('music21.mei.base.noteFromElement')
     @mock.patch('music21.stream.Voice')
     @mock.patch('music21.mei.base._guessTuplets')
-    def testUnit1aLayerFromElemen(self, mockTuplets, mockVoice, mockNoteFromElement):
+    def testUnit1aLayerFromElement(self, mockTuplets, mockVoice, mockNoteFromElement):
         '''
         layerFromElement(): basic functionality (i.e., that the tag-name-to-converter-function
                             mapping works; that tags not in the mapping are ignored; and that a
@@ -1983,7 +1983,7 @@ class Test(unittest.TestCase):
     @mock.patch('music21.mei.base.noteFromElement')
     @mock.patch('music21.stream.Voice')
     @mock.patch('music21.mei.base._guessTuplets')
-    def testUnit1bLayerFromElemen(self, mockTuplets, mockVoice, mockNoteFromElement):
+    def testUnit1bLayerFromElement(self, mockTuplets, mockVoice, mockNoteFromElement):
         '''
         Same as testUnit1a() *but* with ``overrideN`` provided.
         '''
@@ -2584,7 +2584,7 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base._timeSigFromAttrs')
     @mock.patch('music21.mei.base._keySigFromAttrs')
-    def testUnit1ScoreDefFromElemen(self, mockKey, mockTime):
+    def testUnit1ScoreDefFromElement(self, mockKey, mockTime):
         '''
         scoreDefFromElement(): proper handling of the following attributes (see function docstring
             for more information).

--- a/music21/mei/test_base.py
+++ b/music21/mei/test_base.py
@@ -27,9 +27,7 @@ Tests for :mod:`music21.mei.base`.
 # pylint: disable=maybe-no-member
 
 # pylint: disable=ungrouped-imports
-# pylint: disable=redefined-builtin
 # pylint: disable=import-error
-# pylint: disable=unused-import
 import unittest
 
 # To have working MagicMock objects, we can't use cElementTree even though it would be faster.
@@ -56,8 +54,7 @@ from music21 import spanner
 from music21 import stream
 from music21 import tie
 
-# Importing from base.py
-import music21.mei.base as base  # pylint: disable=useless-import-alias
+from music21.mei import base
 from music21.mei.base import _XMLID
 from music21.mei.base import MEI_NS
 

--- a/music21/note.py
+++ b/music21/note.py
@@ -1876,7 +1876,7 @@ class Test(unittest.TestCase):
         self.assertEqual(matchStr, outStr)
         i = 0
         for thisNote in note1.splitAtDurations():
-            matchSub = matchStr.split('\n')[i]
+            matchSub = matchStr.split('\n')[i]  # pylint: disable=use-maxsplit-arg
             conv = LilypondConverter()
             conv.appendM21ObjectToContext(thisNote)
             outStr = str(conv.context).replace(' ', '').strip()

--- a/music21/test/commonTest.py
+++ b/music21/test/commonTest.py
@@ -15,7 +15,6 @@ Things that are common to testing...
 from unittest.signals import registerResult
 
 import doctest
-import importlib
 import os
 import types
 import unittest.runner
@@ -24,6 +23,13 @@ import warnings
 import music21
 from music21 import environment
 from music21 import common
+
+# import importlib
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', DeprecationWarning)
+    warnings.simplefilter('ignore', PendingDeprecationWarning)
+    import imp
+
 
 environLocal = environment.Environment('test.commonTest')
 
@@ -356,11 +362,17 @@ class ModuleGather:
         if skip:
             return None
 
-        name = self._getNamePeriod(fp, addM21=True)
+        name = self._getName(fp)
+        # for importlib
+        # name = self._getNamePeriod(fp, addM21=True)
 
         # print(name, os.path.dirname(fp))
         try:
-            mod = importlib.import_module(name)
+            with warnings.catch_warnings():
+                # warnings.simplefilter('ignore', RuntimeWarning)
+                # importlib is messing with coverage...
+                mod = imp.load_source(name, fp)
+                # mod = importlib.import_module(name)
         except Exception as excp:  # pylint: disable=broad-except
             environLocal.warn(['failed import:', fp, '\n',
                                '\tEXCEPTION:', str(excp).strip()])

--- a/music21/test/commonTest.py
+++ b/music21/test/commonTest.py
@@ -28,7 +28,7 @@ from music21 import common
 with warnings.catch_warnings():
     warnings.simplefilter('ignore', DeprecationWarning)
     warnings.simplefilter('ignore', PendingDeprecationWarning)
-    import imp
+    import imp  # pylint: disable=deprecated-module
 
 
 environLocal = environment.Environment('test.commonTest')

--- a/music21/test/commonTest.py
+++ b/music21/test/commonTest.py
@@ -15,6 +15,7 @@ Things that are common to testing...
 from unittest.signals import registerResult
 
 import doctest
+import importlib
 import os
 import types
 import unittest.runner
@@ -23,13 +24,6 @@ import warnings
 import music21
 from music21 import environment
 from music21 import common
-
-# import importlib
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore', DeprecationWarning)
-    warnings.simplefilter('ignore', PendingDeprecationWarning)
-    import imp
-
 
 environLocal = environment.Environment('test.commonTest')
 
@@ -362,17 +356,11 @@ class ModuleGather:
         if skip:
             return None
 
-        name = self._getName(fp)
-        # for importlib
-        # name = self._getNamePeriod(fp, addM21=True)
+        name = self._getNamePeriod(fp, addM21=True)
 
         # print(name, os.path.dirname(fp))
         try:
-            with warnings.catch_warnings():
-                # warnings.simplefilter('ignore', RuntimeWarning)
-                # importlib is messing with coverage...
-                mod = imp.load_source(name, fp)
-                # mod = importlib.import_module(name)
+            mod = importlib.import_module(name)
         except Exception as excp:  # pylint: disable=broad-except
             environLocal.warn(['failed import:', fp, '\n',
                                '\tEXCEPTION:', str(excp).strip()])

--- a/music21/test/testLint.py
+++ b/music21/test/testLint.py
@@ -85,6 +85,8 @@ def main(fnAccept=None, strict=False):
     disable = [  # These also need to be changed in MUSIC21BASE/.pylintrc
         'arguments-differ',  # -- no -- should be able to add additional arguments so long
         # as initial ones are the same.
+        'arguments-renamed',  # not an issue
+
         'multiple-imports',  # import os, sys -- fine...
         'redefined-variable-type',  # would be good, but currently
         # lines like: if x: y = note.Note() ; else: y = note.Rest()
@@ -117,6 +119,7 @@ def main(fnAccept=None, strict=False):
         # sometimes .keys() is a good test against
         # changing the dictionary size while iterating.
         'consider-iterating-dictionary',
+        'consider-using-dict-items',  # readability improvement depends on excellent variable names
 
         'invalid-name',      # these are good music21 names; fix the regexp instead...
         'no-self-use',       # maybe later

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -1102,8 +1102,8 @@ class VerticalitySequence(prebase.ProtoM21Object, collections.abc.Sequence):
                 if timespan.part not in unwrapped:
                     unwrapped[timespan.part] = []
                 unwrapped[timespan.part].append(timespan)
-        for part, unused_timespans in unwrapped.items():
-            horizontality = Horizontality(timespans=unwrapped[part],)
+        for part, timespans in unwrapped.items():
+            horizontality = Horizontality(timespans=timespans)
             unwrapped[part] = horizontality
         return unwrapped
 

--- a/requirements-minimum.txt
+++ b/requirements-minimum.txt
@@ -1,4 +1,4 @@
 chardet
 joblib
 more-itertools
-webcolors
+webcolors>=1.5


### PR DESCRIPTION
- suppress `consider-using-dict-items` and `arguments-renamed`
- resolve the other pylint issues detected
- accelerate the deprecation timeline for `.sorted` -- emit a DeprecationWarning on stream deletion (for `iter` in v.8, I was planning to do something similar in `__next__`, but there's not a great place to do it on a Stream for `.sorted` --what do you think?)