### PR TITLE
Fix improper call to locale library in multiprocess test text output

### DIFF
--- a/music21/test/multiprocessTest.py
+++ b/music21/test/multiprocessTest.py
@@ -306,9 +306,8 @@ def printSummary(summaryOutput, timeStart, pathsToRun):
     sys.stdout.flush()
 
     import datetime
-    import locale
     lastResults = os.path.join(environLocal.getRootTempDir(), 'lastResults.txt')
-    with open(lastResults, 'w', encoding=locale.getdefaultencoding()) as f:
+    with open(lastResults, 'w', encoding='utf-8') as f:
         f.write(outStr)
         f.write('Run at ' + datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 


### PR DESCRIPTION
- `getdefaultencoding()` is on `sys`, not `locale`. whoops! mistake in #1117.
- Just remove needless complexity and write in 'utf-8', since this is just a library developer tool.