### PR TITLE
Handle .mxl files zipped up from mislabeled .mxl files

### DIFF
--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -174,6 +174,7 @@ class ArchiveManager:
         return post
 
     def _extractContents(self, f: zipfile.ZipFile, name=None, dataFormat='musicxml'):
+        post = None
         if name is None and dataFormat == 'musicxml':  # try to auto-harvest
             # will return data as a string
             # note that we need to read the META-INF/container.xml file

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -186,7 +186,8 @@ class ArchiveManager:
                 # xml file
                 if 'META-INF' in subFp:
                     continue
-                if not subFp.endswith('.xml') and not subFp.endswith('musicxml'):
+                # include .mxl to be kind to users who zipped up mislabeled files
+                if pathlib.Path(subFp).suffix not in ['.musicxml', '.xml', '.mxl']:
                     continue
 
                 post = f.read(subFp)


### PR DESCRIPTION
If a user has mislabeled their uncompressed musicxml file with the `.mxl` filepath, and then actually compressed it, in all likelihood, the zipfile archive will show the original path ending in '.mxl' as the uncompressed contained filepath.

This was never contemplated. It would have failed silently.

After a59c91e4fa it fails loudly with a crash, which was helpful for diagnosing the issue. Handled the crash and the use case.