### PR TITLE
Silence MuseScore command-line output in case of success

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -23,7 +23,6 @@ import io
 import os
 import pathlib
 import subprocess
-import sys
 import unittest
 
 from typing import Union

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -944,7 +944,13 @@ class ConverterMusicXML(SubConverter):
         if completed_process.returncode != 0:
             # Raise same exception class as findNumberedPNGPath()
             # for backward compatibility
-            raise SubConverterFileIOException(completed_process.stderr)
+            stderr_bytes = completed_process.stderr
+            try:
+                import locale
+                stderr_str = stderr_bytes.decode(locale.getpreferredencoding(do_setlocale=False))
+            except UnicodeDecodeError:
+                stderr_str = stderr_bytes  # not really a str, but best we can do.
+            raise SubConverterFileIOException(stderr_str)
 
         if common.runningUnderIPython() and common.getPlatform() == 'nix':
             # Leave environment in original state

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -941,12 +941,7 @@ class ConverterMusicXML(SubConverter):
 
             musescoreRun.extend(['-r', str(defaults.ipythonImageDpi)])
 
-        storedStrErr = sys.stderr
-        fileLikeOpen = io.StringIO()
-        sys.stderr = fileLikeOpen
-        subprocess.run(musescoreRun, check=False)
-        fileLikeOpen.close()
-        sys.stderr = storedStrErr
+        subprocess.run(musescoreRun, capture_output=True, check=False)
 
         if common.runningUnderIPython() and common.getPlatform() == 'nix':
             # Leave environment in original state

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -940,7 +940,11 @@ class ConverterMusicXML(SubConverter):
 
             musescoreRun.extend(['-r', str(defaults.ipythonImageDpi)])
 
-        subprocess.run(musescoreRun, capture_output=True, check=False)
+        completed_process = subprocess.run(musescoreRun, capture_output=True, check=False)
+        if completed_process.returncode != 0:
+            # Raise same exception class as findNumberedPNGPath()
+            # for backward compatibility
+            raise SubConverterFileIOException(completed_process.stderr)
 
         if common.runningUnderIPython() and common.getPlatform() == 'nix':
             # Leave environment in original state


### PR DESCRIPTION
Fixes #1089 -- although silencing everything might seem heavy-handed, printing 7 messages for every success seems much.