### PR TITLE
Surface `__eq__()` and `__getitem__()` in doc builds

### DIFF
--- a/documentation/docbuild/documenters.py
+++ b/documentation/docbuild/documenters.py
@@ -419,6 +419,9 @@ class ClassDocumenter(ObjectDocumenter):
         self._readonlyProperties = []
         self._inheritedReadonlyPropertiesMapping = {}
 
+        # Special (dunder) methods to document, if overridden in music21
+        self._allowedSpecialMethods = ['__eq__', '__getitem__']
+
         self.findAttributes()
 
         if self.referent not in self._identityMap:
@@ -453,11 +456,11 @@ class ClassDocumenter(ObjectDocumenter):
 
 
     def findOneAttribute(self, attr):
-        # Ignore definitions derived directly from object
-        if attr.defining_class is object:
+        # Ignore definitions derived directly from builtins (object, list, etc.)
+        if attr.defining_class in __builtins__.values():
             return
         # Ignore private members ('_') and special members ('__')
-        elif attr.name.startswith('_'):
+        elif attr.name.startswith('_') and attr.name not in self._allowedSpecialMethods:
             return
 
         definingClass = attr.defining_class

--- a/documentation/source/developerReference/documenting.rst
+++ b/documentation/source/developerReference/documenting.rst
@@ -55,7 +55,7 @@ Install Jupyter with::
 
     pip3 install jupyter
 
-And then run it by changing directory to the direction you want to edit and run::
+And then run it by changing directory to the one you want to edit and run::
 
     jupyter notebook
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -712,7 +712,7 @@ class Chord(ChordBase):
 
     def __getitem__(self, key: Union[int, str, note.Note, pitch.Pitch]):
         '''
-        Get item makes access pitch components for the Chord easier
+        Get item makes accessing pitch components for the Chord easier
 
         >>> c = chord.Chord('C#4 D-4')
         >>> cSharp = c[0]


### PR DESCRIPTION
We weren't publishing any of the documentation for special ("dunder") methods like `__eq__()` and `__getitem__()`, some of which are very useful to read about, like the new v7 bracket syntax.

Presumably this was to avoid polluting every class with the docs for Python's base implementations on `list`, etc, but this PR works around that by loosening the check for `object` to any builtin (`list`, etc.)
***


<img width="750" alt="Screen Shot 2022-02-26 at 12 25 44 PM" src="https://user-images.githubusercontent.com/38668450/155852922-a63269cb-919f-4069-8f60-20c8375fa3ac.png">
