### PR TITLE
Disable caches for .parts, .notes, .notesAndRests

### DIFF
--- a/music21/note.py
+++ b/music21/note.py
@@ -1895,12 +1895,14 @@ class TestExternal(unittest.TestCase):
     def testSingle(self):
         '''Need to test direct meter creation w/o stream
         '''
-        a = Note('d-3')
+        from music21 import note
+        a = note.Note('D-3')
         a.quarterLength = 2.25
         if self.show:
             a.show()
 
     def testBasic(self):
+        from music21 import note
         from music21 import stream
         a = stream.Stream()
 
@@ -1909,7 +1911,7 @@ class TestExternal(unittest.TestCase):
                                 ('d-3', 2.5), ('c#6', 3.25), ('a--5', 0.5),
                                 ('f#2', 1.75), ('g-3', (4 / 3)), ('d#6', (2 / 3))
                                 ]:
-            b = Note()
+            b = note.Note()
             b.quarterLength = qLen
             b.name = pitchName
             b.style.color = '#FF00FF'
@@ -1988,23 +1990,25 @@ class Test(unittest.TestCase):
             i += 1
 
     def testNote(self):
-        note2 = Rest()
+        from music21 import note
+        note2 = note.Rest()
         self.assertTrue(note2.isRest)
-        note3 = Note()
+        note3 = note.Note()
         note3.pitch.name = 'B-'
         # not sure how to test not None
         # self.assertFalse (note3.pitch.accidental, None)
         self.assertEqual(note3.pitch.accidental.name, 'flat')
         self.assertEqual(note3.pitch.pitchClass, 10)
 
-        a5 = Note()
+        a5 = note.Note()
         a5.name = 'A'
         a5.octave = 5
         self.assertAlmostEqual(a5.pitch.frequency, 880.0)
         self.assertEqual(a5.pitch.pitchClass, 9)
 
     def testCopyNote(self):
-        a = Note()
+        from music21 import note
+        a = note.Note()
         a.quarterLength = 3.5
         a.name = 'D'
         b = copy.deepcopy(a)
@@ -2021,8 +2025,9 @@ class Test(unittest.TestCase):
         self.assertEqual(len(found), 24)
 
     def testNoteBeatProperty(self):
-        from music21 import stream
         from music21 import meter
+        from music21 import note
+        from music21 import stream
 
         data = [
             ['3/4', 0.5, 6, [1.0, 1.5, 2.0, 2.5, 3.0, 3.5],
@@ -2052,7 +2057,7 @@ class Test(unittest.TestCase):
 
         # one measure case
         for tsStr, nQL, nCount, matchBeat, matchBeatDur in data:
-            n = Note()  # need fully qualified name
+            n = note.Note()  # need fully qualified name
             n.quarterLength = nQL
             m = stream.Measure()
             m.timeSignature = meter.TimeSignature(tsStr)
@@ -2074,7 +2079,7 @@ class Test(unittest.TestCase):
         # two measure case
         for tsStr, nQL, nCount, matchBeat, matchBeatDur in data:
             p = stream.Part()
-            n = Note()
+            n = note.Note()
             n.quarterLength = nQL
 
             # m1 has time signature
@@ -2120,11 +2125,12 @@ class Test(unittest.TestCase):
 
     def testNoteEquality(self):
         from music21 import articulations
+        from music21 import note
 
-        n1 = Note('a#')
-        n2 = Note('g')
-        n3 = Note('a-')
-        n4 = Note('a#')
+        n1 = note.Note('A#')
+        n2 = note.Note('G')
+        n3 = note.Note('A-')
+        n4 = note.Note('A#')
 
         self.assertNotEqual(n1, n2)
         self.assertNotEqual(n1, n3)
@@ -2199,6 +2205,7 @@ class Test(unittest.TestCase):
 
     def testMetricalAccent(self):
         from music21 import meter
+        from music21 import note
         from music21 import stream
         data = [
             ('4/4', 8, 0.5, [1.0, 0.125, 0.25, 0.125, 0.5, 0.125, 0.25, 0.125]),
@@ -2220,27 +2227,27 @@ class Test(unittest.TestCase):
         ]
 
         for tsStr, nCount, dur, match in data:
-
             m = stream.Measure()
             m.timeSignature = meter.TimeSignature(tsStr)
-            n = Note()
+            n = note.Note()
             n.quarterLength = dur
             m.repeatAppend(n, nCount)
 
             self.assertEqual([n.beatStrength for n in m.notesAndRests], match)
 
     def testTieContinue(self):
+        from music21 import note
         from music21 import stream
 
-        n1 = Note()
+        n1 = note.Note()
         n1.tie = tie.Tie()
         n1.tie.type = 'start'
 
-        n2 = Note()
+        n2 = note.Note()
         n2.tie = tie.Tie()
         n2.tie.type = 'continue'
 
-        n3 = Note()
+        n3 = note.Note()
         n3.tie = tie.Tie()
         n3.tie.type = 'stop'
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9822,17 +9822,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
 
         The same caveats about `Stream` classes and `.flatten()` in `.notes` apply here.
         '''
-        if 'notesAndRests' not in self._cache or self._cache['notesAndRests'] is None:
-            # environLocal.printDebug(['updating noteAndRests cache:', str(self), id(self)])
-            noteIterator = self.getElementsByClass('GeneralNote')
-            noteIterator.overrideDerivation = 'notesAndRests'
-            self._cache['notesAndRests'] = noteIterator
-        return self._cache['notesAndRests']
-
-        # return self.getElementsByClass([note.GeneralNote, chord.Chord])
-        # using string class names is import for some test contexts where
-        # absolute class name matching fails
-        # return self.getElementsByClass(['GeneralNote', 'Chord'])
+        noteIterator = self.getElementsByClass(note.GeneralNote)
+        noteIterator.overrideDerivation = 'notesAndRests'
+        return noteIterator
 
     @property
     def notes(self):
@@ -9842,7 +9834,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         :class:`~music21.note.Note`,
         :class:`~music21.chord.Chord`, etc.) found
         in the stream. This excludes :class:`~music21.note.Rest` objects.
-
 
         >>> p1 = stream.Part()
         >>> k1 = key.KeySignature(0)  # key of C
@@ -9891,11 +9882,9 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         Unpitched objects, so that all elements returned by
         `.notes` have a `.pitches` attribute.
         '''
-        if 'notes' not in self._cache or self._cache['notes'] is None:
-            noteIterator = self.getElementsByClass('NotRest')
-            noteIterator.overrideDerivation = 'notes'
-            self._cache['notes'] = noteIterator
-        return self._cache['notes']
+        noteIterator = self.getElementsByClass(note.NotRest)
+        noteIterator.overrideDerivation = 'notes'
+        return noteIterator
 
     @property
     def pitches(self):
@@ -11506,7 +11495,6 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         return self._cache['variants']
 
     # ---- Variant Activation Methods
-
     def activateVariants(self, group=None, *, matchBySpan=True, inPlace=False):
         '''
         For any :class:`~music21.variant.Variant` objects defined in this Stream
@@ -13586,33 +13574,15 @@ class Score(Stream):
         It filters out all other things that might be in a Score object, such as Metadata
         returning just the Parts.
 
-
         >>> s = corpus.parse('bach/bwv66.6')
         >>> s.parts
         <music21.stream.iterator.StreamIterator for Score:0x104af3a58 @:0>
         >>> len(s.parts)
         4
-
-        OMIT_FROM_DOCS
-
-        Ensure that getting from cache still will reset the iteration.
-
-        >>> for i, p in enumerate(s.parts):
-        ...     print(i, p)
-        ...     break
-        0 <music21.stream.Part Soprano>
-
-        >>> for i, p in enumerate(s.parts):
-        ...     print(i, p)
-        ...     break
-        0 <music21.stream.Part Soprano>
         '''
-        # return self.getElementsByClass('Part')
-        if 'parts' not in self._cache or self._cache['parts'] is None:
-            partIterator = self.getElementsByClass('Part')
-            partIterator.overrideDerivation = 'parts'
-            self._cache['parts'] = partIterator
-        return self._cache['parts']
+        partIterator = self.getElementsByClass(Part)
+        partIterator.overrideDerivation = 'parts'
+        return partIterator
 
     def measures(self,
                  numberStart,


### PR DESCRIPTION
Only causes problems, and getElementsByClass is now very fast.  No need for caches.