### PR TITLE
fixes #778

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6062,6 +6062,16 @@ class MeasureExporter(XMLExporterBase):
             mxStaffLines.text = str(staffLayout.staffLines)
 
         # TODO: staff-tuning
+        if hasattr(staffLayout, 'fretboard'):
+            tuning_pitches = staffLayout.fretboard.tuning
+            for i in range(len(tuning_pitches)):
+                mxStaffTuning = SubElement(mxStaffDetails, 'staff-tuning')
+                mxStaffTuning.set('line', str(i + 1))
+                mxTuningStep = SubElement(mxStaffTuning, 'tuning-step')
+                mxTuningStep.text = tuning_pitches[i].name
+                mxTuningOctave = SubElement(mxStaffTuning, 'tuning-octave')
+                mxTuningOctave.text = str(tuning_pitches[i].octave)
+
         # TODO: capo
         # TODO: staff-size
         return mxStaffDetails

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -5691,7 +5691,20 @@ class MeasureParser(XMLParserBase):
                 stl.staffType = stream.enums.StaffType(xmlText)
             except ValueError:
                 environLocal.warn(f'Got an incorrect staff-type in details: {mxStaffType}')
+
         # TODO: staff-tuning*
+        mxStaffTuning = mxDetails.findall('staff-tuning')
+        if mxStaffTuning is not None:
+            tuning_pitches = []
+            for i in range(len(mxStaffTuning)):
+                staff_tuning = mxStaffTuning[i]
+                line = int(staff_tuning.get('line'))
+                tuning_step = staff_tuning.find('tuning-step').text
+                tuning_octave = int(staff_tuning.find('tuning-octave').text)
+                tuning_pitches.append(pitch.Pitch(tuning_step + str(tuning_octave)))
+            fretboard = tablature.FretBoard.getFretBoardFromTuning(tuning_pitches)
+            setattr(stl, 'fretboard', fretboard)
+
         # TODO: capo
         # TODO: show-frets
         # TODO: print-spacing

--- a/music21/tablature.py
+++ b/music21/tablature.py
@@ -244,6 +244,13 @@ class FretBoard(prebase.ProtoM21Object):
 
         return pitchList
 
+    @staticmethod
+    def getFretBoardFromTuning(pitches):
+        standard_fret_boards = [GuitarFretBoard, UkeleleFretBoard, BassGuitarFretBoard, MandolinFretBoard]
+        for standard_fret_board in standard_fret_boards:
+            if pitches == standard_fret_board().tuning:
+                return standard_fret_board()
+        return CustomFretBoard(pitches)
 
 class FirstFret:
     '''
@@ -344,6 +351,17 @@ class MandolinFretBoard(FretBoard):
         super().__init__(numStrings, fretNotes, displayFrets)
 
         self.tuning = [pitch.Pitch('G3'), pitch.Pitch('D4'), pitch.Pitch('A4'), pitch.Pitch('E5')]
+
+class CustomFretBoard(FretBoard):
+    '''
+    A custom fretboard tuned with any list of pitches
+    '''
+
+    def __init__(self, pitches, fretNotes=None, displayFrets=4):
+        numStrings = len(pitches)
+        super().__init__(numStrings, fretNotes, displayFrets)
+
+        self.tuning = pitches.copy()
 # ------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
I followed your recommendations in #778 (thanks for this). I realized that I will have to use `StaffLayout` as 

```
In music21, the <staff-layout> and <staff-details> are
intertwined in a StaffLayout object.
```

so I think this will need to be handled in `xmlStaffLayoutFromStaffDetails`. But therefore I can not  drop the identified fretboard in the beginning of the part as you suggested, so I tried to simply add it as a new attribute in the StaffLayer. Hope it makes sense.

I still haven't added any test, I wanted to first make sure we agree on the direction.