### PR TITLE
Restore original instrument lengths after _transposeByInstrument

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2492,14 +2492,8 @@ class PartExporter(XMLExporterBase):
 
         self.xmlRoot.set('id', str(self.firstInstrumentObject.partId))
 
-        # Split complex durations in place if needed
-        has_complex_durations = bool(
-            self.stream.recurse().getElementsNotOfClass(
-                ['Stream', 'Variant', 'Spanner']
-            ).addFilter(lambda el: el.duration.type == 'complex')
-        )
-        if has_complex_durations:
-            self.stream = self.stream.splitAtDurations(recurse=True)[0]
+        # Split complex durations in place (fast if none are found)
+        self.stream = self.stream.splitAtDurations(recurse=True)[0]
 
         # Suppose that everything below this is a measure
         if self.makeNotation and not self.stream.getElementsByClass(stream.Measure):

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2492,8 +2492,14 @@ class PartExporter(XMLExporterBase):
 
         self.xmlRoot.set('id', str(self.firstInstrumentObject.partId))
 
-        # Split complex durations in place
-        self.stream = self.stream.splitAtDurations(recurse=True)[0]
+        # Split complex durations in place if needed
+        has_complex_durations = bool(
+            self.stream.recurse().getElementsNotOfClass(
+                ['Stream', 'Variant', 'Spanner']
+            ).addFilter(lambda el: el.duration.type == 'complex')
+        )
+        if has_complex_durations:
+            self.stream = self.stream.splitAtDurations(recurse=True)[0]
 
         # Suppose that everything below this is a measure
         if self.makeNotation and not self.stream.getElementsByClass(stream.Measure):
@@ -6735,6 +6741,26 @@ class Test(unittest.TestCase):
         tree = self.getET(s)
         self.assertEqual(len(tree.findall('.//rest')), 1)
 
+    def test_instrumentDoesNotCreateForward(self):
+        '''
+        Instrument tags were causing forward motion in some cases.
+        From Chapter 14, Key Signatures
+
+        This is a transposed score.  Instruments were being extended in duration
+        in the toSoundingPitch and not having their durations restored afterwards
+        leading to Instrument objects being split if the duration was complex
+        '''
+        from music21 import corpus
+        from music21 import meter
+        alto = corpus.parse('bach/bwv57.8').parts['Alto']
+        alto.measure(7).timeSignature = meter.TimeSignature('6/8')
+        newAlto = alto.flat.getElementsNotOfClass(meter.TimeSignature).stream()
+        newAlto.insert(0, meter.TimeSignature('2/4'))
+        newAlto.makeMeasures(inPlace=True)
+        newAltoFixed = newAlto.makeNotation()
+        tree = self.getET(newAltoFixed)
+        self.assertTrue(tree.findall('.//note'))
+        self.assertFalse(tree.findall('.//forward'))
 
 class TestExternal(unittest.TestCase):
     show = True
@@ -6791,4 +6817,4 @@ class TestExternal(unittest.TestCase):
 
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test)  # , runTest='testExceptionMessage')
+    music21.mainTest(Test)  # , runTest='test_instrumentDoesNotCreateForward')

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6751,7 +6751,6 @@ class Test(unittest.TestCase):
         leading to Instrument objects being split if the duration was complex
         '''
         from music21 import corpus
-        from music21 import meter
         alto = corpus.parse('bach/bwv57.8').parts['Alto']
         alto.measure(7).timeSignature = meter.TimeSignature('6/8')
         newAlto = alto.flat.getElementsNotOfClass(meter.TimeSignature).stream()

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -32,7 +32,7 @@ import sys
 from collections import namedtuple
 from fractions import Fraction
 from math import isclose
-from typing import Dict, Union, List, Optional, Set, Tuple, Sequence, TypeVar, TYPE_CHECKING
+from typing import Dict, Union, List, Optional, Set, Tuple, Sequence, TypeVar
 
 from music21 import base
 
@@ -66,9 +66,6 @@ from music21.common.numberTools import opFrac
 from music21.common.enums import GatherSpanners, OffsetSpecial
 
 from music21 import environment
-
-if TYPE_CHECKING:
-    from music21 import instrument
 
 environLocal = environment.Environment('stream')
 
@@ -4961,7 +4958,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             returnObj = self
 
         instrument_stream = returnObj.getInstruments(recurse=True)
-        instrument_map: Dict[instrument.Instrument, Union[float, Fraction]] = {}
+        instrument_map: Dict['music21.instrument.Instrument', Union[float, Fraction]] = {}
         for inst in instrument_stream:
             # keep track of original durations of each instrument
             instrument_map[inst] = inst.duration.quarterLength

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -4957,6 +4957,12 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             returnObj = self
 
         instrument_stream = returnObj.getInstruments(recurse=True)
+        instrument_map: Dict[Instrument, Union[float, Fraction]] = {}
+        for inst in instrument_stream:
+            # keep track of original durations of each instrument
+            instrument_map[inst] = inst.duration.quarterLength
+            # this loses the expression of duration, but should be fine for instruments.
+
         instrument_stream.duration = returnObj.duration
         instrument_stream.extendDuration('Instrument', inPlace=True)
 
@@ -4982,6 +4988,10 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
                 trans = trans.reverse()
             focus.transpose(trans, inPlace=True,
                             classFilterList=classFilterList)
+
+        # restore original durations
+        for inst, original_ql in instrument_map.items():
+            inst.duration.quarterLength = original_ql
 
         return returnObj
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -32,7 +32,7 @@ import sys
 from collections import namedtuple
 from fractions import Fraction
 from math import isclose
-from typing import Dict, Union, List, Optional, Set, Tuple, Sequence, TypeVar
+from typing import Dict, Union, List, Optional, Set, Tuple, Sequence, TypeVar, TYPE_CHECKING
 
 from music21 import base
 
@@ -44,7 +44,6 @@ from music21 import defaults
 from music21 import derivation
 from music21 import duration
 from music21 import exceptions21
-from music21 import instrument  # for typing
 from music21 import interval
 from music21 import key
 from music21 import metadata
@@ -67,6 +66,10 @@ from music21.common.numberTools import opFrac
 from music21.common.enums import GatherSpanners, OffsetSpecial
 
 from music21 import environment
+
+if TYPE_CHECKING:
+    from music21 import instrument
+
 environLocal = environment.Environment('stream')
 
 StreamException = exceptions21.StreamException

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -32,7 +32,7 @@ import sys
 from collections import namedtuple
 from fractions import Fraction
 from math import isclose
-from typing import Union, List, Optional, Set, Tuple, Sequence, TypeVar
+from typing import Dict, Union, List, Optional, Set, Tuple, Sequence, TypeVar
 
 from music21 import base
 
@@ -44,6 +44,7 @@ from music21 import defaults
 from music21 import derivation
 from music21 import duration
 from music21 import exceptions21
+from music21 import instrument  # for typing
 from music21 import interval
 from music21 import key
 from music21 import metadata
@@ -4957,7 +4958,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             returnObj = self
 
         instrument_stream = returnObj.getInstruments(recurse=True)
-        instrument_map: Dict[Instrument, Union[float, Fraction]] = {}
+        instrument_map: Dict[instrument.Instrument, Union[float, Fraction]] = {}
         for inst in instrument_stream:
             # keep track of original durations of each instrument
             instrument_map[inst] = inst.duration.quarterLength

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -7473,6 +7473,9 @@ class Test(unittest.TestCase):
                     r = note.Rest(quarterLength=n.quarterLength)
                     m.remove(n)
                     m.insert(targetOffset, r)
+
+        # not sure what changed, but hidden 8th beams otherwise stay in place.
+        p.makeBeams(inPlace=True)
         # if we iterate, we get a sorted version
         # self.assertEqual([str(n) for n in p.flat.notesAndRests], [])
 


### PR DESCRIPTION
By not restoring original instrument lengths we were creating instruments with quarter lengths like 40.0, which is a complex duration that was being split by  `splitAtDurations`.  Then we'd end up with two Instrument objects in measure 1, one of which was FAR FAR later, so even though it was being removed in output, it caused a massive `<forward>` tag in the musicxml output which caused spacing to be terrible.

Also saves making a second deepcopy of a score for 98% of show() cases which don't have complex durations.