### PR TITLE
add positionPlacement to MetronomeMark

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6603,11 +6603,16 @@ class Test(unittest.TestCase):
         c.useSymbol = False
         f = repeat.Fine()
         mm = tempo.MetronomeMark(text='Langsam')
+        mm.positionPlacement = 'above'
         s.measure(1).storeAtEnd([c, f, mm])
 
         tree = self.getET(s)
         for direction in tree.findall('.//direction'):
             self.assertIsNone(direction.find('offset'))
+
+        # Also check position
+        mxDirection = tree.find('part/measure/direction')
+        self.assertEqual(mxDirection.get('placement'), 'above')
 
     def testFullMeasureRest(self):
         from music21 import converter

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -7014,6 +7014,7 @@ class Test(unittest.TestCase):
         s = converter.parse(testFiles.tabTest)
         metro = s.recurse().getElementsByClass('MetronomeMark').first()
         self.assertEqual(metro.style.absoluteY, 40)
+        self.assertEqual(metro.positionPlacement, 'above')
 
 
 if __name__ == '__main__':

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4809,6 +4809,8 @@ class MeasureParser(XMLParserBase):
         elif tag == 'metronome':
             mm = self.xmlToTempoIndication(mxDir)
             # SAX was offsetMeasureNote; bug? should be totalOffset???
+            _setAttributeFromAttribute(mm, mxDirection,
+                            'placement', 'positionPlacement')
             self.insertCoreAndRef(totalOffset, staffKey, mm)
             self.setEditorial(mxDirection, mm)
 
@@ -4956,10 +4958,6 @@ class MeasureParser(XMLParserBase):
         if paren is not None:
             if paren == 'yes':
                 mm.parentheses = True
-
-        placement = mxMetronome.get('placement')
-        if placement is not None:
-            mm.positionPlacement = placement
 
         _synchronizeIds(mxMetronome, mm)
         self.setPosition(mxMetronome, mm)

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4957,6 +4957,10 @@ class MeasureParser(XMLParserBase):
             if paren == 'yes':
                 mm.parentheses = True
 
+        placement = mxMetronome.get('placement')
+        if placement is not None:
+            mm.positionPlacement = placement
+
         _synchronizeIds(mxMetronome, mm)
         self.setPosition(mxMetronome, mm)
         return mm

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -398,6 +398,8 @@ class MetronomeMark(TempoIndication):
         # TODO: style??
         self.parentheses = parentheses
 
+        self.positionPlacement = None
+
         self._referent = None  # set with property
         if referent is None:
             # if referent is None, set a default quarter note duration
@@ -1666,4 +1668,3 @@ _DOC_ORDER = [MetronomeMark, TempoText, MetricModulation, TempoIndication,
 if __name__ == '__main__':
     import music21
     music21.mainTest(Test)  # , runTest='testStylesAreShared')
-


### PR DESCRIPTION
As suggested, this PR adds a positionPlacement to MetronomeMark. It also enables the corresponding import from xml, converts xml placement to positionPlacement.