### PR TITLE
Raise instead of writing invalid musicxml duration types

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1576,7 +1576,7 @@ class Test(unittest.TestCase):
 
         with self.assertRaises(MusicXMLExportException):
             # must splitAtDurations()!
-            out2 = s.write(makeNotation=False)
+            s.write(makeNotation=False)
 
         s = s.splitAtDurations(recurse=True)[0]
         out2 = s.write(makeNotation=False)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1574,6 +1574,11 @@ class Test(unittest.TestCase):
         self.assertEqual(
             len(round_trip_back.parts.first().getElementsByClass(stream.Measure)[1].notes), 1)
 
+        with self.assertRaises(MusicXMLExportException):
+            # must splitAtDurations()!
+            out2 = s.write(makeNotation=False)
+
+        s = s.splitAtDurations(recurse=True)[0]
         out2 = s.write(makeNotation=False)
         round_trip_back = converter.parse(out2)
         # 4/4 will not be assumed; quarter note will still be split out from 5.0QL

--- a/music21/musicxml/helpers.py
+++ b/music21/musicxml/helpers.py
@@ -180,6 +180,17 @@ def measureNumberComesBefore(mNum1: str, mNum2: str) -> bool:
         return m1Suffix is sortedSuffixes[0]
 
 
+def isFullMeasureRest(r: 'music21.note.Rest') -> bool:
+    isFullMeasure = False
+    if r.fullMeasure in (True, 'always'):
+        isFullMeasure = True
+    elif r.fullMeasure == 'auto':
+        tsContext = r.getContextByClass('TimeSignature')
+        if tsContext and tsContext.barDuration.quarterLength == r.duration.quarterLength:
+            isFullMeasure = True
+    return isFullMeasure
+
+
 if __name__ == '__main__':
     import music21
     music21.mainTest()

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2560,7 +2560,8 @@ class PartExporter(XMLExporterBase):
 
         # Split complex durations in place (fast if none found)
         # must do after fixupNotationFlat(), which may create complex durations
-        self.stream = self.stream.splitAtDurations(recurse=True)[0]
+        if self.makeNotation:
+            self.stream = self.stream.splitAtDurations(recurse=True)[0]
 
         # make sure that all instances of the same class have unique ids
         self.spannerBundle.setIdLocals()

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2549,9 +2549,6 @@ class PartExporter(XMLExporterBase):
         if self.stream.atSoundingPitch is True:
             self.stream.toWrittenPitch(inPlace=True)
 
-        # Split complex durations in place (fast if none found)
-        self.stream = self.stream.splitAtDurations(recurse=True)[0]
-
         # Suppose that everything below this is a measure
         if self.makeNotation and not self.stream.getElementsByClass(stream.Measure):
             self.fixupNotationFlat()
@@ -2560,6 +2557,11 @@ class PartExporter(XMLExporterBase):
         elif not self.stream.getElementsByClass(stream.Measure):
             raise MusicXMLExportException(
                 'Cannot export with makeNotation=False if there are no measures')
+
+        # Split complex durations in place (fast if none found)
+        # must do after fixupNotationFlat(), which may create complex durations
+        self.stream = self.stream.splitAtDurations(recurse=True)[0]
+
         # make sure that all instances of the same class have unique ids
         self.spannerBundle.setIdLocals()
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -72,6 +72,10 @@ def typeToMusicXMLType(value):
     'long'
     >>> musicxml.m21ToXml.typeToMusicXMLType('quarter')
     'quarter'
+    >>> musicxml.m21ToXml.typeToMusicXMLType('duplex-maxima')
+    Traceback (most recent call last):
+    music21.musicxml.xmlObjects.MusicXMLExportException:
+    Cannot convert "duplex-maxima" duration to MusicXML (too long).
     >>> musicxml.m21ToXml.typeToMusicXMLType('inexpressible')
     Traceback (most recent call last):
     music21.musicxml.xmlObjects.MusicXMLExportException:
@@ -86,8 +90,15 @@ def typeToMusicXMLType(value):
         return 'long'
     elif value == '2048th':
         raise MusicXMLExportException('Cannot convert "2048th" duration to MusicXML (too short).')
+    elif value == 'duplex-maxima':
+        raise MusicXMLExportException(
+            'Cannot convert "duplex-maxima" duration to MusicXML (too long).')
     elif value == 'inexpressible':
         raise MusicXMLExportException('Cannot convert inexpressible durations to MusicXML.')
+    elif value == 'complex':
+        raise MusicXMLExportException(
+            'Cannot convert complex durations to MusicXML. '
+            + 'Try exporting with makeNotation=True or manually running splitAtDurations()')
     elif value == 'zero':
         raise MusicXMLExportException('Cannot convert durations without types to MusicXML.')
     else:
@@ -3530,20 +3541,15 @@ class MeasureExporter(XMLExporterBase):
         </note>
 
         Notes with complex durations need to be simplified before coming here
-        otherwise they create an impossible musicxml type of "complex"
+        otherwise they raise :class:`MusicXMLExportException`:
 
         >>> nComplex = note.Note()
         >>> nComplex.duration.quarterLength = 5.0
         >>> mxComplex = MEX.noteToXml(nComplex)
-        >>> MEX.dump(mxComplex)
-        <note>
-          <pitch>
-            <step>C</step>
-            <octave>4</octave>
-          </pitch>
-          <duration>50400</duration>
-          <type>complex</type>
-        </note>
+        Traceback (most recent call last):
+        music21.musicxml.xmlObjects.MusicXMLExportException:
+        Cannot convert complex durations to MusicXML.
+        Try exporting with makeNotation=True or manually running splitAtDurations()
 
         TODO: Test with spanners...
 
@@ -3641,7 +3647,14 @@ class MeasureExporter(XMLExporterBase):
             # Default type-less grace durations to eighths
             mxType.text = 'eighth'
         else:
-            mxType.text = typeToMusicXMLType(d.type)
+            try:
+                mxType.text = typeToMusicXMLType(d.type)
+            except MusicXMLExportException:
+                if n.isRest and helpers.isFullMeasureRest(n):
+                    # type will be removed in xmlToRest()
+                    pass
+                else:
+                    raise
 
         self.setStyleAttributes(mxType, n, 'size', 'noteSize')
         mxNote.append(mxType)
@@ -3862,16 +3875,7 @@ class MeasureExporter(XMLExporterBase):
         if mxRestTag is None:
             raise MusicXMLExportException('Something went wrong -- converted rest w/o rest tag')
 
-        isFullMeasure = False
-        if r.fullMeasure in (True, 'always'):
-            isFullMeasure = True
-            mxRestTag.set('measure', 'yes')
-        elif r.fullMeasure == 'auto':
-            tsContext = r.getContextByClass('TimeSignature')
-            if tsContext and tsContext.barDuration.quarterLength == r.duration.quarterLength:
-                isFullMeasure = True
-
-        if isFullMeasure:
+        if helpers.isFullMeasureRest(r):
             mxRestTag.set('measure', 'yes')
             mxType = mxNote.find('type')
             if mxType is not None:
@@ -6982,6 +6986,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(tree.findall('.//rest')), 1)
         rest = tree.find('.//rest')
         self.assertEqual(rest.get('measure'), 'yes')
+        self.assertIsNone(tree.find('.//note/type'))
 
     def testArticulationSpecialCases(self):
         n = note.Note()

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2576,7 +2576,9 @@ class PartExporter(XMLExporterBase):
                 mxMeasure = measureExporter.parse()
             except MusicXMLExportException as e:
                 e.measureNumber = str(m.number)
-                e.partName = self.stream.partName
+                if isinstance(self.stream, stream.Part):
+                    e.partName = self.stream.partName
+                # else: could be a Score without parts (flat)
                 raise e
             self.xmlRoot.append(mxMeasure)
 


### PR DESCRIPTION
Raise an exception instead of writing invalid values for duration types. Necessary for safety before removing the call to `splitAtDurations()` that makes in-place edits on streams where makeNotation=False (see https://github.com/cuthbertLab/music21/commit/a23a64a44e48ffbbeff4a4ae2dd55d08f366ce71#commitcomment-68049838).

/cc @gregchapman-dev