### PR TITLE
Prevent AttributeError when making accidentals

### DIFF
--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -421,8 +421,11 @@ class Ornament(Expression):
         transposeInterval
     ):
         '''
-        Used by trills and mordants to fill out their realization
+        Used by trills and mordents to fill out their realization.
         '''
+        if not hasattr(srcObj, 'transpose'):
+            raise TypeError(f'Expected note; got {type(srcObj)}')
+
         firstNote = copy.deepcopy(srcObj)
         # TODO: remove expressions
         # firstNote.expressions = None
@@ -1522,6 +1525,14 @@ class Test(unittest.TestCase):
         raw = m21ToXml.GeneralObjectExporter().parse(s)
         # s.show()
         self.assertEqual(raw.count(b'wavy-line'), 2)
+
+    def testUnpitchedUnsupported(self):
+        from music21 import note
+
+        unp = note.Unpitched()
+        mord = Mordent()
+        with self.assertRaises(TypeError):
+            mord.realize(unp)
 
 
 # class TestExternal(unittest.TestCase):

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -1609,7 +1609,7 @@ def getTiePitchSet(prior: 'music21.note.NotRest'):
         previousNotes = [prior]
 
     for n in previousNotes:
-        if n.tie is None or n.tie.type == 'stop':
+        if n.tie is None or n.tie.type == 'stop' or isinstance(n, note.Unpitched):
             continue
         tiePitchSet.add(n.pitch.nameWithOctave)
     return tiePitchSet


### PR DESCRIPTION
```
  File "/Users/jwalls/music21/music21/stream/makeNotation.py", line 1689, in makeAccidentalsInMeasureStream
    tiePitchSet = getTiePitchSet(previousNoteOrChord)
  File "/Users/jwalls/music21/music21/stream/makeNotation.py", line 1625, in getTiePitchSet
    tiePitchSet.add(n.pitch.nameWithOctave)
AttributeError: 'Unpitched' object has no attribute 'pitch'
```

***
The other way to do it is to check `hasattr(n, 'pitch')`, which we do elsewhere, but this is slightly more explicit to say why the check is needed.