### PR TITLE
Clearing bracketedAlterations in RomanNumeral.figure.setter.

### DIFF
--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2977,6 +2977,7 @@ class RomanNumeral(harmony.Harmony):
     def figure(self, newFigure):
         self._figure = newFigure
         if self._parsingComplete:
+            self.bracketedAlterations = []
             self._parseFigure()
             self._updatePitches()
 


### PR DESCRIPTION
Fixes #1205 

Running
```python
import music21
print(music21.__version__)

rn = music21.roman.RomanNumeral("Ger7")
print(rn.pitchNames)
rn.figure = "Ger7"
print(rn.pitchNames)

rn2 = music21.roman.RomanNumeral("#IV")
print(rn2.pitchNames)
rn.figure = "#IV"
print(rn2.pitchNames)
```

Before patch
```python
['F#', 'A-', 'C', 'E-']
['F##', 'A-', 'C', 'E-']
['F#', 'A#', 'C#']
['F#', 'A#', 'C#']
```

and after patch
```python
['F#', 'A-', 'C', 'E-']
['F#', 'A-', 'C', 'E-']
['F#', 'A#', 'C#']
['F#', 'A#', 'C#']
```