### PR TITLE
Prevent some superfluous naturals when updating accidental displayStatus

### DIFF
--- a/music21/braille/test.py
+++ b/music21/braille/test.py
@@ -720,7 +720,9 @@ class Test(unittest.TestCase):
 
         bm = converter.parse("tinynotation: 3/4 e4 e8 a8 c'8 e'8 f'2.", makeNotation=False)
         bm.notes[0].pitch.accidental = pitch.Accidental()
+        bm.notes[0].pitch.accidental.displayStatus = True
         bm.notes[4].pitch.accidental = pitch.Accidental()
+        bm.notes[4].pitch.accidental.displayStatus = True
         bm.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False)
         m = bm.getElementsByClass('Measure')
         m[-1].rightBarline = None

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4670,14 +4670,15 @@ class Pitch(prebase.ProtoM21Object):
 
         # no pitches in past...
         if not pitchPastAll:
-            # if we have no past, we always need to show the accidental,
-            # unless this accidental is in the alteredPitches list
+            # if we have no past, we show the accidental if this accidental
+            # is not in the alteredPitches list, or vice versa for naturals
             if (self.accidental is not None
                     and self.accidental.displayStatus in (False, None)):
-                if not self._nameInKeySignature(alteredPitches):
-                    self.accidental.displayStatus = True
+                name_in_ks = self._nameInKeySignature(alteredPitches)
+                if self.accidental.name == 'natural':
+                    self.accidental.displayStatus = name_in_ks
                 else:
-                    self.accidental.displayStatus = False
+                    self.accidental.displayStatus = not name_in_ks
 
             # in case display set to True and in alteredPitches, makeFalse
             elif (self.accidental is not None
@@ -5404,7 +5405,7 @@ class Test(unittest.TestCase):
         bm.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False)
         notes = bm[note.Note]
         self.assertEqual(notes[0].pitch.accidental.name, 'natural')     # Fn
-        self.assertEqual(notes[0].pitch.accidental.displayStatus, True)
+        self.assertEqual(notes[0].pitch.accidental.displayStatus, False)
         self.assertEqual(notes[1].pitch.accidental.name, 'natural')     # Fn
         self.assertEqual(notes[1].pitch.accidental.displayStatus, True)
         self.assertEqual(notes[2].pitch.accidental.name, 'flat')        # E-4


### PR DESCRIPTION
Spotted two cases in the makeAccidentals flow where a natural with a displayStatus of None is set to True, when we would expect False.

Case 1: the natural appears on the first note in the measure

Case 2: A-natural (explicit) follows A (implicit, no Accidental object)


Had to edit the braille test because it was relying on the incorrect behavior to generate the DeGarmo example of deliberate naturals. If we have deliberate examples, we need displayStatus = True.

For visual thinkers, here is that example from the braille test, showing the superfluous naturals being created even though displayStatus was None:

<img width="524" alt="Screen Shot 2021-10-07 at 6 07 54 PM" src="https://user-images.githubusercontent.com/38668450/136468832-35ceec60-4800-4fab-86bb-a64111299cf0.png">
 