### PR TITLE
Speed up MIDI enum membership tests

### DIFF
--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -350,7 +350,7 @@ class _ContainsEnum(IntEnum):
 
     @classmethod
     def hasValue(cls, val):
-        return val in cls.__members__.values()
+        return val in cls._value2member_map_
 
 
 class ChannelVoiceMessages(_ContainsEnum):


### PR DESCRIPTION
Fixes #1174

Alternative to #1175

@kwikwag, would you be interested to take a look? I added you as a co-author.

Using your benchmark (thank you) I see the same improvement (a hair better, even) as storing a `frozenset`. Avoids managing an extra class attribute (that will then require a mypy disable when we type-check the midi module soon.)