### PR TITLE
Make full scores containing piano parts exportable to braille

### DIFF
--- a/music21/braille/examples.py
+++ b/music21/braille/examples.py
@@ -265,7 +265,8 @@ Barline final ⠣⠅
         from music21.braille.translate import objectToBraille
         verdi = corpus.parse('verdi/laDonnaEMobile')
         x = objectToBraille(verdi, debug=True)
-        y = '''---begin grand segment---
+        y = '''⠠⠍⠕⠧⠑⠍⠑⠝⠞⠀⠠⠝⠁⠍⠑⠒⠀⠇⠁⠠⠙⠕⠝⠝⠁⠠⠑⠠⠍⠕⠃⠊⠇⠑⠲⠍⠭⠇
+---begin grand segment---
 <music21.braille.segment BrailleGrandSegment>
 ===
 Measure 1 Right, Signature Grouping 1:

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -273,7 +273,7 @@ def streamToBraille(music21Stream: Union[stream.Measure, stream.Part, stream.Sco
                             slurLongPhraseWithBrackets=slurLongPhraseWithBrackets,
                             suppressOctaveMarks=suppressOctaveMarks,
                             upperFirstInNoteFingering=upperFirstInNoteFingering,
-                            )
+                             )
     elif isinstance(music21Stream, stream.Measure):
         return measureToBraille(music21Stream,
                                 inPlace=inPlace,
@@ -385,6 +385,7 @@ def scoreToBraille(music21Score,
         allBrailleLines.append(metadataToString(music21Metadata, returnBrailleUnicode=True))
 
     unprocessed_partStaff: Optional[stream.PartStaff] = None
+
     def process_unmatched_part_staff_as_single_part():
         nonlocal unprocessed_partStaff
         if unprocessed_partStaff is None:
@@ -431,7 +432,7 @@ def scoreToBraille(music21Score,
                     slurLongPhraseWithBrackets=slurLongPhraseWithBrackets,
                     suppressOctaveMarks=suppressOctaveMarks,
                     upperFirstInNoteFingering=upperFirstInNoteFingering,
-                    )
+                )
                 allBrailleLines.append(keyboard_parts)
                 unprocessed_partStaff = None
             else:

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -781,6 +781,12 @@ class Test(unittest.TestCase):
         x = objectToBraille(s, maxLineLength=10)
         self.assertEqual([len(line) for line in x.splitlines()], [10, 10, 7, 10])
 
+    def testFullScoreWithPiano(self):
+        from music21 import corpus
+        s = corpus.parse('beach')
+        full_score_measure_1 = s.measure(1)
+        _ = objectToBraille(full_score_measure_1)
+
 
 if __name__ == '__main__':
     import music21


### PR DESCRIPTION
Previously, full scores containing piano music could not be exported.

```python
>>> beach = corpus.parse('beach')
>>> beach.show('braille')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/.../music21/music21/stream/base.py", line 334, in show
    return super().show(fmt=fmt, app=app, **keywords)
  File "/Users/.../music21/music21/base.py", line 2758, in show
    return formatWriter.show(self,
  File "/Users/.../music21/music21/converter/subConverters.py", line 502, in show
    super().show(obj, fmt, app=None, subformats=subformats, **keywords)
  File "/Users/.../music21/music21/converter/subConverters.py", line 212, in show
    returnedFilePath = self.write(obj, fmt, subformats=subformats, **keywords)
  File "/Users/.../music21/music21/converter/subConverters.py", line 510, in write
    dataStr = braille.translate.objectToBraille(obj, **keywords)
  File "/Users/.../music21/music21/braille/translate.py", line 186, in objectToBraille
    return streamToBraille(music21Obj,
  File "/Users/.../music21/music21/braille/translate.py", line 288, in streamToBraille
    return keyboardPartsToBraille(music21Stream,
  File "/Users/.../music21/music21/braille/translate.py", line 620, in keyboardPartsToBraille
    raise BrailleTranslateException('Can only translate two keyboard parts at a time')
music21.braille.translate.BrailleTranslateException: Can only translate two keyboard parts at a time
```