### PR TITLE
Allow making beams in individual measures without time signatures

### DIFF
--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -6522,7 +6522,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
             classFilterList=classFilterList,
         )
 
-    def makeBeams(self, *, inPlace=False, setStemDirections=True):
+    def makeBeams(self, *, inPlace=False, setStemDirections=True, failOnNoTimeSignature=False):
         '''
         Return a new Stream, or modify the Stream in place, with beams applied to all
         notes.
@@ -6530,11 +6530,14 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         See :py:func:`~music21.stream.makeNotation.makeBeams`.
 
         New in v6.7 -- setStemDirections.
+        New in v.7 -- failOnNoTimeSignature raises StreamException if no TimeSignature
+        exists in the stream context from which to make measures.
         '''
         return makeNotation.makeBeams(
             self,
             inPlace=inPlace,
-            setStemDirections=setStemDirections
+            setStemDirections=setStemDirections,
+            failOnNoTimeSignature=failOnNoTimeSignature,
         )
 
     def makeAccidentals(

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -141,12 +141,11 @@ def makeBeams(
     for m in mColl:
         # this means that the first of a stream of time signatures will
         # be used
-        if m.timeSignature is not None:
-            lastTimeSignature = m.timeSignature
+        lastTimeSignature = m.timeSignature or m.getContextByClass(meter.TimeSignature)
         if lastTimeSignature is None:
-            lastTimeSignature = m.getContextByClass(meter.TimeSignature)
-            if lastTimeSignature is None and failOnNoTimeSignature:
-                raise stream.StreamException('cannot process beams in a Measure without a time signature')
+            if failOnNoTimeSignature:
+                raise stream.StreamException(
+                    'cannot process beams in a Measure without a time signature')
             else:
                 continue
         noteGroups = []

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -5,16 +5,16 @@
 #
 # Authors:      Michael Scott Cuthbert
 #               Christopher Ariza
+#               Jacob Walls
 #               Evan Lynch
 #
-# Copyright:    Copyright © 2008-2013 Michael Scott Cuthbert and the music21
+# Copyright:    Copyright © 2008-2021 Michael Scott Cuthbert and the music21
 #               Project
 # License:      BSD, see license.txt
 # -----------------------------------------------------------------------------
 
 import copy
 import unittest
-import warnings
 from typing import List, Generator, Optional, Set, Union
 from fractions import Fraction  # typing only
 
@@ -44,6 +44,7 @@ def makeBeams(
     *,
     inPlace=False,
     setStemDirections=True,
+    failOnNoTimeSignature=False,
 ):
     # noinspection PyShadowingNames
     '''
@@ -144,8 +145,9 @@ def makeBeams(
             lastTimeSignature = m.timeSignature
         if lastTimeSignature is None:
             lastTimeSignature = m.getContextByClass(meter.TimeSignature)
-            if lastTimeSignature is None:
-                warnings.warn('cannot process beams in a Measure without a time signature')
+            if lastTimeSignature is None and failOnNoTimeSignature:
+                raise stream.StreamException('cannot process beams in a Measure without a time signature')
+            else:
                 continue
         noteGroups = []
         if m.hasVoices():
@@ -2007,8 +2009,8 @@ class Test(unittest.TestCase):
         m1 = p[stream.Measure].first()
         m1.timeSignature = None
         msg = 'cannot process beams in a Measure without a time signature'
-        with self.assertWarnsRegex(Warning, msg):
-            m2.makeBeams(inPlace=True)
+        with self.assertRaisesRegex(stream.StreamException, msg):
+            m2.makeBeams(inPlace=True, failOnNoTimeSignature=True)
 
     def testStreamExceptions(self):
         from music21 import converter

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -146,8 +146,7 @@ def makeBeams(
             if failOnNoTimeSignature:
                 raise stream.StreamException(
                     'cannot process beams in a Measure without a time signature')
-            else:
-                continue
+            continue
         noteGroups = []
         if m.hasVoices():
             for v in m.voices:


### PR DESCRIPTION
Allow making beams on individual measures that may lack a `TimeSignature` by getting the time signature from the context.

Useful for operating on, say, just the final measure of a part.