### PR TITLE
Add test showing state of nested tuplet support (brackets)

### DIFF
--- a/music21/duration.py
+++ b/music21/duration.py
@@ -46,8 +46,10 @@ Example usage:
 2
 '''
 
+import contextlib
 import copy
 import fractions
+import io
 import unittest
 from math import inf
 from typing import Union, Tuple, Dict, List, Optional, Iterable
@@ -3507,6 +3509,37 @@ class Test(unittest.TestCase):
             output.append(d.tuplets[0].type)
         # environLocal.printDebug(['got', output])
         self.assertEqual(output, match)
+
+    def testTupletTypeNested(self):
+        '''
+        Nested tuplets are not fully supported (TODO).
+        '''
+        from music21 import note
+        from music21 import stream
+
+        gapful = stream.Measure()
+        half = note.Note(type='half')
+        gapful.repeatAppend(half, 3)
+        for n in gapful:
+            n.duration.appendTuplet(Tuplet(3, 2))
+
+        # create nested tuplet on middle note
+        gapful.notes[1].duration.appendTuplet(Tuplet(2, 1))
+
+        gapless = stream.Measure()
+        for n in gapful:
+            gapless.append(n)
+
+        # Redirect stderr to suppress printed warning
+        # TODO: change to python warnings
+        file_like = io.StringIO()
+        with contextlib.redirect_stderr(file_like):
+            made = stream.makeNotation.makeTupletBrackets(gapless)
+
+        self.assertEqual(
+            [el.duration.tuplets[0].type for el in made],
+            ['startStop', None, 'startStop'],  # was ['start', None, 'stop']
+        )
 
     def testAugmentOrDiminish(self):
 


### PR DESCRIPTION
Follow up to #1072 to show snapshot of current support for nested tuplets and their outer brackets.