### PR TITLE
Safer ElementTree by always importing from same file

### DIFF
--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -175,8 +175,7 @@ tool.
 '''
 # pylint: disable=misplaced-comparison-constant
 from typing import Optional, Union, List, Tuple
-from xml.etree import ElementTree as ETree
-from xml.etree.ElementTree import Element
+from xml.etree.ElementTree import Element, ParseError, fromstring, ElementTree
 
 from collections import defaultdict
 from fractions import Fraction  # for typing
@@ -289,14 +288,14 @@ class MeiToM21Converter:
             self.documentRoot = Element(f'{MEI_NS}mei')
         else:
             try:
-                self.documentRoot = ETree.fromstring(theDocument)
-            except ETree.ParseError as parseErr:
+                self.documentRoot = fromstring(theDocument)
+            except ParseError as parseErr:
                 environLocal.printDebug(
                     '\n\nERROR: Parsing the MEI document with ElementTree failed.')
                 environLocal.printDebug(f'We got the following error:\n{parseErr}')
                 raise MeiValidityError(_INVALID_XML_DOC)
 
-            if isinstance(self.documentRoot, ETree.ElementTree):
+            if isinstance(self.documentRoot, ElementTree):
                 # pylint warns that :class:`Element` doesn't have a getroot() method, which is
                 # true enough, but...
                 self.documentRoot = self.documentRoot.getroot()  # pylint: disable=maybe-no-member

--- a/music21/musicxml/helpers.py
+++ b/music21/musicxml/helpers.py
@@ -10,11 +10,11 @@
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 import copy
-import xml.etree.ElementTree as ET
+from xml.etree.ElementTree import tostring as et_tostring
 
 def dumpString(obj, *, noCopy=False) -> str:
     r'''
-    wrapper around xml.etree.ElementTree as ET that returns a string
+    wrapper around xml.etree.ElementTree that returns a string
     in every case and indents tags and sorts attributes.
 
     >>> from music21.musicxml.m21ToXml import Element
@@ -43,14 +43,14 @@ def dumpString(obj, *, noCopy=False) -> str:
             attribs = sorted(attrib.items())
             attrib.clear()
             attrib.update(attribs)
-    xStr = ET.tostring(xmlEl, encoding='unicode')
+    xStr = et_tostring(xmlEl, encoding='unicode')
     xStr = xStr.rstrip()
     return xStr
 
 
 def dump(obj):
     r'''
-    wrapper around xml.etree.ElementTree as ET that prints a string
+    wrapper around xml.etree.ElementTree that prints a string
     in every case and indents tags and sorts attributes.  (Prints, does not return)
 
     >>> from music21.musicxml.helpers import dump

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -15,8 +15,7 @@ MusicXML `<part>` from multiple music21 `PartStaff` objects.
 '''
 from typing import Dict, List, Optional
 import unittest
-import xml.etree.ElementTree as ET
-from xml.etree.ElementTree import Element, SubElement
+from xml.etree.ElementTree import Element, SubElement, Comment
 
 from music21.key import KeySignature
 from music21.layout import StaffGroup
@@ -377,7 +376,7 @@ class PartStaffExporterMixin:
 
             # Or, gap in measure numbers in target: record necessary insertions until gap is closed
             while helpers.measureNumberComesBefore(sourceNumber, targetNumber):
-                divider: Element = ET.Comment(DIVIDER_COMMENT.replace(PLACEHOLDER, sourceNumber))
+                divider: Element = Comment(DIVIDER_COMMENT.replace(PLACEHOLDER, sourceNumber))
                 try:
                     insertions[i] += [divider, sourceMeasure]
                 except KeyError:
@@ -396,7 +395,7 @@ class PartStaffExporterMixin:
             remainingMeasures.insert(0, sourceMeasure)
         for remaining in remainingMeasures:
             sourceNumber = remaining.get('number')
-            divider: Element = ET.Comment(DIVIDER_COMMENT.replace(PLACEHOLDER, sourceNumber))
+            divider: Element = Comment(DIVIDER_COMMENT.replace(PLACEHOLDER, sourceNumber))
             try:
                 insertions[len(target)] += [divider, remaining]
             except KeyError:


### PR DESCRIPTION
ElementTree in its C form is very delicate (see: https://stackoverflow.com/questions/60470643/python-xml-typeerror-subelement-argument-1-must-be-xml-etree-elementtree-el)  -- I have been running into problems with

```
import xml.etree.ElementTree as ET
from xml.etree.ElementTree import Element, SubElement

root = Element('root')
comment = ET.Comment('hi')
root.append(comment)
```

that they are binary incompatible, when running music21 under other frameworks (Django, etc.) -- it is safer if everything is imported from the same file at the same time.  Thus, all imports on one line, no namespace prefixes.

Prevents: `must be xml.etree.ElementTree.Element, not Element` errors.