### PR TITLE
Avoid exporting superfluous meters and keys in staff groups

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2471,7 +2471,7 @@ class PartExporter(XMLExporterBase):
             self.midiChannelList = parent.midiChannelList  # shared list
             self.makeNotation = parent.makeNotation
 
-        self.higher_sibling_in_group: Optional[stream.PartStaff] = None
+        self.previous_sibling_in_group: Optional[stream.PartStaff] = None
 
         self.instrumentStream = None
         self.firstInstrumentObject = None
@@ -5660,7 +5660,7 @@ class MeasureExporter(XMLExporterBase):
 
         return mxAttributes
 
-    def _matches_earlier_sibling_in_group(self,
+    def _matches_previous_sibling_in_group(self,
                                           obj: base.Music21Object,
                                           attr='keySignature',
                                           comparison='__eq__') -> bool:
@@ -5672,7 +5672,7 @@ class MeasureExporter(XMLExporterBase):
         '''
         if self.parent is None:  # pragma: no cover
             return False
-        if self.parent.higher_sibling_in_group is None:
+        if self.parent.previous_sibling_in_group is None:
             return False
         # Not a foolproof measure lookup: see more robust measure
         # matching algorithm in PartStaffExporterMixin.processSubsequentPartStaff().
@@ -5680,7 +5680,7 @@ class MeasureExporter(XMLExporterBase):
         # see https://groups.google.com/g/music21list/c/ObNOanMQjJU/m/2LMPz5NAAwAJ
         if obj.measureNumber is None:  # pragma: no cover
             return False
-        maybe_measure = self.parent.higher_sibling_in_group.measure(obj.measureNumber)
+        maybe_measure = self.parent.previous_sibling_in_group.measure(obj.measureNumber)
         if maybe_measure is None:
             return False
         comparison_wrapper = getattr(obj, comparison)
@@ -6009,10 +6009,10 @@ class MeasureExporter(XMLExporterBase):
             mxDivisions.text = str(self.currentDivisions)
             self.parent.lastDivisions = self.currentDivisions
 
-        if m.keySignature is not None and not self._matches_earlier_sibling_in_group(
+        if m.keySignature is not None and not self._matches_previous_sibling_in_group(
                 m.keySignature, 'keySignature'):
             mxAttributes.append(self.keySignatureToXml(m.keySignature))
-        if m.timeSignature is not None and not self._matches_earlier_sibling_in_group(
+        if m.timeSignature is not None and not self._matches_previous_sibling_in_group(
                 m.timeSignature, 'timeSignature', comparison='ratioEqual'):
             mxAttributes.append(self.timeSignatureToXml(m.timeSignature))
         smts = list(m.getElementsByClass('SenzaMisuraTimeSignature'))

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5660,10 +5660,16 @@ class MeasureExporter(XMLExporterBase):
 
         return mxAttributes
 
-    def _matches_sibling(self,
-                         obj: base.Music21Object,
-                         attr='keySignature',
-                         comparison='__eq__') -> bool:
+    def _matches_earlier_sibling_in_group(self,
+                                          obj: base.Music21Object,
+                                          attr='keySignature',
+                                          comparison='__eq__') -> bool:
+        '''
+        If this measure is part of a subsequent PartStaff in a joinable staff
+        group (e.g. the left hand of a keyboard part), then look up the
+        corresponding measure by number in the previous PartStaff, retrieve
+        the `attr` value there, and compare it to `obj` by `comparison`.
+        '''
         if self.parent is None:
             return False
         if self.parent.higher_sibling_in_group is None:
@@ -6003,10 +6009,10 @@ class MeasureExporter(XMLExporterBase):
             mxDivisions.text = str(self.currentDivisions)
             self.parent.lastDivisions = self.currentDivisions
 
-        if m.keySignature is not None and not self._matches_sibling(
+        if m.keySignature is not None and not self._matches_earlier_sibling_in_group(
                 m.keySignature, 'keySignature'):
             mxAttributes.append(self.keySignatureToXml(m.keySignature))
-        if m.timeSignature is not None and not self._matches_sibling(
+        if m.timeSignature is not None and not self._matches_earlier_sibling_in_group(
                 m.timeSignature, 'timeSignature', comparison='ratioEqual'):
             mxAttributes.append(self.timeSignatureToXml(m.timeSignature))
         smts = list(m.getElementsByClass('SenzaMisuraTimeSignature'))

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2448,11 +2448,10 @@ class PartExporter(XMLExporterBase):
     '''
     _DOC_ATTR: Mapping[str, str] = {
         'previousPartStaffInGroup': '''
-        If the part being exported is a :class:`~music21.stream.base.PartStaff`,
-        this attribute will be used to store the immediately previous `PartStaff`
-        in the :class:`~music21.layout.StaffGroup`, if any. (E.g. if this is
-        the left hand, store a reference to the right hand.)
-        '''
+            If the part being exported is a :class:`~music21.stream.base.PartStaff`,
+            this attribute will be used to store the immediately previous `PartStaff`
+            in the :class:`~music21.layout.StaffGroup`, if any. (E.g. if this is
+            the left hand, store a reference to the right hand.)''',
     }
 
     def __init__(self,

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5670,7 +5670,7 @@ class MeasureExporter(XMLExporterBase):
         corresponding measure by number in the previous PartStaff, retrieve
         the `attr` value there, and compare it to `obj` by `comparison`.
         '''
-        if self.parent is None:
+        if self.parent is None:  # pragma: no cover
             return False
         if self.parent.higher_sibling_in_group is None:
             return False
@@ -5678,7 +5678,7 @@ class MeasureExporter(XMLExporterBase):
         # matching algorithm in PartStaffExporterMixin.processSubsequentPartStaff().
         # getElementsByOffset() would not be a perfect solution either,
         # see https://groups.google.com/g/music21list/c/ObNOanMQjJU/m/2LMPz5NAAwAJ
-        if obj.measureNumber is None:
+        if obj.measureNumber is None:  # pragma: no cover
             return False
         maybe_measure = self.parent.higher_sibling_in_group.measure(obj.measureNumber)
         if maybe_measure is None:

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -1008,6 +1008,11 @@ class Test(unittest.TestCase):
         # Just two <attributes> tags, a 3/1 in measure 1 and a 4/1 in measure 2
         self.assertEqual(len(root.findall('part/measure/attributes/time')), 2)
 
+        # Edge cases -- no expectation of correctness, just don't crash
+        ps1[stream.Measure].last().number = 0  # was measure 2
+        root = self.getET(s)
+        self.assertEqual(len(root.findall('part/measure/attributes/time')), 3)
+
 
 if __name__ == '__main__':
     import music21

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -145,9 +145,11 @@ class PartStaffExporterMixin:
     def joinableGroups(self) -> List[StaffGroup]:
         '''
         Returns a list of :class:`~music21.layout.StaffGroup` objects that
-        represent :class:`~music21.stream.PartStaff` objects that can be
+        represent :class:`~music21.stream.base.PartStaff` objects that can be
         joined into a single MusicXML `<part>`, so long as there exists a
-        `PartExporter` for it in `ScoreExporter.partExporterList`:
+        `PartExporter` for it in `ScoreExporter.partExporterList`.
+
+        Sets :attr:`~music21.musicxml.m21ToXml.PartExporter.previousPartStaffInGroup`.
 
         >>> s = stream.Score()
 
@@ -261,7 +263,7 @@ class PartStaffExporterMixin:
                 for part_exporter in self.partExporterList:
                     if part_exporter.stream is not part_staff:
                         continue
-                    part_exporter.previous_sibling_in_group = prior_part_staff
+                    part_exporter.previousPartStaffInGroup = prior_part_staff
                     prior_part_staff = part_staff
                     break
 

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -261,7 +261,7 @@ class PartStaffExporterMixin:
                 for part_exporter in self.partExporterList:
                     if part_exporter.stream is not part_staff:
                         continue
-                    part_exporter.higher_sibling_in_group = prior_part_staff
+                    part_exporter.previous_sibling_in_group = prior_part_staff
                     prior_part_staff = part_staff
                     break
 


### PR DESCRIPTION
Take 2 -- fixes #1129. Alternative to #1131.

@gregchapman-dev Another one here -- would you mind checking?