### PR TITLE
NotImplemented fixes for subclass `__eq__()` methods

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -277,6 +277,8 @@ class Chord(note.NotRest):
         >>> c1 != c2
         True
         '''
+        if super().__eq__(other) is NotImplemented:
+            return NotImplemented
         if not super().__eq__(other):
             return False
         if not isinstance(other, self.__class__):

--- a/music21/note.py
+++ b/music21/note.py
@@ -908,6 +908,8 @@ class NotRest(GeneralNote):
     # Special functions
     # ==============================================================================================
     def __eq__(self, other):
+        if super().__eq__(other) is NotImplemented:
+            return NotImplemented
         if not super().__eq__(other):
             return False
         if not isinstance(other, NotRest):
@@ -1637,6 +1639,8 @@ class Unpitched(NotRest):
         self._storedInstrument = None
 
     def __eq__(self, other):
+        if super().__eq__(other) is NotImplemented:
+            return NotImplemented
         if not super().__eq__(other):
             return False
         if not isinstance(other, Unpitched):

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2148,6 +2148,8 @@ class RomanNumeral(harmony.Harmony):
         '''
         Compare equality, just based on NotRest and on figure and key
         '''
+        if note.NotRest.__eq__(self, other) is NotImplemented:
+            return NotImplemented
         if not note.NotRest.__eq__(self, other):
             return False
         if self.key != other.key:


### PR DESCRIPTION
Fixes Python DeprecationWarnings:

`DeprecationWarning: NotImplemented should not be used in a boolean context`.

This is because `NotImplemented` is truthy. Haven't checked to see if this has been causing logic issues.