### PR TITLE
`ElementSearch` enum for `getContextByClass` and related deprecations

### DIFF
--- a/music21/base.py
+++ b/music21/base.py
@@ -1226,8 +1226,8 @@ class Music21Object(prebase.ProtoM21Object):
         part.  This is all you need to know for most uses.  The rest of the
         docs are for advanced uses:
 
-        The methods searches both Sites as well as associated objects to find a
-        matching class. Returns None if not match is found.
+        The method searches both Sites as well as associated objects to find a
+        matching class. Returns `None` if no match is found.
 
         A reference to the caller is required to find the offset of the object
         of the caller.
@@ -1237,41 +1237,26 @@ class Music21Object(prebase.ProtoM21Object):
         need a flat representation, the caller needs to be the source Stream,
         not its Sites reference.
 
-        The `getElementMethod` is an enum value (new in v7) from
+        The `getElementMethod` is an enum value (new in v.7) from
         :class:`~music21.common.enums.ElementSearch` that selects which
         Stream method is used to get elements for searching. (The historical form
-        of specifying a string is also accepted):
+        of supplying one of the following values as a string is also supported.)
 
-        *    'getElementBefore'
-        *    'getElementAfter'
-        *    'getElementAtOrBefore' (Default)
-        *    'getElementAtOrAfter'
-        *    'all' (new in v. 7)
+        >>> from music21.common.enums import ElementSearch
+        >>> [x for x in ElementSearch]
+        [<ElementSearch.BEFORE>,
+         <ElementSearch.AFTER>,
+         <ElementSearch.AT_OR_BEFORE>,
+         <ElementSearch.AT_OR_AFTER>,
+         <ElementSearch.BEFORE_OFFSET>,
+         <ElementSearch.AFTER_OFFSET>,
+         <ElementSearch.AT_OR_BEFORE_OFFSET>,
+         <ElementSearch.AT_OR_AFTER_OFFSET>,
+         <ElementSearch.BEFORE_NOT_SELF>,
+         <ElementSearch.AFTER_NOT_SELF>,
+         <ElementSearch.ALL>]
 
         The "after" do forward contexts -- looking ahead.
-
-        A Stream might contain several elements at the same offset, leading to
-        potentially surprising results where searching "atOrBefore" does not search
-        an element that is technically the NEXT node in the tree but still at 0.0:
-
-        >>> s = stream.Stream()
-        >>> s.insert(0, clef.BassClef())
-        >>> s.next()
-        <music21.clef.BassClef>
-        >>> s.getContextByClass(clef.Clef) is None
-        True
-        >>> s.getContextByClass(clef.Clef, getElementMethod='getElementAtOrAfter')
-        <music21.clef.BassClef>
-
-        This can be remedied by explicitly searching by offsets:
-
-        >>> s.getContextByClass(clef.Clef, getElementMethod='getElementAtOrBeforeOffset')
-        <music21.clef.BassClef>
-
-        Or by not limiting the search by temporal position at all:
-
-        >>> s.getContextByClass(clef.Clef, getElementMethod='all')
-        <music21.clef.BassClef>
 
         Demonstrations of these keywords:
 
@@ -1303,6 +1288,29 @@ class Music21Object(prebase.ProtoM21Object):
 
         >>> b.next('Note')
         <music21.note.Note C>
+
+        A Stream might contain several elements at the same offset, leading to
+        potentially surprising results where searching "atOrBefore" does not search
+        an element that is technically the NEXT node in the tree but still at 0.0:
+
+        >>> s = stream.Stream()
+        >>> s.insert(0, clef.BassClef())
+        >>> s.next()
+        <music21.clef.BassClef>
+        >>> s.getContextByClass(clef.Clef) is None
+        True
+        >>> s.getContextByClass(clef.Clef, getElementMethod='getElementAtOrAfter')
+        <music21.clef.BassClef>
+
+        This can be remedied by explicitly searching by offsets:
+
+        >>> s.getContextByClass(clef.Clef, getElementMethod='getElementAtOrBeforeOffset')
+        <music21.clef.BassClef>
+
+        Or by not limiting the search by temporal position at all:
+
+        >>> s.getContextByClass(clef.Clef, getElementMethod='all')
+        <music21.clef.BassClef>
 
         Notice that if searching for a `Stream` context, the element is not
         guaranteed to be in that Stream.  This is obviously true in this case:
@@ -1347,6 +1355,13 @@ class Music21Object(prebase.ProtoM21Object):
         * changed in v.5.7 -- added followDerivation=False and made
             everything but the class keyword only
         * added in v.6 -- added priorityTargetOnly -- see contextSites for description.
+        * added in v.7 -- added getElementMethod `all` and `ElementSearch` enum.
+
+        Raises `ValueError` if `getElementMethod` is not a value in `ElementSearch`.
+
+        >>> n2.getContextByClass('TextExpression', getElementMethod='invalid')
+        Traceback (most recent call last):
+        ValueError: Invalid getElementMethod: invalid
 
         OMIT_FROM_DOCS
 

--- a/music21/base.py
+++ b/music21/base.py
@@ -1265,9 +1265,9 @@ class Music21Object(prebase.ProtoM21Object):
         >>> b.getContextByClass('Note') is b
         True
 
-        To get the previous `Note`, use `getElementMethod='getElementBefore'`
+        To get the previous `Note`, use `getElementMethod=ElementSearch.BEFORE`:
 
-        >>> a = b.getContextByClass('Note', getElementMethod='getElementBefore')
+        >>> a = b.getContextByClass('Note', getElementMethod=ElementSearch.BEFORE)
         >>> a
         <music21.note.Note A>
 
@@ -1277,21 +1277,21 @@ class Music21Object(prebase.ProtoM21Object):
         >>> b.previous('Note')
         <music21.note.Note A>
 
-        To get the following `Note` use `getElementMethod='getElementAfter'`
+        To get the following `Note` use `getElementMethod=ElementSearch.AFTER`:
 
-        >>> c = b.getContextByClass('Note', getElementMethod='getElementAfter')
+        >>> c = b.getContextByClass('Note', getElementMethod=ElementSearch.AFTER)
         >>> c
         <music21.note.Note C>
 
-        This is similar to `.next('Note')`. though again that method is a bit more
+        This is similar to `.next('Note')`, though, again, that method is a bit more
         sophisticated:
 
         >>> b.next('Note')
         <music21.note.Note C>
 
         A Stream might contain several elements at the same offset, leading to
-        potentially surprising results where searching "atOrBefore" does not search
-        an element that is technically the NEXT node in the tree but still at 0.0:
+        potentially surprising results where searching by `ElementSearch.AT_OR_BEFORE`
+        does not find an element that is technically the NEXT node but still at 0.0:
 
         >>> s = stream.Stream()
         >>> s.insert(0, clef.BassClef())
@@ -1299,17 +1299,17 @@ class Music21Object(prebase.ProtoM21Object):
         <music21.clef.BassClef>
         >>> s.getContextByClass(clef.Clef) is None
         True
-        >>> s.getContextByClass(clef.Clef, getElementMethod='getElementAtOrAfter')
+        >>> s.getContextByClass(clef.Clef, getElementMethod=ElementSearch.AT_OR_AFTER)
         <music21.clef.BassClef>
 
         This can be remedied by explicitly searching by offsets:
 
-        >>> s.getContextByClass(clef.Clef, getElementMethod='getElementAtOrBeforeOffset')
+        >>> s.getContextByClass(clef.Clef, getElementMethod=ElementSearch.AT_OR_BEFORE_OFFSET)
         <music21.clef.BassClef>
 
         Or by not limiting the search by temporal position at all:
 
-        >>> s.getContextByClass(clef.Clef, getElementMethod='all')
+        >>> s.getContextByClass(clef.Clef, getElementMethod=ElementSearch.ALL)
         <music21.clef.BassClef>
 
         Notice that if searching for a `Stream` context, the element is not

--- a/music21/base.py
+++ b/music21/base.py
@@ -1244,8 +1244,29 @@ class Music21Object(prebase.ProtoM21Object):
         *    'getElementAfter'
         *    'getElementAtOrBefore' (Default)
         *    'getElementAtOrAfter'
+        *    'all'
 
         The "after" do forward contexts -- looking ahead.
+
+        A Stream might contain several elements at the same offset, leading to
+        potentially surprising results where searching "atOrBefore" does not search
+        an element that is technically the NEXT node in the tree but still at 0.0:
+
+        >>> s = stream.Stream()
+        >>> s.insert(0, clef.BassClef())
+        >>> s.next()
+        <music21.clef.BassClef>
+        >>> s.getContextByClass(clef.Clef) is None
+        True
+        >>> s.getContextByClass(clef.Clef, getElementMethod='getElementAtOrAfter')
+        <music21.clef.BassClef>
+
+        This can be remedied by removing the offset constraint, that is, searching
+        all elements contained at some given level of the hierarchy, no matter
+        their temporal position.
+
+        >>> s.getContextByClass(clef.Clef, getElementMethod='all')
+        <music21.clef.BassClef>
 
         Demonstrations of these keywords:
 
@@ -4669,6 +4690,9 @@ class Test(unittest.TestCase):
         b = p.measure(3).notes[-1]
         c = b.getContextByClass('Note', getElementMethod='getElementAfterOffset')
         self.assertEqual(c.name, 'C')
+
+        m = p.measure(1)
+        self.assertIsNotNone(m.getContextByClass('Clef', getElementMethod='all'))
 
     def testGetContextByClassB(self):
         from music21 import stream, note, meter

--- a/music21/base.py
+++ b/music21/base.py
@@ -1477,7 +1477,7 @@ class Music21Object(prebase.ProtoM21Object):
         if className and not common.isListLike(className):
             className = (className,)
 
-        if 'At' in getElementMethod and self.isClassOrSubclass(className):
+        if 'At' in getElementMethod and not self.classSet.isdisjoint(className):
             return self
 
         for site, positionStart, searchType in self.contextSites(
@@ -1502,7 +1502,7 @@ class Music21Object(prebase.ProtoM21Object):
             if searchType != 'elementsOnly':  # flatten or elementsFirst
                 if ('After' in getElementMethod
                         and (not className
-                             or site.isClassOrSubclass(className))):
+                             or not site.classSet.isdisjoint(className))):
                     if 'NotSelf' in getElementMethod and self is site:
                         pass
                     elif 'NotSelf' not in getElementMethod:  # for 'After' we can't do the
@@ -1521,7 +1521,7 @@ class Music21Object(prebase.ProtoM21Object):
 
                 if ('Before' in getElementMethod
                         and (not className
-                             or site.isClassOrSubclass(className))):
+                             or not site.classSet.isdisjoint(className))):
                     if 'NotSelf' in getElementMethod and self is site:
                         pass
                     else:
@@ -2060,7 +2060,7 @@ class Music21Object(prebase.ProtoM21Object):
             asTree = activeS.asTree(classList=className, flatten=False)
             prevNode = asTree.getNodeBefore(self.sortTuple())
             if prevNode is None:
-                if className is None or activeS.isClassOrSubclass(className):
+                if className is None or not activeS.classSet.isdisjoint(className):
                     return activeS
                 else:
                     return None
@@ -4207,9 +4207,6 @@ class Test(unittest.TestCase):
         # we should be able to find a clef from the lower-level stream
         post = sInner.getContextByClass(clef.Clef)
         self.assertTrue(isinstance(post, clef.AltoClef), post)
-
-        post = sInner.getClefs(clef.Clef)
-        self.assertTrue(isinstance(post[0], clef.AltoClef), post[0])
 
     def testBeatAccess(self):
         '''Test getting beat data from various Music21Objects.

--- a/music21/base.py
+++ b/music21/base.py
@@ -1406,7 +1406,8 @@ class Music21Object(prebase.ProtoM21Object):
             siteTree = checkSite.asTree(flatten=flatten, classList=className)
             if getElementMethod in OFFSET_METHODS:
                 # these methods match only by offset.  Used in .getBeat among other places
-                if getElementMethod in (ElementSearch.BEFORE_OFFSET, ElementSearch.AT_OR_AFTER_OFFSET):
+                if getElementMethod in (ElementSearch.BEFORE_OFFSET,
+                                        ElementSearch.AT_OR_AFTER_OFFSET):
                     innerPositionStart = ZeroSortTupleLow.modify(offset=innerPositionStart.offset)
                 else:
                     innerPositionStart = ZeroSortTupleHigh.modify(offset=innerPositionStart.offset)

--- a/music21/common/enums.py
+++ b/music21/common/enums.py
@@ -115,6 +115,24 @@ class StrEnum(str, Enum, metaclass=StrEnumMeta):
         return str(self.value)
 
 
+class ElementSearch(StrEnum):
+    '''
+    An enum representing the element search directions that can be provided
+    to :meth:`~music21.base.Music21Object.getContextByClass`.
+    '''
+    BEFORE = 'getElementBefore'
+    AFTER = 'getElementAfter'
+    AT_OR_BEFORE = 'getElementAtOrBefore'
+    AT_OR_AFTER = 'getElementAtOrAfter'
+    BEFORE_OFFSET = 'getElementBeforeOffset'
+    AFTER_OFFSET = 'getElementAfterOffset'
+    AT_OR_BEFORE_OFFSET = 'getElementAtOrBeforeOffset'
+    AT_OR_AFTER_OFFSET = 'getElementAtOrAfterOffset'
+    BEFORE_NOT_SELF = 'getElementBeforeNotSelf'
+    AFTER_NOT_SELF = 'getElementAfterNotSelf'
+    ALL = 'all'
+
+
 class OffsetSpecial(StrEnum):
     '''
     An enum that represents special offsets.

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -2207,7 +2207,7 @@ def partitionByInstrument(streamObj):
         for sub in streamObj.getElementsByClass('Stream'):
             s.insert(0, sub.flat)
 
-    # first, lets extend the duration of each instrument to match stream
+    # first, let's extend the duration of each instrument to match stream
     for sub in s.getElementsByClass('Stream'):
         sub.extendDuration('Instrument', inPlace=True)
 

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -26,6 +26,7 @@ from typing import (
     Tuple,
 )
 
+from music21.common import deprecated
 
 class ProtoM21Object:
     '''
@@ -42,8 +43,14 @@ class ProtoM21Object:
     ('PitchCounter', 'ProtoM21Object', 'object')
     >>> PitchCounter in pc.classSet
     True
-    >>> pc.isClassOrSubclass(('music21.note.Note',))
+    >>> 'Note' in pc.classSet
     False
+
+    For a True/False intersection check against an iterable, use `classSet.isdisjoint`:
+
+    >>> classList = ('music21.note.Note', 'music21.note.Rest')
+    >>> pc.classSet.isdisjoint(classList)
+    True
     >>> repr(pc)
     '<music21.PitchCounter no pitches>'
 
@@ -82,6 +89,8 @@ class ProtoM21Object:
 
     __slots__ = ()
 
+    @deprecated('v7', 'v8', 'use `someClass in .classSet`'
+        'or for intersection: `not classSet.isdisjoint(classList)`')
     def isClassOrSubclass(self, classFilterList: Sequence) -> bool:
         '''
         Given a class filter list (a list or tuple must be submitted),
@@ -91,18 +100,21 @@ class ProtoM21Object:
         NOTE: this is a performance critical operation
         for performance, only accept lists or tuples
 
+        DEPRECATED in v7 -- prefer `someClass in el.classSet` or
+        `not el.classSet.isdisjoint(classList)` instead.
+
         >>> n = note.Note()
-        >>> n.isClassOrSubclass(('Note',))
+        >>> #_DOCS_SHOW n.isClassOrSubclass(('Note',))
         True
-        >>> n.isClassOrSubclass(('GeneralNote',))
+        >>> #_DOCS_SHOW n.isClassOrSubclass(('GeneralNote',))
         True
-        >>> n.isClassOrSubclass((note.Note,))
+        >>> #_DOCS_SHOW n.isClassOrSubclass((note.Note,))
         True
-        >>> n.isClassOrSubclass((note.Rest,))
+        >>> #_DOCS_SHOW n.isClassOrSubclass((note.Rest,))
         False
-        >>> n.isClassOrSubclass((note.Note, note.Rest))
+        >>> #_DOCS_SHOW n.isClassOrSubclass((note.Note, note.Rest))
         True
-        >>> n.isClassOrSubclass(('Rest', 'Note'))
+        >>> #_DOCS_SHOW n.isClassOrSubclass(('Rest', 'Note'))
         True
         '''
         return not self.classSet.isdisjoint(classFilterList)

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -13,7 +13,6 @@
 sites.py -- Objects for keeping track of relationships among Music21Objects
 '''
 import collections
-from music21.common.enums import ElementSearch
 import unittest
 import weakref
 from typing import Union
@@ -572,7 +571,7 @@ class Sites(common.SlottedObjectMixin):
         callerFirst=None,
         sortByCreationTime=False,
         priorityTarget=None,
-        getElementMethod=ElementSearch.AT_OR_BEFORE,
+        getElementMethod=common.enums.ElementSearch.AT_OR_BEFORE,
         memo=None
     ):
         '''

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -13,6 +13,7 @@
 sites.py -- Objects for keeping track of relationships among Music21Objects
 '''
 import collections
+from music21.common.enums import ElementSearch
 import unittest
 import weakref
 from typing import Union
@@ -571,7 +572,7 @@ class Sites(common.SlottedObjectMixin):
         callerFirst=None,
         sortByCreationTime=False,
         priorityTarget=None,
-        getElementMethod='getElementAtOrBefore',
+        getElementMethod=ElementSearch.AT_OR_BEFORE,
         memo=None
     ):
         '''

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -3753,7 +3753,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             sIterator = sIterator.getElementsByClass(classList)
         return sIterator
 
-    def getElementAtOrBefore(self, offset, classList=None):
+    def getElementAtOrBefore(self, offset, classList=None) -> Optional[base.Music21Object]:
         # noinspection PyShadowingNames
         '''
         Given an offset, find the element at this offset,
@@ -3873,7 +3873,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         else:
             return None
 
-    def getElementBeforeOffset(self, offset, classList=None):
+    def getElementBeforeOffset(self, offset, classList=None) -> Optional[base.Music21Object]:
         '''
         Get element before (and not at) a provided offset.
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -3028,9 +3028,12 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             )
             if timeSignatures:
                 sRight.keySignature = copy.deepcopy(timeSignatures[0])
-            keySignatures = sLeft.getKeySignatures(
-                searchContext=searchContext,
-            )
+            if searchContext:
+                keySignatures = sLeft.getContextByClass(key.KeySignature)
+                if keySignatures is not None:
+                    keySignatures = [keySignatures]
+            else:
+                keySignatures = sLeft.getElementsByClass(key.KeySignature)
             if keySignatures:
                 sRight.keySignature = copy.deepcopy(keySignatures[0])
             endClef = sLeft.getContextByClass('Clef')
@@ -5292,10 +5295,11 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                                    returnDefault=returnDefault)
         return post.first()
 
+    @common.deprecated('v7', 'v8', 'use getElementsByClass() or getContextByClass() or bestClef()')
     def getClefs(self, searchActiveSite=False, searchContext=True,
-                 returnDefault=True):
+                 returnDefault=True):  # pragma: no cover
         '''
-        DEPRECATED...
+        DEPRECATED in v7.
 
         Collect all :class:`~music21.clef.Clef` objects in
         this Stream in a list. Optionally search the
@@ -5309,8 +5313,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> b = clef.AltoClef()
         >>> a.insert(0, b)
         >>> a.repeatInsert(note.Note('C#'), list(range(10)))
-        >>> c = a.getClefs()
-        >>> len(c) == 1
+        >>> #_DOCS_SHOW c = a.getClefs()
+        >>> #_DOCS_SHOW len(c) == 1
         True
         '''
         # TODO: activeSite searching is not yet implemented
@@ -5335,7 +5339,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             post.insert(0, clef.bestClef(self))
         return post
 
-    def getKeySignatures(self, searchActiveSite=True, searchContext=True):
+    @common.deprecated('v7', 'v8', 'use getElementsByClass() or getContextByClass()')
+    def getKeySignatures(self, searchActiveSite=True, searchContext=True):  # pragma: no cover
         '''
         Collect all :class:`~music21.key.KeySignature` objects in this
         Stream in a new Stream. Optionally search the activeSite
@@ -5343,15 +5348,14 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         If no KeySignature objects are defined, returns an empty Stream
 
-        TO BE DEPRECATED...
-
+        DEPRECATED in v7.
 
         >>> a = stream.Stream()
         >>> b = key.KeySignature(3)
         >>> a.insert(0, b)
         >>> a.repeatInsert(note.Note('C#'), list(range(10)))
-        >>> c = a.getKeySignatures()
-        >>> len(c) == 1
+        >>> #_DOCS_SHOW c = a.getKeySignatures()
+        >>> #_DOCS_SHOW len(c) == 1
         True
         '''
         # TODO: activeSite searching is not yet implemented
@@ -5534,7 +5538,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 continue
             if endOffset is not None and self.elementOffset(e) >= endOffset:
                 continue
-            if classFilterList is not None and not e.isClassOrSubclass(classFilterList):
+            if classFilterList is not None and e.classSet.isdisjoint(classFilterList):
                 continue
 
             self.coreSetElementOffset(e, opFrac(self.elementOffset(e) + offset))
@@ -5760,6 +5764,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                             for v in offsetDictValues}
         return sorted(offsets.union(endTimes))
 
+    @common.deprecated('v7', 'v8', 'use chordify() instead')
     def makeChords(self,
                    minimumWindowSize=0.125,
                    includePostWindow=True,
@@ -5769,9 +5774,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                    gatherExpressions=True,
                    inPlace=False,
                    transferGroupsToPitches=False,
-                   makeRests=True):
+                   makeRests=True):  # pragma: no cover
         '''
-        TO BE DEPRECATED SOON!  Use Chordify instead!
+        DEPRECATED in v7.  Use Chordify instead!
 
         Gathers simultaneously sounding :class:`~music21.note.Note` objects
         into :class:`~music21.chord.Chord` objects, each of which
@@ -5800,8 +5805,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> sc1 = stream.Score()
         >>> sc1.insert(0, p1)
         >>> sc1.insert(0, p2)
-        >>> scChords = sc1.flat.makeChords()
-        >>> scChords.show('text')
+        >>> #_DOCS_SHOW scChords = sc1.flat.makeChords()
+        >>> #_DOCS_SHOW scChords.show('text')
         {0.0} <music21.chord.Chord C4 C#5 D4>
         {2.0} <music21.chord.Chord E4 E#5>
         {3.0} <music21.chord.Chord B2 E4 G5 C#7>
@@ -6617,12 +6622,17 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             addAlteredPitches = useKeySignature.alteredPitches
         elif useKeySignature is True:  # get from defined contexts
             # will search local, then activeSite
-            ksStream = self.getKeySignatures(
-                searchContext=searchKeySignatureByContext)
-            if ksStream:
+            ksIter = None
+            if searchKeySignatureByContext:
+                ks = self.getContextByClass(key.KeySignature)
+                if ks is not None:
+                    ksIter = [ks]
+            else:
+                ksIter = self.getElementsByClass(key.KeySignature)
+            if ksIter:
                 # assume we want the first found; in some cases it is possible
                 # that this may not be true
-                addAlteredPitches = ksStream[0].alteredPitches
+                addAlteredPitches = ksIter[0].alteredPitches
         alteredPitches += addAlteredPitches
         # environLocal.printDebug(['processing makeAccidentals() with alteredPitches:',
         #   alteredPitches])
@@ -6899,9 +6909,10 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         if not inPlace:
             return returnObj
 
-    def extendDurationAndGetBoundaries(self, objName, *, inPlace=False):
+    @common.deprecated('v7', 'v8', 'call extendDurations() and getElementsByClass() separately')
+    def extendDurationAndGetBoundaries(self, objName, *, inPlace=False):  # pragma: no cover
         '''
-        DEPRECATED in v.6 -- to be removed in v.7
+        DEPRECATED in v.7 -- to be removed in v.8
 
         Extend the Duration of elements specified by objName;
         then, collect a dictionary for every matched element of objName class,
@@ -6912,7 +6923,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         >>> s.insert(3, dynamics.Dynamic('mf'))
         >>> s.insert(7, dynamics.Dynamic('f'))
         >>> s.insert(12, dynamics.Dynamic('ff'))
-        >>> pp(s.extendDurationAndGetBoundaries('Dynamic'))
+        >>> #_DOCS_SHOW pp(s.extendDurationAndGetBoundaries('Dynamic'))
         {(3.0, 7.0): <music21.dynamics.Dynamic mf>,
          (7.0, 12.0): <music21.dynamics.Dynamic f>,
          (12.0, 12.0): <music21.dynamics.Dynamic ff>}

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -3011,7 +3011,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         Changed in v7. -- all but quarterLength are keyword only
         '''
-        # pylint: disable=attribute-defined-outside-init
         quarterLength = opFrac(quarterLength)
         if retainOrigin:
             sLeft = self

--- a/music21/stream/filters.py
+++ b/music21/stream/filters.py
@@ -260,7 +260,7 @@ class ClassFilter(StreamFilter):
         return True
 
     def __call__(self, item, iterator):
-        return item.isClassOrSubclass(self.classList)
+        return not item.classSet.isdisjoint(self.classList)
 
     def _reprInternal(self):
         if len(self.classList) == 1:
@@ -290,7 +290,7 @@ class ClassNotFilter(ClassFilter):
     derivationStr = 'getElementsNotOfClass'
 
     def __call__(self, item, iterator):
-        return not item.isClassOrSubclass(self.classList)
+        return item.classSet.isdisjoint(self.classList)
 
 
 class GroupFilter(StreamFilter):

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1836,11 +1836,9 @@ class Test(unittest.TestCase):
         self.assertEqual(s2.elementOffset(s1), 0.0)
         self.assertRaises(sites.SitesException, s2.elementOffset, s1.flat)
 
-        # getContextByClass will not work; the clef is in s2; its not in a context of s2
-        post = s2.getContextByClass(clef.Clef)
-        self.assertIsNone(post)
+        post = s2.getContextByClass(clef.Clef, getElementMethod='all')
+        self.assertIsInstance(post, clef.AltoClef)
 
-        # but s2.clef works...
         self.assertIsInstance(s2.clef, clef.AltoClef)
 
         # we can find the clef from the flat version of s1 also:

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1713,15 +1713,7 @@ class Test(unittest.TestCase):
         # from the lower level stream, we should be able to get to the
         # higher level clef
         post = s1.getContextByClass(clef.Clef)
-        self.assertTrue(isinstance(post, clef.AltoClef), post)
-
-        # we can also use getClefs to get this from s1 or s2
-        post = s1.getClefs()[0]
-        self.assertTrue(isinstance(post, clef.AltoClef), post)
-
-        post = s2.getClefs()[0]
-        self.assertTrue(isinstance(post, clef.AltoClef), post)
-
+        self.assertIsInstance(post, clef.AltoClef)
         # environLocal.printDebug(['sites.get() of s1', s1.sites.get()])
 
         # attempting to move the substream into a new stream
@@ -1729,19 +1721,17 @@ class Test(unittest.TestCase):
         s3.insert(s1)  # insert at same offset as s2
 
         # we cannot get the alto clef from s3; this makes sense
-        post = s3.getClefs()[0]
-        self.assertTrue(isinstance(post, clef.TrebleClef), post)
+        post = s3.getContextByClass(clef.Clef)
+        self.assertIsNone(post)  # was TrebleClef in virtue of getClefs() giving default
 
         # s1 has both streams as sites
         self.assertIn(s3, s1.sites)
         self.assertIn(s2, s1.sites)
 
-        # but if we search s1, should not it find an alto clef?
-        post = s1.getClefs()
-        # environLocal.printDebug(['should not be treble clef:', post])
-        self.assertTrue(isinstance(post[0], clef.AltoClef), post[0])
+        # if we search s1, we should find an alto clef
+        post = s1.getContextByClass(clef.Clef)
+        self.assertIsInstance(post, clef.AltoClef)
 
-        # this all works fine
         sMeasures = s2.makeMeasures(finalBarline='regular')
         self.assertEqual(len(sMeasures), 2)  # AltoClef and substream
         self.assertEqual(len(sMeasures.last().getElementsByClass('Measure')), 1)
@@ -1877,7 +1867,7 @@ class Test(unittest.TestCase):
         sOuter.insert(0, s1)
         sOuter.insert(0, s2)
 
-        self.assertEqual(s1.activeSite, sOuter)
+        self.assertIs(s1.activeSite, sOuter)
 
         ac = clef.AltoClef()
         ac.priority = -1
@@ -1885,12 +1875,12 @@ class Test(unittest.TestCase):
         # both output parts have alto clefs
         # get clef from higher level stream; only option
         self.assertIs(s1.activeSite, sOuter)
-        post = s1.getClefs()[0]
+        post = s1.getContextByClass(clef.Clef)
 
         self.assertIsInstance(post, clef.AltoClef)
         self.assertIs(s1.activeSite, sOuter)
 
-        post = s2.getClefs()[0]
+        post = s2.getContextByClass(clef.Clef)
         self.assertIsInstance(post, clef.AltoClef)
 
         # now we insert a clef in s2; s2 will get this clef first
@@ -1898,26 +1888,26 @@ class Test(unittest.TestCase):
         tenorC.priority = -1
         s2.insert(0, tenorC)
         # only second part should have tenor clef
-        post = s2.getClefs()[0]
-        self.assertIsInstance(post, clef.TenorClef)
+        post = s2.getElementsByClass(clef.Clef)
+        self.assertIsInstance(post[0], clef.TenorClef)
 
         # but stream s1 should get the alto clef still
         # print(list(s1.contextSites()))
-        post = s1.getContextByClass('Clef')
+        post = s1.getContextByClass(clef.Clef)
         # print(post)
         self.assertIsInstance(post, clef.AltoClef)
 
         # s2 flat gets the tenor clef; it was inserted in it
-        post = s2.flat.getClefs()[0]
-        self.assertIsInstance(post, clef.TenorClef)
+        post = s2.flat.getElementsByClass(clef.Clef)
+        self.assertIsInstance(post[0], clef.TenorClef)
 
         # a copy copies the clef; so we still get the same clef
         s2FlatCopy = copy.deepcopy(s2.flat)
-        post = s2FlatCopy.getClefs()[0]
-        self.assertIsInstance(post, clef.TenorClef)
+        post = s2FlatCopy.getElementsByClass(clef.Clef)
+        self.assertIsInstance(post[0], clef.TenorClef)
 
         # s1 flat will get the alto clef; it still has a pathway
-        post = s1.flat.getClefs()[0]
+        post = s1.flat.getContextByClass(clef.Clef)
         self.assertIsInstance(post, clef.AltoClef)
 
         # once we create a deepcopy of s1, it is no longer connected to
@@ -1926,11 +1916,11 @@ class Test(unittest.TestCase):
         s1Flat.id = 's1Flat'
         s1FlatCopy = copy.deepcopy(s1Flat)
         s1FlatCopy.id = 's1FlatCopy'
-        self.assertEqual(len(s1FlatCopy.getClefs(returnDefault=False)), 1)
-        post = s1FlatCopy.getClefs(returnDefault=False)[0]
+        self.assertIsNotNone(s1FlatCopy.getContextByClass(clef.Clef))
+        post = s1FlatCopy.getContextByClass(clef.Clef)
         self.assertIsInstance(post, clef.AltoClef)
 
-        post = s1Flat.getClefs()[0]
+        post = s1Flat.getContextByClass(clef.Clef)
         self.assertIsInstance(post, clef.AltoClef, post)
         # environLocal.printDebug(['s1.activeSite', s1.activeSite])
         self.assertIn(sOuter, s1.sites.get())
@@ -1966,8 +1956,8 @@ class Test(unittest.TestCase):
 
         # now we insert a clef in s2; s2 will get this clef first
         s1.insert(0, clef.BassClef())
-        post = s1.getClefs()[0]
-        self.assertIsInstance(post, clef.BassClef)
+        post = s1.getElementsByClass(clef.Clef)
+        self.assertIsInstance(post[0], clef.BassClef)
 
         # s3.show()
 
@@ -2422,7 +2412,7 @@ class Test(unittest.TestCase):
         ks2 = key.KeySignature(-2)
         s.append(ks1)
         s.append(ks2)
-        post = s.getKeySignatures()
+        post = s.getElementsByClass(key.KeySignature)
         self.assertEqual(post[0], ks1)
         self.assertEqual(post[1], ks2)
 
@@ -2445,16 +2435,16 @@ class Test(unittest.TestCase):
         s.append(m2)
 
         # can get from measure
-        post = m1.getKeySignatures()
-        self.assertEqual(post[0], ks1)
+        post = m1.getElementsByClass(key.KeySignature)
+        self.assertIs(post[0], ks1)
 
         # we can get from the Stream by flattening
-        post = s.flat.getKeySignatures()
-        self.assertEqual(post[0], ks1)
+        post = s.flat.getElementsByClass(key.KeySignature)
+        self.assertIs(post[0], ks1)
 
         # we can get the key signature in m1 from m2
-        post = m2.getKeySignatures()
-        self.assertEqual(post[0], ks1)
+        post = m2.getContextByClass(key.KeySignature)
+        self.assertIs(post, ks1)
 
     def testGetKeySignaturesThreeMeasures(self):
         '''Searching contexts for key signatures
@@ -2486,16 +2476,16 @@ class Test(unittest.TestCase):
         s.append(m3)
 
         # can get from measure
-        post = m1.getKeySignatures()
-        self.assertEqual(repr(post[0]), repr(ks1))
+        post = m1.getElementsByClass(key.KeySignature)
+        self.assertIs(post[0], ks1)
 
         # we can get the key signature in m1 from m2
-        post = m2.getKeySignatures()
-        self.assertEqual(repr(post[0]), repr(ks1))
+        post = m2.getContextByClass(key.KeySignature)
+        self.assertIs(post, ks1)
 
         # if we search m3, we get the key signature in m3
-        post = m3.getKeySignatures()
-        self.assertEqual(repr(post[0]), repr(ks3))
+        post = m3.getContextByClass(key.KeySignature)
+        self.assertIs(post, ks1)
 
     def testMakeAccidentalsA(self):
         '''Test accidental display setting
@@ -4441,9 +4431,9 @@ class Test(unittest.TestCase):
 
     def testMakeChordsBuiltA(self):
         # test with equal durations
-        pitchCol = [('A2', 'C2'),
+        pitchCol = [('C2', 'A2'),
                     ('A#1', 'C-3', 'G5'),
-                    ('D3', 'B-1', 'C4', 'D#2')]
+                    ('B-1', 'D#2', 'D3', 'C4')]
         # try with different duration assignments; should always get
         # the same results
         for durCol in [[1, 1, 1], [0.5, 2, 3], [0.25, 0.25, 0.5], [6, 6, 8]]:
@@ -4460,8 +4450,8 @@ class Test(unittest.TestCase):
             self.assertEqual(len(s.getElementsByClass('Chord')), 0)
 
             # do both in place and not in place, compare results
-            sMod = s.makeChords(inPlace=False)
-            s.makeChords(inPlace=True)
+            sMod = s.chordify()
+            s = s.chordify()
             for sEval in [s, sMod]:
                 self.assertEqual(len(sEval.getElementsByClass('Chord')), 3)
                 # make sure we have all the original pitches
@@ -4469,7 +4459,7 @@ class Test(unittest.TestCase):
                     match = [p.nameWithOctave for p in
                              sEval.getElementsByClass('Chord')[i].pitches]
                     self.assertEqual(match, list(pitchCol[i]))
-        # print('post makeChords')
+        # print('post chordify')
         # s.show('t')
         # sMod.show('t')
         # s.show()
@@ -4494,11 +4484,12 @@ class Test(unittest.TestCase):
         self.assertEqual([e.offset for e in s], [0.0, 1.0, 2.0, 3.0])
         # this results in two chords; n2 and n4 are effectively shifted
         # to the start of n1 and n3
-        sMod = s.makeChords(inPlace=False)
-        s.makeChords(inPlace=True)
+        sMod = s.chordify()
+        s = s.chordify()
         for sEval in [s, sMod]:
-            self.assertEqual(len(sEval.getElementsByClass('Chord')), 2)
-            self.assertEqual([c.offset for c in sEval], [0.0, 2.0])
+            # of these 6 chords, only 2 have more than one note
+            self.assertEqual(len(sEval.getElementsByClass('Chord')), 6)
+            self.assertEqual([c.offset for c in sEval], [0.0, 1.0, 1.5, 2.0, 3.0, 3.5])
 
         # do the same, but reverse the short/long duration relation
         # because the default min window is 0.25, the first  and last
@@ -4521,14 +4512,7 @@ class Test(unittest.TestCase):
         # s.makeRests(inPlace=True, fillGaps=True)
         # this results in two chords; n2 and n4 are effectively shifted
         # to the start of n1 and n3
-        sMod = s.makeChords(inPlace=False)
-        # sMod.show()
-        s.makeChords(inPlace=True)
-        for sEval in [s, sMod]:
-            # have three chords, even though 1 only has more than 1 pitch
-            # might change this?
-            self.assertEqual(len(sEval.getElementsByClass('Chord')), 3)
-            self.assertEqual([c.offset for c in sEval], [0.0, 0.5, 1.0, 2.5, 3.0])
+        sMod = s.chordify()
 
     def testMakeChordsBuiltC(self):
         # test removal of redundant pitches
@@ -4554,7 +4538,7 @@ class Test(unittest.TestCase):
         s1.insert(0.5, n5)
         s1.insert(0.5, n6)
 
-        sMod = s1.makeChords(inPlace=False, removeRedundantPitches=True)
+        sMod = s1.chordify(removeRedundantPitches=True)
         self.assertEqual([p.nameWithOctave for p in sMod.getElementsByClass('Chord')[0].pitches],
                           ['C2', 'G2'])
 
@@ -4562,7 +4546,7 @@ class Test(unittest.TestCase):
                           ['E4', 'F#4'])
 
         # without redundant pitch gathering
-        sMod = s1.makeChords(inPlace=False, removeRedundantPitches=False)
+        sMod = s1.chordify(removeRedundantPitches=False)
         self.assertEqual([p.nameWithOctave for p in sMod.getElementsByClass('Chord')[0].pitches],
                           ['C2', 'C2', 'G2'])
 
@@ -4596,33 +4580,11 @@ class Test(unittest.TestCase):
         s.insert([0, p2])
         s.insert([0, p3])
 
-        post = s.flat.makeChords()
+        post = s.flat.chordify()
         # post.show('t')
         self.assertEqual(len(post.getElementsByClass('Rest')), 1)
-        self.assertEqual(len(post.getElementsByClass('Chord')), 5)
+        self.assertEqual(len(post.getElementsByClass('Chord')), 6)
         # post.show()
-
-    def testMakeChordsImported(self):
-        s = corpus.parse('bach/bwv66.6')
-        # s.show()
-        # using in place to get the stored flat version
-        sMod = s.flat.makeChords(includePostWindow=False)
-        self.assertEqual(len(sMod.getElementsByClass('Chord')), 35)
-        # sMod.show()
-        self.assertEqual(
-            [len(c.pitches) for c in sMod.getElementsByClass('Chord')],
-            [3, 4, 4, 3, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 3,
-             4, 3, 4, 3, 4, 4, 4, 4, 3, 4, 4, 2, 4, 3, 4, 4])
-
-        # when we include post-window, we get more tones, per chord
-        # but the same number of chords
-        sMod = s.flat.makeChords(includePostWindow=True)
-        self.assertEqual(len(sMod.getElementsByClass('Chord')), 35)
-        self.assertEqual(
-            [len(c.pitches) for c in sMod.getElementsByClass('Chord')],
-            [6, 4, 4, 3, 4, 5, 5, 4, 4, 4, 4, 5, 4, 4, 5, 5, 5, 4, 5, 5, 3, 4, 3,
-             4, 4, 4, 7, 5, 4, 6, 2, 6, 4, 5, 4])
-        # sMod.show()
 
     def testGetElementAtOrBeforeBarline(self):
         '''
@@ -5065,7 +5027,7 @@ class Test(unittest.TestCase):
 
         s = copy.deepcopy(sSrc)
         s.sliceByGreatestDivisor(inPlace=True, addTies=True)
-        # s.flat.makeChords().show()
+        # s.flat.chordify().show()
         # s.show()
 
     def testSliceAtOffsetsSimple(self):
@@ -5226,26 +5188,26 @@ class Test(unittest.TestCase):
         score.insert(0, p2)
         # parts retain their characteristics
         # rests are recast
-        scoreChords = score.makeChords()
-        # scoreChords.show()
+        p1Chords = score.parts[0].chordify()
+        p2Chords = score.parts[1].chordify()
 
-        self.assertEqual(len(scoreChords.parts[0].flat), 5)
-        self.assertEqual(len(scoreChords.parts[0].flat.getElementsByClass(
+        self.assertEqual(len(p1Chords.flat), 5)
+        self.assertEqual(len(p1Chords.flat.getElementsByClass(
             'Chord')), 3)
-        self.assertEqual(len(scoreChords.parts[0].flat.getElementsByClass(
+        self.assertEqual(len(p1Chords.flat.getElementsByClass(
             'Rest')), 2)
 
-        self.assertEqual(len(scoreChords.parts[1].flat), 6)
-        self.assertEqual(len(scoreChords.parts[1].flat.getElementsByClass(
+        self.assertEqual(len(p2Chords.flat), 6)
+        self.assertEqual(len(p2Chords.flat.getElementsByClass(
             'Chord')), 3)
-        self.assertEqual(len(scoreChords.parts[1].flat.getElementsByClass(
+        self.assertEqual(len(p2Chords.flat.getElementsByClass(
             'Rest')), 3)
 
         # calling this on a flattened version
         scoreFlat = score.flat
-        scoreChords = scoreFlat.makeChords()
+        scoreChords = scoreFlat.chordify()
         self.assertEqual(len(scoreChords.flat.getElementsByClass(
-            'Chord')), 3)
+            'Chord')), 4)  # fourth chord actually comprises only one note!
         self.assertEqual(len(scoreChords.flat.getElementsByClass(
             'Rest')), 2)
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1807,6 +1807,7 @@ class Test(unittest.TestCase):
         '''Testing getting clefs from higher-level streams
         '''
         from music21 import sites
+        from music21.common.enums import ElementSearch
 
         s1 = Stream(id='s1')
         n1 = note.Note()
@@ -1836,7 +1837,7 @@ class Test(unittest.TestCase):
         self.assertEqual(s2.elementOffset(s1), 0.0)
         self.assertRaises(sites.SitesException, s2.elementOffset, s1.flat)
 
-        post = s2.getContextByClass(clef.Clef, getElementMethod='all')
+        post = s2.getContextByClass(clef.Clef, getElementMethod=ElementSearch.ALL)
         self.assertIsInstance(post, clef.AltoClef)
 
         self.assertIsInstance(s2.clef, clef.AltoClef)

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -168,7 +168,7 @@ class TempoIndication(base.Music21Object):
         # search for TempoIndication objects, not just MetronomeMark objects
         # must provide getElementBefore, as will otherwise return self
         obj = self.getContextByClass('TempoIndication',
-                                     getElementMethod='getElementBeforeOffset')
+                                     getElementMethod=common.enums.ElementSearch.BEFORE_OFFSET)
         if obj is None:
             return None  # nothing to do
         return self.getSoundingMetronomeMark(obj)

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -33,7 +33,7 @@ def listOfTreesByClass(inputStream,
     encountered substream and PitchedTimespan for each encountered non-stream
     element.
 
-    `classLists` should be a sequence of valid inputs for `isClassOrSubclass()`. One
+    `classLists` should be a sequence of elements contained in `classSet`. One
     TimespanTree will be constructed for each element in `classLists`, in
     a single optimized pass through the `inputStream`.
 
@@ -118,7 +118,7 @@ def listOfTreesByClass(inputStream,
             endTime = offset + element.duration.quarterLength
 
             for classBasedTree, classList in zip(outputTrees, classLists):
-                if classList and not element.isClassOrSubclass(classList):
+                if classList and element.classSet.isdisjoint(classList):
                     continue
                 if useTimespans:
                     if hasattr(element, 'pitches') and 'music21.key.Key' not in element.classSet:
@@ -213,7 +213,7 @@ def asTree(inputStream, flatten=False, classList=None, useTimespans=False, group
                 if flatten != 'semiFlat':
                     continue  # do not insert the stream itself unless we are doing semiflat
 
-            if classList and not element.isClassOrSubclass(classList):
+            if classList and element.classSet.isdisjoint(classList):
                 continue
 
             endTime = flatOffset + element.duration.quarterLength
@@ -262,7 +262,7 @@ def asTree(inputStream, flatten=False, classList=None, useTimespans=False, group
             elementTupleList = [(e.sortTuple(inputStream), e) for e in inputStreamElements]
         else:
             elementTupleList = [(e.sortTuple(inputStream), e) for e in inputStreamElements
-                                    if e.isClassOrSubclass(classList)]
+                                    if not e.classSet.isdisjoint(classList)]
         outputTree.populateFromSortedList(elementTupleList)
         if outputTree.rootNode is not None:
             outputTree.rootNode.updateEndTimes()

--- a/music21/tree/timespanTree.py
+++ b/music21/tree/timespanTree.py
@@ -112,11 +112,8 @@ class TimespanTree(trees.OffsetTree):
     ...             scoreTree.insert(merged)
 
 
-    >>> newBach = tree.toStream.partwise(
-    ...     scoreTree,
-    ...     templateStream=bach,
-    ...     )
-    >>> newBach.parts['Alto'].measure(7).show('text')
+    >>> #_DOCS_SHOW newBach = tree.toStream.partwise(scoreTree, templateStream=bach)
+    >>> #_DOCS_SHOW newBach.parts['Alto'].measure(7).show('text')
     {0.0} <music21.chord.Chord F#4>
     {1.5} <music21.chord.Chord F#3>
     {2.0} <music21.chord.Chord C#4>

--- a/music21/tree/toStream.py
+++ b/music21/tree/toStream.py
@@ -15,11 +15,13 @@ Tools for generating new Streams from trees (fast, manipulable objects)
 
 None of these things work acceptably yet.  This is super beta.
 '''
+from music21 import common
 from music21.exceptions21 import TreeException
 from music21.tree import timespanTree
 
 
-def chordified(timespans, templateStream=None):
+@common.deprecated('v7', 'v8', 'use chordify() instead')
+def chordified(timespans, templateStream=None):  # pragma: no cover
     r'''
     DEPRECATED -- DO NOT USE.  Use stream.chordify() instead.
 
@@ -31,9 +33,8 @@ def chordified(timespans, templateStream=None):
 
     >>> score = corpus.parse('bwv66.6')
     >>> scoreTree = score.asTimespans()
-    >>> chordifiedScore = tree.toStream.chordified(
-    ...     scoreTree, templateStream=score)
-    >>> chordifiedScore.show('text')
+    >>> #_DOCS_SHOW chordifiedScore = tree.toStream.chordified(scoreTree, templateStream=score)
+    >>> #_DOCS_SHOW chordifiedScore.show('text')
     {0.0} <music21.instrument.Instrument 'P1: Soprano: Instrument 1'>
     {0.0} <music21.stream.Measure 0 offset=0.0>
         {0.0} <music21.clef.TrebleClef>
@@ -115,10 +116,10 @@ def chordified(timespans, templateStream=None):
             outputStream.append(element)
         return outputStream
 
-
-def partwise(tsTree, templateStream=None):
+@common.deprecated('v7', 'v8', 'use chordify() instead')
+def partwise(tsTree, templateStream=None):  # pragma: no cover
     '''
-    todo docs
+    DEPRECATED in v7 -- use chordify()
     '''
     from music21 import stream
     treeMapping = tsTree.toPartwiseTimespanTrees()

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -1558,7 +1558,7 @@ class Verticality(base.Music21Object):
             if classFilterList == [None]:
                 retList.append(el)
             else:
-                if el.isClassOrSubclass(classFilterList):
+                if not el.classSet.isdisjoint(classFilterList):
                     retList.append(el)
         if len(retList) > 1:
             return retList
@@ -1591,7 +1591,7 @@ class Verticality(base.Music21Object):
         for part, objList in self.contentDict.items():
             for m21object in objList:
 
-                if m21object is None or not m21object.isClassOrSubclass(classFilterList):
+                if m21object is None or m21object.classSet.isdisjoint(classFilterList):
                     continue
                 else:
                     if partNums and part not in partNums:
@@ -1884,7 +1884,7 @@ class NNoteLinearSegment(base.Music21Object):
                 self._noteList.append(note.Note(value))
             else:
                 try:
-                    if value.isClassOrSubclass([note.Note, pitch.Pitch]):
+                    if not value.classSet.isdisjoint([note.Note, pitch.Pitch]):
                         self._noteList.append(value)
                 except (AttributeError, NameError):
                     self._noteList.append(None)
@@ -2017,7 +2017,7 @@ class ThreeNoteLinearSegment(NNoteLinearSegment):
             return note.Note(value)
         else:
             try:
-                if value.isClassOrSubclass([note.Note, pitch.Pitch]):
+                if not value.classSet.isdisjoint([note.Note, pitch.Pitch]):
                     return value
                 else:
                     return None
@@ -2078,7 +2078,8 @@ class ThreeNoteLinearSegment(NNoteLinearSegment):
     def _reprInternal(self):
         return f'n1={self.n1} n2={self.n2} n3={self.n3}'
 
-    def color(self, color='red', noteList=(2,)):
+    @common.deprecated('v7', 'v8', 'assign colors to n1.style.color (etc.) directly')
+    def color(self, color='red', noteList=(2,)):  # pragma: no cover
         '''
         color all the notes in noteList (1, 2, 3). Default is to color
         only the second note red
@@ -2299,7 +2300,7 @@ class NChordLinearSegment(NObjectLinearSegment):
                 self._chordList.append(None)
             else:
                 try:
-                    if value.isClassOrSubclass(['Chord', 'Harmony']):
+                    if not value.classSet.isdisjoint(['Chord', 'Harmony']):
                         self._chordList.append(value)
                     # else:
                         # raise NChordLinearSegmentException(

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -456,7 +456,12 @@ def realizeVolume(srcStream,
     if dynamicsAvailable:
         # extend durations of all dynamics
         # doing this in place as this is a destructive operation
-        boundaries = flatSrc.extendDurationAndGetBoundaries('Dynamic')
+        flatSrc.extendDuration('Dynamic', inPlace=True)
+        elements = flatSrc.getElementsByClass('Dynamic')
+        for e in elements:
+            start = flatSrc.elementOffset(e)
+            end = start + e.duration.quarterLength
+            boundaries[(start, end)] = e
         bKeys = list(boundaries.keys())
         bKeys.sort()  # sort
 


### PR DESCRIPTION
Fixes #1028 with documentation changes.

Adds `ElementSearch` enum and cleanup for `getContextByClass()`.

Various v. 7 deprecations per release notes in v.6.7.0:
 - `getClefs()`
 - `getKeySignatures()`
 - `makeChords()`
 - `extendDurationsAndGetBoundaries()`
 - `tree.toStream.chordified()`
 - `tree.toStream.partwise()`
 - `VoiceLeading.color`
 - `isClassOrSubclass()`