### PR TITLE
Fix LocalCorpus.removePath() string/path confusion

### DIFF
--- a/music21/corpus/corpora.py
+++ b/music21/corpus/corpora.py
@@ -846,16 +846,30 @@ class LocalCorpus(Corpus):
 
         If that path is included in the list of persisted paths for the given
         corpus, it will be removed permanently.
+
+        >>> testCorpus = corpus.corpora.LocalCorpus(name='test')
+        >>> testCorpus.addPath('~/Desktop')
+        >>> len(testCorpus.directoryPaths)
+        1
+        >>> testCorpus.removePath('~/Desktop')
+        >>> testCorpus.directoryPaths
+        ()
+
+        TODO: test for corpus persisted to disk without actually reindexing
+        files on user's Desktop.
         '''
         temporaryPaths = LocalCorpus._temporaryLocalPaths.get(
             self.name, [])
-        directoryPath = common.cleanpath(directoryPath)
-        if directoryPath in temporaryPaths:
-            temporaryPaths.remove(directoryPath)
+        directoryPathObj: pathlib.Path = common.cleanpath(directoryPath, returnPathlib=True)
+        if directoryPathObj in temporaryPaths:
+            temporaryPaths.remove(directoryPathObj)
+        # Also need string version because LocalCorpusSettings is a list-like
+        # container of strings (see comments in environment.py)
+        directoryPathStr = str(directoryPathObj)
         if self.existsInSettings:
             settings = self._getSettings()
-            if settings is not None and directoryPath in settings:
-                settings.remove(directoryPath)
+            if settings is not None and directoryPathStr in settings:
+                settings.remove(directoryPathStr)
             self.save()
         self._removeNameFromCache(self.name)
 


### PR DESCRIPTION
Removing paths using `LocalCorpus.removePath()` didn't work for corpora persisted to disk because the infrastructure expects strings, not `Path` objects. `Path` objects were being used since v5 when the `common.cleanpath()` default changed.

Added a test for the _in-memory_ corpus to at least add some coverage, but I didn't see a way to add coverage for the case that was failing without rewriting a lot of the system. (E.g. add more `verbose=` arguments to silence warnings, add a step to CI that creates a path that is not Desktop, etc.).

Adding that test was useful, though, since I discovered _that_ codepath _does_ expect `Path` objects.