### PR TITLE
Don't leave yearError et al behind in metadata.Date.loadOther()

### DIFF
--- a/music21/metadata/primitives.py
+++ b/music21/metadata/primitives.py
@@ -251,15 +251,20 @@ class Date(prebase.ProtoM21Object):
         r'''
         Load values based on another Date object:
 
-        >>> a = metadata.Date(year=1843, month=3, day=3)
+        >>> a = metadata.Date(year=1843, month=3, day=3, yearError='approximate')
         >>> b = metadata.Date()
         >>> b.loadOther(a)
         >>> b.year
         1843
+        >>> b.yearError
+        'approximate'
         '''
         for attr in self.attrNames:
             if getattr(other, attr) is not None:
                 setattr(self, attr, getattr(other, attr))
+                errorAttr = attr + 'Error'
+                if getattr(other, errorAttr) is not None:
+                    setattr(self, errorAttr, getattr(other, errorAttr))
 
     def loadStr(self, dateStr):
         r'''


### PR DESCRIPTION
Found this bug while playing around with metadata.  Initializing a DateSingle/DateRelative object from an existing Date object (or initializing a DateBetween/DateSelection object from a list of existing Date objects) drops on the floor any {year,month,day,hour,minute,second}Error attributes that were set on those Date object(s).