### PR TITLE
Explict imports in init.py; support 3.10

### DIFF
--- a/.github/workflows/maincheck.yml
+++ b/.github/workflows/maincheck.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [3.7, 3.8, 3.9]
+                python-version: [3.7, 3.8, 3.9, "3.10"]
         steps:
         - uses: actions/setup-python@v2
           with:

--- a/music21/__init__.py
+++ b/music21/__init__.py
@@ -29,10 +29,8 @@ Music and Theater Arts section and the School of Humanities, Arts,
 and Social Sciences.  Portions of music21 were originally part of
 the PMusic (Perl) library, developed by Cuthbert prior to arriving at MIT.
 
-music21 outputs a subset of XML data defined by the  MusicXML 3.1
-standard, Copyright © Recordare LLC;  License available at
-http://www.recordare.com/dtds/license.html, transferred to MakeMusic
-now transferred to W3C
+music21 outputs a subset of XML data defined by the MusicXML 4.0
+standard, Copyright © 2004-2021 the Contributors to the MusicXML Specification.
 
 The corpus files have copyrights retained by their
 owners who have allowed them to be included with music21.
@@ -44,7 +42,7 @@ minPythonVersionStr = '.'.join([str(x) for x in minPythonVersion])
 if sys.version_info < minPythonVersion:
     # DO NOT CHANGE THIS TO AN f-String -- it needs to run on old python.
     raise ImportError('''
-    Music21 v.6.0+ is a Python {}+ only library.
+    Music21 v.7.0+ is a Python {}+ only library.
     Use music21 v1 to run on Python 2.1-2.6.
     Use music21 v4 to run on Python 2.7.
     Use music21 v5.1 to run on Python 3.4.
@@ -54,7 +52,7 @@ if sys.version_info < minPythonVersion:
     If you have the wrong version there are several options for getting
     the right one.
 
-    - 1. (Best) Upgrade to Python 3, latest (currently 3.9).
+    - 1. (Best) Upgrade to Python 3, latest (currently 3.10).
 
          The great features there will more
          than make up for the headache of downloading
@@ -97,12 +95,14 @@ __all__ = [
     'corpus',
     'features',
     'figuredBass',
+    'graph',
     'humdrum',
     'ipython21',
     'languageExcerpts',
     'lily',
     'mei',
     'metadata',
+    'meter',
     'midi',
     'musedata',
     'musicxml',
@@ -111,6 +111,7 @@ __all__ = [
     'romanText',
     'scale',
     'search',
+    'stream',
     'test',
     'tree',
     'vexflow',
@@ -134,13 +135,11 @@ __all__ = [
     'exceptions21',
     'expressions',
     'freezeThaw',
-    'graph',
     'harmony',
     'instrument',
     'interval',
     'key',
     'layout',
-    'meter',
     'note',
     'percussion',
     'pitch',
@@ -149,9 +148,9 @@ __all__ = [
     'roman',
     'serial',
     'sieve',
+    # sites listed above
     'sorting',
     'spanner',
-    'stream',
     'style',
     'tablature',
     'tempo',
@@ -171,6 +170,8 @@ __all__ = [
 # ------------------------------------------------------------------------------
 # base Music21Object -- all objects should inherit from this!
 from music21 import base  # noqa: E402
+from music21 import prebase  # noqa: E402
+from music21 import sites  # noqa: E402
 
 # should this simply be from music21.base import * since __all__ is well defined?
 from music21.base import Music21Exception  # noqa: E402
@@ -191,7 +192,80 @@ __version__ = VERSION_STR
 from music21.test.testRunner import mainTest  # noqa: E402
 
 # -----------------------------------------------------------------------------
-# this brings all of our own __all__ names into the music21 package namespace
-# pylint: disable=wildcard-import
-from music21 import *  # @UnresolvedImport  # noqa: E402,F403
+# now import all modules so they are accessible from "import music21"
+from music21 import abcFormat  # noqa: E402
+from music21 import alpha  # noqa: E402
+from music21 import analysis  # noqa: E402
+from music21 import audioSearch  # noqa: E402
+from music21 import braille  # noqa: E402
+from music21 import capella  # noqa: E402
+from music21 import chord  # noqa: E402
+from music21 import common  # noqa: E402
+from music21 import converter  # noqa: E402
+from music21 import corpus  # noqa: E402
+from music21 import features  # noqa: E402
+from music21 import figuredBass  # noqa: E402
+from music21 import graph  # noqa: E402
+from music21 import humdrum  # noqa: E402
+from music21 import ipython21  # noqa: E402
+from music21 import languageExcerpts  # noqa: E402
+from music21 import lily  # noqa: E402
+from music21 import mei  # noqa: E402
+from music21 import metadata  # noqa: E402
+from music21 import meter  # noqa: E402
+from music21 import midi  # noqa: E402
+from music21 import musedata  # noqa: E402
+from music21 import musicxml  # noqa: E402
+from music21 import noteworthy  # noqa: E402
+from music21 import omr  # noqa: E402
+from music21 import romanText  # noqa: E402
+from music21 import scale  # noqa: E402
+from music21 import search  # noqa: E402
+from music21 import stream  # noqa: E402
+from music21 import test  # noqa: E402
+from music21 import tree  # noqa: E402
+from music21 import vexflow  # noqa: E402
+
+# individual modules
+from music21 import articulations  # noqa: E402
+from music21 import bar  # noqa: E402
+# base already imported
+from music21 import beam  # noqa: E402
+from music21 import clef  # noqa: E402
+from music21 import configure  # noqa: E402
+from music21 import defaults  # noqa: E402
+from music21 import derivation  # noqa: E402
+from music21 import duration  # noqa: E402
+from music21 import dynamics  # noqa: E402
+from music21 import editorial  # noqa: E402
+from music21 import environment  # noqa: E402
+from music21 import exceptions21  # noqa: E402
+from music21 import expressions  # noqa: E402
+from music21 import freezeThaw  # noqa: E402
+from music21 import harmony  # noqa: E402
+from music21 import instrument  # noqa: E402
+from music21 import interval  # noqa: E402
+from music21 import key  # noqa: E402
+from music21 import layout  # noqa: E402
+from music21 import note  # noqa: E402
+from music21 import percussion  # noqa: E402
+from music21 import pitch  # noqa: E402
+# prebase already imported
+from music21 import repeat  # noqa: E402
+from music21 import roman  # noqa: E402
+from music21 import serial  # noqa: E402
+from music21 import sieve  # noqa: E402
+# sites already imported
+from music21 import sorting  # noqa: E402
+from music21 import spanner  # noqa: E402
+from music21 import style  # noqa: E402
+from music21 import tablature  # noqa: E402
+from music21 import tempo  # noqa: E402
+from music21 import text  # noqa: E402
+from music21 import tie  # noqa: E402
+from music21 import tinyNotation  # noqa: E402
+from music21 import variant  # noqa: E402
+from music21 import voiceLeading  # noqa: E402
+from music21 import volpiano  # noqa: E402
+from music21 import volume  # noqa: E402
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -39,9 +39,8 @@ environLocal = environment.Environment(_MOD)
 
 _ChordType = TypeVar('_ChordType')
 
+
 # ------------------------------------------------------------------------------
-
-
 class ChordException(exceptions21.Music21Exception):
     pass
 
@@ -51,6 +50,9 @@ class ChordBase(note.NotRest):
     '''
     A base class for NotRest objects that have multiple underlying structures
     like notes or unpitched percussion.
+
+    As of Version 7, ChordBase lies between Chord and NotRest in the music21
+    hierarchy, so that features can be shared with PercussionChord.
     '''
     isNote = False
     isRest = False

--- a/music21/note.py
+++ b/music21/note.py
@@ -19,7 +19,7 @@ and used to configure, :class:`~music21.note.Note` objects.
 import copy
 import unittest
 
-from typing import Optional, List, Union, Tuple, Iterable
+from typing import Optional, List, Union, Tuple, Iterable, cast
 
 from music21 import base
 from music21 import beam
@@ -296,7 +296,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         self._syllabic = newSyllabic
 
     @property
-    def identifier(self) -> str:
+    def identifier(self) -> Union[str, int]:
         '''
         By default, this is the same as self.number. However, if there is a
         descriptive identifier like 'part2verse1', it is stored here and
@@ -1131,7 +1131,7 @@ class NotRest(GeneralNote):
             return True
 
     @property
-    def pitches(self) -> Tuple[pitch.Pitch]:
+    def pitches(self) -> Tuple[pitch.Pitch, ...]:
         '''
         Returns an empty tuple.  (Useful for iterating over NotRests since they
         include Notes and Chords.)
@@ -1230,9 +1230,9 @@ class NotRest(GeneralNote):
         >>> m = stream.Measure([n])
         >>> n.getInstrument(returnDefault=False) is None
         True
-        >>> dulc = instrument.Dulcimer()
-        >>> m.insert(0, dulc)
-        >>> n.getInstrument() is dulc
+        >>> dulcimer = instrument.Dulcimer()
+        >>> m.insert(0, dulcimer)
+        >>> n.getInstrument() is dulcimer
         True
 
         Overridden `.storedInstrument` is privileged:
@@ -1245,16 +1245,16 @@ class NotRest(GeneralNote):
         Instruments in containing streams ARE found:
 
         >>> n.storedInstrument = None
-        >>> m.remove(dulc)
+        >>> m.remove(dulcimer)
         >>> p = stream.Part([m])
-        >>> p.insert(0, dulc)
-        >>> n.getInstrument() is dulc
+        >>> p.insert(0, dulcimer)
+        >>> n.getInstrument() is dulcimer
         True
 
         But not if the instrument is only found in a derived stream:
 
         >>> derived = p.stripTies()
-        >>> p.remove(dulc)
+        >>> p.remove(dulcimer)
         >>> derived.getInstruments().first()
         <music21.instrument.Dulcimer 'Dulcimer'>
         >>> n.getInstrument(returnDefault=False) is None
@@ -1272,7 +1272,9 @@ class NotRest(GeneralNote):
             instrument.Instrument, followDerivation=False)
         if returnDefault and instrument_or_none is None:
             return instrument.Instrument()
-        return instrument_or_none
+        elif instrument_or_none is None:
+            return None
+        return cast(instrument.Instrument, instrument_or_none)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Adds all music21 modules by name to `__init__.py` imports, hopefully making life easier for certain IDEs.  For a long time, the music21 core modules were changing almost weekly, so `import *` within `__init__.py` was the best approach.  Now we add or rename a core module maybe once a year, so this should be a good approach.

Also add Python 3.10 to the github matrix.  All tests currently passing without warnings.