### PR TITLE
Fix `stripTies()` crash in certain scenario with matchByPitch=False

### DIFF
--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1321,8 +1321,8 @@ class Test(unittest.TestCase):
         '''
         from music21 import tie
 
-        v1 = Measure([note.Rest()])
-        v2 = Measure([chord.Chord('C4 E-4 B-4')])
+        v1 = Voice([note.Rest()])
+        v2 = Voice([chord.Chord('C4 E-4 B-4')])
         m = Measure([v1, v2])
         v2.notes.first().tie = tie.Tie('stop')
         _ = m.stripTies(inPlace=False, matchByPitch=False)

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1314,6 +1314,21 @@ class Test(unittest.TestCase):
              ]
         )
 
+    def testStripTiesStopTieChordFollowsRest(self):
+        '''
+        Ensure stripTies() gracefully handles "stop" or "continue" tie types
+        following rests as it flattens a stream.
+        '''
+        from music21 import tie
+
+        v1 = Measure([note.Rest()])
+        v2 = Measure([chord.Chord('C4 E-4 B-4')])
+        m = Measure([v1, v2])
+        v2.notes.first().tie = tie.Tie('stop')
+        _ = m.stripTies(inPlace=False, matchByPitch=False)
+        v2.notes.first().tie = tie.Tie('continue')
+        _ = m.stripTies(inPlace=False, matchByPitch=False)
+
     def testGetElementsByOffsetZeroLength(self):
         '''
         Testing multiple zero-length elements with mustBeginInSpan:

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1324,10 +1324,11 @@ class Test(unittest.TestCase):
         v1 = Voice([note.Rest()])
         v2 = Voice([chord.Chord('C4 E-4 B-4')])
         m = Measure([v1, v2])
+        p = Part(m)
         v2.notes.first().tie = tie.Tie('stop')
-        _ = m.stripTies(inPlace=False, matchByPitch=False)
+        _ = p.stripTies(inPlace=False, matchByPitch=False)
         v2.notes.first().tie = tie.Tie('continue')
-        _ = m.stripTies(inPlace=False, matchByPitch=False)
+        _ = p.stripTies(inPlace=False, matchByPitch=False)
 
     def testGetElementsByOffsetZeroLength(self):
         '''


### PR DESCRIPTION
`stripTies()` crashed in a scenario where:
  - `matchByPitch=False` (only currently used in MIDI writing; default is otherwise True)
  - a Chord with "stop" or "continue" ties follows a Rest
  (that would seem malformed, but for the fact that stripTies() flattens the part, so you can have a perfectly valid measure that when flattened gives a stop tie following a rest in virtue of there being voices)

Regression in b7bcad9914 (v7.1)

Luckily, `matchByPitch` defaults True in v7, so this only affects MIDI writing by default.

Reported in StackOverflow [post](https://stackoverflow.com/questions/69140830/music21-write-function-giving-attributeerror-rest-object-has-no-attribute).

***

I'm not certain why `matchByPitch` is still False in the MIDI writer. I suppose I just was unwilling to change something I didn't fully understand. EDIT: opened #1127 to change this.

I expect `mypy` would have caught this. (The variable name `nLast` coaxed out the coding error.) I'll be developing with mypy more.