### PR TITLE
Braille: export bowing symbols

### DIFF
--- a/music21/articulations.py
+++ b/music21/articulations.py
@@ -12,10 +12,10 @@
 
 '''
 Classes for representing and processing articulations.
-Specific articulations are modeled as :class:`~music21.articulation.Articulation` subclasses.
+Specific articulations are modeled as :class:`~music21.articulations.Articulation` subclasses.
 
 A :class:`~music21.note.Note` object has a :attr:`~music21.note.Note.articulations` attribute.
-This list can be used to store one or more :class:`music21.articulation.Articulation` subclasses.
+This list can be used to store one or more :class:`music21.articulations.Articulation` subclasses.
 
 As much as possible, MusicXML names are used for Articulation classes,
 with xxx-yyy changed to XxxYyy.  For instance, "strong-accent" in

--- a/music21/braille/basic.py
+++ b/music21/braille/basic.py
@@ -13,7 +13,7 @@ import unittest
 from typing import List
 
 # from music21 import articulations
-from music21 import clef
+from music21 import articulations, clef
 from music21 import duration
 from music21 import environment
 from music21 import exceptions21
@@ -558,8 +558,8 @@ def yieldBrailleArticulations(noteEl):
 
     '''
     def _brailleArticulationsSortKey(inner_articulation):
-        isBowing = 'Bowing' in inner_articulation.classes
-        isStaccato = 'Staccato' in inner_articulation.classes
+        isBowing = isinstance(inner_articulation, articulations.Bowing)
+        isStaccato = isinstance(inner_articulation, articulations.Staccato)
         # need True to sort before False (reverse alphabetical)
         return (not isBowing, not isStaccato, inner_articulation.name)
 

--- a/music21/braille/basic.py
+++ b/music21/braille/basic.py
@@ -13,7 +13,8 @@ import unittest
 from typing import List
 
 # from music21 import articulations
-from music21 import articulations, clef
+from music21 import articulations
+from music21 import clef
 from music21 import duration
 from music21 import environment
 from music21 import exceptions21

--- a/music21/braille/basic.py
+++ b/music21/braille/basic.py
@@ -518,7 +518,11 @@ def yieldBrailleArticulations(noteEl):
     "When a staccato or staccatissimo is shown with any of the other
     [before note expressions], it is brailled first."
 
-    Beyond that, we yield in alphabetical order
+    "The up-bow and down-bow marks for bowed string instruments are brailled before any other
+    signs from Column A and before an ornament." (BMTM, 114)
+
+    Beyond that, we yield in alphabetical order, which happens to satisfy this:
+    "When an accent is shown with a tenuto, the accent is brailled first." (BMTM, 113)
 
     For reference:
 
@@ -530,31 +534,45 @@ def yieldBrailleArticulations(noteEl):
     >>> print(brailleArt['accent'])
     ⠨⠦
 
+    >>> brailleBowings = braille.lookup.bowingSymbols
+    >>> print(brailleBowings['down bow'])
+    ⠣⠃
+    >>> print(brailleBowings['up bow'])
+    ⠣⠄
+
     >>> n = note.Note()
+    >>> n.articulations.append(articulations.DownBow())
     >>> n.articulations.append(articulations.Tenuto())
     >>> n.articulations.append(articulations.Staccato())
     >>> n.articulations.append(articulations.Accent())
 
-    This will yield in order: Staccato, Accent, Tenuto.
+    This will yield in order: DownBow, Staccato, Accent, Tenuto.
 
     >>> for brailleArt in braille.basic.yieldBrailleArticulations(n):
     ...     print(brailleArt)
+    ⠣⠃
     ⠦
     ⠨⠦
     ⠸⠦
 
     '''
     def _brailleArticulationsSortKey(inner_articulation):
-        isStaccato = (inner_articulation.name not in ('staccato', 'staccatissimo'))
-        return (isStaccato, inner_articulation.name)
+        isBowing = 'Bowing' in inner_articulation.classes
+        isStaccato = 'Staccato' in inner_articulation.classes
+        # need True to sort before False (reverse alphabetical)
+        return (not isBowing, not isStaccato, inner_articulation.name)
 
     if hasattr(noteEl, 'articulations'):  # should be True, but safe side.
         for art in sorted(noteEl.articulations, key=_brailleArticulationsSortKey):
-            if art.name in lookup.beforeNoteExpr:
+            if art.name in lookup.bowingSymbols:
+                brailleArt = lookup.bowingSymbols[art.name]
+            elif art.name in lookup.beforeNoteExpr:
                 brailleArt = lookup.beforeNoteExpr[art.name]
-                if 'brailleEnglish' in noteEl.editorial:
-                    noteEl.editorial.brailleEnglish.append(f'Articulation {art.name} {brailleArt}')
-                yield brailleArt
+            else:
+                continue
+            if 'brailleEnglish' in noteEl.editorial:
+                noteEl.editorial.brailleEnglish.append(f'Articulation {art.name} {brailleArt}')
+            yield brailleArt
 
 
 def noteToBraille(
@@ -705,7 +723,7 @@ def noteToBraille(
             beamStatus['beamContinue'] = False
 
     # signs of expression or execution that precede a note
-    # articulations
+    # articulations and bowings
     # -------------
     for brailleArticulation in yieldBrailleArticulations(music21Note):
         noteTrans.append(brailleArticulation)

--- a/music21/braille/basic.py
+++ b/music21/braille/basic.py
@@ -545,6 +545,7 @@ def yieldBrailleArticulations(noteEl):
     >>> n.articulations.append(articulations.Tenuto())
     >>> n.articulations.append(articulations.Staccato())
     >>> n.articulations.append(articulations.Accent())
+    >>> n.articulations.append(articulations.Scoop())  # example unsupported articulation
 
     This will yield in order: DownBow, Staccato, Accent, Tenuto.
 

--- a/music21/braille/lookup.py
+++ b/music21/braille/lookup.py
@@ -261,7 +261,9 @@ clefs = {'prefix': _B[345],
          'suffix': {False: _B[123],
                     True: _B[13]}
          }
-bowingSymbols = {}
+
+bowingSymbols = {'down bow': _B[126] + _B[12],
+                 'up bow': _B[126] + _B[3]}
 
 beforeNoteExpr = {'staccato': _B[236],
                   'accent': _B[46] + _B[236],

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -999,8 +999,8 @@ class BrailleSegment(text.BrailleText):
           omitted.
 
           It is permissible (not mandatory) to observe this doubling with bowings. (BMTM, 114)
-          For this reason, all TechnicalIndications but for bowings
-          (e.g. fingerings, harmonics) are skipped, because they are not articulations.
+          For this reason, any :class:`~music21.articulations.TechnicalIndication` but for bowings
+          (e.g. fingering, harmonic) is skipped, because it does not braille as an articulation.
 
         * Staccato, Tenuto rule => "If two repeated notes appear to be tied, but either is marked
           staccato or tenuto, they are treated as slurred instead of tied." (BMTM, 112)

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -1046,8 +1046,8 @@ class BrailleSegment(text.BrailleText):
             for noteIndexStart_outer in range(len(allNotes_outer)):
                 music21NoteStart_outer = allNotes_outer[noteIndexStart_outer]
                 for artic_outer in music21NoteStart_outer.articulations:
-                    if ('TechnicalIndication' not in artic_outer.classes
-                            or 'Bowing' in artic_outer.classes):
+                    if (not isinstance(artic_outer, articulations.TechnicalIndication)
+                            or isinstance(artic_outer, articulations.Bowing)):
                         fixOneArticulation(
                             artic_outer,
                             music21NoteStart_outer,

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -998,6 +998,9 @@ class BrailleSegment(text.BrailleText):
           are found in a row, the first instance of the articulation is doubled and the rest are
           omitted.
 
+          It is permissible (not mandatory) to observe this doubling with bowings. (BMTM, 114)
+          For this reason, all TechnicalIndications (fingerings, bowings, harmonics) are skipped.
+
         * Staccato, Tenuto rule => "If two repeated notes appear to be tied, but either is marked
           staccato or tenuto, they are treated as slurred instead of tied." (BMTM, 112)
         '''
@@ -1005,8 +1008,6 @@ class BrailleSegment(text.BrailleText):
 
         def fixOneArticulation(artic, music21NoteStart, allNotes, noteIndexStart):
             articName = artic.name
-            if articName == 'fingering':  # fingerings are not considered articulations...
-                return
             if (isinstance(artic, (articulations.Staccato, articulations.Tenuto))
                     and music21NoteStart.tie is not None):
                 if music21NoteStart.tie.type == 'stop':
@@ -1044,12 +1045,13 @@ class BrailleSegment(text.BrailleText):
             for noteIndexStart_outer in range(len(allNotes_outer)):
                 music21NoteStart_outer = allNotes_outer[noteIndexStart_outer]
                 for artic_outer in music21NoteStart_outer.articulations:
-                    fixOneArticulation(
-                        artic_outer,
-                        music21NoteStart_outer,
-                        allNotes_outer,
-                        noteIndexStart_outer
-                    )
+                    if 'TechnicalIndication' not in artic_outer.classes:
+                        fixOneArticulation(
+                            artic_outer,
+                            music21NoteStart_outer,
+                            allNotes_outer,
+                            noteIndexStart_outer
+                        )
 
 
 class BrailleGrandSegment(BrailleSegment, text.BrailleKeyboard):

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -999,7 +999,8 @@ class BrailleSegment(text.BrailleText):
           omitted.
 
           It is permissible (not mandatory) to observe this doubling with bowings. (BMTM, 114)
-          For this reason, all TechnicalIndications (fingerings, bowings, harmonics) are skipped.
+          For this reason, all TechnicalIndications but for bowings
+          (e.g. fingerings, harmonics) are skipped, because they are not articulations.
 
         * Staccato, Tenuto rule => "If two repeated notes appear to be tied, but either is marked
           staccato or tenuto, they are treated as slurred instead of tied." (BMTM, 112)
@@ -1045,7 +1046,8 @@ class BrailleSegment(text.BrailleText):
             for noteIndexStart_outer in range(len(allNotes_outer)):
                 music21NoteStart_outer = allNotes_outer[noteIndexStart_outer]
                 for artic_outer in music21NoteStart_outer.articulations:
-                    if 'TechnicalIndication' not in artic_outer.classes:
+                    if ('TechnicalIndication' not in artic_outer.classes
+                            or 'Bowing' in artic_outer.classes):
                         fixOneArticulation(
                             artic_outer,
                             music21NoteStart_outer,


### PR DESCRIPTION
In February I was doing some work with MusicXML treatment of fingerings/TechnicalIndications, and I was learning how to debug the braille module to get CI jobs to pass. At the time I looked into the combination of the two, and then I rebased at some point in September but never opened a PR.

This PR:
 - adds bowing symbols to braille export
 - tightens up an edge case involving TechnicalIndications beyond Fingerings that should not be exported
 - adds some coverage
 - small docs fixes