### PR TITLE
Set correct MIDI program when constructing instrument from name given in MIDI file

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (7, 0, 8)  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (7, 0, 9)  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'7.0.8'
+'7.0.9'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3894,9 +3894,9 @@ class Test(unittest.TestCase):
     def testImportInstrumentsWithoutProgramChanges(self):
         '''
         Instrument instances are created from both program changes and
-        track or sequence names. In case the information is redundant,
-        do not let there be a default MIDI program on the instrument created
-        from the name--we should defer to the active patch number.
+        track or sequence names. Since we have a MIDI file, we should not
+        rely on default MIDI programs defined in the instrument file; we
+        should just keep track of the active program number.
         https://github.com/cuthbertLab/music21/issues/1085
         '''
         from music21 import midi as midiModule

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1728,7 +1728,7 @@ def getMetaEvents(events):
     from music21.midi import MetaEvents, ChannelVoiceMessages
 
     metaEvents = []  # store pairs of abs time, m21 object
-    last_program: int = 0
+    last_program: int = -1
     for eventTuple in events:
         t, e = eventTuple
         metaObj = None
@@ -1743,7 +1743,9 @@ def getMetaEvents(events):
             # midiEventsToInstrument() WILL NOT have knowledge of the current
             # program, so set it here
             metaObj = midiEventsToInstrument(e)
-            metaObj.midiProgram = last_program
+            if last_program != -1:
+                # Only update if we have had an initial PROGRAM_CHANGE
+                metaObj.midiProgram = last_program
         elif e.type == ChannelVoiceMessages.PROGRAM_CHANGE:
             # midiEventsToInstrument() WILL set the program on the instance
             metaObj = midiEventsToInstrument(e)
@@ -3918,6 +3920,10 @@ class Test(unittest.TestCase):
         # Second element of the tuple is the instrument instance
         self.assertEqual(meta_event_pairs[0][1].midiProgram, 0)
         self.assertEqual(meta_event_pairs[1][1].midiProgram, 0)
+
+        # Remove the initial PROGRAM_CHANGE and get a default midiProgram
+        meta_event_pairs = getMetaEvents([(DUMMY_DELTA_TIME, event2)])
+        self.assertEqual(meta_event_pairs[0][1].midiProgram, 53)
 
 
 # ------------------------------------------------------------------------------

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3895,7 +3895,7 @@ class Test(unittest.TestCase):
         '''
         Instrument instances are created from both program changes and
         track or sequence names. Since we have a MIDI file, we should not
-        rely on default MIDI programs defined in the instrument file; we
+        rely on default MIDI programs defined in the instrument module; we
         should just keep track of the active program number.
         https://github.com/cuthbertLab/music21/issues/1085
         '''


### PR DESCRIPTION
Fixes #1085 

Thanks to @Meekohi for the report. Oversight in #589.

Bumped the minor version so that parsed files won't accidentally be loaded when testing the fix.

Regression test fails on current version.