### PR TITLE
Resolve warnings emitted by musicxml exporter

### DIFF
--- a/music21/analysis/reduceChords.py
+++ b/music21/analysis/reduceChords.py
@@ -122,10 +122,13 @@ class ChordReducer:
 
         # TODO: make chordified a method on TimespanTree and move stream.chordify guts there
         #   then use that and remove this deprecated call.
-        chordifiedReduction = tree.toStream.chordified(
-            scoreTree,
-            templateStream=inputScore,
-        )
+        import warnings
+        with warnings.catch_warnings():  # catch deprecation warning
+            warnings.simplefilter('ignore', category=exceptions21.Music21DeprecationWarning)
+            chordifiedReduction = tree.toStream.chordified(
+                scoreTree,
+                templateStream=inputScore,
+            )
         chordifiedPart = stream.Part()
         for measure in chordifiedReduction.getElementsByClass('Measure'):
             reducedMeasure = self.reduceMeasureToNChords(

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -961,8 +961,11 @@ class Test(unittest.TestCase):
         # BACH pre;ide !, WTC
 
         src = corpus.parse('bwv846')
-        chords = src.flattenParts().makeChords(minimumWindowSize=4,
-                                    makeRests=False)
+        import warnings
+        with warnings.catch_warnings():  # catch deprecation warning
+            warnings.simplefilter('ignore', category=exceptions21.Music21DeprecationWarning)
+            chords = src.flattenParts().makeChords(minimumWindowSize=4,
+                                        makeRests=False)
         for c in chords.flatten().notes:
             c.quarterLength = 4
         for m in chords.getElementsByClass('Measure'):

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1629,14 +1629,14 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         True
         '''
         if self.makeNotation:
-            # self.parts is a stream of parts
             # hide any rests created at this late stage, because we are
             # merely trying to fill up MusicXML display, not impose things on users
-            self.parts.makeRests(refStreamOrTimeRange=self.refStreamOrTimeRange,
-                                 inPlace=True,
-                                 hideRests=True,
-                                 timeRangeFromBarDuration=True,
-                                 )
+            for p in self.parts:
+                p.makeRests(refStreamOrTimeRange=self.refStreamOrTimeRange,
+                            inPlace=True,
+                            hideRests=True,
+                            timeRangeFromBarDuration=True,
+                            )
 
         count = 0
         sp = list(self.parts)


### PR DESCRIPTION
Prevents warnings emitted since df7308c8960280413289575f31169a8011fea149 (v7 dev)

```
.../music21/music21/musicxml/m21ToXml.py:1635: StreamIteratorInefficientWarning: makeRests is not defined on StreamIterators. Call .stream() first for efficiency
```