### PR TITLE
Only set a default TempoText style if there is no style already set.

### DIFF
--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -183,29 +183,6 @@ class TempoText(TempoIndication):
     <music21.tempo.TempoText 'adagio'>
     >>> print(tm.text)
     adagio
-    >>> print(tm.style.absoluteY)
-    45
-    >>> tm.style.absoluteY = 33
-    >>> print(tm.style.absoluteY)
-    33
-    >>> print(tm.getTextExpression())
-    <music21.expressions.TextExpression 'adagio'>
-    >>> print(tm.style.absoluteY)
-    33
-    >>> te = music21.expressions.TextExpression('andante')
-    >>> te.style.absoluteY = 38
-    >>> print(te)
-    <music21.expressions.TextExpression 'andante'>
-    >>> print(te.style.absoluteY)
-    38
-    >>> tm.setTextExpression(te)
-    >>> print(tm.getTextExpression())
-    <music21.expressions.TextExpression 'andante'>
-    >>> print(tm.text)
-    andante
-    >>> print(tm.style.absoluteY)
-    38
-    >>>
     '''
 
     def __init__(self, text=None):
@@ -1370,6 +1347,70 @@ class Test(unittest.TestCase):
         self.assertEqual(tm2.text, 'très vite')
         mm = tm2.getMetronomeMark()
         self.assertEqual(mm.number, 144)
+
+    def testTempoTextStyle(self):
+        from music21 import tempo
+        tm = tempo.TempoText('adagio')
+        self.assertEqual(tm.style.absoluteY, 45)
+        self.assertEqual(tm.style.fontStyle, 'bold')
+        tm.style.absoluteY = 33
+        self.assertEqual(tm.style.absoluteY, 33)
+        tm.style.fontStyle = 'italic'
+        tm.style.fontWeight = None
+
+        # check that tm.getTextExpression()/tm.text does not modify style
+        tm.text
+        te1 = tm.getTextExpression()
+        self.assertEqual(te1.content, 'adagio')
+        self.assertEqual(tm.style.absoluteY, 33)
+        self.assertEqual(tm.style.fontStyle, 'italic')
+
+        # check that tm.setTextExpression sets tm.style to the te's style (if there is one),
+        # and links the two styles
+        te2 = music21.expressions.TextExpression('andante')
+        te2.style.absoluteY = 38
+        te2.style.fontStyle = 'bolditalic'
+        self.assertEqual(te2.style.absoluteY, 38)
+        self.assertEqual(te2.style.fontStyle, 'bolditalic')
+        tm.setTextExpression(te2)
+        self.assertEqual(tm.style.absoluteY, 38)
+        self.assertEqual(tm.style.fontStyle, 'bolditalic')
+        self.assertIs(tm.style, te2.style) # check for linked styles
+
+        # check again that calling tm.getTextExpression/tm.text doesn't modify style
+        tm.getTextExpression()
+        tm.text
+        self.assertEqual(tm.style.absoluteY, 38)
+        self.assertEqual(tm.style.fontStyle, 'bolditalic')
+
+        # check that tm.setTextExpression (to a textExpression with no style) leaves tm.style in place
+        # and links the two styles.
+        te3 = music21.expressions.TextExpression('andante with no style')
+        self.assertFalse(te3.hasStyleInformation)
+        self.assertTrue(tm.hasStyleInformation)
+        tm.setTextExpression(te3)
+        self.assertEqual(tm.style.absoluteY, 38) # same as before
+        self.assertEqual(tm.style.fontStyle, 'bolditalic') # same as before
+        self.assertIs(tm.style, te2.style) # check for linked styles
+
+        # check again that calling tm.getTextExpression/tm.text doesn't modify style
+        tm.getTextExpression()
+        tm.text
+        self.assertEqual(tm.style.absoluteY, 38)
+        self.assertEqual(tm.style.fontStyle, 'bolditalic')
+
+        # check that tm.setTextExpression(te4) (with tm and te4 with no style) links the
+        # two styles, with default style set in place.
+        tm.style = None
+        te4 = music21.expressions.TextExpression('andante with no style')
+        self.assertFalse(te4.hasStyleInformation)
+        self.assertFalse(tm.hasStyleInformation)
+        tm.setTextExpression(te4)
+        self.assertEqual(tm.style.absoluteY, 45) # default
+        self.assertEqual(tm.style.fontStyle, 'bold') # default
+        self.assertIs(tm.style, te4.style) # check for linked styles
+
+
 
     def testMetronomeMarkA(self):
         from music21 import tempo

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -1359,7 +1359,8 @@ class Test(unittest.TestCase):
         tm.style.fontWeight = None
 
         # check that tm.getTextExpression()/tm.text does not modify style
-        tm.text
+        tx = tm.text
+        self.assertEqual(tx, 'adagio')
         te1 = tm.getTextExpression()
         self.assertEqual(te1.content, 'adagio')
         self.assertEqual(tm.style.absoluteY, 33)
@@ -1375,27 +1376,29 @@ class Test(unittest.TestCase):
         tm.setTextExpression(te2)
         self.assertEqual(tm.style.absoluteY, 38)
         self.assertEqual(tm.style.fontStyle, 'bolditalic')
-        self.assertIs(tm.style, te2.style) # check for linked styles
+        self.assertIs(tm.style, te2.style)      # check for linked styles
 
         # check again that calling tm.getTextExpression/tm.text doesn't modify style
         tm.getTextExpression()
-        tm.text
+        tx = tm.text
+        self.assertEqual(tx, 'andante')
         self.assertEqual(tm.style.absoluteY, 38)
         self.assertEqual(tm.style.fontStyle, 'bolditalic')
 
-        # check that tm.setTextExpression (to a textExpression with no style) leaves tm.style in place
-        # and links the two styles.
+        # check that tm.setTextExpression (to a textExpression with no
+        # style) leaves tm.style in place and links the two styles.
         te3 = music21.expressions.TextExpression('andante with no style')
         self.assertFalse(te3.hasStyleInformation)
         self.assertTrue(tm.hasStyleInformation)
         tm.setTextExpression(te3)
-        self.assertEqual(tm.style.absoluteY, 38) # same as before
-        self.assertEqual(tm.style.fontStyle, 'bolditalic') # same as before
-        self.assertIs(tm.style, te2.style) # check for linked styles
+        self.assertEqual(tm.style.absoluteY, 38)            # same as before
+        self.assertEqual(tm.style.fontStyle, 'bolditalic')  # same as before
+        self.assertIs(tm.style, te2.style)      # check for linked styles
 
         # check again that calling tm.getTextExpression/tm.text doesn't modify style
         tm.getTextExpression()
-        tm.text
+        tx = tm.text
+        self.assertEqual(tx, 'andante with no style')
         self.assertEqual(tm.style.absoluteY, 38)
         self.assertEqual(tm.style.fontStyle, 'bolditalic')
 
@@ -1406,9 +1409,9 @@ class Test(unittest.TestCase):
         self.assertFalse(te4.hasStyleInformation)
         self.assertFalse(tm.hasStyleInformation)
         tm.setTextExpression(te4)
-        self.assertEqual(tm.style.absoluteY, 45) # default
-        self.assertEqual(tm.style.fontStyle, 'bold') # default
-        self.assertIs(tm.style, te4.style) # check for linked styles
+        self.assertEqual(tm.style.absoluteY, 45)        # default
+        self.assertEqual(tm.style.fontStyle, 'bold')    # default
+        self.assertIs(tm.style, te4.style)      # check for linked styles
 
 
 

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -1350,6 +1350,7 @@ class Test(unittest.TestCase):
 
     def testTempoTextStyle(self):
         from music21 import tempo
+        from music21 import expressions
         tm = tempo.TempoText('adagio')
         self.assertEqual(tm.style.absoluteY, 45)
         self.assertEqual(tm.style.fontStyle, 'bold')
@@ -1368,7 +1369,7 @@ class Test(unittest.TestCase):
 
         # check that tm.setTextExpression sets tm.style to the te's style (if there is one),
         # and links the two styles
-        te2 = music21.expressions.TextExpression('andante')
+        te2 = expressions.TextExpression('andante')
         te2.style.absoluteY = 38
         te2.style.fontStyle = 'bolditalic'
         self.assertEqual(te2.style.absoluteY, 38)
@@ -1387,7 +1388,7 @@ class Test(unittest.TestCase):
 
         # check that tm.setTextExpression (to a textExpression with no
         # style) leaves tm.style in place and links the two styles.
-        te3 = music21.expressions.TextExpression('andante with no style')
+        te3 = expressions.TextExpression('andante with no style')
         self.assertFalse(te3.hasStyleInformation)
         self.assertTrue(tm.hasStyleInformation)
         tm.setTextExpression(te3)
@@ -1405,15 +1406,13 @@ class Test(unittest.TestCase):
         # check that tm.setTextExpression(te4) (with tm and te4 with no style) links the
         # two styles, with default style set in place.
         tm.style = None
-        te4 = music21.expressions.TextExpression('andante with no style')
+        te4 = expressions.TextExpression('andante with no style')
         self.assertFalse(te4.hasStyleInformation)
         self.assertFalse(tm.hasStyleInformation)
         tm.setTextExpression(te4)
         self.assertEqual(tm.style.absoluteY, 45)        # default
         self.assertEqual(tm.style.fontStyle, 'bold')    # default
         self.assertIs(tm.style, te4.style)      # check for linked styles
-
-
 
     def testMetronomeMarkA(self):
         from music21 import tempo

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -183,6 +183,29 @@ class TempoText(TempoIndication):
     <music21.tempo.TempoText 'adagio'>
     >>> print(tm.text)
     adagio
+    >>> print(tm.style.absoluteY)
+    45
+    >>> tm.style.absoluteY = 33
+    >>> print(tm.style.absoluteY)
+    33
+    >>> print(tm.getTextExpression())
+    <music21.expressions.TextExpression 'adagio'>
+    >>> print(tm.style.absoluteY)
+    33
+    >>> te = music21.expressions.TextExpression('andante')
+    >>> te.style.absoluteY = 38
+    >>> print(te)
+    <music21.expressions.TextExpression 'andante'>
+    >>> print(te.style.absoluteY)
+    38
+    >>> tm.setTextExpression(te)
+    >>> print(tm.getTextExpression())
+    <music21.expressions.TextExpression 'adagio'>
+    >>> print(tm.text)
+    andante
+    >>> print(tm.style.absoluteY)
+    38
+    >>>
     '''
 
     def __init__(self, text=None):

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -200,7 +200,7 @@ class TempoText(TempoIndication):
     38
     >>> tm.setTextExpression(te)
     >>> print(tm.getTextExpression())
-    <music21.expressions.TextExpression 'adagio'>
+    <music21.expressions.TextExpression 'andante'>
     >>> print(tm.text)
     andante
     >>> print(tm.style.absoluteY)

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -213,8 +213,9 @@ class TempoText(TempoIndication):
             if self.hasStyleInformation:
                 self._textExpression.style = self.style  # link styles
             else:
+                # link the styles and set default style
                 self.style = self._textExpression.style
-            self.applyTextFormatting()
+                self.applyTextFormatting()
         else:
             self._textExpression.content = value
 
@@ -255,7 +256,6 @@ class TempoText(TempoIndication):
         if self._textExpression is None:
             return None
         else:
-            self.applyTextFormatting(numberImplicit=numberImplicit)
             return copy.deepcopy(self._textExpression)
 
     def setTextExpression(self, value):
@@ -263,7 +263,16 @@ class TempoText(TempoIndication):
         Given a TextExpression, set it in this object.
         '''
         self._textExpression = value
-        self.applyTextFormatting()
+        if self._textExpression.hasStyleInformation:
+            # link styles (use the new _textExpression's style)
+            self.style = self._textExpression.style
+        elif self.hasStyleInformation:
+            # link styles (use self.style)
+            self._textExpression.style = self.style
+        else:
+            # no styles at all: link the styles and set default style
+            self.style = self._textExpression.style
+            self.applyTextFormatting()
 
     def applyTextFormatting(self, te=None, numberImplicit=False):
         '''

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -1350,7 +1350,6 @@ class Test(unittest.TestCase):
 
     def testTempoTextStyle(self):
         from music21 import tempo
-        from music21 import expressions
         tm = tempo.TempoText('adagio')
         self.assertEqual(tm.style.absoluteY, 45)
         self.assertEqual(tm.style.fontStyle, 'bold')


### PR DESCRIPTION
… And never set a default TempoText style when getting a property.