### PR TITLE
Don't choke on conductor tracks lacking meters

### DIFF
--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2086,10 +2086,13 @@ def midiTrackToStream(
 
     meterStream: Optional[stream.Stream] = None
     if conductorPart is not None:
-        insertConductorEvents(conductorPart, s, isFirst=isFirst)
         ts_iter = conductorPart['TimeSignature']
         if ts_iter:
             meterStream = ts_iter.stream()
+            # Supply any missing time signature at the start
+            if not meterStream.getElementsByOffset(0):
+                from music21 import meter
+                meterStream.insert(0, meter.TimeSignature())
 
     # Only make measures once time signatures have been inserted
     s.makeMeasures(meterStream=meterStream, inPlace=True)


### PR DESCRIPTION
Fixes regression in v.7 (a56955ae50b87ee9f5145f8b6d63d629dc33e121). when making measures in MIDI import, if there is a non-empty conductor track, it was assumed to have a time signature. If it only had tempos, instrument names, etc., music21 raised:

```music21.exceptions21.StreamException: failed to find TimeSignature in meterStream; cannot process Measures```