### PR TITLE
Replace bèmol with bemol in Spanish translation of flat

### DIFF
--- a/music21/languageExcerpts/naturalLanguageObjects.py
+++ b/music21/languageExcerpts/naturalLanguageObjects.py
@@ -161,7 +161,7 @@ class Test(unittest.TestCase):
                                                                    'it')))
         self.assertEqual('<music21.pitch.Pitch F##>', repr(toPitch('fa doble sostenido',
                                                                    'es')))
-        self.assertEqual('<music21.pitch.Pitch G--->', repr(toPitch('sol triple bèmol',
+        self.assertEqual('<music21.pitch.Pitch G--->', repr(toPitch('sol triple bemol',
                                                                     'es')))
         self.assertEqual('<music21.pitch.Pitch D>', repr(toPitch('re', 'it')))
         self.assertEqual('<music21.pitch.Pitch B-->', repr(toPitch('Heses', 'de')))
@@ -200,7 +200,7 @@ class Test(unittest.TestCase):
         # testing defaults in case of valid input string and valid language
         self.assertEqual('<music21.note.Note C##>', repr(toNote('do doppio diesis', 'it')))
         self.assertEqual('<music21.note.Note F##>', repr(toNote('fa doble sostenido', 'es')))
-        self.assertEqual('<music21.note.Note G--->', repr(toNote('sol triple bèmol', 'es')))
+        self.assertEqual('<music21.note.Note G--->', repr(toNote('sol triple bemol', 'es')))
         self.assertEqual('<music21.note.Note D>', repr(toNote('re', 'it')))
         self.assertEqual('<music21.note.Note B-->', repr(toNote('Heses', 'de')))
         self.assertEqual('<music21.note.Note E##>', repr(toNote('Eisis', 'de')))
@@ -245,7 +245,7 @@ class Test(unittest.TestCase):
         self.assertEqual('<music21.chord.Chord F##>',
                          repr(toChord(['fa doble sostenido'], 'es')))
         self.assertEqual('<music21.chord.Chord G--->',
-                         repr(toChord(['sol triple bèmol'], 'es')))
+                         repr(toChord(['sol triple bemol'], 'es')))
         self.assertEqual('<music21.chord.Chord D>', repr(toChord(['re'], 'it')))
         self.assertEqual('<music21.chord.Chord B-->', repr(toChord(['Heses'], 'de')))
         self.assertEqual('<music21.chord.Chord E##>', repr(toChord(['Eisis'], 'de')))
@@ -257,7 +257,7 @@ class Test(unittest.TestCase):
         self.assertEqual('<music21.chord.Chord C## D>',
                          repr(toChord(['do doppio diesis', 're'], 'it')))
         self.assertEqual('<music21.chord.Chord F## G--->',
-                         repr(toChord(['fa doble sostenido', 'sol triple bèmol'], 'es')))
+                         repr(toChord(['fa doble sostenido', 'sol triple bemol'], 'es')))
         self.assertEqual('<music21.chord.Chord B-- E##>',
                          repr(toChord(['Heses', 'Eisis'], 'de')))
         self.assertEqual('<music21.chord.Chord A#### B--->',

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -3179,13 +3179,13 @@ class Pitch(prebase.ProtoM21Object):
         (Microtones and Quarter tones raise an error).
 
         >>> print(pitch.Pitch('B-').spanish)
-        si bèmol
+        si bemol
         >>> print(pitch.Pitch('E-').spanish)
-        mi bèmol
+        mi bemol
         >>> print(pitch.Pitch('C#').spanish)
         do sostenido
         >>> print(pitch.Pitch('A--').spanish)
-        la doble bèmol
+        la doble bemol
         >>> p1 = pitch.Pitch('C')
         >>> p1.accidental = pitch.Accidental('half-sharp')
         >>> p1.spanish
@@ -3195,7 +3195,7 @@ class Pitch(prebase.ProtoM21Object):
         Note these rarely used pitches:
 
         >>> print(pitch.Pitch('B--').spanish)
-        si doble bèmol
+        si doble bemol
         >>> print(pitch.Pitch('B#').spanish)
         si sostenido
         '''
@@ -3212,7 +3212,7 @@ class Pitch(prebase.ProtoM21Object):
         elif abs(tempAlter) > 4:
             raise PitchException('Unsupported accidental type.')
         elif tempAlter in {-4, -3, -2, -1}:
-            return solfege + self._getSpanishCardinal() + ' bèmol'
+            return solfege + self._getSpanishCardinal() + ' bemol'
         elif tempAlter in {1, 2, 3, 4}:
             return solfege + self._getSpanishCardinal() + ' sostenido'
 


### PR DESCRIPTION
The Spanish translation of "flat" is "bemol". The accent mark that is currently used in music21 doesn't exist in Spanish. 

For reference:
https://es.wikipedia.org/wiki/Alteraci%C3%B3n_(m%C3%BAsica)
https://catalog.ldc.upenn.edu/docs/LDC2019S07/Rules_for_Spanish_Accent_Marks.pdf