### PR TITLE
Improve test for advanced usage of ConverterMusicXML

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1536,14 +1536,15 @@ class Test(unittest.TestCase):
             with open(mxlPath, 'r', encoding='utf-8') as f:
                 f.read(20)
 
-        # Same, but from the ConverterMusicXML object directly
+        # Also test ConverterMusicXML object directly
         conv = ConverterMusicXML()
-        conv.write(fp=mxlPath, obj=s, fmt='musicxml')
+        mxlPath2 = conv.write(obj=s, fmt='mxl')
         with self.assertRaises(UnicodeDecodeError):
-            with open(mxlPath, 'r', encoding='utf-8') as f:
+            with open(mxlPath2, 'r', encoding='utf-8') as f:
                 f.read(20)
 
         os.remove(mxlPath)
+        os.remove(mxlPath2)
 
     def testWriteMusicXMLMakeNotation(self):
         from music21 import converter


### PR DESCRIPTION
Follow up to #1104 -- this test was supposed to target the uncovered line in #1104 where there is _not_ a provided filepath. Not a typical usage scenario, best to just call `my_stream.write()` with any of:
 - path ending in .mxl
 - fmt = 'mxl'
 - compress=True