### PR TITLE
Return UnpitchedPercussion instance when MIDI instrument lookup fails on channel 10

### DIFF
--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -765,11 +765,13 @@ def midiEventsToInstrument(eventList):
             i = instrument.fromString(decoded)
         elif event.channel == 10:
             pm = percussion.PercussionMapper()
+            # PercussionMapper.midiPitchToInstrument() is 1-indexed
             i = pm.midiPitchToInstrument(event.data + 1)
+            i.midiProgram = event.data
         else:
             i = instrument.instrumentFromMidiProgram(event.data)
-        # Instrument.midiProgram and event.data are both 0-indexed
-        i.midiProgram = event.data
+            # Instrument.midiProgram and event.data are both 0-indexed
+            i.midiProgram = event.data
     except UnicodeDecodeError:
         warnings.warn(
             f'Unable to determine instrument from {event}; getting generic Instrument',


### PR DESCRIPTION
The basic idea is that we should create a better fallback instrument when we have bad MIDI data on channel 10, because this information is starting to be used to create and manage `note.Unpitched` instances.

And a side benefit: reduce indentation