### PR TITLE
Improvements to single measure extraction to musicxml

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -488,6 +488,7 @@ class GeneralObjectExporter:
         representation of a Measure, not for partial
         solutions in Part or Stream production.
         '''
+        m.coreGatherMissingSpanners()
         mCopy = m.makeNotation()
         if mCopy.style.measureNumbering is None:
             # Provide a default

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -492,8 +492,14 @@ class GeneralObjectExporter:
         if mCopy.style.measureNumbering is None:
             # Provide a default
             mCopy.style.measureNumbering = 'measure'
-        if not m.recurse().getElementsByClass('Clef').getElementsByOffset(0.0):
+        clef_from_measure_start_or_context = m.getContextByClass(
+            clef.Clef,
+            getElementMethod=common.enums.ElementSearch.AT_OR_BEFORE_OFFSET
+        )
+        if clef_from_measure_start_or_context is None:
             mCopy.clef = clef.bestClef(mCopy, recurse=True)
+        else:
+            mCopy.clef = clef_from_measure_start_or_context
         p = stream.Part()
         p.append(mCopy)
         p.metadata = copy.deepcopy(getMetadataFromContext(m))

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -489,11 +489,18 @@ class GeneralObjectExporter:
         solutions in Part or Stream production.
         '''
         mCopy = m.makeNotation()
+        if mCopy.style.measureNumbering is None:
+            # Provide a default
+            mCopy.style.measureNumbering = 'measure'
         if not m.recurse().getElementsByClass('Clef').getElementsByOffset(0.0):
             mCopy.clef = clef.bestClef(mCopy, recurse=True)
         p = stream.Part()
         p.append(mCopy)
         p.metadata = copy.deepcopy(getMetadataFromContext(m))
+        context_part = m.getContextByClass(stream.Part)
+        if context_part is not None:
+            p.partName = context_part.partName
+            p.partAbbreviation = context_part.partAbbreviation
         return self.fromPart(p)
 
     def fromVoice(self, v):
@@ -6493,7 +6500,7 @@ class MeasureExporter(XMLExporterBase):
                 mxPrint = Element('print')
             mxMeasureNumbering = SubElement(mxPrint, 'measure-numbering')
             mxMeasureNumbering.text = m.style.measureNumbering
-            mnStyle = m.style.measureNumberingStyle
+            mnStyle = m.style.measureNumberStyle
             if mnStyle is not None:
                 self.setPrintStyleAlign(mxMeasureNumbering, mnStyle)
         # TODO: part-name-display


### PR DESCRIPTION
Improvements to `.measure(n).show()`:
- show the measure number (if no measure number style was set) so you can see what you exported
- show the part name and part abbreviation from the containing part
- fix a bug in musicxml export with a nonexistent member: `AttributeError: 'StreamStyle' object has no attribute 'measureNumberingStyle'`
- get the measure's clef from earlier in the context (previous measure)
- gather spanners