### PR TITLE
Rename `positionPlacement` to `placement` on Dynamic, TextExpression, and MetronomeMark

### DIFF
--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -212,6 +212,7 @@ class Dynamic(base.Music21Object):
             >>> d.englishName
             'very soft'
             ''',
+        'placement': "Staff placement: 'above', 'below', or None.",
     }
 
     def __init__(self, value=None):
@@ -237,7 +238,7 @@ class Dynamic(base.Music21Object):
         self.style.absoluteX = -36
         self.style.absoluteY = -80  # below top line
         # this value provides good 16th note alignment
-        self.positionPlacement = None
+        self.placement = None
 
     def _reprInternal(self):
         return str(self.value)

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -322,6 +322,10 @@ class TextExpression(Expression):
     classSortOrder = -30
     _styleClass = style.TextStyle
 
+    _DOC_ATTR = {
+        'placement': "Staff placement: 'above', 'below', or None.",
+    }
+
     def __init__(self, content=None):
         super().__init__()
         # numerous properties are inherited from TextFormat
@@ -335,7 +339,7 @@ class TextExpression(Expression):
         self._enclosure = None
 
         # this does not do anything if default y is defined
-        self.positionPlacement = None
+        self.placement = None
 
     def _reprInternal(self):
         if len(self._content) >= 13:

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5003,9 +5003,9 @@ class MeasureExporter(XMLExporterBase):
         mxDirectionType = SubElement(mxDirection, 'direction-type')
         mxDirectionType.append(mxObj)
         if (m21Obj is not None
-                and hasattr(m21Obj, 'positionPlacement')
-                and m21Obj.positionPlacement is not None):
-            mxDirection.set('placement', m21Obj.positionPlacement)
+                and hasattr(m21Obj, 'placement')
+                and m21Obj.placement is not None):
+            mxDirection.set('placement', m21Obj.placement)
 
         return mxDirection
 
@@ -6603,7 +6603,7 @@ class Test(unittest.TestCase):
         c.useSymbol = False
         f = repeat.Fine()
         mm = tempo.MetronomeMark(text='Langsam')
-        mm.positionPlacement = 'above'
+        mm.placement = 'above'
         s.measure(1).storeAtEnd([c, f, mm])
 
         tree = self.getET(s)

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4777,8 +4777,7 @@ class MeasureParser(XMLParserBase):
                 d = dynamics.Dynamic(m21DynamicText)
 
                 _synchronizeIds(dyn, d)
-                _setAttributeFromAttribute(d, mxDirection,
-                                           'placement', 'positionPlacement')
+                _setAttributeFromAttribute(d, mxDirection, 'placement', 'placement')
 
                 self.insertCoreAndRef(totalOffset, staffKey, d)
                 self.setPosition(mxDir, d)
@@ -4809,8 +4808,7 @@ class MeasureParser(XMLParserBase):
         elif tag == 'metronome':
             mm = self.xmlToTempoIndication(mxDir)
             # SAX was offsetMeasureNote; bug? should be totalOffset???
-            _setAttributeFromAttribute(mm, mxDirection,
-                            'placement', 'positionPlacement')
+            _setAttributeFromAttribute(mm, mxDirection, 'placement', 'placement')
             self.insertCoreAndRef(totalOffset, staffKey, mm)
             self.setEditorial(mxDirection, mm)
 
@@ -4825,8 +4823,7 @@ class MeasureParser(XMLParserBase):
             # environLocal.printDebug(['got TextExpression object', repr(te)])
             # offset here is a combination of the current position
             # (offsetMeasureNote) and and the direction's offset
-            _setAttributeFromAttribute(textExpression, mxDirection,
-                                       'placement', 'positionPlacement')
+            _setAttributeFromAttribute(textExpression, mxDirection, 'placement', 'placement')
 
             repeatExpression = textExpression.getRepeatExpression()
             if repeatExpression is not None:
@@ -7012,7 +7009,7 @@ class Test(unittest.TestCase):
         s = converter.parse(testFiles.tabTest)
         metro = s.recurse().getElementsByClass('MetronomeMark').first()
         self.assertEqual(metro.style.absoluteY, 40)
-        self.assertEqual(metro.positionPlacement, 'above')
+        self.assertEqual(metro.placement, 'above')
 
 
 if __name__ == '__main__':

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -377,6 +377,9 @@ class MetronomeMark(TempoIndication):
     >>> tm2.number
     144
     '''
+    _DOC_ATTR = {
+        'placement': "Staff placement: 'above', 'below', or None.",
+    }
 
     def __init__(self, text=None, number=None, referent=None, parentheses=False):
         super().__init__()
@@ -398,7 +401,7 @@ class MetronomeMark(TempoIndication):
         # TODO: style??
         self.parentheses = parentheses
 
-        self.positionPlacement = None
+        self.placement = None
 
         self._referent = None  # set with property
         if referent is None:


### PR DESCRIPTION
Fixes #377 

Also, document the attribute for the first time.

cc @gesellkammer
cc @gregchapman-dev