### PR TITLE
Use matchByPitch=True in MIDI export

### DIFF
--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2440,7 +2440,7 @@ def streamHierarchyToMidiTracks(
 
     # strip all ties inPlace
     for subs in substreamList:
-        subs.stripTies(inPlace=True, matchByPitch=False)
+        subs.stripTies(inPlace=True, matchByPitch=True)
 
     packetStorage = packetStorageFromSubstreamList(substreamList, addStartDelay=addStartDelay)
     updatePacketStorageWithChannelInfo(packetStorage, channelByInstrument)
@@ -2483,12 +2483,13 @@ def midiTracksToStreams(
     quantizePost=True,
     inputM21: stream.Score = None,
     **keywords
-) -> stream.Stream():
+) -> stream.Score:
     '''
     Given a list of midiTracks, populate either a new stream.Score or inputM21
     with a Part for each track.
     '''
     # environLocal.printDebug(['midi track count', len(midiTracks)])
+    s: stream.Score
     if inputM21 is None:
         s = stream.Score()
     else:


### PR DESCRIPTION
Another way of preventing the issue in #1126 is to just use the safer method of stripping ties during MIDI export.

matchByPitch was False since the inception of the MIDI exporter, and since then the speed vs. accuracy tradeoff has swung way, way in favor of accuracy. Essentially a follow-up to #818.