### PR TITLE
Avoid gaps that don't fit quantization scheme

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (7, 0, 7, 'b1')  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (7, 0, 8)  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'7.0.7b1'
+'7.0.8'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1978,5 +1978,3 @@ if __name__ == '__main__':
     # sys.arg test options will be used in mainTest()
     import music21
     music21.mainTest(Test)  # , runTest='testConverterFromPath')
-
-

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9071,7 +9071,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                             and not e.duration.isGrace):
                         e.quarterLength = 1 / max(quarterLengthDivisors)
                         if hasattr(e, 'editorial'):
-                            e.editorial.quarterLengthQuantizationError = 0 - e.quarterLength
+                            e.editorial.quarterLengthQuantizationError = ql - e.quarterLength
                     elif d_matchTuple.match == 0 and 'Rest' in e.classes:
                         rests_lacking_durations.append(e)
                     else:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -71,7 +71,8 @@ environLocal = environment.Environment('stream')
 StreamException = exceptions21.StreamException
 ImmutableStreamException = exceptions21.ImmutableStreamException
 
-BestQuantizationMatch = namedtuple('BestQuantizationMatch', ['error', 'match', 'signedError', 'divisor'])
+BestQuantizationMatch = namedtuple('BestQuantizationMatch',
+    ['error', 'match', 'signedError', 'divisor'])
 
 class StreamDeprecationWarning(UserWarning):
     # Do not subclass Deprecation warning, because these
@@ -9061,10 +9062,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                         look_ahead_result = bestMatch(float(next_offset), quarterLengthDivisors)
                         next_offset = look_ahead_result.match
                         next_divisor = look_ahead_result.divisor
-                        if (0
-                            < next_offset - (e.offset + matchTuple.match)
-                            < 1 / max(quarterLengthDivisors)
-                        ):
+                        if (0 < next_offset - (e.offset + matchTuple.match)
+                                < 1 / max(quarterLengthDivisors)):
                             # Overwrite the earlier matchTuple with a better result
                             matchTuple = bestMatch(float(ql), (next_divisor,))
                     # Enforce nonzero duration for non-grace notes

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -72,7 +72,7 @@ StreamException = exceptions21.StreamException
 ImmutableStreamException = exceptions21.ImmutableStreamException
 
 BestQuantizationMatch = namedtuple('BestQuantizationMatch',
-    ['error', 'match', 'signedError', 'divisor'])
+    ['error', 'tick', 'match', 'signedError', 'divisor'])
 
 class StreamDeprecationWarning(UserWarning):
     # Do not subclass Deprecation warning, because these
@@ -9016,8 +9016,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             found = []
             for div in divisors:
                 match, error, signedErrorInner = common.nearestMultiple(target, (1 / div))
-                # reverse match, error for sorting
-                found.append(BestQuantizationMatch(error, match, signedErrorInner, div))
+                # Sort by unsigned error, then "tick" (divisor expressed as QL, e.g. 0.25)
+                found.append(BestQuantizationMatch(error, 1 / div, match, signedErrorInner, div))
             # get first, and leave out the error
             bestMatchTuple = sorted(found)[0]
             return bestMatchTuple

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -3817,16 +3817,25 @@ class Test(unittest.TestCase):
 
     def testQuantizeMinimumDuration(self):
         '''
-        Notes of nonzero duration should retain a nonzero
-        duration after quantizing.
+        Notes (not rests!) of nonzero duration should retain a nonzero
+        duration after quantizing. Zero duration rests should be removed.
         '''
         from music21 import converter
 
         dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
         fp = dirLib / 'test15.mid'  # 3 16ths, 2 32nds
         s = converter.parse(fp, quarterLengthDivisors=[2])
-        self.assertEqual(s.flat.notes[-1].duration.quarterLength, 0.5)
-        self.assertEqual(s.flat.notes[-1].editorial.quarterLengthQuantizationError, .125 - .5)
+        last_note = s.flat.notes[-1]
+        self.assertEqual(last_note.duration.quarterLength, 0.5)
+        self.assertEqual(last_note.editorial.quarterLengthQuantizationError, .125 - .5)
+
+        # build up the same score from scratch and show
+        # minimum duration constraint does not apply to rests
+        s2 = Stream()
+        s2.repeatAppend(note.Note(type='16th'), 3)
+        s2.repeatAppend(note.Rest(type='32nd'), 2)
+        s2.quantize(inPlace=True, quarterLengthDivisors=[2])
+        self.assertEqual(len(s2.notesAndRests), 3)
 
     def testAnalyze(self):
 


### PR DESCRIPTION
Fixes #811

Avoid gaps that don't fit quantization scheme (1/6 QL rests, etc.) by looking ahead to see the divisor that will be used to quantize the subsequent offset.

***

Example file: https://github.com/cuthbertLab/music21/blob/master/music21/midi/testPrimitive/test01.mid

**Finale (reference)**
![Screen Shot 2021-07-14 at 12 49 42 PM](https://user-images.githubusercontent.com/38668450/125661180-f9e48679-405b-466b-8e1b-7268b1f88893.png)


**m21 roundtrip Before**
![Screen Shot 2021-07-14 at 12 48 01 PM](https://user-images.githubusercontent.com/38668450/125660994-8fa875aa-0532-4267-9cfc-98e83910e6be.png)

**m21 roundtrip After**

![Screen Shot 2021-07-14 at 12 47 52 PM](https://user-images.githubusercontent.com/38668450/125660983-5fa649b3-cc02-4c37-be1c-d634f9b68f29.png)
