### PR TITLE
Make text file encoding explicit

### DIFF
--- a/.github/workflows/pythonpylint.yml
+++ b/.github/workflows/pythonpylint.yml
@@ -23,7 +23,7 @@ jobs:
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
                   pip install IPython
-                  pip install pylint==2.9.6
+                  pip install pylint
             - name: Lint with pylint
               run: |
                   pylint -j0 music21

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1968,7 +1968,7 @@ class Test(unittest.TestCase):
         # This file should have been written, above
         destFp = Converter()._getDownloadFp(e.getRootTempDir(), '.krn', url)
         # Hack garbage into it so that we can test whether or not forceSource works
-        with open(destFp, 'a') as fp:
+        with open(destFp, 'a', encoding='utf-8') as fp:
             fp.write('all sorts of garbage that Humdrum cannot parse')
 
         with self.assertRaises(HumdrumException):

--- a/music21/converter/qmConverter.py
+++ b/music21/converter/qmConverter.py
@@ -93,7 +93,7 @@ class QMConverter(converter.subConverters.SubConverter):
             {2.0} <music21.note.Note C>
             {3.0} <music21.bar.Barline type=final>
         '''
-        with open(filePath, 'r') as f:
+        with open(filePath, 'r', encoding='utf-8') as f:
             self.parseData(f.read())
 
     def write(self, obj, fmt, fp=None, subformats=None, **keywords):  # pragma: no cover
@@ -105,7 +105,7 @@ class QMConverter(converter.subConverters.SubConverter):
             music = music + n.name + ' '
         music += '\n'
 
-        with open(fp, 'w') as f:
+        with open(fp, 'w', encoding='utf-8') as f:
             f.write(music)
 
         return fp

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -101,10 +101,11 @@ class SubConverter:
         '''
         Called when a file is encountered. If all that needs to be done is
         loading the file and putting the data into parseData then there is no need
-        to do implement this method.  Just set self.readBinary to True|False.
+        to implement this method.  Just set self.readBinary to True|False.
         '''
         if self.readBinary is False:
-            with open(filePath) as f:
+            import locale
+            with open(filePath, encoding=locale.getpreferredencoding()) as f:
                 dataStream = f.read()
         else:
             with open(filePath, 'rb') as f:
@@ -1246,7 +1247,7 @@ class ConverterRomanText(SubConverter):
         if fp is None:
             fp = self.getTemporaryFile()
 
-        with open(fp, 'w') as text_file:
+        with open(fp, 'w', encoding='utf-8') as text_file:
             for entry in writeRoman.RnWriter(obj).combinedList:
                 text_file.write(entry + '\n')
 
@@ -1589,7 +1590,7 @@ class Test(unittest.TestCase):
 
         p = converter.parse('tinyNotation: c1 d1 e1 f1')
         out = p.write('braille', debug=True)
-        with open(out, 'r') as f:
+        with open(out, 'r', encoding='utf-8') as f:
             self.assertIn('<music21.braille.segment BrailleSegment>', f.read())
         os.remove(out)
 

--- a/music21/features/outputFormats.py
+++ b/music21/features/outputFormats.py
@@ -33,7 +33,7 @@ class OutputFormat:
             fp = environLocal.getTempFile(suffix=self.ext)
         if not str(fp).endswith(self.ext):
             raise OutputFormatException('Could not get a temp file with the right extension')
-        with open(fp, 'w') as f:
+        with open(fp, 'w', encoding='utf-8') as f:
             f.write(self.getString(includeClassLabel=includeClassLabel,
                                    includeId=includeId))
         return fp

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -684,7 +684,7 @@ class StreamFreezer(StreamFreezeThawBase):
             if zipType == 'zlib':
                 data = zlib.compress(data)
 
-            with open(fp, 'w') as f:
+            with open(fp, 'w', encoding='utf-8') as f:
                 f.write(data)
 
         else:  # pragma: no cover
@@ -951,7 +951,7 @@ class StreamThawer(StreamFreezeThawBase):
             common.restorePathClassesAfterUnpickling()
         elif fmt == 'jsonpickle':
             import jsonpickle
-            with open(fp, 'r') as f:
+            with open(fp, 'r', encoding='utf-8') as f:
                 data = f.read()
             storage = jsonpickle.decode(data)
             self.stream = self.unpackStream(storage)

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -1537,7 +1537,8 @@ class MidiFile(prebase.ProtoM21Object):
         '''
         if attrib not in ['rb', 'wb']:
             raise MidiException('cannot read or write unless in binary mode, not:', attrib)
-        self.file = open(filename, attrib)  # pylint: disable=consider-using-with
+        # pylint: disable-next=consider-using-with, unspecified-encoding
+        self.file = open(filename, attrib)
 
     def openFileLike(self, fileLike):
         '''Assign a file-like object, such as those provided by BytesIO, as an open file object.

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6550,10 +6550,9 @@ class Test(unittest.TestCase):
         p.append(m)
         s.append(p)
 
-        self.assertEqual(3, self.getXml(s).count(u'<harmony'))
-        self.assertEqual(1, self.getXml(s).count(u'<kind '
-                                                  u'text="N.C.">none</kind>'))
-        self.assertEqual(1, self.getXml(s).count(u'<root-step text="">'))
+        self.assertEqual(3, self.getXml(s).count('<harmony'))
+        self.assertEqual(1, self.getXml(s).count('<kind text="N.C.">none</kind>'))
+        self.assertEqual(1, self.getXml(s).count('<root-step text="">'))
 
         s = stream.Score()
         p = stream.Part()
@@ -6571,10 +6570,8 @@ class Test(unittest.TestCase):
         p.append(m)
         s.append(p)
 
-        self.assertEqual(1, self.getXml(s).count(u'<kind '
-                                                 u'text="N.C.">none</kind>'))
-        self.assertEqual(1, self.getXml(s).count(u'<kind '
-                                                 u'text="No Chord">none</kind>'))
+        self.assertEqual(1, self.getXml(s).count('<kind text="N.C.">none</kind>'))
+        self.assertEqual(1, self.getXml(s).count('<kind text="No Chord">none</kind>'))
 
     def testSetPartsAndRefStreamMeasure(self):
         from music21 import converter

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -290,7 +290,7 @@ class TsvHandler:
 
         fileName = self.tsvFileName
 
-        with open(fileName, 'r') as f:
+        with open(fileName, 'r', encoding='utf-8') as f:
             data = []
             for row_num, line in enumerate(f):
                 if row_num == 0:  # Ignore first row (headers)
@@ -505,7 +505,7 @@ class M21toTSV:
         '''
         Writes a list of lists (e.g. from m21ToTsv()) to a tsv file.
         '''
-        with open(filePathAndName, 'a', newline='') as csvFile:
+        with open(filePathAndName, 'a', newline='', encoding='utf-8') as csvFile:
             csvOut = csv.writer(csvFile,
                                 delimiter='\t',
                                 quotechar='"',

--- a/music21/test/multiprocessTest.py
+++ b/music21/test/multiprocessTest.py
@@ -306,8 +306,9 @@ def printSummary(summaryOutput, timeStart, pathsToRun):
     sys.stdout.flush()
 
     import datetime
+    import locale
     lastResults = os.path.join(environLocal.getRootTempDir(), 'lastResults.txt')
-    with open(lastResults, 'w') as f:
+    with open(lastResults, 'w', encoding=locale.getdefaultencoding()) as f:
         f.write(outStr)
         f.write('Run at ' + datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 

--- a/music21/vexflow/toMusic21j.py
+++ b/music21/vexflow/toMusic21j.py
@@ -296,7 +296,7 @@ class TestCuthbert(unittest.TestCase):  # pragma: no cover
         vfp.defaults['requireURI'] = 'file:///Users/Cuthbert/git/music21j/ext/require/require.js'
         data = vfp.fromObject(s)
         fp = environLocal.getTempFile('.html')
-        with open(fp, 'w') as f:
+        with open(fp, 'w', encoding='utf-8') as f:
             f.write(data)
         # environLocal.launch('vexflow', fp)
 


### PR DESCRIPTION
Pylint 2.10.x introduced `unspecified-encoding` to force projects to decide if they support cross-platform file I/O. We can suppress this check, or, better I suppose, make explicit whether we are relying on `utf-8` or can tolerate the system default. We may as well help people stay platform-agnostic, no?

How does this look? (I pulled over one other commit from the `september-miscellany` branch (u-prefixes) so I can unpin Pylint on this one.)