### PR TITLE
Clearing bracketedAlterations in RomanNumeral.figure.setter.

### DIFF
--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2977,6 +2977,7 @@ class RomanNumeral(harmony.Harmony):
     def figure(self, newFigure):
         self._figure = newFigure
         if self._parsingComplete:
+            self.bracketedAlterations = []
             self._parseFigure()
             self._updatePitches()
 

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -3926,6 +3926,17 @@ class Test(unittest.TestCase):
             rn_out = romanNumeralFromChord(ch, c_major)
             self.assertEqual(rn.figure, rn_out.figure, f'{aug6}: {rn_out}')
 
+    def testSetFigureAgain(self):
+        """Setting the figure again doesn't double the alterations"""
+        ger = RomanNumeral('Ger7')
+        pitches_before = ger.pitches
+        ger.figure = 'Ger7'
+        self.assertEqual(ger.pitches, pitches_before)
+
+        sharp_four = RomanNumeral('#IV')
+        pitches_before = sharp_four.pitches
+        sharp_four.figure = '#IV'
+        self.assertEqual(sharp_four.pitches, pitches_before)
 
     def testZeroForDiminished(self):
         from music21 import roman


### PR DESCRIPTION
Fixes  #1205. Patch by @napulen (Néstor Nápoles López)

See #1209 for original PR