### PR TITLE
add a placement attribute for MetronomeMark 

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5331,7 +5331,7 @@ class MeasureExporter(XMLExporterBase):
                 te.offset = ti.offset
                 unused_mxDirectionText = self.textExpressionToXml(te)
 
-        if ti.placement is not None:
+        if hasattr(ti, 'placement') and ti.placement is not None:
             assert ti.placement in {'above', 'below'}
             mxDirection.set('placement', ti.placement)
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5331,6 +5331,10 @@ class MeasureExporter(XMLExporterBase):
                 te.offset = ti.offset
                 unused_mxDirectionText = self.textExpressionToXml(te)
 
+        if ti.placement is not None:
+            assert ti.placement in {'above', 'below'}
+            mxDirection.set('placement', ti.placement)
+
         return mxDirection
 
     def rehearsalMarkToXml(self, rm):

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -903,6 +903,8 @@ class MetricModulation(TempoIndication):
         # showing parens or not
         self.parentheses = False
 
+        self.placement = None
+
         # store two MetronomeMark objects
         self._oldMetronome = None
         self._newMetronome = None

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -376,9 +376,12 @@ class MetronomeMark(TempoIndication):
     True
     >>> tm2.number
     144
+
+    If placement is given, it must be either 'above' or 'below' and will force
+    metronome mark to be placed either above or below the staff
     '''
 
-    def __init__(self, text=None, number=None, referent=None, parentheses=False):
+    def __init__(self, text=None, number=None, referent=None, parentheses=False, placement=None):
         super().__init__()
 
         if number is None and isinstance(text, int):
@@ -397,6 +400,10 @@ class MetronomeMark(TempoIndication):
 
         # TODO: style??
         self.parentheses = parentheses
+
+        if placement is not None:
+            assert placement in {'above', 'below'}
+        self.placement = placement
 
         self._referent = None  # set with property
         if referent is None:
@@ -1666,4 +1673,3 @@ _DOC_ORDER = [MetronomeMark, TempoText, MetricModulation, TempoIndication,
 if __name__ == '__main__':
     import music21
     music21.mainTest(Test)  # , runTest='testStylesAreShared')
-


### PR DESCRIPTION
This PR adds a placement' attribute for MetronomeMark. Without that some musicxml applications (like musescore) misinterpret this and place metronome marks below the staff