### PR TITLE
Handle more expressionIsInferred toggling on Durations

### DIFF
--- a/music21/duration.py
+++ b/music21/duration.py
@@ -2593,7 +2593,8 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         for i, dt in enumerate(self._components):
             self._components[i] = durationTupleFromTypeDots(dt.type, value)
         self._quarterLengthNeedsUpdating = True
-        self.expressionIsInferred = False
+        if self.linked is True:
+            self.expressionIsInferred = False
         self.informClient()
 
     @property
@@ -2787,7 +2788,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         return self._qtrLength
 
     def _setQuarterLength(self, value: OffsetQLIn):
-        self.expressionIsInferred = True
         if self.linked is False:
             self._qtrLength = value
         elif (self._qtrLength != value
@@ -2797,6 +2797,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             if value == 0.0 and self.linked is True:
                 self.clear()
             self._qtrLength = value
+            self.expressionIsInferred = True
             self._componentsNeedUpdating = True
             self._quarterLengthNeedsUpdating = False
 
@@ -3681,13 +3682,17 @@ class Test(unittest.TestCase):
         d.dots = 1
         self.assertEqual(d.expressionIsInferred, False)
 
-        d.linked = False
-        d.quarterLength = 4
-        self.assertEqual(d.expressionIsInferred, True)
-
         d.appendTuplet(Tuplet(3, 2))
         # No change
-        self.assertEqual(d.expressionIsInferred, True)
+        self.assertEqual(d.expressionIsInferred, False)
+
+        d.linked = False
+        d.quarterLength = 4
+        d.dots = 1
+        # No change, since this relationship between type
+        # and quarterLength is usually accomplished in multiple
+        # attribute assignments that could occur in any order
+        self.assertEqual(d.expressionIsInferred, False)
 
 
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
#908 didn't handle toggling `.expressionIsInferred` back to False when setting type/dots after construction.

No change when setting tuplets, since part of the point is that for numeric durations such as 4/3, they still bear .expressionIsInferred = True even when expressed with tuplets.

While here, I noticed that the attribute should likely be set True when setting numeric qL on unlinked durations, not just on linked durations.