### PR TITLE
Pylint removed misplaced-comparison-constant

### DIFF
--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -173,7 +173,6 @@ tool.
 * <sb>: a system break
 
 '''
-# pylint: disable=misplaced-comparison-constant
 from typing import Optional, Union, List, Tuple
 from xml.etree.ElementTree import Element, ParseError, fromstring, ElementTree
 

--- a/music21/test/testLint.py
+++ b/music21/test/testLint.py
@@ -113,7 +113,6 @@ def main(fnAccept=None, strict=False):
         # can be fine...
         'too-many-boolean-expressions',
 
-        'misplaced-comparison-constant',  # sometimes 2 < x is what we want
         'unsubscriptable-object',  # unfortunately, thinks that Streams are unsubscriptable.
 
         # sometimes .keys() is a good test against


### PR DESCRIPTION
Gave `bad-option-value` once this check was removed to extensions.

Refs https://github.com/PyCQA/pylint/pull/5298