### PR TITLE
Prefer "isinstance" to "in x.classes"

### DIFF
--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -695,7 +695,8 @@ class Test(unittest.TestCase):
         self.assertEqual(sharps, 7, 'C# key signature should be parsed as 7 sharps')
 
     def testAbc21(self):
-        from music21 import abcFormat, note
+        from music21 import abcFormat
+        from music21 import note
         from music21.abcFormat import translate
 
         af = abcFormat.ABCFile(abcVersion=(2, 1, 0))
@@ -727,7 +728,8 @@ class Test(unittest.TestCase):
         # self.assertEqual(notes[6].pitch.midi, 69, 'Tied-over sharp persists past the tie')
 
     def testAbc21DirectiveCarryPitch(self):
-        from music21 import abcFormat, note
+        from music21 import abcFormat
+        from music21 import note
         from music21.abcFormat import translate
 
         af = abcFormat.ABCFile()
@@ -757,7 +759,8 @@ class Test(unittest.TestCase):
         self.assertEqual(notes[12].pitch.midi, 72, 'Natural is ignored')
 
     def testAbc21DirectiveCarryOctave(self):
-        from music21 import abcFormat, note
+        from music21 import abcFormat
+        from music21 import note
         from music21.abcFormat import translate
 
         af = abcFormat.ABCFile()
@@ -787,7 +790,8 @@ class Test(unittest.TestCase):
         self.assertEqual(notes[12].pitch.midi, 72, 'Natural is ignored')
 
     def testAbc21DirectiveCarryNot(self):
-        from music21 import abcFormat, note
+        from music21 import abcFormat
+        from music21 import note
         from music21.abcFormat import translate
 
         af = abcFormat.ABCFile()
@@ -820,7 +824,8 @@ class Test(unittest.TestCase):
         '''
         Translation of ABC Chord variations
         '''
-        from music21 import abcFormat, chord
+        from music21 import abcFormat
+        from music21 import chord
         from music21.abcFormat import translate
 
         af = abcFormat.ABCFile()
@@ -868,7 +873,8 @@ class Test(unittest.TestCase):
 
     def testAbc21ChordSymbol(self):
         # Test the chord symbol for note and chord
-        from music21 import abcFormat, harmony
+        from music21 import abcFormat
+        from music21 import harmony
         from music21.abcFormat import translate
 
         # default length of this test
@@ -886,7 +892,8 @@ class Test(unittest.TestCase):
 
     def testAbc21BrokenRhythm(self):
         # Test the chord symbol for note and chord
-        from music21 import abcFormat, note
+        from music21 import abcFormat
+        from music21 import note
         from music21.abcFormat import translate
 
         # default length of this test

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -832,7 +832,8 @@ class Test(unittest.TestCase):
         # sMerged.show()
 
     def testChordSymbols(self):
-        from music21 import corpus, pitch
+        from music21 import corpus
+        from music21 import pitch
         # noinspection SpellCheckingInspection
         o = corpus.parse('nottingham-dataset/reelsa-c')
         self.assertEqual(len(o), 2)

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -170,7 +170,7 @@ def abcToStreamPart(abcHandler, inputM21=None, spannerBundle=None):
 
         # append measure to part; in the case of trailing meta data
         # dst may be part, even though useMeasures is True
-        if useMeasures and 'Measure' in dst.classes:
+        if useMeasures and isinstance(dst, stream.Measure):
             # check for incomplete bars
             # must have a time signature in this bar, or defined recently
             # could use getTimeSignatures() on Stream

--- a/music21/alpha/analysis/search.py
+++ b/music21/alpha/analysis/search.py
@@ -250,8 +250,6 @@ def findConsecutiveScale(source, targetScale, degreesRequired=5,
 class Test(unittest.TestCase):
 
     def testFindConsecutiveScaleA(self):
-        from music21 import note
-
         sc = scale.MajorScale('a4')
 
         # fixed collection

--- a/music21/alpha/analysis/search.py
+++ b/music21/alpha/analysis/search.py
@@ -13,6 +13,9 @@ import unittest
 
 from music21 import exceptions21
 
+from music21 import chord
+from music21 import note
+from music21 import pitch
 from music21 import scale
 from music21 import stream
 
@@ -76,13 +79,13 @@ def findConsecutiveScale(source, targetScale, degreesRequired=5,
     # strip them out of a copy of the source
     sourceClean = stream.Stream()
     for e in source:
-        if 'Chord' in e.classes:
+        if isinstance(e, chord.Chord):
             continue  # do not insert for now
-        if 'Rest' in e.classes and restsAllowed:
+        if isinstance(e, note.Rest) and restsAllowed:
             continue  # do not insert if allowed
 
         # just takes notes or pitches
-        if 'Note' in e.classes or 'Pitch' in e.classes:
+        if isinstance(e, (pitch.Pitch, note.Note)):
             sourceClean.insert(source.elementOffset(e), e)
 
     # not taking flat

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -1462,7 +1462,8 @@ class Test(unittest.TestCase):
         # print(post)
 
     def testIntervalDiversity(self):
-        from music21 import note, stream, corpus
+        from music21 import stream
+        from music21 import corpus
 
         s = stream.Stream()
         s.append(note.Note('g#3'))
@@ -1515,7 +1516,7 @@ class Test(unittest.TestCase):
         self.assertEqual(str(midDict['m2']), '[<music21.interval.Interval m2>, 43]')
 
     def testKeyAnalysisSpelling(self):
-        from music21 import stream, note
+        from music21 import stream
 
         for p in ['A', 'B-', 'A-']:
             s = stream.Stream()
@@ -1560,7 +1561,7 @@ class Test(unittest.TestCase):
         self.assertEqual(str(post[1]), 'minor')
 
     def testKeyAnalysisLikelyKeys(self):
-        from music21 import note, stream
+        from music21 import stream
         s = stream.Stream()
         s.repeatAppend(note.Note('c'), 6)
         s.repeatAppend(note.Note('g'), 4)

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -30,9 +30,12 @@ from typing import Union, List, Any, Tuple, Iterable, Optional
 from collections import OrderedDict
 from music21 import exceptions21
 
-from music21 import pitch
+from music21 import chord
+from music21 import harmony
 from music21 import interval
+from music21 import note
 from music21 import key
+from music21 import pitch
 
 
 from music21 import environment
@@ -1049,13 +1052,13 @@ class Ambitus(DiscreteAnalysis):
         for n in justNotes:
             # environLocal.printDebug([n])
             pitches = []
-            if 'Chord' in n.classes and 'ChordSymbol' not in n.classes:
+            if isinstance(n, chord.Chord) and not isinstance(n, harmony.ChordSymbol):
                 pitches = n.pitches
-            elif 'Note' in n.classes:
+            elif isinstance(n, note.Note):
                 pitches = [n.pitch]
             psFound += [p.ps for p in pitches]
             pitchesFound.extend(pitches)
-        # in some cases there is stil nothing -- perhaps only ChordSymbols
+        # in some cases there is still nothing -- perhaps only ChordSymbols
         if not psFound:
             return None
         # use built-in functions

--- a/music21/analysis/metrical.py
+++ b/music21/analysis/metrical.py
@@ -166,7 +166,8 @@ class TestExternal(unittest.TestCase):
     def testSingle(self):
         '''Need to test direct meter creation w/o stream
         '''
-        from music21 import note, meter
+        from music21 import note
+        from music21 import meter
         s = stream.Stream()
         ts = meter.TimeSignature('4/4')
 

--- a/music21/analysis/reduceChords.py
+++ b/music21/analysis/reduceChords.py
@@ -72,7 +72,7 @@ class ChordReducer:
             closedPosition=False,
             forbiddenChords=None,
             maximumNumberOfChords=3):
-        if 'Score' not in inputScore.classes:
+        if not isinstance(inputScore, stream.Score):
             raise ChordReducerException("Must be called on a stream.Score")
 
         if allowableChords is not None:

--- a/music21/analysis/reduceChordsOld.py
+++ b/music21/analysis/reduceChordsOld.py
@@ -14,13 +14,11 @@ Automatically reduce a MeasureStack to a single chord or group of chords.
 import unittest
 import copy
 
+from music21 import chord
 from music21 import clef
 from music21 import meter
 from music21 import stream
 from music21 import tie
-
-
-
 
 def testMeasureStream1():
     '''
@@ -33,7 +31,6 @@ def testMeasureStream1():
     {2.0} <music21.chord.Chord C4 E4 F4 B4>
     {3.0} <music21.chord.Chord C4 E4 G4 C5>
     '''
-    from music21 import chord
     s = stream.Measure()
     t = meter.TimeSignature('4/4')
     c1 = chord.Chord('C4 E4 G4 C5')
@@ -328,7 +325,6 @@ class ChordReducer:
 class Test(unittest.TestCase):
 
     def testSimpleMeasure(self):
-        from music21 import chord
         s = stream.Measure()
         c1 = chord.Chord('C4 E4 G4 C5')
         c1.quarterLength = 2.0

--- a/music21/analysis/reduceChordsOld.py
+++ b/music21/analysis/reduceChordsOld.py
@@ -363,7 +363,8 @@ class TestExternal(unittest.TestCase):
         # cr.printDebug = True
         p = cr.multiPartReduction(c, maxChords=3)
         # p = cr.multiPartReduction(c, closedPosition=True)
-        from music21 import key, roman
+        from music21 import key
+        from music21 import roman
         cm = key.Key('G')
         for thisChord in p.recurse().getElementsByClass('Chord'):
             thisChord.lyric = roman.romanNumeralFromChord(thisChord,

--- a/music21/analysis/reduceChordsOld.py
+++ b/music21/analysis/reduceChordsOld.py
@@ -278,7 +278,7 @@ class ChordReducer:
         cLastEnd = 0.0
         for cEl in newPart:
             cElCopy = copy.deepcopy(cEl)
-            if 'Chord' in cEl.classes and closedPosition is not False:
+            if isinstance(cEl, chord.Chord) and closedPosition is not False:
                 if forceOctave is not False:
                     cElCopy.closedPosition(forceOctave=forceOctave, inPlace=True)
                 else:

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -21,6 +21,7 @@ import copy
 
 from music21 import exceptions21
 
+from music21 import chord
 from music21 import clef
 from music21 import common
 from music21 import expressions
@@ -989,12 +990,12 @@ class Test(unittest.TestCase):
 
         src = corpus.parse('schoenberg/opus19', 6)
         for n in src.flat.notes:
-            if 'Note' in n.classes:
+            if isinstance(n, note.Note):
                 if n.pitch.name == 'F#':
                     n.addLyric('::/p:f#/o:4')
         #                 if n.pitch.name == 'C':
         #                     n.addLyric('::/p:c/o:4/g:C')
-            elif 'Chord' in n.classes:
+            elif isinstance(n, chord.Chord):
                 if 'F#' in [p.name for p in n.pitches]:
                     n.addLyric('::/p:f#/o:4')
         #                 if 'C' in [p.name for p in n.pitches]:
@@ -1012,12 +1013,12 @@ class Test(unittest.TestCase):
 
         src = corpus.parse('schoenberg/opus19', 6)
         for n in src.flat.notes:
-            if 'Note' in n.classes:
+            if isinstance(n, note.Note):
                 if n.pitch.name == 'F#':
                     n.addLyric('::/p:f#/o:4/g:F#')
                 if n.pitch.name == 'C':
                     n.addLyric('::/p:c/o:4/g:C')
-            elif 'Chord' in n.classes:
+            elif isinstance(n, chord.Chord):
                 if 'F#' in [p.name for p in n.pitches]:
                     n.addLyric('::/p:f#/o:4/g:F#')
                 if 'C' in [p.name for p in n.pitches]:

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -892,7 +892,8 @@ class PartReduction:
 class Test(unittest.TestCase):
 
     def testExtractionA(self):
-        from music21 import analysis, corpus
+        from music21 import analysis
+        from music21 import corpus
         s = corpus.parse('bwv66.6')
         # s.show()
         s.parts[0].flat.notes[3].addLyric('test')
@@ -930,7 +931,8 @@ class Test(unittest.TestCase):
 
 
     def testExtractionB(self):
-        from music21 import analysis, corpus
+        from music21 import analysis
+        from music21 import corpus
         s = corpus.parse('bwv66.6')
 
         s.parts[0].flat.notes[4].addLyric('::/o:6/v:1/tb:s/g:Ursatz')
@@ -951,7 +953,8 @@ class Test(unittest.TestCase):
         # post.show()
 
     def testExtractionC(self):
-        from music21 import analysis, corpus
+        from music21 import analysis
+        from music21 import corpus
         # http://solomonsmusic.net/schenker.htm
         # shows extracting an Ursatz line
 
@@ -986,7 +989,8 @@ class Test(unittest.TestCase):
 
     def testExtractionD(self):
         # this shows a score, extracting a single pitch
-        from music21 import analysis, corpus
+        from music21 import analysis
+        from music21 import corpus
 
         src = corpus.parse('schoenberg/opus19', 6)
         for n in src.flat.notes:
@@ -1009,7 +1013,8 @@ class Test(unittest.TestCase):
 
     def testExtractionD2(self):
         # this shows a score, extracting a single pitch
-        from music21 import analysis, corpus
+        from music21 import analysis
+        from music21 import corpus
 
         src = corpus.parse('schoenberg/opus19', 6)
         for n in src.flat.notes:
@@ -1032,7 +1037,8 @@ class Test(unittest.TestCase):
 
 
     def testExtractionE(self):
-        from music21 import analysis, corpus
+        from music21 import analysis
+        from music21 import corpus
 
         src = corpus.parse('corelli/opus3no1/1grave')
 
@@ -1047,8 +1053,8 @@ class Test(unittest.TestCase):
 
 
     def testPartReductionA(self):
-
-        from music21 import analysis, corpus
+        from music21 import analysis
+        from music21 import corpus
 
         s = corpus.parse('bwv66.6')
 
@@ -1093,7 +1099,9 @@ class Test(unittest.TestCase):
     def testPartReductionB(self, show=False):
         '''Artificially create test cases.
         '''
-        from music21 import dynamics, graph, analysis
+        from music21 import dynamics
+        from music21 import graph
+        from music21 import analysis
         durDynPairsA = [(1, 'mf'), (3, 'f'), (2, 'p'), (4, 'ff'), (2, 'mf')]
         durDynPairsB = [(1, 'mf'), (3, 'f'), (2, 'p'), (4, 'ff'), (2, 'mf')]
 
@@ -1138,7 +1146,8 @@ class Test(unittest.TestCase):
     def testPartReductionC(self):
         '''Artificially create test cases.
         '''
-        from music21 import dynamics, analysis
+        from music21 import dynamics
+        from music21 import analysis
 
         s = stream.Score()
         p1 = stream.Part()
@@ -1172,7 +1181,8 @@ class Test(unittest.TestCase):
     def testPartReductionD(self):
         '''Artificially create test cases. Here, uses rests.
         '''
-        from music21 import dynamics, analysis
+        from music21 import dynamics
+        from music21 import analysis
 
         s = stream.Score()
         p1 = stream.Part()
@@ -1212,7 +1222,8 @@ class Test(unittest.TestCase):
     def testPartReductionE(self):
         '''Artificially create test cases.
         '''
-        from music21 import dynamics, analysis
+        from music21 import dynamics
+        from music21 import analysis
         s = stream.Score()
         p1 = stream.Part()
         p1.id = 0

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -212,7 +212,7 @@ class ScoreReduction:
 
 
     def _setScore(self, value):
-        if 'Stream' not in value.classes:
+        if not isinstance(value, stream.Stream):
             raise ScoreReductionException('cannot set a non Stream')
         if value.hasPartLikeStreams:
             # make a local copy
@@ -237,7 +237,7 @@ class ScoreReduction:
 
 
     def _setChordReduction(self, value):
-        if 'Stream' not in value.classes:
+        if not isinstance(value, stream.Stream):
             raise ScoreReductionException('cannot set a non Stream')
         if value.hasPartLikeStreams():
             # make a local copy
@@ -466,7 +466,7 @@ class PartReduction:
     def __init__(self, srcScore=None, *args, **keywords):
         if srcScore is None:
             return
-        if 'Score' not in srcScore.classes:
+        if not isinstance(srcScore, stream.Score):
             raise PartReductionException('provided Stream must be Score')
         self._score = srcScore
         # an ordered list of dictionaries for

--- a/music21/analysis/segmentByRests.py
+++ b/music21/analysis/segmentByRests.py
@@ -12,9 +12,12 @@
 
 import unittest
 
-from music21 import exceptions21
-from music21 import interval
+from music21 import clef
 from music21 import converter
+from music21 import exceptions21
+from music21 import note
+from music21 import interval
+
 
 from music21 import environment
 _MOD = 'analysis.segmentByRests'
@@ -53,12 +56,12 @@ class Segmenter:
         partNotes = workOrPart.recurse().getElementsByClass(['Note', 'Rest', 'Clef'])
         for i in range(len(partNotes)):
             n = partNotes[i]
-            if 'Note' in n.classes:
+            if isinstance(n, note.Note):
                 thisSegment.append(n)
                 # for final segment as workOrPart usually ends with a note not clef or rest
                 if i == len(partNotes) - 1:
                     segments.append(thisSegment)
-            if 'Rest' in n.classes or 'Clef' in n.classes:
+            if isinstance(n, (note.Rest, clef.Clef)):
                 segments.append(thisSegment)
                 thisSegment = []
                 continue
@@ -86,10 +89,10 @@ class Segmenter:
         elementList = workOrPart.recurse().getElementsByClass(['Note', 'Rest', 'Clef'])
         for i in range(len(elementList) - 1):
             n1 = elementList[i]
-            if 'Rest' in n1.classes or 'Clef' in n1.classes:
+            if isinstance(n1, (note.Rest, clef.Clef)):
                 continue
             n2 = elementList[i + 1]
-            if 'Rest' in n2.classes or 'Clef' in n2.classes:
+            if isinstance(n2, (note.Rest, clef.Clef)):
                 continue
             intervalObj = interval.Interval(n1, n2)
             intervalList.append(intervalObj)

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -445,7 +445,8 @@ class Test(unittest.TestCase):
 
     def testVariableWindowing(self):
         from music21.analysis import discrete
-        from music21 import corpus, graph
+        from music21 import corpus
+        from music21 import graph
 
         p = discrete.KrumhanslSchmuckler()
         s = corpus.parse('bach/bwv66.6')

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -56,7 +56,7 @@ class WindowedAnalysis:
     def __init__(self, streamObj, analysisProcessor):
         self.processor = analysisProcessor
         # environLocal.printDebug(self.processor)
-        if 'Stream' not in streamObj.classes:
+        if not isinstance(streamObj, stream.Stream):
             raise WindowedAnalysisException('non-stream provided as argument')
         if streamObj.hasPartLikeStreams():
             raise WindowedAnalysisException('part-like substreams are not supported; use .flat')

--- a/music21/bar.py
+++ b/music21/bar.py
@@ -375,7 +375,10 @@ class Repeat(repeat.RepeatMark, Barline):
 class Test(unittest.TestCase):
 
     def testSortOrder(self):
-        from music21 import stream, clef, note, metadata
+        from music21 import stream
+        from music21 import clef
+        from music21 import note
+        from music21 import metadata
         m = stream.Measure()
         b = Repeat()
         m.leftBarline = b
@@ -397,7 +400,8 @@ class Test(unittest.TestCase):
         self.assertEqual(m[1], b)
 
     def testFreezeThaw(self):
-        from music21 import converter, stream
+        from music21 import converter
+        from music21 import stream
 
         b = Barline()
         self.assertNotIn('StyleMixin', b.classes)

--- a/music21/base.py
+++ b/music21/base.py
@@ -3015,9 +3015,7 @@ class Music21Object(prebase.ProtoM21Object):
 
         # some higher-level classes need this functionality
         # set ties
-        if addTies and (isinstance(e, note.Note)
-                        or isinstance(e, note.Unpitched)):
-
+        if addTies and isinstance(e, (note.Note, note.Unpitched)):
             forceEndTieType = 'stop'
             if hasattr(e, 'tie') and e.tie is not None:
                 # the last tie of what was formally a start should

--- a/music21/base.py
+++ b/music21/base.py
@@ -4072,7 +4072,8 @@ class Test(unittest.TestCase):
         self.assertEqual(a.offset, 23.0)
 
     def testObjectsAndElements(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         note1 = note.Note('B-')
         note1.duration.type = 'whole'
         stream1 = stream.Stream()
@@ -4093,7 +4094,8 @@ class Test(unittest.TestCase):
         '''
         Basic testing of M21 base object sites
         '''
-        from music21 import stream, base  # self import needed.
+        from music21 import stream
+        from music21 import base  # self import needed.
         a = base.Music21Object()
         b = stream.Stream()
 
@@ -4133,7 +4135,8 @@ class Test(unittest.TestCase):
         '''
         Basic testing of M21 base object
         '''
-        from music21 import stream, base
+        from music21 import stream
+        from music21 import base
         a = stream.Stream()
         a.id = 'a obj'
         b = base.Music21Object()
@@ -4153,7 +4156,8 @@ class Test(unittest.TestCase):
     def testM21BaseLocationsCopyB(self):
         # the active site of a deepcopy should not be the same?
         # self.assertEqual(post[-1].activeSite, a)
-        from music21 import stream, base
+        from music21 import stream
+        from music21 import base
         a = stream.Stream()
         b = base.Music21Object()
         b.id = 'test'
@@ -4173,7 +4177,9 @@ class Test(unittest.TestCase):
         # this fails! post[-1].getOffsetBySite(a)
 
     def testSitesSearch(self):
-        from music21 import note, stream, clef
+        from music21 import note
+        from music21 import stream
+        from music21 import clef
 
         n1 = note.Note('A')
         n2 = note.Note('B')
@@ -4223,7 +4229,9 @@ class Test(unittest.TestCase):
     def testSitesMeasures(self):
         '''Can a measure determine the last Clef used?
         '''
-        from music21 import corpus, clef, stream
+        from music21 import corpus
+        from music21 import clef
+        from music21 import stream
         a = corpus.parse('bach/bwv324.xml')
         measures = a.parts[0].getElementsByClass('Measure').stream()  # measures of first part
 
@@ -4262,7 +4270,9 @@ class Test(unittest.TestCase):
         self.assertTrue(isinstance(post, clef.TrebleClef), post)
 
     def testSitesClef(self):
-        from music21 import note, stream, clef
+        from music21 import note
+        from music21 import stream
+        from music21 import clef
         sOuter = stream.Stream()
         sOuter.id = 'sOuter'
         sInner = stream.Stream()
@@ -4358,7 +4368,9 @@ class Test(unittest.TestCase):
         self.assertEqual(post, [None, None, None, None, None, None, None, None, None, None])
 
     def testGetBeatStrengthA(self):
-        from music21 import stream, note, meter
+        from music21 import stream
+        from music21 import note
+        from music21 import meter
 
         n = note.Note('g')
         n.quarterLength = 1
@@ -4379,7 +4391,9 @@ class Test(unittest.TestCase):
     def testMeasureNumberAccess(self):
         '''Test getting measure number data from various Music21Objects.
         '''
-        from music21 import corpus, stream, note
+        from music21 import corpus
+        from music21 import stream
+        from music21 import note
 
         s = corpus.parse('bach/bwv66.6.xml')
         p1 = s.parts['Soprano']
@@ -4407,7 +4421,9 @@ class Test(unittest.TestCase):
         self.assertEqual(n.measureNumber, 74)
 
     def testPickupMeasuresBuilt(self):
-        from music21 import stream, meter, note
+        from music21 import stream
+        from music21 import meter
+        from music21 import note
 
         s = stream.Score()
 
@@ -4506,7 +4522,9 @@ class Test(unittest.TestCase):
                           43.0, 44.0, 44.5, 45.0, 47.0])
 
     def testHighestTime(self):
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
         s = stream.Stream()
         n1 = note.Note()
         n1.quarterLength = 30
@@ -4525,7 +4543,9 @@ class Test(unittest.TestCase):
         self.assertEqual(b1.getOffsetBySite(s), 50.0)
 
     def testRecurseByClass(self):
-        from music21 import note, stream, clef
+        from music21 import note
+        from music21 import stream
+        from music21 import clef
         s1 = stream.Stream()
         s2 = stream.Stream()
         s3 = stream.Stream()
@@ -4572,7 +4592,8 @@ class Test(unittest.TestCase):
         self.assertEqual(id(n2.derivation.origin), id(n1))
 
     def testHasElement(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         n1 = note.Note()
         s1 = stream.Stream()
         s1.append(n1)
@@ -4585,7 +4606,9 @@ class Test(unittest.TestCase):
         self.assertTrue(s2 in n2.sites)
 
     def testGetContextByClassA(self):
-        from music21 import stream, note, tempo
+        from music21 import stream
+        from music21 import note
+        from music21 import tempo
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -4608,7 +4631,8 @@ class Test(unittest.TestCase):
                          '<music21.tempo.MetronomeMark lento 16th=50>')
 
     def testElementWrapperOffsetAccess(self):
-        from music21 import stream, meter
+        from music21 import stream
+        from music21 import meter
         from music21 import base
 
         class Mock:
@@ -4634,7 +4658,8 @@ class Test(unittest.TestCase):
 
     def testGetActiveSiteTimeSignature(self):
         from music21 import base
-        from music21 import stream, meter
+        from music21 import stream
+        from music21 import meter
 
         class Wave_read:
             def getnchannels(self):
@@ -4669,7 +4694,9 @@ class Test(unittest.TestCase):
 
     def testGetMeasureOffsetOrMeterModulusOffsetA(self):
         # test getting metric position in a Stream with a TS
-        from music21 import stream, note, meter
+        from music21 import stream
+        from music21 import note
+        from music21 import meter
 
         s = stream.Stream()
         s.repeatAppend(note.Note(), 12)
@@ -4688,7 +4715,9 @@ class Test(unittest.TestCase):
         self.assertEqual(match, [1.0, 0.5, 0.5, 1.0, 0.5, 0.5, 1.0, 0.5, 0.5, 1.0, 0.5, 0.5])
 
     def testGetMeasureOffsetOrMeterModulusOffsetB(self):
-        from music21 import stream, note, meter
+        from music21 import stream
+        from music21 import note
+        from music21 import meter
 
         s = stream.Stream()
         s.repeatAppend(note.Note(), 12)
@@ -4706,7 +4735,9 @@ class Test(unittest.TestCase):
         self.assertEqual(match, [1.0, 0.5, 0.5, 1.0, 0.25, 0.5, 0.25, 1.0, 0.5, 1.0, 0.5, 1.0])
 
     def testSecondsPropertyA(self):
-        from music21 import stream, note, tempo
+        from music21 import stream
+        from music21 import note
+        from music21 import tempo
         s = stream.Stream()
         s.repeatAppend(note.Note(), 12)
         s.insert(0, tempo.MetronomeMark(number=120))
@@ -4749,7 +4780,9 @@ class Test(unittest.TestCase):
         self.assertIsNotNone(m.getContextByClass('Clef', getElementMethod='all'))
 
     def testGetContextByClassB(self):
-        from music21 import stream, note, meter
+        from music21 import stream
+        from music21 import note
+        from music21 import meter
 
         s = stream.Score()
 
@@ -4807,7 +4840,9 @@ class Test(unittest.TestCase):
                          '<music21.meter.TimeSignature 3/4>')
 
     def testNextA(self):
-        from music21 import stream, scale, note
+        from music21 import stream
+        from music21 import scale
+        from music21 import note
         s = stream.Stream()
         sc = scale.MajorScale()
         notes = []
@@ -4829,7 +4864,8 @@ class Test(unittest.TestCase):
         self.assertEqual(notes[7], s.notes[6].next())
 
     def testNextB(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
 
         m1 = stream.Measure()
         m1.number = 1
@@ -4896,7 +4932,8 @@ class Test(unittest.TestCase):
         self.assertEqual(str(measures[0].previous()), str(p1))
 
     def testActiveSiteCopyingA(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
 
         n1 = note.Note()
         s1 = stream.Stream()
@@ -4908,7 +4945,9 @@ class Test(unittest.TestCase):
         self.assertIs(n2.derivation.origin.activeSite, s1)
 
     def testSpannerSites(self):
-        from music21 import note, spanner, dynamics
+        from music21 import note
+        from music21 import spanner
+        from music21 import dynamics
 
         n1 = note.Note('C4')
         n2 = note.Note('D4')
@@ -4995,7 +5034,8 @@ class Test(unittest.TestCase):
                           "(<music21.stream.Score bach>, 9.0, 'elementsOnly')"])
 
     def testContextSitesB(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
         p1 = stream.Part()
         p1.id = 'p1'
         m1 = stream.Measure()
@@ -5074,7 +5114,8 @@ class Test(unittest.TestCase):
 #             i -= 1
 
     def testPreviousAfterDeepcopy(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
         e1 = note.Note('C')
         e2 = note.Note('D')
         s = stream.Stream()

--- a/music21/braille/basic.py
+++ b/music21/braille/basic.py
@@ -14,6 +14,7 @@ from typing import List
 
 # from music21 import articulations
 from music21 import clef
+from music21 import duration
 from music21 import environment
 from music21 import exceptions21
 from music21 import interval
@@ -743,7 +744,7 @@ def noteToBraille(
 
     # note duration
     # -------------
-    if 'GraceDuration' in music21Note.duration.classes:
+    if isinstance(music21Note.duration, duration.GraceDuration):
         # TODO: Short Appoggiatura mark...
         nameWithDuration = notesInStep['eighth']
         noteTrans.append(nameWithDuration)

--- a/music21/braille/noteGrouping.py
+++ b/music21/braille/noteGrouping.py
@@ -256,7 +256,8 @@ class NoteGroupingTranscriber:
         if (isinstance(prev, dynamics.Dynamic)
             or (isinstance(prev, clef.Clef)
                 and self.showClefSigns)
-            or (isinstance(prev, expressions.TextExpression)  # TE is an abbreviation, no extra dot 3 necessary
+            or (isinstance(prev, expressions.TextExpression)
+                # TE is an abbreviation, no extra dot 3 necessary
                 and prev.content[-1] != '.')):
             for dot in basic.yieldDots(self.trans[-1][0]):
                 self.trans.insert(-1, dot)  # insert one before the end, not append...

--- a/music21/braille/noteGrouping.py
+++ b/music21/braille/noteGrouping.py
@@ -12,7 +12,10 @@ import unittest
 
 from collections import OrderedDict
 
+from music21 import clef
+from music21 import dynamics
 from music21 import environment
+from music21 import expressions
 from music21.braille import basic
 from music21.braille.lookup import symbols
 
@@ -245,15 +248,15 @@ class NoteGroupingTranscriber:
         if not self.trans:
             return False  # need to consult previous element in translation
 
-        if el is not None and 'Dynamic' in el.classes:
+        if el is not None and isinstance(el, dynamics.Dynamic):
             return False
-        if el is not None and 'TextExpression' in el.classes:
+        if el is not None and isinstance(el, expressions.TextExpression):
             return False
 
-        if ('Dynamic' in prev.classes
-            or ('Clef' in prev.classes
+        if (isinstance(prev, dynamics.Dynamic)
+            or (isinstance(prev, clef.Clef)
                 and self.showClefSigns)
-            or ('TextExpression' in prev.classes  # TE is an abbreviation, no extra dot 3 necessary
+            or (isinstance(prev, expressions.TextExpression)  # TE is an abbreviation, no extra dot 3 necessary
                 and prev.content[-1] != '.')):
             for dot in basic.yieldDots(self.trans[-1][0]):
                 self.trans.insert(-1, dot)  # insert one before the end, not append...

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -703,7 +703,7 @@ class BrailleSegment(text.BrailleText):
             return False
 
         # can't use Filter because noteGrouping is list-like not Stream-like
-        allNotes = [n for n in noteGrouping if 'Note' in n.classes]
+        allNotes = [n for n in noteGrouping if isinstance(n, note.Note)]
         showLeadingOctave = True
         if allNotes:
             if self.lastNote is not None:
@@ -1913,7 +1913,7 @@ def getRawSegments(music21Part, setHand=None):
                 # All cases: continue, so we don't add anything to the segment
                 continue
             elif (
-                'Barline' in brailleElement.classes
+                isinstance(brailleElement, bar.Barline)
                 and elementsInCurrentSegment > MAX_ELEMENTS_IN_SEGMENT
                 and brailleElement.type in ('double', 'final')
             ):

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -476,7 +476,7 @@ class Chord(note.NotRest):
             raise ValueError('Chord index must be set to a valid note object')
         elif isinstance(value, pitch.Pitch):
             value = note.Note(pitch=value)
-        elif 'Note' not in value.classes:
+        elif not isinstance(value, note.Note):
             raise ValueError('Chord index must be set to a valid note object')
 
         self._notes[keyIndex] = value

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -391,7 +391,7 @@ class Chord(note.NotRest):
         elif not hasattr(key, 'classes'):
             raise KeyError(keyErrorStr)
 
-        elif 'Note' in key.classes:
+        elif isinstance(key, note.Note):
             for n in self._notes:
                 if n is key:
                     foundNote = n
@@ -404,7 +404,7 @@ class Chord(note.NotRest):
                 else:
                     raise KeyError(keyErrorStr)
 
-        elif 'Pitch' in key.classes:
+        elif isinstance(key, pitch.Pitch):
             for n in self._notes:
                 if n.pitch is key:
                     foundNote = n
@@ -474,7 +474,7 @@ class Chord(note.NotRest):
             value = note.Note(value)
         elif not hasattr(value, 'classes'):
             raise ValueError('Chord index must be set to a valid note object')
-        elif 'Pitch' in value.classes:
+        elif isinstance(value, pitch.Pitch):
             value = note.Note(pitch=value)
         elif 'Note' not in value.classes:
             raise ValueError('Chord index must be set to a valid note object')
@@ -770,7 +770,7 @@ class Chord(note.NotRest):
         if not hasattr(removeItem, 'classes'):
             raise ValueError('Cannot remove {} from a chord; try a Pitch or Note object'.format(
                 removeItem))
-        if 'Pitch' in removeItem.classes:
+        if isinstance(removeItem, pitch.Pitch):
             for n in self._notes:
                 if n.pitch == removeItem:
                     self._notes.remove(n)
@@ -1424,7 +1424,7 @@ class Chord(note.NotRest):
             if testRoot is None:
                 # can this be tested?
                 raise ChordException('Cannot run getChordStep without a root')
-        elif 'Note' in testRoot.classes:
+        elif isinstance(testRoot, note.Note):
             testRoot = testRoot.pitch
 
         rootDNN = testRoot.diatonicNoteNum

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -5965,7 +5965,8 @@ class Test(unittest.TestCase):
                          + '(3, <music21.pitch.Accidental flat>), (3, None), (4, None)]')
 
     def testScaleDegreesB(self):
-        from music21 import stream, key
+        from music21 import stream
+        from music21 import key
         # trying to isolate problematic context searches
         chord1 = Chord(['C#5', 'E#5', 'G#5'])
         st1 = stream.Stream()
@@ -6058,7 +6059,8 @@ class Test(unittest.TestCase):
                         out)
 
     def testTiesB(self):
-        from music21 import stream, scale
+        from music21 import stream
+        from music21 import scale
         sc = scale.WholeToneScale()
         s = stream.Stream()
         for i in range(7):
@@ -6136,7 +6138,8 @@ class Test(unittest.TestCase):
 
     def testVolumePerPitchC(self):
         import random
-        from music21 import stream, tempo
+        from music21 import stream
+        from music21 import tempo
         c = Chord(['f-2', 'a-2', 'c-3', 'f-3', 'g3', 'b-3', 'd-4', 'e-4'])
         c.duration.quarterLength = 0.5
         s = stream.Stream()

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1522,8 +1522,9 @@ class Test(unittest.TestCase):
         self.assertEqual(len(clefs), 18)
 
     def testConversionMXClefTimeCorpus(self):
-
-        from music21 import corpus, clef, meter
+        from music21 import corpus
+        from music21 import clef
+        from music21 import meter
         a = corpus.parse('luca')
 
         # there should be only one clef in each part
@@ -1671,7 +1672,10 @@ class Test(unittest.TestCase):
         parse(data)
 
     def testConversionMidiNotes(self):
-        from music21 import meter, key, chord, note
+        from music21 import meter
+        from music21 import key
+        from music21 import chord
+        from music21 import note
 
         fp = common.getSourceFilePath() / 'midi' / 'testPrimitive' / 'test01.mid'
         # a simple file created in athenacl

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1483,7 +1483,7 @@ class Test(unittest.TestCase):
                 self.assertEqual(knownSize[i], len(chords[i].pitches))
 
     def testConversionMXBeams(self):
-
+        from music21 import note
         from music21.musicxml import testPrimitive
 
         mxString = testPrimitive.beams01
@@ -1492,7 +1492,7 @@ class Test(unittest.TestCase):
         notes = part.flat.notesAndRests
         beams = []
         for n in notes:
-            if 'Note' in n.classes:
+            if isinstance(n, note.Note):
                 beams += n.beams.beamsList
         self.assertEqual(len(beams), 152)
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1571,7 +1571,8 @@ class TestExternal(unittest.TestCase):
         '''
         tests whether show() works for music that is 10-99 pages long
         '''
-        from music21 import omr, converter
+        from music21 import omr
+        from music21 import converter
         K525 = omr.correctors.K525groundTruthFilePath
         K525 = converter.parse(K525)
         if self.show:

--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -467,7 +467,8 @@ class Test(unittest.TestCase):
         self.assertNotEqual(xmlOut.find(match), -1, xmlOut)
 
     def testDynamicsPositionA(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
         s = stream.Stream()
         selections = ['pp', 'f', 'mf', 'fff']
         # positions = [-20, 0, 20]
@@ -479,7 +480,9 @@ class Test(unittest.TestCase):
 
     def testDynamicsPositionB(self):
         import random
-        from music21 import stream, note, layout
+        from music21 import stream
+        from music21 import note
+        from music21 import layout
         s = stream.Stream()
         for i in range(6):
             m = stream.Measure(number=i + 1)

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -1433,7 +1433,11 @@ class Test(unittest.TestCase):
         self.assertEqual(re.getTextExpression().content, 'd.s. al fine')
 
     def testExpandTurns(self):
-        from music21 import note, stream, clef, key, meter
+        from music21 import note
+        from music21 import stream
+        from music21 import clef
+        from music21 import key
+        from music21 import meter
         p1 = stream.Part()
         m1 = stream.Measure()
         m2 = stream.Measure()
@@ -1469,7 +1473,11 @@ class Test(unittest.TestCase):
 
 
     def testExpandTrills(self):
-        from music21 import note, stream, clef, key, meter
+        from music21 import note
+        from music21 import stream
+        from music21 import clef
+        from music21 import key
+        from music21 import meter
         p1 = stream.Part()
         m1 = stream.Measure()
         p1.append(clef.TrebleClef())
@@ -1491,7 +1499,10 @@ class Test(unittest.TestCase):
         '''Test basic wave line creation and output, as well as passing
         objects through make measure calls.
         '''
-        from music21 import stream, note, chord, expressions
+        from music21 import stream
+        from music21 import note
+        from music21 import chord
+        from music21 import expressions
         from music21.musicxml import m21ToXml
         s = stream.Stream()
         s.repeatAppend(note.Note(), 12)

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -20,6 +20,7 @@ from music21 import common
 from music21 import converter
 from music21 import corpus
 from music21 import exceptions21
+from music21 import note
 from music21 import stream
 from music21 import text
 
@@ -165,7 +166,7 @@ class FeatureExtractor:
         '''
         if dataOrStream is not None:
             if (hasattr(dataOrStream, 'classes')
-                    and 'Stream' in dataOrStream.classes):
+                    and isinstance(dataOrStream, stream.Stream)):
                 # environLocal.printDebug(['creating new DataInstance: this should be a Stream:',
                 #     dataOrStream])
                 # if we are passed a stream, create a DataInstance to
@@ -412,7 +413,7 @@ class StreamForms:
         return histo
 
     def formGetElementsByClassMeasure(self, prepared):
-        if 'Score' in prepared.classes:
+        if isinstance(prepared, stream.Score):
             post = stream.Stream()
             for p in prepared.parts:
                 # insert in overlapping offset positions
@@ -423,7 +424,7 @@ class StreamForms:
         return post
 
     def formChordify(self, prepared):
-        if 'Score' in prepared.classes:
+        if isinstance(prepared, stream.Score):
             # options here permit getting part information out
             # of chordified representation
             return prepared.chordify(
@@ -489,7 +490,7 @@ class StreamForms:
         secondsMap = prepared.secondsMap
         # filter only notes; all elements would otherwise be gathered
         for bundle in secondsMap:
-            if 'NotRest' in bundle['element'].classes:
+            if isinstance(bundle['element'], note.NotRest):
                 post.append(bundle)
         return post
 

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -1324,8 +1324,7 @@ class Test(unittest.TestCase):
                          [47, 2, 25, 0, 25, 42, 0, 33, 0, 38, 22, 4])
 
     def testStreamFormsB(self):
-
-        from music21 import features, note
+        from music21 import features
 
         s = stream.Stream()
         for p in ['c4', 'c4', 'd-4', 'd#4', 'f#4', 'a#4', 'd#5', 'a5', 'a5']:
@@ -1342,7 +1341,7 @@ class Test(unittest.TestCase):
 
     def testStreamFormsC(self):
         from pprint import pformat
-        from music21 import features, note
+        from music21 import features
 
         s = stream.Stream()
         for p in ['c4', 'c4', 'd-4', 'd#4', 'f#4', 'a#4', 'd#5', 'a5']:

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -1457,7 +1457,8 @@ class Test(unittest.TestCase):
             ds.process()
 
     def testEmptyStreamCustomErrors(self):
-        from music21 import analysis, features
+        from music21 import analysis
+        from music21 import features
         from music21.features import jSymbolic, native
 
         ds = DataSet(classLabel='')

--- a/music21/features/jSymbolic.py
+++ b/music21/features/jSymbolic.py
@@ -4460,7 +4460,10 @@ def getCompletionStats():
 class Test(unittest.TestCase):
 
     def testAverageMelodicIntervalFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4475,7 +4478,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [6.0])
 
     def testMostCommonMelodicIntervalFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4490,7 +4496,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [5])
 
     def testDistanceBetweenMostCommonMelodicIntervalsFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4504,7 +4513,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [2])
 
     def testMostCommonMelodicIntervalPrevalenceFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4518,7 +4530,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [0.5])
 
     def testRelativeStrengthOfMostCommonIntervalsFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4532,7 +4547,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [0.75])
 
     def testNumberOfCommonMelodicIntervalsFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4546,7 +4564,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [1])
 
     def testAmountOfArpeggiationFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4560,7 +4581,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [0.5])
 
     def testRepeatedNotesFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4574,7 +4598,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [0.5])
 
     def testChromaticMotionFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4588,7 +4615,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [0.5])
 
     def testStepwiseMotionFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4602,7 +4632,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [2 / 3])
 
     def testMelodicThirdsFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4616,7 +4649,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [1 / 6])
 
     def testMelodicFifthsFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4630,7 +4666,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [2 / 6])
 
     def testMelodicTritonesFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4644,7 +4683,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [1 / 6])
 
     def testMelodicOctavesFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         s = stream.Stream()
         p = pitch.Pitch('c2')
         s.append(note.Note(copy.deepcopy(p)))
@@ -4658,7 +4700,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [1 / 6])
 
     def testDirectionOfMotionFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         # all up
         s = stream.Stream()
         p = pitch.Pitch('c2')
@@ -4693,7 +4738,10 @@ class Test(unittest.TestCase):
         self.assertEqual(f.vector, [0.0])
 
     def testDurationOfMelodicArcsFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         # all up
         # in jSymbolic implementation, all up means there
         # is no melodic arc and thus the average duration
@@ -4719,7 +4767,10 @@ class Test(unittest.TestCase):
         self.assertAlmostEqual(f.vector[0], 8 / 5)
 
     def testSizeOfMelodicArcsFeature(self):
-        from music21 import stream, pitch, note, features
+        from music21 import stream
+        from music21 import pitch
+        from music21 import note
+        from music21 import features
         # all up
         s = stream.Stream()
         p = pitch.Pitch('c2')
@@ -4742,7 +4793,10 @@ class Test(unittest.TestCase):
         # self.assertAlmostEqual(f.vector[0], 1 + 2/3)
 
     def testNoteDensityFeatureA(self):
-        from music21 import stream, note, tempo, features
+        from music21 import stream
+        from music21 import note
+        from music21 import tempo
+        from music21 import features
         s = stream.Stream()
         s.insert(0, tempo.MetronomeMark(number=60))
         s.insert(0, note.Note(quarterLength=8))
@@ -4790,7 +4844,8 @@ class Test(unittest.TestCase):
                                  feImplemented, 'percent', feImplemented / feTotal])
 
     def testBeatHistogram(self):
-        from music21 import corpus, tempo
+        from music21 import corpus
+        from music21 import tempo
         sch = corpus.parse('schoenberg/opus19', 2)
         for p in sch.parts:
             p.insert(0, tempo.MetronomeMark('Langsam', 70))

--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -977,7 +977,9 @@ featureExtractors = [
 class Test(unittest.TestCase):
 
     def testIncorrectlySpelledTriadPrevalence(self):
-        from music21 import stream, features, chord
+        from music21 import stream
+        from music21 import features
+        from music21 import chord
 
         s = stream.Stream()
         s.append(chord.Chord(['c', 'e', 'g']))
@@ -989,7 +991,8 @@ class Test(unittest.TestCase):
         self.assertEqual(str(fe.extract().vector[0]), '0.5')
 
     def testLandiniCadence(self):
-        from music21 import converter, features
+        from music21 import converter
+        from music21 import features
 
         s = converter.parse('tinynotation: 3/4 f#4 f# e g2')
         fe = features.native.LandiniCadence(s)

--- a/music21/figuredBass/examples.py
+++ b/music21/figuredBass/examples.py
@@ -136,7 +136,8 @@ def exampleD():
     .. image:: images/figuredBass/fbExamples_sol3D.*
             :width: 700
     '''
-    from music21 import converter, key
+    from music21 import converter
+    from music21 import key
     s = converter.parse("tinynotation: 3/4 BB4 C#4_#6 D4_6 E2 E#4_7,5,#3 F#2_6,4 "
                         "F#4_5,#3 G2 E4_6 F#2_6,4 E4_#4,2 D2_6 EE4_7,5,#3 AA2.",
                         makeNotation=False)
@@ -182,7 +183,8 @@ def exampleB():
     .. image:: images/figuredBass/fbExamples_sol2B.*
         :width: 700
     '''
-    from music21 import converter, key
+    from music21 import converter
+    from music21 import key
     s = converter.parse("tinynotation: 4/4 D4 A4_7,5,#3 B-4 F4_6 G4_6 AA4_7,5,#3 D2",
                         makeNotation=False)
     s.insert(0, key.Key('d'))
@@ -227,7 +229,8 @@ def exampleC():
     .. image:: images/figuredBass/fbExamples_sol2C.*
         :width: 700
     '''
-    from music21 import converter, key
+    from music21 import converter
+    from music21 import key
     s = converter.parse("tinynotation: 4/4 FF#4 GG#4_#6 AA4_6 FF#4 BB4_6,5 C#4_7,5,#3 F#2",
                         makeNotation=False)
     s.insert(0, key.Key('f#'))
@@ -248,7 +251,8 @@ def V43ResolutionExample():
     .. image:: images/figuredBass/fbExamples_V43.*
         :width: 350
     '''
-    from music21 import converter, key
+    from music21 import converter
+    from music21 import key
     s = converter.parse("tinynotation: 4/4 D2 E2_4,3 D2_5,3 E2_4,3 F#1_6,3", makeNotation=False)
     s.insert(0, key.Key('D'))
     return realizer.figuredBassFromStream(s)
@@ -278,7 +282,8 @@ def viio65ResolutionExample():
     .. image:: images/figuredBass/fbExamples_vii65.*
         :width: 700
     '''
-    from music21 import converter, key
+    from music21 import converter
+    from music21 import key
     s = converter.parse("tinyNotation: 4/4 D2 E2_6,b5 D2 E2_6,b5 F#1_6", makeNotation=False)
     s.insert(0, key.Key('D'))
     return realizer.figuredBassFromStream(s)
@@ -304,7 +309,8 @@ def augmentedSixthResolutionExample():
     .. image:: images/figuredBass/fbExamples_a6.*
         :width: 700
     '''
-    from music21 import converter, key
+    from music21 import converter
+    from music21 import key
     s = converter.parse("tinynotation: 4/4 D4 BB-4_8,#6,3 AA2_# D4 BB-4_#6,4,3 "
                         "AA2_# D4 BB-4_#6,5,3 AA2_# D4 BB-4_#6,#4,3 AA2_# D4 "
                         "BB-4_#6,5,3 AA2_6,4",
@@ -350,7 +356,8 @@ def italianA6ResolutionExample():
     .. image:: images/figuredBass/fbExamples_it+6.*
         :width: 700
     '''
-    from music21 import converter, key
+    from music21 import converter
+    from music21 import key
     s = converter.parse(
         "tinynotation: D4 BB-4_#6,3 AA2_# D4 BB-4_#6,3 AA2_6,4 D4 BB-4_#6,3 AA2_#6,4",
         makeNotation=False)
@@ -391,7 +398,8 @@ def twelveBarBlues():
     .. image:: images/figuredBass/fbExamples_twelveBarBlues.*
         :width: 700
     '''
-    from music21 import converter, key
+    from music21 import converter
+    from music21 import key
     s = converter.parse(
         "tinynotation: BB-1 E-1 BB-1 BB-1_7 E-1 E-1 BB-1 BB-1_7 F1_7 G1_6 BB-1 BB-1",
         makeNotation=False)
@@ -417,7 +425,9 @@ def generateBoogieVamp(blRealization=None, numRepeats=5):
     .. image:: images/figuredBass/fbExamples_boogieVamp.*
         :width: 700
     '''
-    from music21 import converter, stream, interval
+    from music21 import converter
+    from music21 import stream
+    from music21 import interval
     if blRealization is None:
         bluesLine = twelveBarBlues()
         fbRules = rules.Rules()
@@ -463,7 +473,10 @@ def generateTripletBlues(blRealization=None, numRepeats=5):  # 12/8
     .. image:: images/figuredBass/fbExamples_tripletBlues.*
         :width: 700
     '''
-    from music21 import converter, stream, interval, meter
+    from music21 import converter
+    from music21 import stream
+    from music21 import interval
+    from music21 import meter
     if blRealization is None:
         bluesLine = twelveBarBlues()
         fbRules = rules.Rules()

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -82,6 +82,8 @@ from music21 import common
 from music21 import defaults
 from music21 import derivation
 from music21 import exceptions21
+from music21 import spanner
+from music21 import variant
 # from music21.tree.trees import ElementTree
 
 from music21 import environment
@@ -275,7 +277,7 @@ class StreamFreezer(StreamFreezeThawBase):
             self.findActiveStreamIdsInHierarchy(streamObj)
 
         for el in allEls:
-            if 'Variant' in el.classes:
+            if isinstance(el, variant.Variant):
                 # works like a whole new hierarchy...  # no need for deepcopy
                 subSF = StreamFreezer(
                     el._stream,
@@ -284,7 +286,7 @@ class StreamFreezer(StreamFreezeThawBase):
                     topLevel=False,
                 )
                 subSF.setupSerializationScaffold()
-            elif 'Spanner' in el.classes:
+            elif isinstance(el, spanner.Spanner):
                 # works like a whole new hierarchy...  # no need for deepcopy
                 subSF = StreamFreezer(
                     el.spannerStorage,
@@ -380,9 +382,9 @@ class StreamFreezer(StreamFreezeThawBase):
             for el, unused_offset in storedElementOffsetTuples:
                 if el.isStream:
                     self.recursiveClearSites(el)
-                if 'Spanner' in el.classes:
+                if isinstance(el, spanner.Spanner):
                     self.recursiveClearSites(el.spannerStorage)
-                if 'Variant' in el.classes:
+                if isinstance(el, variant.Variant):
                     self.recursiveClearSites(el._stream)
                 if hasattr(el, '_derivation'):
                     el._derivation = derivation.Derivation()  # reset

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -993,7 +993,8 @@ class StreamThawer(StreamFreezeThawBase):
 class Test(unittest.TestCase):
 
     def testSimpleFreezeThaw(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
         s = stream.Stream()
         sDummy = stream.Stream()
         n = note.Note()
@@ -1014,7 +1015,8 @@ class Test(unittest.TestCase):
         self.assertEqual(outStream[0].offset, 2.0)
 
     def testFreezeThawWithSpanner(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
         s = stream.Stream()
         sDummy = stream.Stream()
         n = note.Note()
@@ -1189,7 +1191,8 @@ class Test(unittest.TestCase):
         # v2.show('t')
 
     def testSerializationScaffoldA(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         from music21 import freezeThaw
 
         n1 = note.Note()
@@ -1208,7 +1211,9 @@ class Test(unittest.TestCase):
         self.assertTrue(s1.hasElement(n1))
 
     def testJSONPickleSpanner(self):
-        from music21 import converter, note, stream
+        from music21 import converter
+        from music21 import note
+        from music21 import stream
         n1 = note.Note('C')
         n2 = note.Note('D')
         s1 = stream.Stream()

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -1014,7 +1014,7 @@ class Test(unittest.TestCase):
         self.assertEqual(outStream[0].offset, 2.0)
 
     def testFreezeThawWithSpanner(self):
-        from music21 import stream, note, spanner
+        from music21 import stream, note
         s = stream.Stream()
         sDummy = stream.Stream()
         n = note.Note()
@@ -1123,7 +1123,6 @@ class Test(unittest.TestCase):
 
     def testFreezeThawSimpleVariant(self):
         from music21 import freezeThaw
-        from music21 import variant
         from music21 import stream
         from music21 import note
 
@@ -1152,7 +1151,6 @@ class Test(unittest.TestCase):
     def testFreezeThawVariant(self):
         from music21 import freezeThaw
         from music21 import corpus
-        from music21 import variant
         from music21 import stream
         from music21 import note
 
@@ -1210,7 +1208,7 @@ class Test(unittest.TestCase):
         self.assertTrue(s1.hasElement(n1))
 
     def testJSONPickleSpanner(self):
-        from music21 import converter, note, stream, spanner
+        from music21 import converter, note, stream
         n1 = note.Note('C')
         n2 = note.Note('D')
         s1 = stream.Stream()

--- a/music21/graph/__init__.py
+++ b/music21/graph/__init__.py
@@ -132,7 +132,8 @@ class TestExternal(unittest.TestCase):
     show = True
 
     def testAll(self):
-        from music21 import corpus, dynamics
+        from music21 import corpus
+        from music21 import dynamics
         a = corpus.parse('bach/bwv57.8')
         a.parts[0].insert(0, dynamics.Dynamic('mf'))
         a.parts[0].insert(10, dynamics.Dynamic('f'))
@@ -171,7 +172,10 @@ class Test(unittest.TestCase):
         plotStream(a.flat, doneAction=None)
 
     def testPlotChordsC(self):
-        from music21 import dynamics, note, stream, scale
+        from music21 import dynamics
+        from music21 import note
+        from music21 import stream
+        from music21 import scale
 
         sc = scale.MajorScale('c4')
 
@@ -204,7 +208,8 @@ class Test(unittest.TestCase):
             s.plot(*args, doneAction=None)
 
     def testHorizontalInstrumentationB(self):
-        from music21 import corpus, dynamics
+        from music21 import corpus
+        from music21 import dynamics
         s = corpus.parse('bwv66.6')
         dyn = ['p', 'mf', 'f', 'ff', 'mp', 'fff', 'ppp']
         i = 0

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -32,7 +32,7 @@ from music21 import dynamics
 from music21 import features
 from music21 import note
 from music21 import prebase
-from music21 import stream
+from music21 import stream  # circular, but okay, because not used at top level.
 
 from music21.graph import axis
 from music21.graph import primitives
@@ -1696,7 +1696,7 @@ class Test(unittest.TestCase):
         b.run()
 
     def testChordsA(self):
-        from music21 import stream, scale
+        from music21 import scale
         sc = scale.MajorScale('c4')
 
         b = Histogram(stream.Stream(), doneAction=None)
@@ -1749,7 +1749,7 @@ class Test(unittest.TestCase):
         # matching the number of pitches for each data point may be needed
 
     def testChordsA2(self):
-        from music21 import stream, scale
+        from music21 import scale
         sc = scale.MajorScale('c4')
 
         s = stream.Stream()
@@ -1770,7 +1770,7 @@ class Test(unittest.TestCase):
         # b.write()
 
     def testChordsA3(self):
-        from music21 import stream, scale
+        from music21 import scale
         sc = scale.MajorScale('c4')
 
         s = stream.Stream()
@@ -1789,7 +1789,7 @@ class Test(unittest.TestCase):
         # b.write()
 
     def testChordsA4(self):
-        from music21 import stream, scale
+        from music21 import scale
         sc = scale.MajorScale('c4')
 
         s = stream.Stream()
@@ -1811,7 +1811,7 @@ class Test(unittest.TestCase):
         # b.write()
 
     def testChordsA5(self):
-        from music21 import stream, scale
+        from music21 import scale
         sc = scale.MajorScale('c4')
 
         s = stream.Stream()
@@ -1833,7 +1833,7 @@ class Test(unittest.TestCase):
         # b.write()
 
     def testChordsB(self):
-        from music21 import stream, scale
+        from music21 import scale
         sc = scale.MajorScale('c4')
 
         s = stream.Stream()
@@ -1927,7 +1927,7 @@ class Test(unittest.TestCase):
         # b.write()
 
     def testChordsB2(self):
-        from music21 import stream, scale
+        from music21 import scale
         sc = scale.MajorScale('c4')
 
         s = stream.Stream()
@@ -1964,7 +1964,7 @@ class Test(unittest.TestCase):
         # b.write()
 
     def testChordsB3(self):
-        from music21 import stream, scale
+        from music21 import scale
         sc = scale.MajorScale('c4')
 
         s = stream.Stream()

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -32,6 +32,7 @@ from music21 import dynamics
 from music21 import features
 from music21 import note
 from music21 import prebase
+from music21 import stream
 
 from music21.graph import axis
 from music21.graph import primitives
@@ -233,7 +234,7 @@ class PlotStreamMixin(prebase.ProtoM21Object):
         formatDict = {}
         # should be two for most things...
 
-        if 'Chord' not in el.classes:
+        if not isinstance(el, chord.Chord):
             for i, thisAxis in enumerate(self.allAxes):
                 axisValue = thisAxis.extractOneElement(el, formatDict)
                 # use isinstance(List) not isiterable, since
@@ -1107,7 +1108,7 @@ class HorizontalBarWeighted(primitives.GraphHorizontalBarWeighted, PlotStreamMix
         '''
         Extract the data from the Stream.
         '''
-        if 'Score' not in self.streamObj.classes:
+        if not isinstance(self.streamObj, stream.Score):
             raise GraphException('provided Stream must be Score')
         # parameters: x, span, heightScalar, color, alpha, yShift
         pr = reduction.PartReduction(

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -639,7 +639,7 @@ class ChordStepModification(prebase.ProtoM21Object):
     def interval(self, value):
         if value in (None,):
             self._interval = None
-        elif hasattr(value, 'classes') and isinstance(value, interval.Interval):
+        elif isinstance(value, interval.Interval):
             # an interval object: set directly
             self._interval = value
         else:

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2552,7 +2552,8 @@ class Test(unittest.TestCase):
         because ChordSymbol used to have the same `.classSortOrder`
         as Note.
         '''
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
 
         cs = ChordSymbol('C')
         n = note.Note('C')
@@ -3083,7 +3084,8 @@ class TestExternal(unittest.TestCase):
 
     def testReadInXML(self):
         from music21 import harmony
-        from music21 import corpus, stream
+        from music21 import corpus
+        from music21 import stream
         testFile = corpus.parse('leadSheet/fosterBrownHair.xml')
 
         # testFile.show('text')
@@ -3101,7 +3103,10 @@ class TestExternal(unittest.TestCase):
         # self.assertEqual(len(csChords), 40)
 
     def testChordRealization(self):
-        from music21 import harmony, corpus, note, stream
+        from music21 import harmony
+        from music21 import corpus
+        from music21 import note
+        from music21 import stream
         # There is a test file under demos called ComprehensiveChordSymbolsTestFile.xml
         # that should contain a complete iteration of tests of chord symbol objects
         # this test makes sure that no error exists, and checks that 57 chords were

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -639,7 +639,7 @@ class ChordStepModification(prebase.ProtoM21Object):
     def interval(self, value):
         if value in (None,):
             self._interval = None
-        elif hasattr(value, 'classes') and 'Interval' in value.classes:
+        elif hasattr(value, 'classes') and isinstance(value, interval.Interval):
             # an interval object: set directly
             self._interval = value
         else:

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1206,7 +1206,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
         currentMeasureOffset = 0
         hasMeasureOne = False
         for el in streamIn:
-            if 'Stream' in el.classes:
+            if isinstance(el, stream.Stream):
                 if currentMeasureNumber != 0 or currentMeasure:
                     currentMeasure.coreElementsChanged()
                     # streamOut.append(currentMeasure)
@@ -1237,7 +1237,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
                 m1.number = 1
             beginningStuff = streamOut.getElementsByOffset(0)
             for el in beginningStuff:
-                if 'Stream' in el.classes:
+                if isinstance(el, stream.Stream):
                     pass
                 elif 'MiscTandem' in el.classes:
                     pass
@@ -1834,7 +1834,7 @@ class SpineCollection(prebase.ProtoM21Object):
             voiceNumber += 1
             voiceStr = 'voice' + str(voiceNumber)
             for insertEl in insertSpine.stream._elements:
-                if insertSpine.isFirstVoice is False and 'Measure' in insertEl.classes:
+                if insertSpine.isFirstVoice is False and isinstance(insertEl, stream.Measure):
                     pass  # only insert one measure object per spine
                 else:
                     insertEl.groups.append(voiceStr)
@@ -1938,7 +1938,7 @@ class SpineCollection(prebase.ProtoM21Object):
                     break
             if thisSpine.spineType == 'dynam':
                 for dynamic in thisSpine.stream.flat:
-                    if 'Dynamic' in dynamic.classes:
+                    if isinstance(dynamic, dynamics.Dynamic):
                         prioritiesToSearch[dynamic.humdrumPosition] = dynamic
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]
@@ -1955,7 +1955,7 @@ class SpineCollection(prebase.ProtoM21Object):
                             #    copy.deepcopy(prioritiesToSearch[el.priority]))
             elif thisSpine.spineType == 'harm':
                 for harm in thisSpine.stream.flat:
-                    if 'RomanNumeral' in harm.classes:
+                    if isinstance(harm, roman.RomanNumeral):
                         prioritiesToSearch[harm.humdrumPosition] = harm
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -29,6 +29,7 @@ from collections import OrderedDict
 from music21 import base
 from music21 import common
 from music21 import interval
+from music21 import note
 from music21 import pitch
 from music21.stream import Stream  # for typing
 from music21.tree.trees import OffsetTree
@@ -66,7 +67,7 @@ def unbundleInstruments(streamIn, *, inPlace=False):
         s = streamIn.coreCopyAsDerivation('unbundleInstruments')
 
     for thisObj in s:
-        if 'Unpitched' in thisObj.classes:
+        if isinstance(thisObj, note.Unpitched):
             i = thisObj.storedInstrument
             if i is not None:
                 off = thisObj.offset
@@ -109,7 +110,7 @@ def bundleInstruments(streamIn, *, inPlace=False):
         if 'Instrument' in thisObj.classes:
             lastInstrument = thisObj
             s.remove(thisObj)
-        elif 'Unpitched' in thisObj.classes:
+        elif isinstance(thisObj, note.Unpitched):
             thisObj.storedInstrument = lastInstrument
 
     if inPlace is False:

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -2472,7 +2472,7 @@ class Test(unittest.TestCase):
                 j = copy.deepcopy(obj)
 
     def testMusicXMLExport(self):
-        from music21 import stream, note
+        from music21 import stream
 
         s1 = stream.Stream()
         i1 = Violin()
@@ -2523,7 +2523,7 @@ class Test(unittest.TestCase):
         # post.show('t')
 
     def testPartitionByInstrumentB(self):
-        from music21 import instrument, stream, note
+        from music21 import instrument, stream
 
         # basic case of instruments in Parts
         s = stream.Score()
@@ -2544,7 +2544,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(post.parts[1].notes), 12)
 
     def testPartitionByInstrumentC(self):
-        from music21 import instrument, stream, note
+        from music21 import instrument, stream
 
         # basic case of instruments in Parts
         s = stream.Score()
@@ -2580,7 +2580,7 @@ class Test(unittest.TestCase):
         # post.show('t')
 
     def testPartitionByInstrumentD(self):
-        from music21 import instrument, stream, note
+        from music21 import instrument, stream
 
         # basic case of instruments in Parts
         s = stream.Score()
@@ -2618,7 +2618,7 @@ class Test(unittest.TestCase):
         # post.show('t')
 
     def testPartitionByInstrumentE(self):
-        from music21 import instrument, stream, note
+        from music21 import instrument, stream
 
         # basic case of instruments in Parts
         # s = stream.Score()
@@ -2656,7 +2656,7 @@ class Test(unittest.TestCase):
                          [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 9.0, 10.0, 11.0, 12.0, 13.0, 20.0])
 
     def testPartitionByInstrumentF(self):
-        from music21 import instrument, stream, note
+        from music21 import instrument, stream
 
         s1 = stream.Stream()
         s1.append(instrument.AcousticGuitar())

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -2494,7 +2494,8 @@ class Test(unittest.TestCase):
         # s3.show()
 
     def testPartitionByInstrumentA(self):
-        from music21 import instrument, stream
+        from music21 import instrument
+        from music21 import stream
 
         # basic case of instruments in Parts
         s = stream.Score()
@@ -2523,7 +2524,8 @@ class Test(unittest.TestCase):
         # post.show('t')
 
     def testPartitionByInstrumentB(self):
-        from music21 import instrument, stream
+        from music21 import instrument
+        from music21 import stream
 
         # basic case of instruments in Parts
         s = stream.Score()
@@ -2544,7 +2546,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(post.parts[1].notes), 12)
 
     def testPartitionByInstrumentC(self):
-        from music21 import instrument, stream
+        from music21 import instrument
+        from music21 import stream
 
         # basic case of instruments in Parts
         s = stream.Score()
@@ -2580,7 +2583,8 @@ class Test(unittest.TestCase):
         # post.show('t')
 
     def testPartitionByInstrumentD(self):
-        from music21 import instrument, stream
+        from music21 import instrument
+        from music21 import stream
 
         # basic case of instruments in Parts
         s = stream.Score()
@@ -2618,7 +2622,8 @@ class Test(unittest.TestCase):
         # post.show('t')
 
     def testPartitionByInstrumentE(self):
-        from music21 import instrument, stream
+        from music21 import instrument
+        from music21 import stream
 
         # basic case of instruments in Parts
         # s = stream.Score()
@@ -2656,7 +2661,8 @@ class Test(unittest.TestCase):
                          [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 9.0, 10.0, 11.0, 12.0, 13.0, 20.0])
 
     def testPartitionByInstrumentF(self):
-        from music21 import instrument, stream
+        from music21 import instrument
+        from music21 import stream
 
         s1 = stream.Stream()
         s1.append(instrument.AcousticGuitar())

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -4163,7 +4163,8 @@ class Test(unittest.TestCase):
                           None, 'x', 'x', 'x', None, None, None])
 
     def testIntervalMicrotonesA(self):
-        from music21 import interval, pitch
+        from music21 import interval
+        from music21 import pitch
 
         i = interval.Interval('m3')
         self.assertEqual(i.chromatic.cents, 300)
@@ -4266,7 +4267,8 @@ class Test(unittest.TestCase):
         self.assertEqual(str(p2), 'E`5(+15c)')
 
     def testIntervalMicrotonesB(self):
-        from music21 import interval, note
+        from music21 import interval
+        from music21 import note
         i = interval.Interval(note.Note('c4'), note.Note('c#4'))
         self.assertEqual(str(i), '<music21.interval.Interval A1>')
 
@@ -4274,7 +4276,8 @@ class Test(unittest.TestCase):
         self.assertEqual(str(i), '<music21.interval.Interval A1 (-50c)>')
 
     def testDescendingAugmentedUnison(self):
-        from music21 import interval, note
+        from music21 import interval
+        from music21 import note
         ns = note.Note('C4')
         ne = note.Note('C-4')
         i = interval.Interval(noteStart=ns, noteEnd=ne)
@@ -4282,7 +4285,8 @@ class Test(unittest.TestCase):
         self.assertEqual(directedNiceName, 'Descending Diminished Unison')
 
     def testTransposeWithChromaticInterval(self):
-        from music21 import interval, note
+        from music21 import interval
+        from music21 import note
         ns = note.Note('C4')
         i = interval.ChromaticInterval(5)
         n2 = ns.transpose(i)
@@ -4294,7 +4298,8 @@ class Test(unittest.TestCase):
         self.assertEqual(n2.nameWithOctave, 'F4')
 
     def testIntervalWithOneNoteGiven(self):
-        from music21 import interval, note
+        from music21 import interval
+        from music21 import note
         noteC = note.Note('C4')
         i = interval.Interval(name='P4', noteStart=noteC)
         self.assertEqual(i.noteEnd.nameWithOctave, 'F4')

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -305,7 +305,7 @@ class IntervalException(exceptions21.Music21Exception):
 # some utility functions
 
 
-def _extractPitch(nOrP):
+def _extractPitch(nOrP: Union['music21.note.Note', 'music21.pitch.Pitch']):
     '''
     utility function to return either the object itself
     or the `.pitch` if it's a Note.
@@ -318,10 +318,10 @@ def _extractPitch(nOrP):
     True
 
     '''
-    if 'Pitch' in nOrP.classes:
-        return nOrP
-    else:
+    if hasattr(nOrP, 'pitch'):
         return nOrP.pitch
+    else:
+        return nOrP
 
 
 def convertStaffDistanceToInterval(staffDist):

--- a/music21/key.py
+++ b/music21/key.py
@@ -895,8 +895,7 @@ class Key(KeySignature, scale.DiatonicScale):
     def __init__(self,
                  tonic: Union[str, pitch.Pitch, note.Note] = 'C',
                  mode=None):
-        if hasattr(tonic, 'classes') and (isinstance(tonic, base.Music21Object)
-                                          or isinstance(tonic, pitch.Pitch)):
+        if isinstance(tonic, (base.Music21Object, pitch.Pitch)):
             if hasattr(tonic, 'name'):
                 tonic = tonic.name
             elif hasattr(tonic, 'pitches') and tonic.pitches:  # chord w/ >= 1 pitch
@@ -925,7 +924,7 @@ class Key(KeySignature, scale.DiatonicScale):
         KeySignature.__init__(self, sharps)
         scale.DiatonicScale.__init__(self, tonic=tonic)
 
-        if hasattr(tonic, 'classes') and isinstance(tonic, pitch.Pitch):
+        if isinstance(tonic, pitch.Pitch):
             self.tonic = tonic
         else:
             self.tonic = pitch.Pitch(tonic)

--- a/music21/key.py
+++ b/music21/key.py
@@ -1274,7 +1274,8 @@ class Test(unittest.TestCase):
         self.assertEqual(a.sharps, 0)
 
     def testTonalAmbiguityA(self):
-        from music21 import corpus, stream
+        from music21 import corpus
+        from music21 import stream
         # s = corpus.parse('bwv64.2')
         # k = s.analyze('KrumhanslSchmuckler')
         # k.tonalCertainty(method='correlationCoefficient')

--- a/music21/key.py
+++ b/music21/key.py
@@ -223,9 +223,9 @@ def pitchToSharps(value, mode=None):
     '''
     if isinstance(value, str):
         value = pitch.Pitch(value)
-    elif 'Pitch' in value.classes:
+    elif isinstance(value, pitch.Pitch):
         pass
-    elif 'Note' in value.classes:
+    elif isinstance(value, note.Note):
         value = value.pitch
     else:
         raise KeyException('Cannot get a sharp number from value')
@@ -527,9 +527,9 @@ class KeySignature(base.Music21Object):
         for p in newAlteredPitches:
             if not hasattr(p, 'classes'):
                 newList.append(pitch.Pitch(p))
-            elif 'Pitch' in p.classes:
+            elif isinstance(p, pitch.Pitch):
                 newList.append(p)
-            elif 'Note' in p.classes:
+            elif isinstance(p, note.Note):
                 newList.append(copy.deepcopy(p.pitch))
         self._alteredPitches = newList
 
@@ -895,8 +895,8 @@ class Key(KeySignature, scale.DiatonicScale):
     def __init__(self,
                  tonic: Union[str, pitch.Pitch, note.Note] = 'C',
                  mode=None):
-        if hasattr(tonic, 'classes') and ('Music21Object' in tonic.classes
-                                          or 'Pitch' in tonic.classes):
+        if hasattr(tonic, 'classes') and (isinstance(tonic, base.Music21Object)
+                                          or isinstance(tonic, pitch.Pitch)):
             if hasattr(tonic, 'name'):
                 tonic = tonic.name
             elif hasattr(tonic, 'pitches') and tonic.pitches:  # chord w/ >= 1 pitch
@@ -925,7 +925,7 @@ class Key(KeySignature, scale.DiatonicScale):
         KeySignature.__init__(self, sharps)
         scale.DiatonicScale.__init__(self, tonic=tonic)
 
-        if hasattr(tonic, 'classes') and 'Pitch' in tonic.classes:
+        if hasattr(tonic, 'classes') and isinstance(tonic, pitch.Pitch):
             self.tonic = tonic
         else:
             self.tonic = pitch.Pitch(tonic)

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -597,7 +597,7 @@ def divideByPages(scoreIn, printUpdates=False, fastMeasures=False):
 
     >>> firstSystem
     <music21.layout.System ...>
-    >>> 'Score' in firstSystem.classes
+    >>> isinstance(firstSystem, stream.Score)
     True
 
     Each System has staves (layout.Staff objects) not parts, though Staff is a subclass of Part
@@ -607,7 +607,7 @@ def divideByPages(scoreIn, printUpdates=False, fastMeasures=False):
     5
     >>> secondStaff
     <music21.layout.Staff ...>
-    >>> 'Part' in secondStaff.classes
+    >>> isinstance(secondStaff, stream.Part)
     True
     '''
     def getRichSystemLayout(inner_allSystemLayouts):

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -635,7 +635,7 @@ def divideByPages(scoreIn, printUpdates=False, fastMeasures=False):
     scoreLists.measureStart = firstMeasureNumber
     scoreLists.measureEnd = lastMeasureNumber
     for el in scoreIn:
-        if 'Part' not in el.classes:
+        if not isinstance(el, stream.Part):
             if 'ScoreLayout' in el.classes:
                 scoreLists.scoreLayout = el
             scoreLists.insert(scoreIn.elementOffset(el), el)
@@ -658,7 +658,7 @@ def divideByPages(scoreIn, printUpdates=False, fastMeasures=False):
             thisPageAll = scoreIn.measures(pageStartM, pageEndM)
         thisPage.systemStart = systemNumber + 1
         for el in thisPageAll:
-            if 'Part' not in el.classes and 'StaffGroup' not in el.classes:
+            if not isinstance(el.classes and 'StaffGroup' not in el, stream.Part):
                 thisPage.insert(thisPageAll.elementOffset(el), el)
         firstMeasureOfFirstPart = thisPageAll.parts.first().getElementsByClass('Measure').first()
         for el in firstMeasureOfFirstPart:

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -283,7 +283,6 @@ class LilypondConverter:
         TODO: make lilypond automatically run makeNotation.makeTupletBrackets(s)
         TODO: Add tests...
         '''
-        from music21 import stream
         c = m21ObjectIn.classes
         if 'Stream' in c:
             if m21ObjectIn.recurse().variants:
@@ -1815,8 +1814,8 @@ class LilypondConverter:
                 else:
                     variantDict[variantName] = [variantObject]
 
-            for key in variantDict:
-                variantList = variantDict[key]
+            for variant_key in variantDict:
+                variantList = variantDict[variant_key]
                 if len(variantList) == 1:
                     variantObject = variantList[0]
                     replacedElements = variantObject.replacedElements(activeSite)
@@ -2566,7 +2565,7 @@ class Test(unittest.TestCase):
         # print(lpc.topLevelObject)
 
     def testComplexDuration(self):
-        from music21 import stream, meter
+        from music21 import meter
         s = stream.Stream()
         n1 = note.Note('C')  # test no octave also!
         n1.duration.quarterLength = 2.5  # BUG 2.3333333333 doesn't work right
@@ -2631,7 +2630,7 @@ class TestExternal(unittest.TestCase):
             fifeOpus.show('lily.png')
 
     def xtestBreve(self):
-        from music21 import stream, meter
+        from music21 import meter
         n = note.Note('C5')
         n.duration.quarterLength = 8.0
         m = stream.Measure()
@@ -2645,7 +2644,6 @@ class TestExternal(unittest.TestCase):
             s.show('lily.png')
 
     def testStaffLines(self):
-        from music21 import stream
         s = stream.Score()
         p = stream.Part()
         p.append(note.Note('B4', type='whole'))

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -29,6 +29,7 @@ from music21 import corpus
 from music21 import duration
 from music21 import environment
 from music21 import exceptions21
+from music21 import key
 from music21 import note
 from music21 import stream
 from music21 import variant
@@ -583,7 +584,7 @@ class LilypondConverter:
         # mostRecentDur = ''
         # recentDurCount = 0
         for el in streamIn:
-            if 'Measure' not in el.classes:
+            if not isinstance(el, stream.Measure):
                 continue
             if el.duration.quarterLength == 0.0:
                 continue
@@ -1658,7 +1659,7 @@ class LilypondConverter:
         \key fis \major
 
         '''
-        if 'music21.key.Key' not in keyObj.classSet:
+        if not isinstance(keyObj, key.Key):
             keyObj = keyObj.asKey('major')
 
         p = keyObj.tonic

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -24,13 +24,14 @@ from collections import OrderedDict
 from importlib.util import find_spec
 
 from music21 import common
+from music21.converter.subConverters import SubConverter
 from music21 import corpus
 from music21 import duration
 from music21 import environment
 from music21 import exceptions21
-from music21 import variant
 from music21 import note
-from music21.converter.subConverters import SubConverter
+from music21 import stream
+from music21 import variant
 from music21.lily import lilyObjects as lyo
 
 _MOD = 'lily.translate'
@@ -991,9 +992,9 @@ class LilypondConverter:
                 variantList = []
                 otherList = []
                 for el in groupedElements:
-                    if 'Voice' in el.classes:
+                    if isinstance(el, stream.Voice):
                         voiceList.append(el)
-                    elif 'Variant' in el.classes:
+                    elif isinstance(el, variant.Variant):
                         variantList.append(el)
                     else:
                         el.activeSite = streamObject
@@ -1169,7 +1170,7 @@ class LilypondConverter:
         # commented out until complete
 #         if self.variantMode is True:
 #             # TODO: attach \noBeam to note if it is the last note
-#             if 'NotRest' in noteOrRest.classes:
+#             if isinstance(noteOrRest, note.NotRest):
 #                 n = noteOrRest
 #                 activeSite = n.activeSite
 #                 offset = n.offset
@@ -1956,7 +1957,7 @@ class LilypondConverter:
 
         def findOffsetOfFirstNonSpacerElement(inputStream):
             for el in inputStream:
-                if 'Rest' in el.classes and el.style.hideObjectOnPrint:
+                if isinstance(el, note.Rest) and el.style.hideObjectOnPrint:
                     pass
                 else:
                     return inputStream.elementOffset(el)

--- a/music21/midi/realtime.py
+++ b/music21/midi/realtime.py
@@ -255,7 +255,8 @@ class TestExternal(unittest.TestCase):  # pragma: no cover
         doesn't work -- no matter what there's always at least a small lag, even with queues
         '''
         # pylint: disable=attribute-defined-outside-init
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
         import random
 
         def getRandomStream():

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2094,7 +2094,8 @@ def conductorStream(s: stream.Stream) -> stream.Part:
         {0.0} <music21.stream.Stream measureLike>
             {0.0} <music21.note.Note C>
     '''
-    from music21 import tempo, meter
+    from music21 import tempo
+    from music21 import meter
     partsList = list(s.getElementsByClass('Stream').getElementsByOffset(0))
     minPriority = min(p.priority for p in partsList) if partsList else 0
     conductorPriority = minPriority - 1
@@ -2882,7 +2883,8 @@ class Test(unittest.TestCase):
         self.assertTrue(common.whitespaceEqual(conductorEvents, match), conductorEvents)
 
     def testKeySignature(self):
-        from music21 import meter, key
+        from music21 import meter
+        from music21 import key
         n = note.Note()
         n.quarterLength = 0.5
         s = stream.Stream()
@@ -3092,7 +3094,8 @@ class Test(unittest.TestCase):
         # s.show('midi')
 
     def testMidiProgramChangeB(self):
-        from music21 import instrument, scale
+        from music21 import instrument
+        from music21 import scale
         import random
 
         iList = [instrument.Harpsichord,
@@ -3171,7 +3174,8 @@ class Test(unittest.TestCase):
         # s.show('midi')
 
     def testOverlappedEventsC(self):
-        from music21 import meter, key
+        from music21 import meter
+        from music21 import key
 
         s = stream.Stream()
         s.insert(key.KeySignature(3))
@@ -3194,7 +3198,8 @@ class Test(unittest.TestCase):
         # s.show('midi')
 
     def testExternalMidiProgramChangeB(self):
-        from music21 import instrument, scale
+        from music21 import instrument
+        from music21 import scale
 
         iList = [instrument.Harpsichord, instrument.Clavichord, instrument.Accordion,
                  instrument.Celesta, instrument.Contrabass, instrument.Viola,
@@ -3348,7 +3353,8 @@ class Test(unittest.TestCase):
         # s.show('midi')
 
     def testMicrotonalOutputE(self):
-        from music21 import corpus, interval
+        from music21 import corpus
+        from music21 import interval
         s = corpus.parse('bwv66.6')
         p1 = s.parts[0]
         p2 = copy.deepcopy(p1)
@@ -3369,7 +3375,8 @@ class Test(unittest.TestCase):
         # post.show('midi', app='Logic Express')
 
     def testMicrotonalOutputF(self):
-        from music21 import corpus, interval
+        from music21 import corpus
+        from music21 import interval
         s = corpus.parse('bwv66.6')
         p1 = s.parts[0]
         p2 = copy.deepcopy(p1)
@@ -3397,8 +3404,9 @@ class Test(unittest.TestCase):
         # post.show('midi', app='Logic Express')
 
     def testMicrotonalOutputG(self):
-
-        from music21 import corpus, interval, instrument
+        from music21 import corpus
+        from music21 import interval
+        from music21 import instrument
         s = corpus.parse('bwv66.6')
         p1 = s.parts[0]
         p1.remove(p1.getElementsByClass('Instrument').first())
@@ -3492,7 +3500,8 @@ class Test(unittest.TestCase):
 
     def testMidiExportConductorA(self):
         '''Export conductor data to MIDI conductor track.'''
-        from music21 import meter, tempo
+        from music21 import meter
+        from music21 import tempo
 
         p1 = stream.Part()
         p1.repeatAppend(note.Note('c4'), 12)
@@ -3523,7 +3532,8 @@ class Test(unittest.TestCase):
         # s.show('midi', app='Logic Express')
 
     def testMidiExportConductorB(self):
-        from music21 import tempo, corpus
+        from music21 import tempo
+        from music21 import corpus
         s = corpus.parse('bwv66.6')
         s.insert(0, tempo.MetronomeMark(number=240))
         s.insert(4, tempo.MetronomeMark(number=30))
@@ -3568,7 +3578,9 @@ class Test(unittest.TestCase):
 
     def testMidiExportConductorE(self):
         '''The conductor only gets the first element at an offset.'''
-        from music21 import converter, tempo, key
+        from music21 import converter
+        from music21 import tempo
+        from music21 import key
 
         s = stream.Stream()
         p1 = converter.parse('tinynotation: c1')

--- a/music21/musedata/translate.py
+++ b/music21/musedata/translate.py
@@ -507,7 +507,8 @@ class Test(unittest.TestCase):
 
 
     def testBackBasic(self):
-        from music21 import converter, common
+        from music21 import converter
+        from music21 import common
         fpDir = common.getSourceFilePath() / 'musedata' / 'testPrimitive' / 'test01'
         s = converter.parse(fpDir)
         # note: this is a multi-staff work, but presently gets encoded

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6366,7 +6366,9 @@ class Test(unittest.TestCase):
         objects, where usually all the spanners will remain on the first object.
         '''
         import re
-        from music21 import converter, dynamics, layout
+        from music21 import converter
+        from music21 import dynamics
+        from music21 import layout
         xmlDir = common.getSourceFilePath() / 'musicxml' / 'lilypondTestSuite'
         s = converter.parse(xmlDir / '43e-Multistaff-ClefDynamics.xml')
 
@@ -6566,7 +6568,8 @@ class Test(unittest.TestCase):
         self.assertEqual(root.find('.//step').text, 'D')
 
     def testMidiInstrumentNoName(self):
-        from music21 import converter, instrument
+        from music21 import converter
+        from music21 import instrument
 
         i = instrument.Instrument()
         i.midiProgram = 42
@@ -6669,7 +6672,7 @@ class TestExternal(unittest.TestCase):
     show = True
 
     def testSimple(self):
-        from music21 import corpus  # , converter
+        from music21 import corpus
         import difflib
 
         # b = converter.parse(corpus.corpora.CoreCorpus().getWorkList('cpebach')[0],

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -34,6 +34,7 @@ from music21 import common
 from music21 import defaults
 from music21 import exceptions21
 
+from music21 import articulations
 from music21 import bar
 from music21 import clef
 from music21 import chord
@@ -402,7 +403,7 @@ class GeneralObjectExporter:
             outObj = self.fromGeneralObject(obj)
             return self.parseWellformedObject(outObj)
         else:
-            if 'Score' not in obj.classes:
+            if not isinstance(obj, stream.Score):
                 raise MusicXMLExportException('Can only export Scores with makeNotation=False')
             return self.parseWellformedObject(obj)
 
@@ -4140,7 +4141,7 @@ class MeasureExporter(XMLExporterBase):
         applicableArticulations = []
         fingeringNumber = 0
         for a in chordOrNote.articulations:
-            if 'Fingering' in a.classSet:
+            if isinstance(a, articulations.Fingering):
                 if fingeringNumber == noteIndexInChord:
                     applicableArticulations.append(a)
                 fingeringNumber += 1
@@ -4148,11 +4149,11 @@ class MeasureExporter(XMLExporterBase):
                 applicableArticulations.append(a)
 
         for artObj in applicableArticulations:
-            if 'Pizzicato' in artObj.classes:
+            if isinstance(artObj, articulations.Pizzicato):
                 continue
-            if 'StringIndication' in artObj.classes and artObj.number < 1:
+            if isinstance(artObj, articulations.StringIndication) and artObj.number < 1:
                 continue
-            if 'TechnicalIndication' in artObj.classes:
+            if isinstance(artObj, articulations.TechnicalIndication):
                 if mxTechnicalMark is None:
                     mxTechnicalMark = Element('technical')
                 mxTechnicalMark.append(self.articulationToXmlTechnical(artObj))

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4897,8 +4897,6 @@ class MeasureExporter(XMLExporterBase):
         if cs.writeAsChord is True:
             return self.chordToXml(cs)
 
-        from music21 import harmony
-
         mxHarmony = Element('harmony')
         _synchronizeIds(mxHarmony, cs)
 
@@ -6467,8 +6465,6 @@ class Test(unittest.TestCase):
         self.assertEqual(ly2.findall('text')[1].text, 'e')
 
     def testExportNC(self):
-        from music21 import harmony
-
         s = stream.Score()
         p = stream.Part()
         m = stream.Measure()
@@ -6613,7 +6609,8 @@ class Test(unittest.TestCase):
     def testTextExpressionOffset(self):
         '''Transfer element offset after calling getTextExpression().'''
         # https://github.com/cuthbertLab/music21/issues/624
-        from music21 import converter, repeat, tempo
+        from music21 import converter
+        from music21 import repeat
 
         s = converter.parse('tinynotation: 4/4 c1')
         c = repeat.Coda()
@@ -6645,8 +6642,6 @@ class Test(unittest.TestCase):
         self.assertEqual(rest.get('measure'), 'yes')
 
     def testArticulationSpecialCases(self):
-        from music21 import articulations
-
         n = note.Note()
         a = articulations.StringIndication()
         n.articulations.append(a)

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -36,8 +36,9 @@ from music21 import exceptions21
 
 from music21 import bar
 from music21 import clef
-from music21 import chord  # for typing
+from music21 import chord
 from music21 import duration
+from music21 import harmony
 from music21 import metadata
 from music21 import note
 from music21 import meter
@@ -45,6 +46,7 @@ from music21 import pitch
 from music21 import spanner
 from music21 import stream
 from music21 import style
+from music21 import tempo
 from music21.stream.iterator import OffsetIterator
 
 from music21.musicxml import helpers
@@ -2897,7 +2899,7 @@ class MeasureExporter(XMLExporterBase):
         root = self.xmlRoot
         divisions = self.currentDivisions
         self.offsetInMeasure = 0.0
-        if 'Voice' in m.classes:
+        if isinstance(m, stream.Voice):
             m: stream.Voice
             if isinstance(m.id, int) and m.id < defaults.minIdNumberToConsiderMemoryLocation:
                 voiceId = m.id
@@ -2930,7 +2932,7 @@ class MeasureExporter(XMLExporterBase):
             for obj in objGroup:
                 # we do all non-note elements (including ChordSymbols)
                 # first before note elements, in musicxml
-                if 'GeneralNote' in obj.classes and 'Harmony' not in obj.classes:
+                if isinstance(obj, note.GeneralNote) and not isinstance(obj, harmony.Harmony):
                     notesForLater.append(obj)
                 else:
                     self.parseOneElement(obj)
@@ -5277,7 +5279,7 @@ class MeasureExporter(XMLExporterBase):
         hideNumber = []  # hide the number after equal, e.g., quarter=120, hide 120
         # store the last value necessary as a sounding tag in bpm
         soundingQuarterBPM = False
-        if 'MetronomeMark' in ti.classes:
+        if isinstance(ti, tempo.MetronomeMark):
             # will not show a number of implicit
             if ti.numberImplicit or ti.number is None:
                 # environLocal.printDebug(['found numberImplicit', ti.numberImplicit])
@@ -5290,7 +5292,7 @@ class MeasureExporter(XMLExporterBase):
             # number (if implicit, that is fine); get in terms of quarter bpm
             soundingQuarterBPM = ti.getQuarterBPM()
 
-        elif 'MetricModulation' in ti.classes:
+        elif isinstance(ti, tempo.MetricModulation):
             # may need to reverse order if classical style or otherwise
             # may want to show first number
             hideNumericalMetro = False  # must show for metric modulation
@@ -5339,7 +5341,7 @@ class MeasureExporter(XMLExporterBase):
         if hideNumericalMetro is not None:
             self.xmlRoot.append(mxDirection)
 
-        if 'MetronomeMark' in ti.classes:
+        if isinstance(ti, tempo.MetronomeMark):
             if ti.getTextExpression(returnImplicit=False) is not None:
                 te = ti.getTextExpression(returnImplicit=False)
                 te.offset = ti.offset
@@ -5638,7 +5640,7 @@ class MeasureExporter(XMLExporterBase):
         if barline is None:
             mxBarline = Element('barline')
         else:
-            if 'Repeat' in barline.classes:
+            if isinstance(barline, bar.Repeat):
                 mxBarline = Element('barline')
                 mxRepeat = self.repeatToXml(barline)
             else:
@@ -5761,7 +5763,7 @@ class MeasureExporter(XMLExporterBase):
             mxDivisions.text = str(self.currentDivisions)
             self.parent.lastDivisions = self.currentDivisions
 
-        if 'Measure' in m.classes:
+        if isinstance(m, stream.Measure):
             if m.keySignature is not None:
                 mxAttributes.append(self.keySignatureToXml(m.keySignature))
             if m.timeSignature is not None:

--- a/music21/musicxml/testPrimitive.py
+++ b/music21/musicxml/testPrimitive.py
@@ -18170,7 +18170,12 @@ class Test(unittest.TestCase):
         '''
         Tests if there are mid-measure clefs clefs: single staff
         '''
-        from music21 import stream, note, clef, musicxml, converter, meter
+        from music21 import stream
+        from music21 import note
+        from music21 import clef
+        from music21 import musicxml
+        from music21 import converter
+        from music21 import meter
 
         orig_stream = stream.Stream()
         orig_stream.append(meter.TimeSignature('4/4'))
@@ -18195,7 +18200,12 @@ class Test(unittest.TestCase):
         '''
         Tests if there are mid-measure clefs clefs: multiple staves.
         '''
-        from music21 import stream, note, clef, musicxml, converter, meter
+        from music21 import clef
+        from music21 import converter
+        from music21 import meter
+        from music21 import musicxml
+        from music21 import note
+        from music21 import stream
 
         orig_stream = stream.Stream()
         orig_stream.append(stream.Part())

--- a/music21/note.py
+++ b/music21/note.py
@@ -1538,7 +1538,7 @@ class Note(NotRest):
         {1.0} <music21.note.Note G->
 
         '''
-        if hasattr(value, 'classes') and isinstance(value, interval.IntervalBase):
+        if isinstance(value, interval.IntervalBase):
             intervalObj = value
         else:  # try to process
             intervalObj = interval.Interval(value)

--- a/music21/note.py
+++ b/music21/note.py
@@ -1921,7 +1921,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(found), 24)
 
     def testNoteBeatProperty(self):
-        from music21 import stream, meter
+        from music21 import stream
+        from music21 import meter
 
         data = [
             ['3/4', 0.5, 6, [1.0, 1.5, 2.0, 2.5, 3.0, 3.5],
@@ -2097,7 +2098,8 @@ class Test(unittest.TestCase):
             self.assertEqual(a == b, match)  # sub6
 
     def testMetricalAccent(self):
-        from music21 import meter, stream
+        from music21 import meter
+        from music21 import stream
         data = [
             ('4/4', 8, 0.5, [1.0, 0.125, 0.25, 0.125, 0.5, 0.125, 0.25, 0.125]),
             ('3/4', 6, 0.5, [1.0, 0.25, 0.5, 0.25, 0.5, 0.25]),

--- a/music21/note.py
+++ b/music21/note.py
@@ -1538,7 +1538,7 @@ class Note(NotRest):
         {1.0} <music21.note.Note G->
 
         '''
-        if hasattr(value, 'classes') and 'IntervalBase' in value.classes:
+        if hasattr(value, 'classes') and isinstance(value, interval.IntervalBase):
             intervalObj = value
         else:  # try to process
             intervalObj = interval.Interval(value)
@@ -1858,7 +1858,8 @@ class Test(unittest.TestCase):
         self.assertEqual(repr(ly), "<music21.note.Lyric number=1 identifier='verse'>")
 
     def testComplex(self):
-        note1 = Note()
+        from music21 import note
+        note1 = note.Note()
         note1.duration.clear()
         d1 = duration.DurationTuple('whole', 0, 4.0)
         d2 = duration.DurationTuple('quarter', 0, 1.0)
@@ -2149,10 +2150,11 @@ class Test(unittest.TestCase):
         # s.show()
 
     def testVolumeA(self):
+        from music21 import note
         v1 = volume.Volume()
 
-        n1 = Note()
-        n2 = Note()
+        n1 = note.Note()
+        n2 = note.Note()
 
         n1.volume = v1  # can set as v1 has no client
         self.assertEqual(n1.volume, v1)
@@ -2163,8 +2165,9 @@ class Test(unittest.TestCase):
         self.assertIsNotNone(n2.volume)
 
     def testVolumeB(self):
+        from music21 import note
         # manage deepcopying properly
-        n1 = Note()
+        n1 = note.Note()
 
         n1.volume.velocity = 100
         self.assertEqual(n1.volume.velocity, 100)

--- a/music21/omr/correctors.py
+++ b/music21/omr/correctors.py
@@ -9,13 +9,14 @@
 # Copyright:    Copyright © 2014 Maura Church, Michael Scott Cuthbert, and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
-import math
-import difflib
 import copy
 import collections
-
-import os
+import difflib
 import inspect
+import math
+import os
+
+from music21 import note
 
 pathName = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 
@@ -321,7 +322,7 @@ class ScoreCorrector:
         for el in correctMeasure:
             newEl = copy.deepcopy(el)
             try:
-                if 'Note' in newEl.classes:
+                if isinstance(newEl, note.Note):
                     oldPitch = oldNotePitches[pitchIndex]
                     newEl.pitch.octave = oldPitch.octave
                     newEl.pitch.name = oldPitch.name

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4982,7 +4982,8 @@ class Pitch(prebase.ProtoM21Object):
 
         '''
         # Takes in a chord, finds the interval between the notes
-        from music21 import note, chord
+        from music21 import note
+        from music21 import chord
 
         pitchList = chordIn.pitches
         isStringHarmonic = False
@@ -5387,7 +5388,8 @@ class Test(unittest.TestCase):
         cautionaryNotImmediateRepeat=False
         and key signature conflicts.
         '''
-        from music21 import converter, key
+        from music21 import converter
+        from music21 import key
         bm = converter.parse("tinynotation: 4/4 fn1 fn1 e-8 e'-8 fn4 en4 e'n4").flat
         bm.insert(0, key.KeySignature(1))
         bm.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False)
@@ -5441,7 +5443,9 @@ class Test(unittest.TestCase):
         self.assertEqual(lowC.octave, -1)
 
     def testQuarterToneA(self):
-        from music21 import stream, note, scale
+        from music21 import stream
+        from music21 import note
+        from music21 import scale
         from music21.musicxml import m21ToXml
 
         p1 = Pitch('D#~')

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -151,7 +151,7 @@ class ProtoM21Object:
         >>> s.insert(50, clef.BassClef())
         >>> s2 = stream.Stream()
         >>> for t in s:
-        ...    if 'GClef' in t.classes and 'TrebleClef' not in t.classes:
+        ...    if isinstance(t, clef.GClef) and not isinstance(t, clef.TrebleClef):
         ...        s2.insert(t)
         >>> s2.show('text')
         {10.0} <music21.clef.GClef>

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -869,7 +869,7 @@ class Expander:
         if lb is not None and 'music21.bar.Repeat' in lb.classSet:
             # environLocal.printDebug(['inserting new barline: %s' % newStyle])
             m.leftBarline = bar.Barline(newType)
-        if rb is not None  and 'music21.bar.Repeat' in rb.classSet:
+        if rb is not None and 'music21.bar.Repeat' in rb.classSet:
             m.rightBarline = bar.Barline(newType)
 
     def _stripRepeatExpressions(self, streamObj):
@@ -1634,7 +1634,7 @@ class Expander:
             # if mLast does not have a repeat bar, its probably not a repeat
             mLastRightBar = mLast.rightBarline
             if (mLastRightBar is not None
-                    and  'music21.bar.Repeat' in mLastRightBar.classSet):
+                    and 'music21.bar.Repeat' in mLastRightBar.classSet):
                 indices = list(range(startIndex, endIndex + 1))
             # condition of when to repeat next is not always clear
             # if we have  [1 x :|[2 x | x still need to repeat

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -866,10 +866,10 @@ class Expander:
         from music21 import bar
         lb = m.leftBarline
         rb = m.rightBarline
-        if lb is not None and 'Repeat' in lb.classes:
+        if lb is not None and 'music21.bar.Repeat' in lb.classSet:
             # environLocal.printDebug(['inserting new barline: %s' % newStyle])
             m.leftBarline = bar.Barline(newType)
-        if rb is not None and 'Repeat' in rb.classes:
+        if rb is not None  and 'music21.bar.Repeat' in rb.classSet:
             m.rightBarline = bar.Barline(newType)
 
     def _stripRepeatExpressions(self, streamObj):
@@ -900,7 +900,7 @@ class Expander:
             lb = m.leftBarline
             rb = m.rightBarline
 
-            if lb is not None and 'Repeat' in lb.classes:
+            if lb is not None and 'music21.bar.Repeat' in lb.classSet:
                 if lb.direction == 'start':
                     startCount += 1
                     countBalance += 1
@@ -911,7 +911,7 @@ class Expander:
                         countBalance += 1  # simulate first
                     endCount += 1
                     countBalance -= 1
-            if rb is not None and 'Repeat' in rb.classes:
+            if rb is not None and 'music21.bar.Repeat' in rb.classSet:
                 if rb.direction == 'end':
                     # if this is the first of all repeats found, then we
                     # have an acceptable case where the first repeat is omitted
@@ -1208,10 +1208,10 @@ class Expander:
             # this does not check for well-balanced formations,
             # only presence
             if (lb is not None
-                    and 'Repeat' in lb.classes):
+                    and 'music21.bar.Repeat' in lb.classSet):
                 return True
             if (rb is not None
-                    and 'Repeat' in rb.classes
+                    and 'music21.bar.Repeat' in rb.classSet
                     and rb.direction == 'end'):
                 return True
         return False
@@ -1255,7 +1255,7 @@ class Expander:
             except AttributeError:
                 continue  # probably not a measure
 
-            if lb is not None and 'Repeat' in lb.classes:
+            if lb is not None and 'music21.bar.Repeat' in lb.classSet:
                 if lb.direction == 'start':
                     startIndices.append(i)
                 # an end may be placed on the left barline; of the next measure
@@ -1270,7 +1270,7 @@ class Expander:
                         barRepeatIndices = range(startIndices[-1], i)
                         break
             if (rb is not None
-                    and 'Repeat' in rb.classes
+                    and 'music21.bar.Repeat' in rb.classSet
                     and rb.direction == 'end'):
                 # if this is the first end found and no starts found,
                 # assume we are counting from zero
@@ -1298,7 +1298,7 @@ class Expander:
         rb = mLast.rightBarline
         # if right barline of end is a repeat
         if (rb is not None
-                and 'Repeat' in rb.classes
+                and 'music21.bar.Repeat' in rb.classSet
                 and rb.direction == 'end'):
             mEndBarline = mLast  # they are the same
             repeatTimes = rb.times
@@ -1311,7 +1311,7 @@ class Expander:
             mEndBarline = streamObj[index + 1]
             lb = mEndBarline.leftBarline
             if (lb is not None
-                    and 'Repeat' in lb.classes
+                    and 'music21.bar.Repeat' in lb.classSet
                     and lb.direction == 'end'):
                 repeatTimes = lb.times
             else:
@@ -1634,7 +1634,7 @@ class Expander:
             # if mLast does not have a repeat bar, its probably not a repeat
             mLastRightBar = mLast.rightBarline
             if (mLastRightBar is not None
-                    and 'Repeat' in mLastRightBar.classes):
+                    and  'music21.bar.Repeat' in mLastRightBar.classSet):
                 indices = list(range(startIndex, endIndex + 1))
             # condition of when to repeat next is not always clear
             # if we have  [1 x :|[2 x | x still need to repeat

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -2595,7 +2595,10 @@ class RepeatFinder:
 class Test(unittest.TestCase):
 
     def testFilterByRepeatMark(self):
-        from music21 import stream, bar, repeat, note
+        from music21 import stream
+        from music21 import bar
+        from music21 import repeat
+        from music21 import note
 
         s = stream.Part()
         m1 = stream.Measure()
@@ -2624,7 +2627,10 @@ class Test(unittest.TestCase):
         self.assertEqual(ex.findInnermostRepeatIndices(s), [0])
 
     def testRepeatCoherenceB(self):
-        from music21 import stream, bar, repeat, note
+        from music21 import stream
+        from music21 import bar
+        from music21 import repeat
+        from music21 import note
 
         s = stream.Part()
         m1 = stream.Measure()
@@ -2649,7 +2655,10 @@ class Test(unittest.TestCase):
         self.assertEqual(ex.findInnermostRepeatIndices(s), [0])
 
     def testRepeatCoherenceB2(self):
-        from music21 import stream, bar, repeat, note
+        from music21 import stream
+        from music21 import bar
+        from music21 import repeat
+        from music21 import note
 
         # a nested repeat; acceptable
         s = stream.Part()
@@ -2706,7 +2715,8 @@ class Test(unittest.TestCase):
     def testRepeatCoherenceC(self):
         '''Using da capo/dal segno
         '''
-        from music21 import stream, repeat
+        from music21 import stream
+        from music21 import repeat
 
         # no repeats
         s = stream.Part()
@@ -2828,7 +2838,10 @@ class Test(unittest.TestCase):
         # ex._processRepeatExpression(s, s)
 
     def testExpandRepeatA(self):
-        from music21 import stream, bar, repeat, note
+        from music21 import stream
+        from music21 import bar
+        from music21 import repeat
+        from music21 import note
 
         # two repeat bars in a row
         p = stream.Part()
@@ -2899,7 +2912,8 @@ class Test(unittest.TestCase):
 
     def testExpandRepeatB(self):
         from music21.abcFormat import testFiles
-        from music21 import converter, repeat
+        from music21 import converter
+        from music21 import repeat
 
         s = converter.parse(testFiles.draughtOfAle)
         # s.show()
@@ -2921,7 +2935,8 @@ class Test(unittest.TestCase):
 
     def testExpandRepeatC(self):
         from music21.abcFormat import testFiles
-        from music21 import converter, repeat
+        from music21 import converter
+        from music21 import repeat
 
         s = converter.parse(testFiles.kingOfTheFairies)
         self.assertEqual(len(s.parts[0].getElementsByClass('Measure')),
@@ -2947,7 +2962,9 @@ class Test(unittest.TestCase):
     def testExpandRepeatD(self):
 
         # test one back repeat at end of a measure
-        from music21 import stream, bar, note
+        from music21 import stream
+        from music21 import bar
+        from music21 import note
 
         m1 = stream.Measure()
         m1.repeatAppend(note.Note('c4', type='half'), 2)
@@ -2971,7 +2988,9 @@ class Test(unittest.TestCase):
     def testExpandRepeatE(self):
 
         # test one back repeat at end of a measure
-        from music21 import stream, bar, note
+        from music21 import stream
+        from music21 import bar
+        from music21 import note
 
         m1 = stream.Measure()
         m1.repeatAppend(note.Note('c4', type='half'), 2)
@@ -3013,7 +3032,10 @@ class Test(unittest.TestCase):
     def testExpandRepeatF(self):
         # an algorithmic generation approach
         import random
-        from music21 import bar, note, stream, meter
+        from music21 import bar
+        from music21 import note
+        from music21 import stream
+        from music21 import meter
 
         dur = [0.125, 0.25, 0.5, 0.125]
         durA = dur
@@ -3056,9 +3078,12 @@ class Test(unittest.TestCase):
 
     def testExpandRepeatH(self):
         # an algorithmic generation approach
-
-        from music21 import bar, note, stream, meter, pitch
+        from music21 import bar
         from music21 import features
+        from music21 import meter
+        from music21 import note
+        from music21 import pitch
+        from music21 import stream
 
         dur = [0.125, 0.25, 0.5, 0.125]
         repeatTimesCycle = [0, 1, 3, 5]
@@ -3157,7 +3182,10 @@ class Test(unittest.TestCase):
         self.assertTrue(rm.isValidText('dal segno al coda'))
 
     def testRepeatExpressionOnStream(self):
-        from music21 import stream, repeat, meter, converter
+        from music21 import stream
+        from music21 import repeat
+        from music21 import meter
+        from music21 import converter
         from music21.musicxml import m21ToXml
 
         GEX = m21ToXml.GeneralObjectExporter()
@@ -3193,7 +3221,9 @@ class Test(unittest.TestCase):
     def testExpandDaCapoA(self):
 
         # test one back repeat at end of a measure
-        from music21 import stream, bar, note
+        from music21 import stream
+        from music21 import bar
+        from music21 import note
 
         m1 = stream.Measure()
         m1.repeatAppend(note.Note('c4', type='half'), 2)
@@ -3241,7 +3271,9 @@ class Test(unittest.TestCase):
         self.assertEqual(ex._daCapoOrSegno(), DaCapo)
 
     def testRemoveRepeatExpressions(self):
-        from music21 import stream, repeat, bar
+        from music21 import stream
+        from music21 import repeat
+        from music21 import bar
 
         s = stream.Part()
         m1 = stream.Measure()
@@ -3316,7 +3348,8 @@ class Test(unittest.TestCase):
     def testExpandRepeatExpressionA(self):
 
         # test one back repeat at end of a measure
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
 
         # a da capo al fine without a fine is not valid
         m1 = stream.Measure()
@@ -3372,7 +3405,8 @@ class Test(unittest.TestCase):
     def testExpandRepeatExpressionB(self):
 
         # test one back repeat at end of a measure
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
 
         # simple da capo alone
         m1 = stream.Measure()
@@ -3397,7 +3431,8 @@ class Test(unittest.TestCase):
                           'E4', 'E4', 'G4', 'G4', 'A4', 'A4'])
 
     def testExpandRepeatExpressionC(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
 
         # da capo al fine
         m1 = stream.Measure()
@@ -3423,7 +3458,8 @@ class Test(unittest.TestCase):
                          ['C4', 'C4', 'E4', 'E4', 'G4', 'G4', 'C4', 'C4', 'E4', 'E4'])
 
     def testExpandRepeatExpressionD(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
 
         # da capo al coda
         m1 = stream.Measure()
@@ -3454,7 +3490,9 @@ class Test(unittest.TestCase):
                           'E4', 'E4', 'A4', 'A4', 'B4', 'B4'])
 
     def testExpandRepeatExpressionE(self):
-        from music21 import repeat, stream, note
+        from music21 import repeat
+        from music21 import stream
+        from music21 import note
         # dal segno simple
         m1 = stream.Measure()
         m1.repeatAppend(note.Note('c4', type='half'), 2)
@@ -3482,7 +3520,8 @@ class Test(unittest.TestCase):
                           'G4', 'G4', 'A4', 'A4'])
 
     def testExpandRepeatExpressionF(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
         from music21 import repeat
         # dal segno al fine
         m1 = stream.Measure()
@@ -3513,7 +3552,8 @@ class Test(unittest.TestCase):
                           'E4', 'E4', 'G4', 'G4'])
 
     def testExpandRepeatExpressionG(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
         from music21 import repeat
         # dal segno al coda
         m1 = stream.Measure()
@@ -3551,7 +3591,9 @@ class Test(unittest.TestCase):
 
     def testExpandRepeatExpressionH(self):
         # test one back repeat at end of a measure
-        from music21 import stream, bar, note
+        from music21 import stream
+        from music21 import bar
+        from music21 import note
 
         # simple da capo alone
         m1 = stream.Measure()
@@ -3601,7 +3643,10 @@ class Test(unittest.TestCase):
 
     def testExpandRepeatExpressionI(self):
         # test one back repeat at end of a measure
-        from music21 import stream, bar, note, repeat
+        from music21 import stream
+        from music21 import bar
+        from music21 import note
+        from music21 import repeat
 
         # simple da capo alone
         m1 = stream.Measure()
@@ -3640,7 +3685,11 @@ class Test(unittest.TestCase):
 
     def testExpandRepeatExpressionJ(self):
         # test one back repeat at end of a measure
-        from music21 import stream, bar, note, repeat, instrument
+        from music21 import stream
+        from music21 import bar
+        from music21 import note
+        from music21 import repeat
+        from music21 import instrument
 
         # simple da capo alone
         m1 = stream.Measure()
@@ -3778,7 +3827,9 @@ class Test(unittest.TestCase):
         self.assertEqual(len(ex._repeatBrackets), 2)
 
     def testRepeatEndingsB(self):
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -3825,7 +3876,9 @@ class Test(unittest.TestCase):
         # p.show()
 
     def testRepeatEndingsB2(self):
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -3872,7 +3925,9 @@ class Test(unittest.TestCase):
         # p.show()
 
     def testRepeatEndingsC(self):
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -3910,7 +3965,9 @@ class Test(unittest.TestCase):
         self.assertTrue(ex._repeatBracketsAreCoherent())
 
     def testRepeatEndingsD(self):
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure(number=1)
@@ -3946,7 +4003,9 @@ class Test(unittest.TestCase):
     def testRepeatEndingsE(self):
         '''Expanding two endings (1, 2, then 3) without a start repeat
         '''
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -3981,7 +4040,9 @@ class Test(unittest.TestCase):
     def testRepeatEndingsF(self):
         '''Two sets of two endings (1, 2, then 3) without a start repeat
         '''
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -4035,7 +4096,9 @@ class Test(unittest.TestCase):
     def testRepeatEndingsG(self):
         '''Two sets of two endings (1, 2, then 3) without a start repeat
         '''
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -4076,7 +4139,9 @@ class Test(unittest.TestCase):
     def testRepeatEndingsH(self):
         '''Two sets of two endings (1, 2, then 3) without a start repeat
         '''
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure(number=1)
@@ -4121,7 +4186,9 @@ class Test(unittest.TestCase):
     def testRepeatEndingsI(self):
         '''Two sets of two endings (1, 2, then 3) without a start repeat
         '''
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure(number=1)
@@ -4177,7 +4244,9 @@ class Test(unittest.TestCase):
     def testRepeatEndingsJ(self):
         '''Two sets of two endings (1, 2, then 3) without a start repeat
         '''
-        from music21 import stream, note, bar
+        from music21 import stream
+        from music21 import note
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure(number=1)

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2648,7 +2648,7 @@ class RomanNumeral(harmony.Harmony):
 
         if aug6Match:
             # NB -- could be Key or Scale
-            if (('Key' in useScale.classes and useScale.mode == 'major')
+            if ((isinstance(useScale, key.Key) and useScale.mode == 'major')
                     or ('DiatonicScale' in useScale.classes and useScale.type == 'major')):
                 useScale = key.Key(useScale.tonic, 'minor')
                 self.impliedScale = useScale
@@ -3652,7 +3652,7 @@ class Test(unittest.TestCase):
             targetCount,
         )
         for e in s3.recurse(streamsOnly=True):
-            if 'KeySignature' in e.classes:
+            if isinstance(e, key.KeySignature):
                 # all active sites are None because of deep-copying
                 if e.activeSite is not None:
                     e.activeSite.remove(e)
@@ -3665,7 +3665,7 @@ class Test(unittest.TestCase):
         )
         # do not remove in iteration.
         for c in list(s4.recurse(streamsOnly=False)):
-            if 'Stream' in c.classes:
+            if isinstance(c, stream.Stream):
                 for e in c.getElementsByClass('KeySignature'):
                     c.remove(e)
 
@@ -4084,7 +4084,7 @@ class TestExternal(unittest.TestCase):
         cKey = b.analyze('key')
         figuresCache = {}
         for x in c.recurse():
-            if 'Chord' in x.classes:
+            if isinstance(x, chord.Chord):
                 rnc = romanNumeralFromChord(x, cKey)
                 figure = rnc.figure
                 if figure not in figuresCache:

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -38,7 +38,7 @@ the data to make a histogram of scale degree usage within a key:
 
 >>> degreeDictionary = {}
 >>> for el in monteverdi.recurse():
-...    if 'RomanNumeral' in el.classes:
+...    if isinstance(el, roman.RomanNumeral):
 ...         print(f'{el.figure} {el.key}')
 ...         for p in el.pitches:
 ...              degree, accidental = el.key.getScaleDegreeAndAccidentalFromPitch(p)
@@ -1278,7 +1278,7 @@ class TestSlow(unittest.TestCase):  # pragma: no cover
 
         # make sure a normal file is still a Score
         s = converter.parse(testFiles.riemenschneider001)
-        self.assertTrue('Score' in s.classes)
+        self.assertTrue(isinstance(s, stream.Score))
 
 
 class Test(unittest.TestCase):

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -3846,7 +3846,8 @@ Franck Jedrzejewski continued fractions approx. of 12-tet
 
     def testScalaScaleB(self):
         # test importing from scala archive
-        from music21 import stream, meter
+        from music21 import stream
+        from music21 import meter
 
         sc = ScalaScale('e2', 'fj 12tet')
         self.assertEqual(sc._abstract._net.pitchSimplification, 'mostCommon')
@@ -3987,7 +3988,8 @@ Franck Jedrzejewski continued fractions approx. of 12-tet
         and then uses Marchetto da Padova's very high sharps and very low
         flats (except B-flat) to inflect the accidentals
         '''
-        from music21 import corpus, instrument
+        from music21 import corpus
+        from music21 import instrument
 
         s = corpus.parse('luca/gloria').measures(70, 79)
         for p in s.parts:

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -75,6 +75,7 @@ from music21 import base
 from music21 import common
 from music21 import environment
 from music21 import exceptions21
+from music21 import note
 from music21 import pitch
 from music21 import interval
 from music21 import sieve
@@ -174,7 +175,7 @@ class Scale(base.Music21Object):
             for p in other:
                 if hasattr(p, 'pitch'):
                     pre.append(p.pitch)
-                elif hasattr(p, 'classes') and 'Pitch' in p.classes:
+                elif hasattr(p, 'classes') and isinstance(p, pitch.Pitch):
                     pre.append(p)
                 else:
                     pre.append(pitch.Pitch(p))
@@ -303,7 +304,7 @@ class AbstractScale(Scale):
         for p in pitchList:
             if isinstance(p, str):
                 pitchListReal.append(pitch.Pitch(p))
-            elif hasattr(p, 'classes') and 'Note' in p.classes:
+            elif hasattr(p, 'classes') and isinstance(p, note.Note):
                 pitchListReal.append(p.pitch)
             else:  # assume this is a pitch object
                 pitchListReal.append(p)
@@ -1282,7 +1283,7 @@ class ConcreteScale(Scale):
             self.tonic = None  # pitch.Pitch()
         elif isinstance(tonic, str):
             self.tonic = pitch.Pitch(tonic)
-        elif hasattr(tonic, 'classes') and 'GeneralNote' in tonic.classes:
+        elif hasattr(tonic, 'classes') and isinstance(tonic, note.GeneralNote):
             self.tonic = tonic.pitch
         else:  # assume this is a pitch object
             self.tonic = tonic

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -175,7 +175,7 @@ class Scale(base.Music21Object):
             for p in other:
                 if hasattr(p, 'pitch'):
                     pre.append(p.pitch)
-                elif hasattr(p, 'classes') and isinstance(p, pitch.Pitch):
+                elif isinstance(p, pitch.Pitch):
                     pre.append(p)
                 else:
                     pre.append(pitch.Pitch(p))
@@ -304,7 +304,7 @@ class AbstractScale(Scale):
         for p in pitchList:
             if isinstance(p, str):
                 pitchListReal.append(pitch.Pitch(p))
-            elif hasattr(p, 'classes') and isinstance(p, note.Note):
+            elif isinstance(p, note.Note):
                 pitchListReal.append(p.pitch)
             else:  # assume this is a pitch object
                 pitchListReal.append(p)
@@ -1257,7 +1257,7 @@ class ConcreteScale(Scale):
     usePitchDegreeCache = False
 
     def __init__(self,
-                 tonic: Optional[Union[str, pitch.Pitch, 'music21.note.Note']] = None,
+                 tonic: Optional[Union[str, pitch.Pitch, note.Note]] = None,
                  pitches: Optional[List[Union[pitch.Pitch, str]]] = None):
         super().__init__()
 
@@ -1283,7 +1283,7 @@ class ConcreteScale(Scale):
             self.tonic = None  # pitch.Pitch()
         elif isinstance(tonic, str):
             self.tonic = pitch.Pitch(tonic)
-        elif hasattr(tonic, 'classes') and isinstance(tonic, note.GeneralNote):
+        elif isinstance(tonic, note.GeneralNote):
             self.tonic = tonic.pitch
         else:  # assume this is a pitch object
             self.tonic = tonic
@@ -3204,7 +3204,6 @@ class Test(unittest.TestCase):
         return out
 
     def testBasicLegacy(self):
-        from music21 import note
         from music21 import scale
 
         n1 = note.Note()
@@ -3278,7 +3277,6 @@ class Test(unittest.TestCase):
     def testBasic(self):
         from music21 import corpus
         from music21 import stream
-        from music21 import note
         from music21 import scale
         # deriving a scale from a Stream
 
@@ -3526,7 +3524,7 @@ class Test(unittest.TestCase):
     def testMelodicMinorB(self):
         '''Need to test descending form of getting pitches with no defined min and max
         '''
-        from music21 import stream, note
+        from music21 import stream
         mm = MelodicMinorScale('a')
         # self.assertEqual(str(mm.getPitches(None, None, direction='ascending')),
         #    '[A4, B4, C5, D5, E5, F#5, G#5, A5]')
@@ -3848,7 +3846,7 @@ Franck Jedrzejewski continued fractions approx. of 12-tet
 
     def testScalaScaleB(self):
         # test importing from scala archive
-        from music21 import stream, meter, note
+        from music21 import stream, meter
 
         sc = ScalaScale('e2', 'fj 12tet')
         self.assertEqual(sc._abstract._net.pitchSimplification, 'mostCommon')

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -34,9 +34,10 @@ import unittest
 
 from collections import OrderedDict
 
+from music21 import common
 from music21 import exceptions21
 from music21 import interval
-from music21 import common
+from music21 import note
 from music21 import pitch
 from music21 import prebase
 
@@ -2310,7 +2311,7 @@ class IntervalNetwork:
 
         if isinstance(pitchTarget, str):
             pitchTarget = pitch.Pitch(pitchTarget)
-        elif 'Note' in pitchTarget.classes:
+        elif isinstance(pitchTarget, note.Note):
             pitchTarget = pitchTarget.pitch
 
         saveOctave = pitchTarget.octave

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -24,6 +24,7 @@ from more_itertools import windowed
 from music21 import base as m21Base
 from music21 import exceptions21
 from music21 import duration
+from music21 import note
 from music21.stream import filters
 
 __all__ = [
@@ -1079,7 +1080,7 @@ def mostCommonMeasureRhythms(streamIn, transposeDiatonic=False):
             measureNotes = thisMeasure.notes
             foundNote = False
             for i in range(len(measureNotes)):
-                if 'Note' in measureNotes[i].classes:
+                if isinstance(measureNotes[i], note.Note):
                     distanceToTranspose = 72 - measureNotes[0].pitch.ps
                     foundNote = True
                     break

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -386,7 +386,8 @@ class Test(unittest.TestCase):
         '''
         This score uses a non-breaking space as an elision
         '''
-        from music21 import converter, search
+        from music21 import converter
+        from music21 import search
 
         partXML = '''
         <score-partwise>
@@ -433,7 +434,8 @@ class Test(unittest.TestCase):
         runSearch()
 
     def testMultipleVerses(self):
-        from music21 import converter, search
+        from music21 import converter
+        from music21 import search
 
         # noinspection SpellCheckingInspection
         partXML = '''

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -977,7 +977,10 @@ class Sites(common.SlottedObjectMixin):
 
 class Test(unittest.TestCase):
     def testSites(self):
-        from music21 import note, stream, corpus, clef
+        from music21 import note
+        from music21 import stream
+        from music21 import corpus
+        from music21 import clef
 
         m = stream.Measure()
         m.number = 34

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -1844,7 +1844,9 @@ class Test(unittest.TestCase):
     def testBasic(self):
 
         # how parts might be grouped
-        from music21 import stream, note, layout
+        from music21 import stream
+        from music21 import note
+        from music21 import layout
         s = stream.Score()
         p1 = stream.Part()
         p2 = stream.Part()
@@ -1896,7 +1898,8 @@ class Test(unittest.TestCase):
         self.assertEqual(repr(su1), '<music21.spanner.Slur>')
 
     def testSpannerBundle(self):
-        from music21 import spanner, stream
+        from music21 import spanner
+        from music21 import stream
 
         su1 = spanner.Slur()
         su1.idLocal = 1
@@ -1921,7 +1924,8 @@ class Test(unittest.TestCase):
         self.assertEqual(sb2[1], su4)
 
     def testDeepcopySpanner(self):
-        from music21 import spanner, note
+        from music21 import spanner
+        from music21 import note
 
         # how slurs might be defined
         n1 = note.Note()
@@ -1950,7 +1954,8 @@ class Test(unittest.TestCase):
         self.assertNotEqual(id(sb2[0]), id(sb1[0]))
 
     def testReplaceSpannedElement(self):
-        from music21 import note, spanner
+        from music21 import note
+        from music21 import spanner
 
         n1 = note.Note()
         n2 = note.Note()
@@ -2009,7 +2014,8 @@ class Test(unittest.TestCase):
         self.assertEqual(sb1[2].getSpannedElements(), [n4a, n5])
 
     def testRepeatBracketA(self):
-        from music21 import spanner, stream
+        from music21 import spanner
+        from music21 import stream
 
         m1 = stream.Measure()
         rb1 = spanner.RepeatBracket(m1)
@@ -2018,7 +2024,10 @@ class Test(unittest.TestCase):
         self.assertEqual(len(rb1), 1)
 
     def testRepeatBracketB(self):
-        from music21 import note, spanner, stream, bar
+        from music21 import note
+        from music21 import spanner
+        from music21 import stream
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -2055,7 +2064,10 @@ class Test(unittest.TestCase):
 
     # noinspection DuplicatedCode
     def testRepeatBracketC(self):
-        from music21 import note, spanner, stream, bar
+        from music21 import note
+        from music21 import spanner
+        from music21 import stream
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -2097,7 +2109,10 @@ class Test(unittest.TestCase):
 
     # noinspection DuplicatedCode
     def testRepeatBracketD(self):
-        from music21 import note, spanner, stream, bar
+        from music21 import note
+        from music21 import spanner
+        from music21 import stream
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -2194,7 +2209,10 @@ class Test(unittest.TestCase):
         self.assertGreater(raw.find('''<ending number="2" type="start" />'''), 1)
 
     def testRepeatBracketE(self):
-        from music21 import note, spanner, stream, bar
+        from music21 import note
+        from music21 import spanner
+        from music21 import stream
+        from music21 import bar
 
         p = stream.Part()
         m1 = stream.Measure(number=1)
@@ -2257,7 +2275,9 @@ class Test(unittest.TestCase):
         '''Test basic octave shift creation and output, as well as passing
         objects through make measure calls.
         '''
-        from music21 import stream, note, chord
+        from music21 import stream
+        from music21 import note
+        from music21 import chord
         from music21.spanner import Ottava   # need to do it this way for classSet
         s = stream.Stream()
         s.repeatAppend(chord.Chord(['c-3', 'g4']), 12)
@@ -2307,7 +2327,9 @@ class Test(unittest.TestCase):
     def testOttavaShiftB(self):
         '''Test a single note octave
         '''
-        from music21 import stream, note, spanner
+        from music21 import stream
+        from music21 import note
+        from music21 import spanner
         s = stream.Stream()
         n = note.Note('c4')
         sp = spanner.Ottava(n)
@@ -2319,7 +2341,9 @@ class Test(unittest.TestCase):
         self.assertEqual(raw.count('type="down"'), 1)
 
     def testCrescendoA(self):
-        from music21 import stream, note, dynamics
+        from music21 import stream
+        from music21 import note
+        from music21 import dynamics
         s = stream.Stream()
         # n1 = note.Note('C')
         # n2 = note.Note('D')
@@ -2355,7 +2379,9 @@ class Test(unittest.TestCase):
         # self.assertEqual(raw.count('octave-shift'), 2)
 
     def testLineA(self):
-        from music21 import stream, note, spanner
+        from music21 import stream
+        from music21 import note
+        from music21 import spanner
 
         s = stream.Stream()
         s.repeatAppend(note.Note(), 12)
@@ -2373,7 +2399,9 @@ class Test(unittest.TestCase):
         self.assertEqual(raw.count('<bracket'), 4)
 
     def testLineB(self):
-        from music21 import stream, note, spanner
+        from music21 import stream
+        from music21 import note
+        from music21 import spanner
 
         s = stream.Stream()
         s.repeatAppend(note.Note(), 12)
@@ -2398,7 +2426,9 @@ class Test(unittest.TestCase):
         self.assertEqual(raw.count('line-end="down"'), 1)
 
     def testGlissandoA(self):
-        from music21 import stream, note, spanner
+        from music21 import stream
+        from music21 import note
+        from music21 import spanner
 
         s = stream.Stream()
         s.repeatAppend(note.Note(), 3)
@@ -2422,7 +2452,9 @@ class Test(unittest.TestCase):
         self.assertEqual(raw.count('line-type="dashed"'), 2)
 
     def testGlissandoB(self):
-        from music21 import stream, note, spanner
+        from music21 import stream
+        from music21 import note
+        from music21 import spanner
 
         s = stream.Stream()
         s.repeatAppend(note.Note(), 12)
@@ -2518,7 +2550,8 @@ class Test(unittest.TestCase):
         unused_data = converter.freezeStr(p, fmt='pickle')
 
     def testDeepcopyJustSpannerAndNotes(self):
-        from music21 import note, clef
+        from music21 import note
+        from music21 import clef
         from music21.spanner import Spanner
 
         n1 = note.Note('g')
@@ -2535,7 +2568,9 @@ class Test(unittest.TestCase):
         self.assertIs(sp2[0], n1)
 
     def testDeepcopySpannerInStreamNotNotes(self):
-        from music21 import note, clef, stream
+        from music21 import note
+        from music21 import clef
+        from music21 import stream
         from music21.spanner import Spanner
 
         n1 = note.Note('g')
@@ -2556,7 +2591,9 @@ class Test(unittest.TestCase):
         self.assertIs(sp2[0], n1)
 
     def testDeepcopyNotesInStreamNotSpanner(self):
-        from music21 import note, clef, stream
+        from music21 import note
+        from music21 import clef
+        from music21 import stream
         from music21.spanner import Spanner
 
         n1 = note.Note('g')
@@ -2579,7 +2616,8 @@ class Test(unittest.TestCase):
         self.assertIs(sp2[0], n1)
 
     def testDeepcopyNotesAndSpannerInStream(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         from music21.spanner import Spanner
 
         n1 = note.Note('g')
@@ -2604,7 +2642,8 @@ class Test(unittest.TestCase):
         self.assertIs(sp2[0], n3)
 
     def testDeepcopyStreamWithSpanners(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         from music21.spanner import Slur
 
         n1 = note.Note()

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -2476,7 +2476,7 @@ class Test(unittest.TestCase):
     def testRemoveSpanners(self):
         from music21 import stream
         from music21 import note
-        from music21.spanner import Slur
+        from music21.spanner import Spanner, Slur
 
         p = stream.Part()
         m1 = stream.Measure()
@@ -2492,7 +2492,7 @@ class Test(unittest.TestCase):
         sl = Slur([n1, n2])
         p.insert(0, sl)
         for x in p:
-            if 'Spanner' in x.classes:
+            if isinstance(x, Spanner):
                 p.remove(x)
         self.assertEqual(len(p.spanners), 0)
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -44,6 +44,7 @@ from music21 import defaults
 from music21 import derivation
 from music21 import duration
 from music21 import exceptions21
+from music21 import harmony
 from music21 import interval
 from music21 import key
 from music21 import metadata
@@ -1420,7 +1421,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         raise StreamException(f'cannot find object ({el}) in Stream')
 
     def remove(self,
-               targetOrList,
+               targetOrList: Union[base.Music21Object, List[base.Music21Object]],
                *,
                shiftOffsets=False,
                recurse=False):
@@ -1803,7 +1804,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                     newElement = e._deepcopySubclassable(memo)
 
                 # ## TEST on copying!!!!
-                # if 'Note' in newElement.classes:
+                # if isinstance(newElement, note.Note):
                 #     newElement.pitch.ps += 2.0
                 new.coreInsert(offset, newElement, ignoreSort=True)
         if '_endElements' in ignoreAttributes:
@@ -2252,30 +2253,30 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
             target = targets[0]  # assume first
             removeTarget = target
-            if 'Rest' in target.classes:
-                if 'Note' in noteOrChord.classes:
+            if isinstance(target, note.Rest):
+                if isinstance(noteOrChord, note.Note):
                     pitches = [noteOrChord.pitch]
                     components = [noteOrChord]
-                elif 'Chord' in noteOrChord.classes:
+                elif isinstance(noteOrChord, chord.Chord):
                     pitches = list(noteOrChord.pitches)
                     components = list(noteOrChord)
-            if 'Note' in target.classes:
+            if isinstance(target, note.Note):
                 # if a note, make it into a chord
-                if 'Note' in noteOrChord.classes:
+                if isinstance(noteOrChord, note.Note):
                     pitches = [target.pitch, noteOrChord.pitch]
                     components = [target, noteOrChord]
-                elif 'Chord' in noteOrChord.classes:
+                elif isinstance(noteOrChord, chord.Chord):
                     pitches = [target.pitch] + list(noteOrChord.pitches)
                     components = [target] + list(noteOrChord)
                 else:
                     pitches = [target.pitch]
                     components = [target]
-            if 'Chord' in target.classes:
+            if isinstance(target, chord.Chord):
                 # if a chord, make it into a chord
-                if 'Note' in noteOrChord.classes:
+                if isinstance(noteOrChord, note.Note):
                     pitches = list(target.pitches) + [noteOrChord.pitch]
                     components = list(target) + [noteOrChord]
-                elif 'Chord' in noteOrChord.classes:
+                elif isinstance(noteOrChord, chord.Chord):
                     pitches = list(target.pitches) + list(noteOrChord.pitches)
                     components = list(target) + list(noteOrChord)
                 else:
@@ -2304,7 +2305,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 finalTarget.noteheadFill = target.noteheadFill
 
             # fill component details
-            if 'Chord' in finalTarget.classes:
+            if isinstance(finalTarget, chord.Chord):
                 for i, n in enumerate(finalTarget):
                     nPrevious = components[i]
                     n.noteheadFill = nPrevious.noteheadFill
@@ -2960,9 +2961,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             for complexObj in container.getElementsNotOfClass(['Stream', 'Variant', 'Spanner']):
                 if complexObj.duration.type != 'complex':
                     continue
-                if 'Rest' in complexObj.classes and complexObj.fullMeasure in (True, 'always'):
+                if isinstance(complexObj, note.Rest) and complexObj.fullMeasure in (True, 'always'):
                     continue
-                if 'Rest' in complexObj.classes and complexObj.fullMeasure == 'auto':
+                if isinstance(complexObj, note.Rest) and complexObj.fullMeasure == 'auto':
                     if container.isMeasure and (complexObj.duration == container.barDuration):
                         continue
                     elif ('Voice' in container.classes
@@ -3355,7 +3356,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         'sharp'
 
         >>> foundStream = found.stream()
-        >>> 'Score' in foundStream.classes
+        >>> isinstance(foundStream, stream.Score)
         True
 
 
@@ -4359,7 +4360,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
     def measure(self,
                 measureNumber,
                 collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature'),
-                indicesNotNumbers=False):
+                indicesNotNumbers=False) -> 'music21.stream.Measure':
         '''
         Given a measure number, return a single
         :class:`~music21.stream.Measure` object if the Measure number exists, otherwise return None.
@@ -5128,7 +5129,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         else:
             returnObj = self
 
-        if returnObj.hasPartLikeStreams() or 'Opus' in returnObj.classSet:
+        if returnObj.hasPartLikeStreams() or 'Opus' in returnObj.classes:
             for partLike in returnObj.getElementsByClass(Stream):
                 # call on each part
                 partLike.toWrittenPitch(inPlace=True)
@@ -6299,7 +6300,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         if template.hasMeasures():
             measureIterator = template.getElementsByClass('Measure')
+            templateMeasure: 'Measure'
             for i, templateMeasure in enumerate(measureIterator):
+                measurePart: 'Measure'
                 measurePart = workObj.measure(i, collect=(), indicesNotNumbers=True)
                 if measurePart is not None:
                     chordifyOneMeasure(templateMeasure, measurePart)
@@ -7222,7 +7225,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 # need to find the offset of the first thing that is not rest
                 for j in range(currentIndex + 1, len(srcStream._elements)):
                     el = srcStream._elements[j]
-                    if 'NotRest' in el.classes:
+                    if isinstance(el, note.NotRest):
                         # change target offset to this position
                         targetOffset = srcStream._elements[j].getOffsetBySite(
                             srcStream)
@@ -7231,7 +7234,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # filter matched elements
             post = []
             for matchEl in match:
-                if 'NotRest' in matchEl.classes:
+                if isinstance(matchEl, note.NotRest):
                     post.append(matchEl)
             return post
 
@@ -7241,9 +7244,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         srcFlat = self.flat.notes.stream()
         for i, e in enumerate(srcFlat):
             pSrc = []
-            if 'Note' in e.classes:
+            if isinstance(e, note.Note):
                 pSrc = [e]
-            elif 'Chord' in e.classes:
+            elif isinstance(e, chord.Chord):
                 pSrc = list(e)  # get components
             else:
                 continue
@@ -7256,9 +7259,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 # for each p, see if there is match in the next position
                 # for each element, look for a pitch to match
                 mSrc = []
-                if 'Note' in m.classes:
+                if isinstance(m, note.Note):
                     mSrc = [m]
-                elif 'Chord' in m.classes:
+                elif isinstance(m, chord.Chord):
                     mSrc = list(m)  # get components
                 # final note comparison
                 for q in mSrc:
@@ -9079,16 +9082,16 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                             d_matchTuple = bestMatch(float(ql), (next_divisor,))
                     # Enforce nonzero duration for non-grace notes
                     if (d_matchTuple.match == 0
-                            and 'NotRest' in e.classes
+                            and isinstance(e, note.NotRest)
                             and not e.duration.isGrace):
                         e.quarterLength = 1 / max(quarterLengthDivisors)
                         if hasattr(e, 'editorial'):
                             e.editorial.quarterLengthQuantizationError = ql - e.quarterLength
-                    elif d_matchTuple.match == 0 and 'Rest' in e.classes:
+                    elif d_matchTuple.match == 0 and isinstance(e, note.Rest):
                         rests_lacking_durations.append(e)
                     else:
                         e.duration.quarterLength = d_matchTuple.match
-                        if (hasattr(e, 'editorial') and d_matchTuple.signedError != 0):
+                        if hasattr(e, 'editorial') and d_matchTuple.signedError != 0:
                             e.editorial.quarterLengthQuantizationError = d_matchTuple.signedError
 
             # end for e in ._elements
@@ -9436,7 +9439,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             # do not need to look in endElements
             for obj in self._elements:
                 # if obj is a Part, we have multi-parts
-                if 'Measure' in obj.classes:
+                if getattr(obj, 'isMeasure', False):
                     post = True
                     break  # only need one
             self._cache['hasMeasures'] = post
@@ -9512,6 +9515,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             multiPart = False
             if not self.isFlat:  # if flat, does not have parts!
                 # do not need to look in endElements
+                obj: base.Music21Object
                 for obj in self.getElementsByClass('Stream'):
                     # if obj is a Part, we have multi-parts
                     if 'Part' in obj.classes:
@@ -10524,8 +10528,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         previousObject = None
         while currentObject is not None:
             if (previousObject is not None
-                    and 'Note' in currentObject.classes
-                    and 'Note' in previousObject.classes):
+                    and isinstance(currentObject, note.Note)
+                    and isinstance(previousObject, note.Note)):
                 currentObject.editorial.melodicInterval = interval.notesToInterval(
                     previousObject, currentObject)
             previousObject = currentObject
@@ -11710,7 +11714,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                     # extract the variant component and insert into place
                     self.insert(oInStream, e)
 
-                    if 'Measure' in targetToReplace.classes:
+                    if getattr(targetToReplace, 'isMeasure', False):
                         e.number = targetToReplace.number
             # only remove old and add removed if we matched
             if targetsMatched > 0:
@@ -11736,13 +11740,14 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 # environLocal.printDebug(
                 #     ['matchBySpan', matchBySpan, 'activateVariants', 'removing', e])
                 self.remove(e)
-                if 'Measure' in e.classes:  # Save deleted measure numbers.
+                if getattr(e, 'isMeasure', False):
+                    # Save deleted measure numbers.
                     deletedMeasures.append(e.number)
 
             for e in v.elements:
                 oInStream = vStart + e.getOffsetBySite(v.containedSite)
                 self.insert(oInStream, e)
-                if 'Measure' in e.classes:
+                if getattr(e, 'isMeasure', False):
                     if deletedMeasures:  # If there measure numbers left to use, use them.
                         # Assign the next highest deleted measure number
                         e.number = deletedMeasures.pop(False)
@@ -11858,7 +11863,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         # this will always remove elements before inserting
         for e in targets:
-            if 'Measure' in e.classes:  # if a measure is deleted, save its number
+            if getattr(e, 'isMeasure', False):  # if a measure is deleted, save its number
                 deletedMeasures.append(e.number)
             oInVariant = self.elementOffset(e) - vStart
             removed.insert(oInVariant, e)
@@ -11868,7 +11873,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         highestNumber = None
         insertedMeasures = []
         for e in v.elements:
-            if 'Measure' in e.classes:
+            if getattr(e, 'isMeasure', False):
                 # If there are deleted numbers still saved, assign this measure the
                 # next highest and remove it from the list.
                 if deletedMeasures:
@@ -11988,7 +11993,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         # this will always remove elements before inserting
         for e in targets:
-            if 'Measure' in e.classes:  # Save deleted measure numbers.
+            if getattr(e, 'isMeasure', False):  # Save deleted measure numbers.
                 deletedMeasures.append(e.number)
             oInVariant = self.elementOffset(e) - vStart
             removed.insert(oInVariant, e)
@@ -11998,7 +12003,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         highestMeasure = None
         insertedMeasures = []
         for e in v.elements:
-            if 'Measure' in e.classes:
+            if getattr(e, 'isMeasure', False):
                 # If there are deleted measure numbers left, assign the next
                 # inserted measure the next highest number and remove it.
                 if deletedMeasures:
@@ -13036,7 +13041,7 @@ class Measure(Stream):
         # directly access _elements, as do not want to get any bars
         # in _endElements
         for e in self._elements:
-            if 'Barline' in e.classes:  # take the first
+            if isinstance(e, bar.Barline):  # take the first
                 if self.elementOffset(e) == 0.0:
                     barList.append(e)
                     break
@@ -13079,7 +13084,7 @@ class Measure(Stream):
         # look on _endElements
         barList = []
         for e in self._endElements:
-            if 'Barline' in e.classes:  # take the first
+            if isinstance(e, bar.Barline):  # take the first
                 barList.append(e)
                 break
         # barList = self.getElementsByClass(bar.Barline)
@@ -13099,7 +13104,7 @@ class Measure(Stream):
             barlineObj.location = 'right'
 
         # if a repeat, setup direction if not assigned
-        if barlineObj is not None and 'Repeat' in barlineObj.classes:
+        if barlineObj is not None and isinstance(barlineObj, bar.Repeat):
             # environLocal.printDebug(['got barline obj w/ direction', barlineObj.direction])
             if barlineObj.direction in ['start', None]:
                 barlineObj.direction = 'end'
@@ -13867,7 +13872,7 @@ class Score(Stream):
         >>> len(s.flat.notes)
         165
         >>> post = s.flattenParts()
-        >>> 'Part' in post.classes
+        >>> isinstance(post, stream.Part)
         True
         >>> len(post.flat.notes)
         165

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -44,7 +44,6 @@ from music21 import defaults
 from music21 import derivation
 from music21 import duration
 from music21 import exceptions21
-from music21 import harmony
 from music21 import interval
 from music21 import key
 from music21 import metadata

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -1853,7 +1853,8 @@ class RecursiveIterator(StreamIterator):
 
 class Test(unittest.TestCase):
     def testSimpleClone(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         s = stream.Stream()
         r = note.Rest()
         n = note.Note()
@@ -1867,7 +1868,8 @@ class Test(unittest.TestCase):
         self.assertIs(s_notes[0], n)
 
     def testAddingFiltersMidIteration(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         s = stream.Stream()
         r = note.Rest()
         n = note.Note()
@@ -1894,7 +1896,8 @@ class Test(unittest.TestCase):
         self.assertEqual(n.activeSite.number, 2)
 
     def testCurrentHierarchyOffsetReset(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         p = stream.Part()
         m = stream.Measure()
         m.append(note.Note('D'))
@@ -1910,7 +1913,8 @@ class Test(unittest.TestCase):
         self.assertIsNone(currentOffset)
 
     def testAddingFiltersMidRecursiveIteration(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         from music21.stream.iterator import RecursiveIterator as ImportedRecursiveIterator
         m = stream.Measure()
         r = note.Rest()

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -19,6 +19,7 @@ from typing import List, Generator, Optional
 from music21 import beam
 from music21 import clef
 from music21 import common
+from music21 import chord
 from music21 import defaults
 from music21 import environment
 from music21 import meter
@@ -119,7 +120,7 @@ def makeBeams(
 
     # if s.isClass(Measure):
     mColl: List[stream.Measure]
-    if 'Measure' in s.classes:
+    if isinstance(s, stream.Measure):
         returnObj: stream.Measure
         mColl = [returnObj]  # store a list of measures for processing
     else:
@@ -602,7 +603,7 @@ def makeMeasures(
         # can contain this element
 
         # collect all spanners and move to outer Stream
-        if 'Spanner' in e.classes:
+        if isinstance(e, spanner.Spanner):
             spannerBundleAccum.append(e)
             continue
 
@@ -646,7 +647,7 @@ def makeMeasures(
             continue
         # do not accept another time signature at the zero position: this
         # is handled above
-        if oNew == 0 and 'TimeSignature' in e.classes:
+        if oNew == 0 and isinstance(e, meter.TimeSignature):
             continue
 
         # environLocal.printDebug(['makeMeasures()', 'inserting', oNew, e])
@@ -1594,7 +1595,7 @@ def getTiePitchSet(prior):
         return None
     else:
         tiePitchSet = set()
-        if 'Chord' in prior.classes:
+        if isinstance(prior, chord.Chord):
             previousNotes = list(prior)
         else:
             previousNotes = [prior]

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -1877,7 +1877,7 @@ class Test(unittest.TestCase):
                          )
 
     def testMakeBeamsOnEmptyChord(self):
-        from music21 import chord, converter
+        from music21 import converter
         p = converter.parse('tinyNotation: 4/4')
         c1 = chord.Chord('d f')
         c1.quarterLength = 0.5
@@ -1894,7 +1894,9 @@ class Test(unittest.TestCase):
         )
 
     def testStreamExceptions(self):
-        from music21 import converter, duration, stream
+        from music21 import converter
+        from music21 import duration
+        from music21 import stream
         p = converter.parse(self.allaBreveBeamTest)
         with self.assertRaises(stream.StreamException) as cm:
             p.makeMeasures(meterStream=duration.Duration())

--- a/music21/stream/streamStatus.py
+++ b/music21/stream/streamStatus.py
@@ -203,7 +203,8 @@ class Test(unittest.TestCase):
 
     def testHaveBeamsBeenMadeAfterDeepcopy(self):
         import copy
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
         m = stream.Measure()
         c = note.Note('C4', type='quarter')
         m.append(c)

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -705,7 +705,8 @@ class Test(unittest.TestCase):
         self.assertEqual(n.getOffsetBySite(a), 10)
 
     def testExtractedNoteAssignLyric(self):
-        from music21 import converter, text
+        from music21 import converter
+        from music21 import text
         a = converter.parse(corpus.getWork('corelli/opus3no1/1grave'))
         b = a.parts[1]
         c = b.flat
@@ -7168,7 +7169,8 @@ class Test(unittest.TestCase):
                          ['C4', 'D4', 'E4', 'F4', 'G4', 'A4', 'B4', 'C5'])
 
     def testTransposeByPitchC(self):
-        from music21 import converter, instrument
+        from music21 import converter
+        from music21 import instrument
         p = converter.parse('tinyNotation: c1 d1')
         p.insert(0, instrument.Horn())
         s = Score(p)
@@ -7954,7 +7956,8 @@ class Test(unittest.TestCase):
     def testActivateVariantsBySpanA(self):
         # this tests replacing 1 note with a 3-note variant
 
-        from music21 import variant, dynamics
+        from music21 import variant
+        from music21 import dynamics
 
         s = Stream()
         s.repeatAppend(note.Note('d2'), 12)

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -2240,7 +2240,8 @@ class Test(unittest.TestCase):
 
         expected = "clef.TrebleClef is not a Music21Object; got <class 'str'>"
         with self.assertRaisesRegex(TypeError, expected):
-            s.remove('clef.TrebleClef')
+            # noinspection PyTypeChecker
+            s.remove('clef.TrebleClef')  # cannot remove by Class str.
 
     def testRemoveByClass(self):
         s = Stream()
@@ -7194,7 +7195,7 @@ class Test(unittest.TestCase):
         s.extendTies()
         post = []
         for n in s.flat.getElementsByClass('GeneralNote'):
-            if 'Chord' in n.classes:
+            if isinstance(n, chord.Chord):
                 post.append([repr(q.tie) for q in n])
             else:
                 post.append(repr(n.tie))
@@ -8035,7 +8036,7 @@ class Test(unittest.TestCase):
         bass = b.parts[3]
         bassEmpty = bass.template(fillWithRests=False, removeClasses=True)
         for x in bassEmpty:
-            if 'Measure' in x.classes:
+            if isinstance(x, Measure):
                 self.assertEqual(len(x), 0)
 
     def testSetElements(self):

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -141,9 +141,9 @@ class TempoIndication(base.Music21Object):
         if found is None:
             found = self
 
-        if 'MetricModulation' in found.classes:
+        if isinstance(found, MetricModulation):
             return found.newMetronome
-        elif 'MetronomeMark' in found.classes:
+        elif isinstance(found, MetronomeMark):
             return found
         elif 'TempoText' in found.classes:
             return found.getMetronomeMark()

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -453,7 +453,7 @@ class MetronomeMark(TempoIndication):
         # assume ql value or a type string
         elif common.isNum(value) or isinstance(value, str):
             self._referent = duration.Duration(value)
-        elif 'Duration' not in value.classes:
+        elif not isinstance(value, duration.Duration):
             # try get duration object, like from Note
             self._referent = value.duration
         elif 'Duration' in value.classes:

--- a/music21/test/testPerformance.py
+++ b/music21/test/testPerformance.py
@@ -35,7 +35,8 @@ class Test(unittest.TestCase):
     def runStreamIterationByIterator(self):
         '''Stream iteration by iterator
         '''
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         # create a stream with 750 notes, 250 rests
         s = stream.Stream()
         for i in range(1000):
@@ -52,7 +53,8 @@ class Test(unittest.TestCase):
     def runStreamIterationByElements(self):
         '''Stream iteration by .elements access
         '''
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         # create a stream with 750 notes, 250 rests
         s = stream.Stream()
         for i in range(1000):
@@ -69,7 +71,8 @@ class Test(unittest.TestCase):
     def runGetElementsByClassType(self):
         '''Getting elements by class type
         '''
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
 
         # create a stream with 750 notes, 250 rests
         s = stream.Stream()
@@ -87,7 +90,8 @@ class Test(unittest.TestCase):
     def runGetElementsByClassString(self):
         '''Getting elements by string
         '''
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
 
         # create a stream with 750 notes, 250 rests
         s = stream.Stream()

--- a/music21/test/testSerialization.py
+++ b/music21/test/testSerialization.py
@@ -25,7 +25,9 @@ environLocal = environment.Environment(_MOD)
 class Test(unittest.TestCase):
 
     def testBasicC(self):
-        from music21 import stream, note, converter
+        from music21 import stream
+        from music21 import note
+        from music21 import converter
 
         s = stream.Stream()
         n1 = note.Note('d2', quarterLength=2.0)
@@ -38,7 +40,10 @@ class Test(unittest.TestCase):
         self.assertEqual(str(post.notes[0].pitch), 'D2')
 
     def testBasicD(self):
-        from music21 import stream, note, converter, spanner
+        from music21 import stream
+        from music21 import note
+        from music21 import converter
+        from music21 import spanner
         import copy
 
         s = stream.Stream()
@@ -65,7 +70,8 @@ class Test(unittest.TestCase):
         self.assertEqual(spPost.getSpannedElementIds(), [id(post.notes[0]), id(post.notes[1])])
 
     def testBasicE(self):
-        from music21 import corpus, converter
+        from music21 import corpus
+        from music21 import converter
         s = corpus.parse('bwv66.6')
 
         temp = converter.freezeStr(s, fmt='pickle')
@@ -78,7 +84,10 @@ class Test(unittest.TestCase):
         # sPost.parts[0].notes
 
     def testBasicF(self):
-        from music21 import stream, note, converter, spanner
+        from music21 import stream
+        from music21 import note
+        from music21 import converter
+        from music21 import spanner
 
         s = stream.Score()
         s.repeatAppend(note.Note('G4'), 5)
@@ -95,7 +104,9 @@ class Test(unittest.TestCase):
         # sPost.show()
 
     def testBasicJ(self):
-        from music21 import stream, note, converter
+        from music21 import stream
+        from music21 import note
+        from music21 import converter
 
         p1 = stream.Part()
         for m in range(3):
@@ -124,7 +135,9 @@ class Test(unittest.TestCase):
         self.assertEqual(len(sPost.flat.notes), 24)
 
     def testBasicI(self):
-        from music21 import stream, note, converter
+        from music21 import stream
+        from music21 import note
+        from music21 import converter
 
         p1 = stream.Part()
         p1.repeatAppend(note.Note('C4'), 12)
@@ -149,7 +162,9 @@ class Test(unittest.TestCase):
         test to see if spanners serialize properly if they
         contain notes not in the pickle...
         '''
-        from music21 import stream, spanner, converter
+        from music21 import stream
+        from music21 import spanner
+        from music21 import converter
         from music21 import note
         n1 = note.Note('D4')
         n2 = note.Note('E4')
@@ -164,7 +179,8 @@ class Test(unittest.TestCase):
         # s2.show('text')
 
     def testBigCorpus(self):
-        from music21 import corpus, converter
+        from music21 import corpus
+        from music21 import converter
         # import time
         # print(time.time())  # 8.3 sec from pickle; 10.3 sec for forceSource...
         # s = corpus.parse('beethoven/opus133') #, forceSource = True)

--- a/music21/test/timeGraphs.py
+++ b/music21/test/timeGraphs.py
@@ -186,7 +186,7 @@ class TestGetContextByClassA(Test):
 
 
     def testFocus(self):
-        from music21 import clef, meter, key
+        from music21 import clef
         for p in self.s.parts:
             for m in p.getElementsByClass('Measure'):
                 m.getContextByClass(clef.Clef)
@@ -212,7 +212,8 @@ class TestParseRNText(Test):
 class TestMusicXMLMultiPartOutput(Test):
 
     def __init__(self):
-        from music21 import note, stream
+        from music21 import note
+        from music21 import stream
         self.s = stream.Score()
         for i in range(10):  # parts
             p = stream.Part()
@@ -267,7 +268,11 @@ class TestGetElementsByClassA(Test):
 class TestGetElementsByClassB(Test):
 
     def __init__(self):
-        from music21 import stream, note, clef, meter, chord
+        from music21 import stream
+        from music21 import note
+        from music21 import clef
+        from music21 import meter
+        from music21 import chord
         self.s = stream.Stream()
         self.s.repeatAppend(note.Note(), 300)
         self.s.repeatAppend(note.Rest(), 300)
@@ -288,7 +293,9 @@ class TestGetElementsByClassB(Test):
 
 class TestGetContextByClassB(Test):
     def __init__(self):
-        from music21 import stream, note, meter
+        from music21 import meter
+        from music21 import note
+        from music21 import stream
 
         self.s = stream.Score()
 
@@ -356,7 +363,9 @@ class TestMeasuresA(Test):
 
 class TestMeasuresB(Test):
     def __init__(self):
-        from music21 import stream, note, meter
+        from music21 import stream
+        from music21 import note
+        from music21 import meter
 
         self.s = stream.Score()
         for j in [1]:

--- a/music21/test/timeGraphs.py
+++ b/music21/test/timeGraphs.py
@@ -182,11 +182,18 @@ class TestGetContextByClassA(Test):
 
     def __init__(self):
         from music21 import corpus
+        from music21 import meter
+        from music21 import clef
+        from music21 import key
         self.s = corpus.parse('bwv66.6')
-
+        self.m = meter
+        self.c = clef
+        self.k = key
 
     def testFocus(self):
-        from music21 import clef
+        meter = self.m
+        clef = self.c
+        key = self.k
         for p in self.s.parts:
             for m in p.getElementsByClass('Measure'):
                 m.getContextByClass(clef.Clef)

--- a/music21/test/treeYield.py
+++ b/music21/test/treeYield.py
@@ -139,7 +139,8 @@ def testCode():
 
 
 def testMIDIParse():
-    from music21 import converter, common
+    from music21 import converter
+    from music21 import common
     from music21 import freezeThaw
 
     # a = 'https://github.com/ELVIS-Project/vis/raw/master/test_corpus/prolationum-sanctus.midi'

--- a/music21/text.py
+++ b/music21/text.py
@@ -610,7 +610,8 @@ class Trigram:
 class Test(unittest.TestCase):
 
     def testBasic(self):
-        from music21 import converter, corpus
+        from music21 import converter
+        from music21 import corpus
 
         a = converter.parse(corpus.getWork('haydn/opus1no1/movement4.xml'))
         post = assembleLyrics(a)
@@ -622,7 +623,8 @@ class Test(unittest.TestCase):
 
 
     def testAssembleLyricsA(self):
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
         s = stream.Stream()
         for syl in ['hel-', '-lo', 'a-', '-gain']:
             n = note.Note()

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -17,6 +17,7 @@ import unittest
 
 from music21.base import Music21Object
 from music21 import common
+from music21 import key
 from music21.tree import spans
 from music21.tree import timespanTree
 from music21.tree import trees
@@ -121,7 +122,7 @@ def listOfTreesByClass(inputStream,
                 if classList and element.classSet.isdisjoint(classList):
                     continue
                 if useTimespans:
-                    if hasattr(element, 'pitches') and 'music21.key.Key' not in element.classSet:
+                    if hasattr(element, 'pitches') and not isinstance(element, key.Key):
                         spanClass = spans.PitchedTimespan
                     else:
                         spanClass = spans.ElementTimespan

--- a/music21/tree/timespanTree.py
+++ b/music21/tree/timespanTree.py
@@ -737,7 +737,9 @@ class TimespanTree(trees.OffsetTree):
 class Test(unittest.TestCase):
 
     def testGetVerticalityAtWithKey(self):
-        from music21 import stream, key, note
+        from music21 import stream
+        from music21 import key
+        from music21 import note
         s = stream.Stream()
         s.insert(0, key.Key('C'))
         s.insert(0, note.Note('F#4'))

--- a/music21/tree/trees.py
+++ b/music21/tree/trees.py
@@ -1477,7 +1477,8 @@ class Test(unittest.TestCase):
         test that get position after works with
         an offset when the tree is built on SortTuples.
         '''
-        from music21 import stream, note
+        from music21 import stream
+        from music21 import note
 
         et = ElementTree()
 
@@ -1535,7 +1536,9 @@ class Test(unittest.TestCase):
 
         G# was coming from an incorrect activeSite.  activeSite should not be used!
         '''
-        from music21 import corpus, stream, note
+        from music21 import corpus
+        from music21 import stream
+        from music21 import note
         s = stream.Stream()
         n0 = note.Note('A')
         n0.duration.quarterLength = 3.0

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -827,7 +827,7 @@ class Verticality(prebase.ProtoM21Object):
             if not isinstance(ts, spans.PitchedTimespan):
                 continue
             el = ts.element
-            if 'Chord' in el.classes:
+            if isinstance(el, chord.Chord):
                 if len(el) == 0:  # pylint: disable=len-as-condition
                     continue
 

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -27,9 +27,11 @@ import copy
 import difflib
 
 from music21 import base
+from music21 import clef
 from music21 import common
 from music21 import environment
 from music21 import exceptions21
+from music21 import meter
 from music21 import note
 from music21 import search
 from music21 import stream
@@ -939,7 +941,7 @@ def addVariant(
     if sVariant is None:  # deletion
         pass
     else:  # replacement or insertion
-        if 'Measure' in sVariant.classes:  # sVariant is a measure put it in a variant and insert.
+        if isinstance(sVariant, stream.Measure):  # sVariant is a measure put it in a variant and insert.
             tempVariant.append(sVariant)
         else:  # sVariant is not a measure
             sVariantMeasures = sVariant.getElementsByClass('Measure')
@@ -1798,10 +1800,10 @@ def _doVariantFixingOnStream(s, variantNames=None):
             targetElement = _getNextElements(s, v)
 
             # Delete initial clefs, etc. from initial insertion targetElement if it exists
-            if 'Stream' in targetElement.classes:
+            if isinstance(targetElement, stream.Stream):
                 # Must use .elements, because of removal of elements
                 for e in targetElement.elements:
-                    if 'Clef' in e.classes or 'TimeSignature' in e.classes:
+                    if isinstance(e, (clef.Clef, meter.TimeSignature)):
                         targetElement.remove(e)
 
             v.append(copy.deepcopy(targetElement))  # Appends a copy

--- a/music21/vexflow/toMusic21j.py
+++ b/music21/vexflow/toMusic21j.py
@@ -284,7 +284,8 @@ class TestCuthbert(unittest.TestCase):  # pragma: no cover
         '''
         test a local version of this mess...
         '''
-        from music21 import corpus, environment
+        from music21 import corpus
+        from music21 import environment
         environLocal = environment.Environment()
 
         s = corpus.parse('luca/gloria').measures(1, 19)

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -180,7 +180,7 @@ class VoiceLeadingQuartet(base.Music21Object):
                 ) from e
         else:
             try:
-                isKey = ('Key' in keyValue.classes)
+                isKey = (isinstance(keyValue, key.Key))
                 if isKey is False:
                     raise AttributeError
             except AttributeError:  # pragma: no cover  # pylint: disable=raise-missing-from
@@ -197,9 +197,9 @@ class VoiceLeadingQuartet(base.Music21Object):
             setattr(self, which, note.Note(value))
         else:
             try:
-                if 'Note' in value.classes:
+                if isinstance(value, note.Note):
                     setattr(self, which, value)
-                elif 'Pitch' in value.classes:
+                elif isinstance(value, pitch.Pitch):
                     n = note.Note()
                     n.duration.quarterLength = 0.0
                     n.pitch = value
@@ -1428,10 +1428,10 @@ class Verticality(base.Music21Object):
         '''
         pitches = []
         for el in self.objects:
-            if 'Chord' in el.classes:
+            if isinstance(el, chord.Chord):
                 for x in el.pitches:
                     pitches.append(x.nameWithOctave)
-            elif 'Note' in el.classes:
+            elif isinstance(el, note.Note):
                 pitches.append(el)
         ch = chord.Chord(pitches)
         ch.style = self.style

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -23,7 +23,7 @@ from music21 import common
 from music21.common.objects import SlottedObjectMixin
 from music21 import dynamics
 from music21 import prebase
-from music21 import note
+from music21 import note  # circular but acceptable, because not used at highest level.
 
 from music21 import environment
 _MOD = 'volume'
@@ -132,7 +132,7 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
             self.velocityIsRelative = other.velocityIsRelative
 
     def getRealizedStr(self,
-                       useDynamicContext: Union['music21.dynamics.Dynamic', bool] = True,
+                       useDynamicContext: Union[dynamics.Dynamic, bool] = True,
                        useVelocity=True,
                        useArticulations: Union[bool, 'music21.articulations.Articulation'] = True,
                        baseLevel=0.5,
@@ -153,7 +153,7 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
 
     def getRealized(
         self,
-        useDynamicContext: Union[bool, 'music21.dynamics.Dynamic'] = True,
+        useDynamicContext: Union[bool, dynamics.Dynamic] = True,
         useVelocity=True,
         useArticulations: Union[bool, 'music21.articulations.Articulation'] = True,
         baseLevel=0.5,
@@ -325,7 +325,7 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
     @client.setter
     def client(self, client):
         if client is not None:
-            if hasattr(client, 'classes') and isinstance(client, note.NotRest):
+            if isinstance(client, note.NotRest):
                 self._client = common.wrapWeakref(client)
         else:
             self._client = None
@@ -449,7 +449,7 @@ def realizeVolume(srcStream,
 
     # check for any dynamics
     dynamicsAvailable = False
-    if flatSrc.getElementsByClass('Dynamic'):
+    if flatSrc.getElementsByClass(dynamics.Dynamic):
         dynamicsAvailable = True
     else:  # no dynamics available
         if useDynamicContext is True:  # only if True, and non avail, override
@@ -458,8 +458,8 @@ def realizeVolume(srcStream,
     if dynamicsAvailable:
         # extend durations of all dynamics
         # doing this in place as this is a destructive operation
-        flatSrc.extendDuration('Dynamic', inPlace=True)
-        elements = flatSrc.getElementsByClass('Dynamic')
+        flatSrc.extendDuration(dynamics.Dynamic, inPlace=True)
+        elements = flatSrc.getElementsByClass(dynamics.Dynamic)
         for e in elements:
             start = flatSrc.elementOffset(e)
             end = start + e.duration.quarterLength
@@ -505,7 +505,7 @@ class Test(unittest.TestCase):
 
     def testBasic(self):
         import gc
-        from music21 import volume, note
+        from music21 import volume
 
         n1 = note.Note()
         v = volume.Volume(client=n1)
@@ -517,7 +517,7 @@ class Test(unittest.TestCase):
 
 
     def testGetContextSearchA(self):
-        from music21 import stream, note, volume, dynamics
+        from music21 import stream, volume
 
         s = stream.Stream()
         d1 = dynamics.Dynamic('mf')
@@ -535,7 +535,7 @@ class Test(unittest.TestCase):
 
 
     def testGetContextSearchB(self):
-        from music21 import stream, note, dynamics
+        from music21 import stream
 
         s = stream.Stream()
         d1 = dynamics.Dynamic('mf')
@@ -552,7 +552,7 @@ class Test(unittest.TestCase):
 
     def testDeepCopyA(self):
         import copy
-        from music21 import volume, note
+        from music21 import volume
         n1 = note.Note()
 
         v1 = volume.Volume()
@@ -568,7 +568,7 @@ class Test(unittest.TestCase):
 
 
     def testGetRealizedA(self):
-        from music21 import volume, dynamics
+        from music21 import volume
 
         v1 = volume.Volume(velocity=64)
         self.assertEqual(v1.getRealizedStr(), '0.5')
@@ -617,7 +617,7 @@ class Test(unittest.TestCase):
 
 
     def testRealizeVolumeA(self):
-        from music21 import stream, dynamics, note, volume
+        from music21 import stream, volume
 
         s = stream.Stream()
         s.repeatAppend(note.Note('g3'), 16)
@@ -671,7 +671,7 @@ class Test(unittest.TestCase):
         # s.show('midi')
 
     def testRealizeVolumeB(self):
-        from music21 import corpus, dynamics
+        from music21 import corpus
         s = corpus.parse('bwv66.6')
 
         durUnit = s.highestTime // 8  # let floor
@@ -727,7 +727,7 @@ class Test(unittest.TestCase):
 
 
     def testRealizeVolumeC(self):
-        from music21 import stream, note, articulations
+        from music21 import stream, articulations
 
         s = stream.Stream()
         s.repeatAppend(note.Note('g3'), 16)

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -21,7 +21,9 @@ import unittest
 from music21 import exceptions21
 from music21 import common
 from music21.common.objects import SlottedObjectMixin
+from music21 import dynamics
 from music21 import prebase
+from music21 import note
 
 from music21 import environment
 _MOD = 'volume'
@@ -241,7 +243,7 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
         if self.velocityIsRelative:
             if useDynamicContext is not False:
                 if (hasattr(useDynamicContext, 'classes')
-                        and 'Dynamic' in useDynamicContext.classes):
+                        and isinstance(useDynamicContext, dynamics.Dynamic)):
                     dm = useDynamicContext  # it is a dynamic
                 elif self.client is not None:
                     dm = self.getDynamicContext()  # dm may be None
@@ -323,7 +325,7 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
     @client.setter
     def client(self, client):
         if client is not None:
-            if hasattr(client, 'classes') and 'NotRest' in client.classes:
+            if hasattr(client, 'classes') and isinstance(client, note.NotRest):
                 self._client = common.wrapWeakref(client)
         else:
             self._client = None
@@ -470,7 +472,7 @@ def realizeVolume(srcStream,
     # key, avoiding searching through entire list every time
     lastRelevantKeyIndex = 0
     for e in flatSrc:  # iterate over all elements
-        if hasattr(e, 'volume') and 'NotRest' in e.classes:
+        if hasattr(e, 'volume') and isinstance(e, note.NotRest):
             # try to find a dynamic
             eStart = e.getOffsetBySite(flatSrc)
 

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -517,7 +517,8 @@ class Test(unittest.TestCase):
 
 
     def testGetContextSearchA(self):
-        from music21 import stream, volume
+        from music21 import stream
+        from music21 import volume
 
         s = stream.Stream()
         d1 = dynamics.Dynamic('mf')
@@ -617,7 +618,8 @@ class Test(unittest.TestCase):
 
 
     def testRealizeVolumeA(self):
-        from music21 import stream, volume
+        from music21 import stream
+        from music21 import volume
 
         s = stream.Stream()
         s.repeatAppend(note.Note('g3'), 16)
@@ -727,7 +729,8 @@ class Test(unittest.TestCase):
 
 
     def testRealizeVolumeC(self):
-        from music21 import stream, articulations
+        from music21 import stream
+        from music21 import articulations
 
         s = stream.Stream()
         s.repeatAppend(note.Note('g3'), 16)


### PR DESCRIPTION
Definitely NOT trying to bend over backwards to get rid of `x in el.classes` but where it's easy we should take advantage of `isinstance()` now being faster than this search, and more general Python style

Stream.base will be a significant challenge here.