### PR TITLE
Postpone consider-using-f-string

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -105,7 +105,6 @@ disable=
     import-outside-toplevel,  # allow for import music21, etc.
     not-callable,  # false positives, for instance on x.next()
     raise-missing-from,  # want to do this eventually, but adding 1000 msgs not helpful
-    consider-using-in,  # future?
     consider-using-f-string,  # future?
 
 #       'protected-access', # this is an important one, but for now we do a lot of

--- a/.pylintrc
+++ b/.pylintrc
@@ -105,6 +105,8 @@ disable=
     import-outside-toplevel,  # allow for import music21, etc.
     not-callable,  # false positives, for instance on x.next()
     raise-missing-from,  # want to do this eventually, but adding 1000 msgs not helpful
+    consider-using-in,  # future?
+    consider-using-f-string,  # future?
 
 #       'protected-access', # this is an important one, but for now we do a lot of
 #                           # x = copy.deepcopy(self); x._volume = ... which is not a problem...

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -838,7 +838,7 @@ class Test(unittest.TestCase):
             s = translate.abcToStreamScore(ah)
             part = s.parts[0]
             self.assertFalse(part.getElementsByClass(chord.Chord),
-                             'Empty chord "%s" in Score' % abc_chord)
+                             f'Empty chord "{abc_chord}" in Score')
 
         # list of test abc chords and their quarter lengths at the default length of 1/8
         # list[tuple(str, int)] = of abc chords and= [( abc_chord: str)]
@@ -861,7 +861,7 @@ class Test(unittest.TestCase):
             ah = af.readstr(abc_dl + abc_chord)
             s = translate.abcToStreamScore(ah)
             self.assertEqual(s.duration.quarterLength, quarter_length,
-                             'invalid duration of chord "%s"' % abc_chord)
+                             f'invalid duration of chord "{abc_chord}"')
 
             notes = s.parts[0].notes
             chord0 = notes[0]
@@ -869,7 +869,7 @@ class Test(unittest.TestCase):
             self.assertIsInstance(chord0, chord.Chord, 'Not a Chord!')
             for pitch_name in chord_pitches:
                 self.assertIn(pitch_name, chord0.pitchNames,
-                              'Pitch not in Chord "%s"' % abc_chord)
+                              f'Pitch not in Chord "{abc_chord}"')
 
     def testAbc21ChordSymbol(self):
         # Test the chord symbol for note and chord
@@ -885,10 +885,10 @@ class Test(unittest.TestCase):
             ah = af.readstr(abc_dl + abc_text)
             part = translate.abcToStreamScore(ah).parts[0]
             chord_symbol = part.getElementsByClass(harmony.ChordSymbol)
-            self.assertTrue(chord_symbol, 'No ChordSymbol found in abc: "%s"' % abc_text)
+            self.assertTrue(chord_symbol, f'No ChordSymbol found in abc: "{abc_text}"')
             for pitch_name in 'CEG':
                 self.assertIn(pitch_name, chord_symbol[0].pitchNames,
-                              'Pitch not in ChordSymbol of abc: "%s"' % abc_text)
+                              f'Pitch not in ChordSymbol of abc: "{abc_text}"')
 
     def testAbc21BrokenRhythm(self):
         # Test the chord symbol for note and chord

--- a/music21/alpha/analysis/ornamentRecognizer.py
+++ b/music21/alpha/analysis/ornamentRecognizer.py
@@ -143,7 +143,7 @@ class TrillRecognizer(OrnamentRecognizer):
         simpleNote = simpleNotes[0]
 
         # enharmonic invariant checker
-        if not(simpleNote.pitch.midi == n1.pitch.midi or simpleNote.pitch.midi == n2.pitch.midi):
+        if simpleNote.pitch.midi not in (n1.pitch.midi, n2.pitch.midi):
             return False
 
         endNote = n2

--- a/music21/braille/basic.py
+++ b/music21/braille/basic.py
@@ -1133,7 +1133,7 @@ def showOctaveWithNote(previousNote, currentNote):
         return True
     i = interval.notesToInterval(previousNote, currentNote)
     isSixthOrGreater = i.generic.undirected >= 6
-    isFourthOrFifth = i.generic.undirected == 4 or i.generic.undirected == 5
+    isFourthOrFifth = i.generic.undirected in (4, 5)
     sameOctaveAsPrevious = previousNote.octave == currentNote.octave
     doShowOctave = False
     if isSixthOrGreater or (isFourthOrFifth and not sameOctaveAsPrevious):

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -2632,7 +2632,7 @@ class Chord(ChordBase):
 
         for thisPitch in self.pitches:
             thisInterval = interval.notesToInterval(self.root(), thisPitch)
-            if (thisInterval.chromatic.mod12 != 0) and (thisInterval.chromatic.mod12 != 4):
+            if thisInterval.chromatic.mod12 not in (0, 4):
                 return False
 
         return True
@@ -2678,7 +2678,7 @@ class Chord(ChordBase):
 
         for thisPitch in self.pitches:
             thisInterval = interval.notesToInterval(self.root(), thisPitch)
-            if (thisInterval.chromatic.mod12 != 0) and (thisInterval.chromatic.mod12 != 3):
+            if thisInterval.chromatic.mod12 not in (0, 3):
                 return False
 
         return True

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1631,7 +1631,7 @@ class Test(unittest.TestCase):
             for n in p.recurse().notes:
                 if n.tie is not None:
                     countTies += 1
-                    if n.tie.type == 'start' or n.tie.type == 'continue':
+                    if n.tie.type in ('start', 'continue'):
                         countStartTies += 1
 
         self.assertEqual(countTies, 57)

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -481,7 +481,7 @@ class GeneralMordent(Ornament):
         '''
         from music21 import key
 
-        if self.direction != 'up' and self.direction != 'down':
+        if self.direction not in ('up', 'down'):
             raise ExpressionException('Cannot realize a mordent if I do not know its direction')
         if self.size == '':
             raise ExpressionException('Cannot realize a mordent if there is no size given')
@@ -1080,7 +1080,7 @@ class GeneralAppoggiatura(Ornament):
         :type srcObj: base.Music21Object
         '''
         from music21 import key
-        if self.direction != 'up' and self.direction != 'down':
+        if self.direction not in ('up', 'down'):
             raise ExpressionException(
                 'Cannot realize an Appoggiatura if I do not know its direction')
         if self.size == '':

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -800,7 +800,7 @@ class LilypondConverter:
             if el.syllabic == 'end':
                 text = text + '__'
                 inWord = False
-            elif el.syllabic == 'begin' or el.syllabic == 'middle':
+            elif el.syllabic in ('begin', 'middle'):
                 text = text + ' --'
                 inWord = True
             # else: pass

--- a/music21/mei/test_base.py
+++ b/music21/mei/test_base.py
@@ -505,7 +505,7 @@ class Test(unittest.TestCase):
         actual = base.metaSetComposer(work, meta)
 
         self.assertIs(meta, actual)
-        if expComposer1 != actual.composer and expComposer2 != actual.composer:
+        if actual.composer not in (expComposer1, expComposer2):
             self.fail('composer names do not match in either order')
 
     def testMetaDate1(self):

--- a/music21/mei/test_base.py
+++ b/music21/mei/test_base.py
@@ -3897,7 +3897,7 @@ class Test(unittest.TestCase):
         # ensure the right number and @n of parts
         self.assertEqual(4, len(actual.keys()))
         for eachN in expectedNs:
-            self.assertTrue(eachN in actual.keys())
+            self.assertTrue(eachN in actual)
         # ensure the measure number is set properly,
         #        there is one voice with one note with its octave set equal to the staff's @n,
         #        the right barline was set properly
@@ -4020,8 +4020,8 @@ class Test(unittest.TestCase):
         # ensure the right number and @n of parts (we expect one additional key, for the "rptboth")
         self.assertEqual(5, len(actual.keys()))
         for eachN in expectedNs:
-            self.assertTrue(eachN in actual.keys())
-        self.assertTrue('next @left' in actual.keys())
+            self.assertTrue(eachN in actual)
+        self.assertTrue('next @left' in actual)
         # ensure the measure number is set properly,
         #        there is one voice with one note with its octave set equal to the staff's @n,
         #        the right barline was set properly

--- a/music21/metadata/primitives.py
+++ b/music21/metadata/primitives.py
@@ -1040,7 +1040,7 @@ class Contributor(prebase.ProtoM21Object):
     def role(self, value):
         if value is None or value in self.roleAbbreviationsDict.values():
             self._role = value
-        elif value in self.roleAbbreviationsDict.keys():
+        elif value in self.roleAbbreviationsDict:
             self._role = self.roleAbbreviationsDict[value]
         else:
             self._role = value

--- a/music21/romanText/rtObjects.py
+++ b/music21/romanText/rtObjects.py
@@ -977,7 +977,7 @@ class RTOptionalKeyClose(RTAtom):
 
     def getKey(self):
         # alter flat symbol
-        if self.src == '?)b:' or self.src == '?)b':
+        if self.src in ('?)b:', '?)b'):
             return key.Key('b')
         else:
             keyStr = self.src.replace('b', '-')

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -2386,7 +2386,7 @@ class Variant(base.Music21Object):
             spacerDuration = 0.0
 
 
-        if self.lengthType == 'replacement' or self.lengthType == 'elongation':
+        if self.lengthType in ('replacement', 'elongation'):
             vEnd = vStart + self.replacementDuration + spacerDuration
             classes = []
             for e in self.elements:

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -2199,10 +2199,8 @@ class ThreeNoteLinearSegment(NNoteLinearSegment):
         '''
 
         return (self._isComplete()
-                and ((self.iLeft.generic.undirected == 2
-                            or self.iLeft.generic.undirected == 1)
-                     and (self.iRight.generic.undirected == 2
-                            or self.iRight.generic.undirected == 1)
+                and (self.iLeft.generic.undirected in (1, 2)
+                     and self.iRight.generic.undirected in (1, 2)
                      and self.iLeft.generic.undirected * self.iRight.generic.undirected == 2
                      and self.iLeft.isChromaticStep
                      and self.iRight.isChromaticStep


### PR DESCRIPTION
Postpone `consider-using-f-string` until existing codebase is updated (53 warnings). Leave `consider-iterating-dictionary` and `consider-using-in` enabled.

Cherry-picked from #1131 so that it can be merged faster and unblock other PRs.