### PR TITLE
Set sixthMinor and seventhMinor to CAUTIONARY in romanNumeralFromChord()

### DIFF
--- a/music21/roman.py
+++ b/music21/roman.py
@@ -756,6 +756,8 @@ def romanNumeralFromChord(
     ...     )
     >>> romanNumeral4
     <music21.roman.RomanNumeral bVI in c minor>
+    >>> romanNumeral4.sixthMinor
+    <Minor67Default.CAUTIONARY: 2>
 
     >>> romanNumeral5 = roman.romanNumeralFromChord(
     ...     chord.Chord(['B4', 'D5', 'F5']),
@@ -1084,7 +1086,8 @@ def romanNumeralFromChord(
             keyObj = _getKeyFromCache(chordObj.seventh.name.lower())
 
     try:
-        rn = RomanNumeral(rnString, keyObj, updatePitches=False)
+        rn = RomanNumeral(rnString, keyObj, updatePitches=False, 
+            sixthMinor=Minor67Default.CAUTIONARY, seventhMinor=Minor67Default.CAUTIONARY)
     except fbNotation.ModifierException as strerror:
         raise RomanNumeralException(
             'Could not parse {0} from chord {1} as an RN '

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -1086,7 +1086,8 @@ def romanNumeralFromChord(
             keyObj = _getKeyFromCache(chordObj.seventh.name.lower())
 
     try:
-        rn = RomanNumeral(rnString, keyObj, updatePitches=False, 
+        rn = RomanNumeral(rnString, keyObj, updatePitches=False,
+            # correctRNAlterationForMinor() adds cautionary
             sixthMinor=Minor67Default.CAUTIONARY, seventhMinor=Minor67Default.CAUTIONARY)
     except fbNotation.ModifierException as strerror:
         raise RomanNumeralException(


### PR DESCRIPTION
Fixes #1217 
Fixes #1229 

FYI @napulen what do you think?

Clarification: this does not change any default behavior of figure or pitch parsing, but simply sets the attributes on the created RomanNumeral object to reflect how the figure should be interpreted, given the figure it was created with. (i.e., the method creates a cautionary "b" in "bVI", so set `sixthMinor` to `CAUTIONARY`.)