### PR TITLE
Do not import pygame/pyaudio until needed

### DIFF
--- a/music21/audioSearch/recording.py
+++ b/music21/audioSearch/recording.py
@@ -20,6 +20,7 @@ users of 64-bit windows but 32-bit python should download the win32 port
 
 users of 64-bit windows and 64-bit python should download the amd64 port
 '''
+from importlib.util import find_spec
 import unittest
 import wave
 
@@ -111,14 +112,16 @@ class Test(unittest.TestCase):
     pass
 
 
-class TestExternal(unittest.TestCase):  # pragma: no cover
-    try:
-        import pygame
-        pygame_installed = True
-    except ImportError:
-        pygame_installed = False
 
-    @unittest.skipUnless(pygame_installed, 'pygame must be installed')
+
+class TestExternal(unittest.TestCase):  # pragma: no cover
+    loader = find_spec('pyaudio')
+    if loader is not None:  # pragma: no cover
+        pyaudio_installed = True
+    else:
+        pyaudio_installed = False
+
+    @unittest.skipUnless(pyaudio_installed, 'pyaudio must be installed')
     def testRecording(self):
         '''
         record one second of data and print 10 records

--- a/music21/midi/realtime.py
+++ b/music21/midi/realtime.py
@@ -22,6 +22,7 @@ how-can-i-produce-real-time-audio-output-from-music-made-with-music21
 
 Requires pygame: http://www.pygame.org/download.shtml
 '''
+from importlib.util import find_spec
 import unittest
 from io import BytesIO
 
@@ -178,10 +179,10 @@ class Test(unittest.TestCase):
 
 
 class TestExternal(unittest.TestCase):  # pragma: no cover
-    try:
-        import pygame
+    loader = find_spec('pygame')
+    if loader is not None:  # pragma: no cover
         pygame_installed = True
-    except (ModuleNotFoundError, ImportError):
+    else:
         pygame_installed = False
 
     @unittest.skipUnless(pygame_installed, 'pygame is not installed')


### PR DESCRIPTION
A recent change to run TestExternal had the drawback that it imported pygame and pyaudio every time music21 was started (if it was installed), adding half a second to music21 start. 

All parts of a Class definition that are not in a `def` are run on music21 startup.  Therefore setup commands, etc. for test modules / rarely run modules need to be fast, or music21 startup will slow to a crawl.  (hence lazy importing of matplotlib, etc.)