### PR TITLE
Import/export unpitched percussion instruments <--> MusicXML

### DIFF
--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -833,6 +833,7 @@ class Whistle(Flute):
         self.instrumentAbbreviation = 'Whs'
         self.instrumentSound = 'wind.flutes.whistle'
         self.inGMPercMap = True
+        # TODO: why is this not inheriting from UnpitchedPercussion if we're giving it percMapPitch?
         self.percMapPitch = 71
         self.midiProgram = 78
 

--- a/music21/midi/percussion.py
+++ b/music21/midi/percussion.py
@@ -23,13 +23,12 @@ class MIDIPercussionException(exceptions21.Music21Exception):
 
 class PercussionMapper:
     '''
-    PercussionMapper provides tools to convert between MIDI notes and music21 instruments,
-    based on the official General MIDI Level 1 Percussion Key Map.
+    PercussionMapper provides tools to convert between 0-indexed MIDI pitches
+    and music21 instruments, based on the official General MIDI Level 1 Percussion Key Map.
     This mapping is conventionally applied to MIDI channel 10;
     see https://www.midi.org/specifications/item/gm-level-1-sound-set for more info.
 
     Give me the instrument that corresponds to MIDI note 58!
-
 
     >>> pm = midi.percussion.PercussionMapper()
     >>> pm.reverseInstrumentMapping[58]
@@ -38,11 +37,6 @@ class PercussionMapper:
     That's right, vibraslap.
 
     But you're better off using the midiPitchToInstrument() method below!
-
-    .. warning::
-
-        Accepts 1-indexed MIDI programs, unlike music21's 0-indexed `.midiProgram`
-        and `.midiChannel` attributes on Instrument instances.
     '''
 
     i = instrument
@@ -99,9 +93,8 @@ class PercussionMapper:
 
     def midiPitchToInstrument(self, midiPitch):
         '''
-        Takes a pitch.Pitch object or int and returns the corresponding
-        instrument in the GM Percussion Map, using 1-indexed MIDI programs.
-
+        Takes a pitch.Pitch object or int ranging from 0-127 and returns
+        the corresponding instrument in the GM Percussion Map.
 
         >>> pm = midi.percussion.PercussionMapper()
         >>> cowPitch = pitch.Pitch(56)

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -29,7 +29,6 @@ from music21 import environment
 from music21 import stream
 
 from music21.instrument import Conductor, deduplicate
-from music21.midi import percussion
 
 _MOD = 'midi.translate'
 environLocal = environment.Environment(_MOD)

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -774,8 +774,8 @@ def midiEventsToInstrument(eventList):
             i = instrument.fromString(decoded)
         elif event.channel == 10:
             pm = percussion.PercussionMapper()
-            # PercussionMapper.midiPitchToInstrument() is 1-indexed
-            i = pm.midiPitchToInstrument(event.data + 1)
+            # PercussionMapper.midiPitchToInstrument() is 0-indexed
+            i = pm.midiPitchToInstrument(event.data)
             i.midiProgram = event.data
         else:
             i = instrument.instrumentFromMidiProgram(event.data)

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -750,7 +750,7 @@ def midiEventsToInstrument(eventList):
     >>> me.channel = 10
     >>> i = midi.translate.midiEventsToInstrument(me)
     >>> i
-    <music21.instrument.Tambourine 'Tambourine'>
+    <music21.instrument.UnpitchedPercussion 'Percussion'>
     >>> i.midiChannel  # 0-indexed in music21
     9
     >>> i.midiProgram  # 0-indexed in music21
@@ -773,9 +773,8 @@ def midiEventsToInstrument(eventList):
             decoded = decoded.strip()
             i = instrument.fromString(decoded)
         elif event.channel == 10:
-            pm = percussion.PercussionMapper()
-            # PercussionMapper.midiPitchToInstrument() is 0-indexed
-            i = pm.midiPitchToInstrument(event.data)
+            # Can only get correct instruments from reading NOTE_ON
+            i = instrument.UnpitchedPercussion()
             i.midiProgram = event.data
         else:
             i = instrument.instrumentFromMidiProgram(event.data)
@@ -786,11 +785,6 @@ def midiEventsToInstrument(eventList):
             f'Unable to determine instrument from {event}; getting generic Instrument',
             TranslateWarning)
         i = instrument.Instrument()
-    except percussion.MIDIPercussionException:
-        warnings.warn(
-            f'Unable to determine instrument from {event}; getting generic UnpitchedPercussion',
-            TranslateWarning)
-        i = instrument.UnpitchedPercussion()
     except instrument.InstrumentException:
         # Debug logging would be better than warning here
         i = instrument.Instrument()
@@ -3855,12 +3849,8 @@ class Test(unittest.TestCase):
         event.channel = 10
         event.type = midiModule.ChannelVoiceMessages.PROGRAM_CHANGE
 
-        expected = 'Unable to determine instrument from '
-        expected += '<music21.midi.MidiEvent PROGRAM_CHANGE, track=None, channel=10, data=0>'
-        expected += '; getting generic UnpitchedPercussion'
-        with self.assertWarnsRegex(TranslateWarning, expected):
-            i = midiEventsToInstrument(event)
-            self.assertIsInstance(i, instrument.UnpitchedPercussion)
+        i = midiEventsToInstrument(event)
+        self.assertIsInstance(i, instrument.UnpitchedPercussion)
 
     def testConductorStream(self):
         s = stream.Stream()

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -48,6 +48,7 @@ from music21 import interval  # for transposing instruments
 from music21 import key
 from music21 import layout
 from music21 import metadata
+from music21.midi.percussion import MIDIPercussionException, PercussionMapper
 from music21 import note
 from music21 import meter
 from music21 import percussion
@@ -1605,7 +1606,6 @@ class PartParser(XMLParserBase):
         # TODO: midi-device
         # TODO: midi-name
         # TODO: midi-bank transform=_adjustMidiData
-        # TODO: midi-unpitched
         # TODO: midi-volume
         # TODO: pan
         # TODO: elevation
@@ -1614,7 +1614,17 @@ class PartParser(XMLParserBase):
         i: Optional[instrument.Instrument] = None
         if mxMIDIInstrument is not None:
             mxMidiProgram = mxMIDIInstrument.find('midi-program')
-            if textStripValid(mxMidiProgram):
+            mxMidiUnpitched = mxMIDIInstrument.find('midi-unpitched')
+            if textStripValid(mxMidiUnpitched):
+                pm = PercussionMapper()
+                try:
+                    i = pm.midiPitchToInstrument(_adjustMidiData(mxMidiUnpitched.text))
+                except MIDIPercussionException as mpe:
+                    # objects not yet existing in m21 such as Cabasa
+                    warnings.warn(MusicXMLWarning(mpe))
+                    i = instrument.UnpitchedPercussion()
+                    i.percMapPitch = int(_adjustMidiData(mxMidiUnpitched.text))
+            elif textStripValid(mxMidiProgram):
                 try:
                     i = instrument.instrumentFromMidiProgram(_adjustMidiData(mxMidiProgram.text))
                 except instrument.InstrumentException as ie:
@@ -7137,6 +7147,39 @@ class Test(unittest.TestCase):
         MP.xmlToDuration(mxNoteNoType, inputM21=d)
         self.assertEqual(len(d.tuplets), 0)
         self.assertEqual(d.linked, True)
+
+    def testImportUnpitchedPercussion(self):
+        from xml.etree.ElementTree import fromstring as EL
+        scorePart = '''
+        <score-part id="P4"><part-name>Tambourine</part-name>
+        <part-abbreviation>Tamb.</part-abbreviation>
+        <score-instrument id="P4-I55">
+            <instrument-name>Tambourine</instrument-name>
+        </score-instrument>
+        <midi-instrument id="P4-I55">
+           <midi-channel>10</midi-channel>
+           <midi-unpitched>55</midi-unpitched>
+        </midi-instrument>
+        </score-part>
+        '''
+
+        PP = PartParser()
+        mxScorePart = EL(scorePart)
+        tmb = PP.getDefaultInstrument(mxScorePart)
+        self.assertIsInstance(tmb, instrument.Tambourine)
+        self.assertEqual(tmb.percMapPitch, 54)  # 1-indexed
+
+        # An instrument music21 doesn't have yet (Cabasa):
+        scorePart = scorePart.replace('Tambourine', 'Cabasa')
+        scorePart = scorePart.replace('Tamb.', 'Cab.')
+        scorePart = scorePart.replace('55', '70')  # 1-indexed
+        PP = PartParser()
+        mxScorePart = EL(scorePart)
+        msg = '69 does not map to a valid instrument!'
+        with self.assertWarnsRegex(MusicXMLWarning, msg):
+            unp = PP.getDefaultInstrument(mxScorePart)
+        self.assertIsInstance(unp, instrument.UnpitchedPercussion)
+        self.assertEqual(unp.percMapPitch, 69)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Read and write `<midi-unpitched>` tag so as to import and export unpitched percussion instruments in MusicXML.

Also resolve confusion over whether m21's percussion mapper is 1-indexed (it's not). (Fixed up the confusion over this I introduced to docs and MIDI import.)