### PR TITLE
Export music in voices to braille

### DIFF
--- a/music21/braille/examples.py
+++ b/music21/braille/examples.py
@@ -1175,7 +1175,8 @@ Barline final ⠣⠅
 
         demo = corpus.parse('demos/two-voices')
         x = objectToBraille(demo, debug=True)
-        y = '''
+        y = '''Movement Name: two-voices.xml
+Title: Music21 Fragment
 ---begin segment---
 <music21.braille.segment BrailleSegment>
 Measure 1, Signature Grouping 1:

--- a/music21/braille/examples.py
+++ b/music21/braille/examples.py
@@ -151,6 +151,7 @@ Ascending Chord:
 F eighth ⠛
 Interval 3 ⠬
 Interval 7 ⠒
+full inaccord ⠣⠜
 Octave 2 ⠘
 F quarter ⠻
 Dot ⠄
@@ -331,6 +332,7 @@ Ascending Chord:
 F eighth ⠛
 Interval 3 ⠬
 Interval 7 ⠒
+full inaccord ⠣⠜
 Octave 2 ⠘
 F quarter ⠻
 Dot ⠄
@@ -375,6 +377,7 @@ Ascending Chord:
 F eighth ⠛
 Interval 4 ⠼
 Interval 6 ⠴
+full inaccord ⠣⠜
 Octave 2 ⠘
 F quarter ⠻
 Dot ⠄
@@ -421,6 +424,7 @@ Ascending Chord:
 F eighth ⠛
 Interval 5 ⠔
 Interval 7 ⠒
+full inaccord ⠣⠜
 Octave 2 ⠘
 F quarter ⠻
 Dot ⠄
@@ -466,6 +470,7 @@ Ascending Chord:
 F eighth ⠛
 Interval 4 ⠼
 Interval 6 ⠴
+full inaccord ⠣⠜
 Octave 2 ⠘
 B quarter ⠺
 Dot ⠄
@@ -518,6 +523,7 @@ Ascending Chord:
 A 16th ⠮
 Interval 5 ⠔
 F 16th ⠿
+full inaccord ⠣⠜
 Octave 2 ⠘
 F quarter ⠻
 Dot ⠄
@@ -564,6 +570,7 @@ Ascending Chord:
 B 16th ⠾
 Interval 3 ⠬
 F 16th ⠿
+full inaccord ⠣⠜
 Octave 2 ⠘
 B quarter ⠺
 Dot ⠄
@@ -614,6 +621,7 @@ Ascending Chord:
 A 16th ⠮
 Interval 5 ⠔
 F 16th ⠿
+full inaccord ⠣⠜
 Octave 2 ⠘
 F quarter ⠻
 Dot ⠄
@@ -661,6 +669,7 @@ Ascending Chord:
 B 16th ⠾
 Interval 3 ⠬
 F 16th ⠿
+full inaccord ⠣⠜
 Octave 2 ⠘
 B quarter ⠺
 Dot ⠄
@@ -711,6 +720,7 @@ Interval 3 ⠬
 Ascending Chord:
 A eighth ⠊
 Interval 3 ⠬
+full inaccord ⠣⠜
 Octave 3 ⠸
 F quarter ⠻
 Dot ⠄
@@ -761,6 +771,7 @@ Interval 3 ⠬
 Ascending Chord:
 B eighth ⠚
 Interval 3 ⠬
+full inaccord ⠣⠜
 Octave 3 ⠸
 G quarter ⠳
 Dot ⠄
@@ -866,6 +877,7 @@ Dot ⠄
 Opening single slur ⠉
 Octave 6 ⠰
 F 32nd ⠟
+full inaccord ⠣⠜
 Rest quarter ⠧
 Dot ⠄
 
@@ -877,6 +889,7 @@ F eighth ⠛
 Interval 3 ⠬
 Interval 5 ⠔
 Rest eighth ⠭
+full inaccord ⠣⠜
 Ascending Chord:
 Octave 3 ⠸
 F quarter ⠻
@@ -901,6 +914,7 @@ Octave 3 ⠸
 B eighth ⠚
 Interval 3 ⠬
 Rest eighth ⠭
+full inaccord ⠣⠜
 Ascending Chord:
 Octave 3 ⠸
 B quarter ⠺
@@ -984,6 +998,7 @@ Dot ⠄
 Opening single slur ⠉
 Octave 6 ⠰
 F 32nd ⠟
+full inaccord ⠣⠜
 Rest quarter ⠧
 Dot ⠄
 
@@ -998,6 +1013,7 @@ Ascending Chord:
 F eighth ⠛
 Interval 3 ⠬
 Interval 7 ⠒
+full inaccord ⠣⠜
 Octave 2 ⠘
 F quarter ⠻
 Dot ⠄
@@ -1031,6 +1047,7 @@ Ascending Chord:
 F eighth ⠛
 Interval 4 ⠼
 Interval 6 ⠴
+full inaccord ⠣⠜
 Octave 2 ⠘
 F quarter ⠻
 Dot ⠄
@@ -1108,6 +1125,7 @@ Octave 3 ⠸
 F eighth ⠛
 Interval 3 ⠬
 Interval 7 ⠒
+full inaccord ⠣⠜
 Ascending Chord:
 Octave 3 ⠸
 E quarter ⠫
@@ -1151,7 +1169,87 @@ Barline final ⠣⠅
         self.assertEqual(x.splitlines(), y.splitlines())
 
 
+    def testVoices(self):
+        from music21 import corpus
+        from music21.braille.translate import objectToBraille
+
+        demo = corpus.parse('demos/two-voices')
+        x = objectToBraille(demo, debug=True)
+        y = '''
+---begin segment---
+<music21.braille.segment BrailleSegment>
+Measure 1, Signature Grouping 1:
+Key Signature 2 sharp(s) ⠩⠩
+Time Signature 4/4 ⠼⠙⠲
+===
+Measure 1, Inaccord Grouping 1:
+<music21.clef.BassClef>
+Octave 4 ⠐
+E eighth ⠋
+Accidental sharp ⠩
+D eighth ⠑
+D eighth ⠑
+E eighth ⠋
+F eighth ⠛
+Rest eighth ⠭
+Rest quarter ⠧
+full inaccord ⠣⠜
+Octave 2 ⠘
+F eighth ⠛
+Octave 3 ⠸
+F eighth ⠛
+E eighth ⠋
+Octave 2 ⠘
+E eighth ⠋
+Accidental sharp ⠩
+D eighth ⠑
+Accidental sharp ⠩
+Octave 3 ⠸
+D eighth ⠑
+B eighth ⠚
+Octave 3 ⠸
+B eighth ⠚
+===
+Measure 2, Inaccord Grouping 1:
+Octave 4 ⠐
+E eighth ⠋
+Octave 3 ⠸
+B eighth ⠚
+Tie ⠈⠉
+B eighth ⠚
+Octave 4 ⠐
+E eighth ⠋
+E eighth ⠋
+Rest eighth ⠭
+Rest quarter ⠧
+full inaccord ⠣⠜
+Octave 2 ⠘
+E eighth ⠋
+Octave 3 ⠸
+E eighth ⠋
+Accidental natural ⠡
+D eighth ⠑
+Accidental natural ⠡
+Octave 2 ⠘
+D eighth ⠑
+C eighth ⠙
+Octave 3 ⠸
+C eighth ⠙
+A eighth ⠊
+Octave 3 ⠸
+A eighth ⠊
+===
+Measure 3, Note Grouping 1:
+Rest whole ⠍
+Barline final ⠣⠅
+===
+---end segment---
+'''
+        self.maxDiff = None
+        self.assertEqual(x.splitlines(), y.splitlines())
+
+
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test)  # , runTest='testVerdiDebug')
+    music21.mainTest(Test)  # , runTest='testVoices')
 

--- a/music21/braille/examples.py
+++ b/music21/braille/examples.py
@@ -266,7 +266,7 @@ Barline final ⠣⠅
         from music21.braille.translate import objectToBraille
         verdi = corpus.parse('verdi/laDonnaEMobile')
         x = objectToBraille(verdi, debug=True)
-        y = '''⠠⠍⠕⠧⠑⠍⠑⠝⠞⠀⠠⠝⠁⠍⠑⠒⠀⠇⠁⠠⠙⠕⠝⠝⠁⠠⠑⠠⠍⠕⠃⠊⠇⠑⠲⠍⠭⠇
+        y = '''Movement Name: laDonnaEMobile.mxl
 ---begin grand segment---
 <music21.braille.segment BrailleGrandSegment>
 ===

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -240,18 +240,23 @@ class BrailleElementGrouping(ProtoM21Object):
         of each object in the BrailleElementGrouping.
         '''
         allObjects = []
+        previous_was_voice: bool = False
         for obj in self:
             if isinstance(obj, stream.Voice):
+                if previous_was_voice:
+                    allObjects.append(f"full inaccord {lookup.symbols['full_inaccord']}")
                 for obj2 in obj:
                     try:
                         allObjects.append('\n'.join(obj2.editorial.brailleEnglish))
                     except (AttributeError, TypeError):
                         allObjects.append(str(obj2))
+                previous_was_voice = True
             else:
                 try:
                     allObjects.append('\n'.join(obj.editorial.brailleEnglish))
                 except (AttributeError, TypeError):
                     allObjects.append(str(obj))
+                previous_was_voice = False
         if self.numRepeats > 0:
             allObjects.append(f'** Grouping x {self.numRepeats + 1} **')
         if self.withHyphen is True:
@@ -470,8 +475,8 @@ class BrailleSegment(text.BrailleText):
                 self.extractSignatureGrouping()  # Signature(s) Grouping
             elif cgkAffinityGroup == Affinity.LONG_TEXTEXPR:
                 self.extractLongExpressionGrouping()  # Long Expression(s) Grouping
-            # elif cgkAffinityGroup == Affinity.INACCORD:
-            #     self.extractInaccordGrouping()  # In Accord Grouping
+            elif cgkAffinityGroup == Affinity.INACCORD:
+                self.extractInaccordGrouping()  # In Accord Grouping
             elif cgkAffinityGroup == Affinity.TTEXT:
                 self.extractTempoTextGrouping()  # Tempo Text Grouping
             # noinspection PyAttributeOutsideInit
@@ -589,17 +594,27 @@ class BrailleSegment(text.BrailleText):
             self.addHeading(brailleHeading)
 
 
-    # def extractInaccordGrouping(self):
-    #     inaccords = self._groupingDict.get(self.currentGroupingKey)
-    #     voice_trans = []
-    #     for music21Voice in inaccords:
-    #         noteGrouping = extractBrailleElements(music21Voice)
-    #         noteGrouping.descendingChords = inaccords.descendingChords
-    #         noteGrouping.showClefSigns = inaccords.showClefSigns
-    #         noteGrouping.upperFirstInNoteFingering = inaccords.upperFirstInNoteFingering
-    #         voice_trans.append(ngMod.transcribeNoteGrouping(noteGrouping))
-    #     brailleInaccord = symbols['full_inaccord'].join(voice_trans)
-    #     self.addInaccord(brailleInaccord)
+    def extractInaccordGrouping(self):
+        inaccords = self._groupingDict.get(self.currentGroupingKey)
+        last_clef: Optional[clef.Clef] = None
+        seen_voice: bool = False
+        for music21VoiceOrClef in inaccords:
+            if isinstance(music21VoiceOrClef, clef.Clef):
+                last_clef = music21VoiceOrClef
+                continue
+            if not isinstance(music21VoiceOrClef, stream.Voice):
+                environRules.warn(f'{music21VoiceOrClef} is neither a voice nor clef; ignoring!')
+            noteGrouping = extractBrailleElements(music21VoiceOrClef)
+            if last_clef:
+                noteGrouping.insert(0, last_clef)
+                last_clef = None
+            noteGrouping.descendingChords = inaccords.descendingChords
+            noteGrouping.showClefSigns = inaccords.showClefSigns
+            noteGrouping.upperFirstInNoteFingering = inaccords.upperFirstInNoteFingering
+            brailleInaccord = symbols['full_inaccord'] if seen_voice else ''
+            brailleInaccord += ngMod.transcribeNoteGrouping(noteGrouping)
+            self.addInaccord(brailleInaccord)
+            seen_voice = True
 
 
     def extractLongExpressionGrouping(self):
@@ -979,7 +994,7 @@ class BrailleSegment(text.BrailleText):
                     elif isinstance(brailleElement, key.KeySignature):
                         brailleElement.outgoingKeySig = currentKeySig
                         currentKeySig = brailleElement
-            elif groupingKey.affinity == Affinity.NOTEGROUP:
+            elif groupingKey.affinity in (Affinity.INACCORD, Affinity.NOTEGROUP):
                 if isinstance(groupingList[0], clef.Clef):
                     if isinstance(groupingList[0], (clef.TrebleClef, clef.AltoClef)):
                         self.descendingChords = True
@@ -1333,6 +1348,7 @@ class BrailleGrandSegment(BrailleSegment, text.BrailleKeyboard):
                     noteGrouping.upperFirstInNoteFingering = inaccords.upperFirstInNoteFingering
                     voice_trans.append(ngMod.transcribeNoteGrouping(noteGrouping))
                     self._cleanupAttributes(noteGrouping)
+                # Inaccord symbol unnecessary before first voice
                 brailleStr = symbols['full_inaccord'].join(voice_trans)
             elif rightOrLeftKey is not None:
                 noteGrouping = self._groupingDict.get(rightOrLeftKey)
@@ -1881,8 +1897,7 @@ def getRawSegments(music21Part,
 
     startANewSegment: bool = False
 
-    # TODO: why is this skipping the measure layer and getting voices?
-    for music21Measure in music21Part.getElementsByClass([stream.Measure, stream.Voice]):
+    for music21Measure in music21Part.getElementsByClass(stream.Measure):
         prepareBeamedNotes(music21Measure)
         brailleElements = extractBrailleElements(music21Measure)
         ordinal: int = 0
@@ -1996,14 +2011,31 @@ def extractBrailleElements(music21Measure):
     <music21.bar.Barline type=final>
     '''
     allElements = BrailleElementGrouping()
+    last_clef: Optional[clef.Clef] = None
     for music21Object in music21Measure:
+        # Hold the clef in memory in case the next object is a voice
+        if isinstance(music21Object, clef.Clef):
+            last_clef = music21Object
+            continue
         try:
             if isinstance(music21Object, bar.Barline):
                 if music21Object.type == 'regular':
                     continue
             setAffinityCode(music21Object)
-            music21Object.editorial.brailleEnglish = [str(music21Object)]
+
+            if last_clef is not None and isinstance(
+                    music21Object, (note.GeneralNote, stream.Voice)):
+                # Dispose of last clef
+                setAffinityCode(last_clef)
+                # Correct affinity code to ensure it is grouped with voice (inaccord) if need be
+                last_clef.affinityCode = music21Object.affinityCode
+                last_clef.editorial.brailleEnglish = [str(last_clef)]
+                allElements.append(last_clef)
+                last_clef = None
+
             allElements.append(music21Object)
+            music21Object.editorial.brailleEnglish = [str(music21Object)]
+
         except BrailleSegmentException as notSupportedException:  # pragma: no cover
             isExempt = [isinstance(music21Object, music21Class)
                         for music21Class in excludeFromBrailleElements]

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -21,7 +21,7 @@ import copy
 import enum
 import unittest
 
-from typing import Optional
+from typing import Optional, Union
 
 from music21 import bar
 from music21 import chord
@@ -1342,6 +1342,8 @@ class BrailleGrandSegment(BrailleSegment, text.BrailleKeyboard):
                 inaccords = self._groupingDict.get(rightOrLeftKey)
                 voice_trans = []
                 for music21Voice in inaccords:
+                    if not isinstance(music21Voice, stream.Voice):
+                        continue  # could be clef preceding empty voice? untranslated at present.
                     noteGrouping = extractBrailleElements(music21Voice)
                     noteGrouping.descendingChords = inaccords.descendingChords
                     noteGrouping.showClefSigns = inaccords.showClefSigns
@@ -1967,10 +1969,10 @@ def getRawSegments(music21Part,
     return allSegments
 
 
-def extractBrailleElements(music21Measure):
+def extractBrailleElements(music21MeasureOrVoice: Union[stream.Measure, stream.Voice]):
     '''
-    Takes in a :class:`~music21.stream.Measure` and returns a
-    :class:`~music21.braille.segment.BrailleElementGrouping` of correctly ordered
+    Takes in a :class:`~music21.stream.Measure` or :class:`~music21.stream.Voice`
+    and returns a :class:`~music21.braille.segment.BrailleElementGrouping` of correctly ordered
     :class:`~music21.base.Music21Object` instances which can be directly transcribed to
     braille.
 
@@ -2012,7 +2014,7 @@ def extractBrailleElements(music21Measure):
     '''
     allElements = BrailleElementGrouping()
     last_clef: Optional[clef.Clef] = None
-    for music21Object in music21Measure:
+    for music21Object in music21MeasureOrVoice:
         # Hold the clef in memory in case the next object is a voice
         if isinstance(music21Object, clef.Clef):
             last_clef = music21Object

--- a/music21/braille/text.py
+++ b/music21/braille/text.py
@@ -182,24 +182,23 @@ class BrailleText(prebase.ProtoM21Object):
             self.makeNewLine()
             self.currentLine.insert(2, brailleExpr)
 
-    # def addInaccord(self, inaccord):
-    #     addSpace = self.optionalAddKeyboardSymbolsAndDots(inaccord)
-    #
-    #     try:
-    #         self.currentLine.append(inaccord, addSpace=addSpace)
-    #     except BrailleTextException:
-    #         self.makeNewLine()
-    #         if self.rightHandSymbol or self.leftHandSymbol:
-    #             if self.rightHandSymbol:
-    #                 self.currentLine.insert(2, symbols['rh_keyboard'])
-    #             elif self.leftHandSymbol:
-    #                 self.currentLine.insert(2, symbols['lh_keyboard'])
-    #             for dot in yieldDots(inaccord[0]):
-    #                 self.currentLine.append(dot, addSpace=False)
-    #             self.currentLine.append(inaccord, addSpace=False)
-    #         else:
-    #             self.currentLine.insert(2, inaccord)
-    #     self.currentLine.containsNoteGrouping = True
+    def addInaccord(self, inaccord):
+        addSpace = self.optionalAddKeyboardSymbolsAndDots(inaccord)
+        try:
+            self.currentLine.append(inaccord, addSpace=addSpace)
+        except BrailleTextException:
+            self.makeNewLine()
+            if self.rightHandSymbol or self.leftHandSymbol:
+                if self.rightHandSymbol:
+                    self.currentLine.insert(2, symbols['rh_keyboard'])
+                elif self.leftHandSymbol:
+                    self.currentLine.insert(2, symbols['lh_keyboard'])
+                for dot in yieldDots(inaccord[0]):
+                    self.currentLine.append(dot, addSpace=False)
+                self.currentLine.append(inaccord, addSpace=False)
+            else:
+                self.currentLine.insert(2, inaccord)
+        self.currentLine.containsNoteGrouping = True
 
     def addMeasureNumber(self, measureNumber):
         '''

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -160,27 +160,23 @@ def objectToBraille(music21Obj,
     >>> print(translate.objectToBraille(sampleDynamic))
     ⠜⠋⠋⠋
 
+    >>> sample_voice = stream.Voice([note.Note()])
+    >>> sample_measure = stream.Measure([sample_voice])
+    >>> print(translate.objectToBraille(sample_measure))
+    ⠀⠼⠁⠲⠀
+    ⠼⠚⠀⠐⠹
+
+    >>> empty_measure = stream.Measure()
+    >>> print(translate.objectToBraille(empty_measure))
+    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠙⠲⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+    ⠼⠚
+
     Not currently supported: generic `stream.Stream` objects:
 
     >>> sample_generic_stream = stream.Stream([note.Note()])
     >>> translate.objectToBraille(sample_generic_stream)
     Traceback (most recent call last):
     music21.braille.translate.BrailleTranslateException: Stream cannot be translated to Braille.
-
-    OMIT_FROM_DOCS
-
-    Not currently working: extracting music from voices
-
-    >>> sample_voice = stream.Voice([note.Note()])
-    >>> sample_measure = stream.Measure([sample_voice])
-    >>> print(translate.objectToBraille(sample_measure))
-    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠲⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-    ⠼⠚
-    >>> empty_measure = stream.Measure()
-    >>> print(translate.objectToBraille(empty_measure))
-    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠙⠲⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
-    ⠼⠚
-
     '''
     if isinstance(music21Obj, stream.Stream) and not isinstance(music21Obj, stream.Voice):
         return streamToBraille(music21Obj,

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -368,7 +368,7 @@ def scoreToBraille(music21Score,
     '''
     allBrailleLines = []
     for music21Metadata in music21Score.getElementsByClass(metadata.Metadata):
-        allBrailleLines.append(metadataToString(music21Metadata, returnBrailleUnicode=True))
+        allBrailleLines.append(metadataToString(music21Metadata, returnBrailleUnicode=not debug))
     for p in music21Score.getElementsByClass(stream.Part):
         braillePart = partToBraille(p,
                                     inPlace=inPlace,


### PR DESCRIPTION
- Add support for exporting music in voices to braille.
- Don't return braille unicode for metadata if `debug=True`

#### output of testVoices() failing before PR, showing translation improvements
(- lines are actual, + lines are expected, this is with a `debug=True` export)
```python
AssertionError: Lists differ: ['⠠⠍⠕⠧⠑⠍⠑⠝⠞⠀⠠⠝⠁⠍⠑⠒⠀⠞⠺⠕⠴⠧⠕⠊⠉⠑⠎⠲⠭⠍⠇', '⠠⠞⠊⠞⠇⠑[1228 chars]---'] != ['Movement Name: two-voices.xml', 'Title: M[1179 chars]---']

First differing element 0:
'⠠⠍⠕⠧⠑⠍⠑⠝⠞⠀⠠⠝⠁⠍⠑⠒⠀⠞⠺⠕⠴⠧⠕⠊⠉⠑⠎⠲⠭⠍⠇'
'Movement Name: two-voices.xml'

Second list contains 19 additional elements.
First extra element 51:
'Octave 3 ⠸'

- ['⠠⠍⠕⠧⠑⠍⠑⠝⠞⠀⠠⠝⠁⠍⠑⠒⠀⠞⠺⠕⠴⠧⠕⠊⠉⠑⠎⠲⠭⠍⠇',
-  '⠠⠞⠊⠞⠇⠑⠒⠀⠠⠍⠥⠎⠊⠉⠼⠃⠁⠀⠠⠋⠗⠁⠛⠍⠑⠝⠞',
+ ['Movement Name: two-voices.xml',
+  'Title: Music21 Fragment',
   '---begin segment---',
   '<music21.braille.segment BrailleSegment>',
   'Measure 1, Signature Grouping 1:',
   'Key Signature 2 sharp(s) ⠩⠩',
   'Time Signature 4/4 ⠼⠙⠲',
   '===',
-  'Measure 1, Note Grouping 1:',
?              ^ ^^

+  'Measure 1, Inaccord Grouping 1:',
?              ^^^^^ ^^

   '<music21.clef.BassClef>',
-  'music hyphen ⠐',
-  '===',
-  'Measure 1, Inaccord Grouping 2:',
-  '<music21.note.Note E>',
-  '<music21.note.Note D#>',
-  '<music21.note.Note D#>',
-  '<music21.note.Note E>',
-  '<music21.note.Note F#>',
-  '<music21.note.Rest eighth>',
-  '<music21.note.Rest quarter>',
-  '<music21.note.Note F#>',
-  '<music21.note.Note F#>',
-  '<music21.note.Note E>',
-  '<music21.note.Note E>',
-  '<music21.note.Note D#>',
-  '<music21.note.Note D#>',
-  '<music21.note.Note B>',
-  '<music21.note.Note B>',
+  'Octave 4 ⠐',
+  'E eighth ⠋',
+  'Accidental sharp ⠩',
+  'D eighth ⠑',
+  'D eighth ⠑',
+  'E eighth ⠋',
+  'F eighth ⠛',
+  'Rest eighth ⠭',
+  'Rest quarter ⠧',
+  'full inaccord ⠣⠜',
+  'Octave 2 ⠘',
+  'F eighth ⠛',
+  'Octave 3 ⠸',
+  'F eighth ⠛',
+  'E eighth ⠋',
+  'Octave 2 ⠘',
+  'E eighth ⠋',
+  'Accidental sharp ⠩',
+  'D eighth ⠑',
+  'Accidental sharp ⠩',
+  'Octave 3 ⠸',
+  'D eighth ⠑',
+  'B eighth ⠚',
+  'Octave 3 ⠸',
+  'B eighth ⠚',
   '===',
   'Measure 2, Inaccord Grouping 1:',
-  '<music21.note.Note E>',
-  '<music21.note.Note B>',
-  '<music21.note.Note B>',
-  '<music21.note.Note E>',
-  '<music21.note.Note E>',
-  '<music21.note.Rest eighth>',
-  '<music21.note.Rest quarter>',
-  '<music21.note.Note E>',
-  '<music21.note.Note E>',
-  '<music21.note.Note D>',
-  '<music21.note.Note D>',
-  '<music21.note.Note C#>',
-  '<music21.note.Note C#>',
-  '<music21.note.Note A>',
-  '<music21.note.Note A>',
+  'Octave 4 ⠐',
+  'E eighth ⠋',
+  'Octave 3 ⠸',
+  'B eighth ⠚',
+  'Tie ⠈⠉',
+  'B eighth ⠚',
+  'Octave 4 ⠐',
+  'E eighth ⠋',
+  'E eighth ⠋',
+  'Rest eighth ⠭',
+  'Rest quarter ⠧',
+  'full inaccord ⠣⠜',
+  'Octave 2 ⠘',
+  'E eighth ⠋',
+  'Octave 3 ⠸',
+  'E eighth ⠋',
+  'Accidental natural ⠡',
+  'D eighth ⠑',
+  'Accidental natural ⠡',
+  'Octave 2 ⠘',
+  'D eighth ⠑',
+  'C eighth ⠙',
+  'Octave 3 ⠸',
+  'C eighth ⠙',
+  'A eighth ⠊',
+  'Octave 3 ⠸',
+  'A eighth ⠊',
   '===',
   'Measure 3, Note Grouping 1:',
   'Rest whole ⠍',
   'Barline final ⠣⠅',
   '===',
   '---end segment---']
```