### PR TITLE
Support multiple figures in single lyric (e.g "64") in `figuredBassFromStream()` 

### DIFF
--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -133,7 +133,8 @@ def figuredBassFromStream(streamPart):
         # Is there more?
         if inputText[stop_index_exclusive:]:
             annotationString += ', '
-            annotationString = updateAnnotationString(annotationString, inputText[stop_index_exclusive:])
+            annotationString = updateAnnotationString(
+                annotationString, inputText[stop_index_exclusive:])
         return annotationString
 
     for n in sfn:

--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -811,6 +811,10 @@ class Test(unittest.TestCase):
         fb = figuredBassFromStream(s)
         self.assertEqual(third_note.notationString, '6, 4')
 
+        third_note.lyric = '6\n4'
+        fb = figuredBassFromStream(s)
+        self.assertEqual(third_note.notationString, '6, 4')
+
 
 if __name__ == '__main__':
     import music21


### PR DESCRIPTION
**Previously**
Only line-separated lyrics such as `'6\n4'` were supported in `figuredBassFromStream()`.

**Now**
Lyrics such as `'64'` and `'#6#4'` are supported.

This allows for fast entry of figured bass using tinyNotation, which doesn't support line breaks.