### PR TITLE
expandRepeats() partname (Fixes #1165)

### DIFF
--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -26,9 +26,6 @@ from music21 import expressions
 from music21 import spanner
 from music21 import style
 
-from music21 import converter
-from music21 import bar
-
 from music21 import environment
 _MOD = 'repeat'
 environLocal = environment.Environment(_MOD)
@@ -4370,6 +4367,10 @@ class Test(unittest.TestCase):
     def test_expand_repeats(self):
         # Test case provided by jacobtylerwalls on issue #1165
         # https://github.com/cuthbertLab/music21/issues/1165#issuecomment-967293691
+
+        from music21 import converter
+        from music21 import bar
+
         p = converter.parse('tinyNotation: c1 d e f')
         p.measure(2).storeAtEnd(bar.Repeat(direction='end', times=1))
         p.partName = 'mypartname'

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -26,6 +26,9 @@ from music21 import expressions
 from music21 import spanner
 from music21 import style
 
+from music21 import converter
+from music21 import bar
+
 from music21 import environment
 _MOD = 'repeat'
 environLocal = environment.Environment(_MOD)
@@ -4363,6 +4366,16 @@ class Test(unittest.TestCase):
 #         s = converter.parse(testFiles.hectorTheHero)
 #         s.show()
 #         post = s.expandRepeats()
+
+    def test_expand_repeats(self):
+        # Test case provided by jacobtylerwalls on issue #1165
+        # https://github.com/cuthbertLab/music21/issues/1165#issuecomment-967293691
+        p = converter.parse('tinyNotation: c1 d e f')
+        p.measure(2).storeAtEnd(bar.Repeat(direction='end', times=1))
+        p.partName = 'mypartname'
+        exp = p.expandRepeats()
+        self.assertEqual(exp.partName, 'mypartname')
+
 
 
 # ------------------------------------------------------------------------------

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -4366,7 +4366,7 @@ class Test(unittest.TestCase):
 #         s.show()
 #         post = s.expandRepeats()
 
-    def test_expand_repeats(self):
+    def test_expand_repeats_preserves_name(self):
         # Test case provided by jacobtylerwalls on issue #1165
         # https://github.com/cuthbertLab/music21/issues/1165#issuecomment-967293691
 
@@ -4376,8 +4376,9 @@ class Test(unittest.TestCase):
         p = converter.parse('tinyNotation: c1 d e f')
         p.measure(2).storeAtEnd(bar.Repeat(direction='end', times=1))
         p.partName = 'mypartname'
+        p.partAbbreviation = 'mypartabbreviation'
         exp = p.expandRepeats()
-        self.assertEqual(exp.partName, 'mypartname')
+        self.assertEqual(exp.partAbbreviation, 'mypartabbreviation')
 
 
 # ------------------------------------------------------------------------------

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -4380,7 +4380,6 @@ class Test(unittest.TestCase):
         self.assertEqual(exp.partName, 'mypartname')
 
 
-
 # ------------------------------------------------------------------------------
 # define presented order in documentation
 _DOC_ORDER = [RepeatExpression, RepeatExpressionMarker, Coda, Segno, Fine,

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -4378,6 +4378,7 @@ class Test(unittest.TestCase):
         p.partName = 'mypartname'
         p.partAbbreviation = 'mypartabbreviation'
         exp = p.expandRepeats()
+        self.assertEqual(exp.partName, 'mypartname')
         self.assertEqual(exp.partAbbreviation, 'mypartabbreviation')
 
 

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -802,6 +802,8 @@ class Expander:
         # TODO: need to copy spanners from each sub-group into their newest connects;
         #   must be done here as more than one connection is made
 
+        post.mergeAttributes(srcStream)
+
         return post
 
     def measureMap(self, returnType='index'):

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1213,7 +1213,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         super().mergeAttributes(other)
 
         for attr in ('autoSort', 'isSorted', 'definesExplicitSystemBreaks',
-                     'definesExplicitPageBreaks', '_atSoundingPitch', '_mutable', '_partName', '_partAbbreviation'):
+                     'definesExplicitPageBreaks', '_atSoundingPitch', '_mutable'):
             if hasattr(other, attr):
                 setattr(self, attr, getattr(other, attr))
 
@@ -13516,6 +13516,19 @@ class Part(Stream):
         else:  # in place
             return None
 
+    def mergeAttributes(self, other: 'Part'):
+        '''
+        Merge relevant attributes from the Other part
+        into this one. Key attributes of difference: partName and partAbbreviation.
+        
+        TODO: doc test
+        '''
+
+        super().mergeAttributes(other)
+
+        for attr in ('_partName', '_partAbbreviation'):
+            if hasattr(other, attr):
+                setattr(self, attr, getattr(other, attr))
 
 class PartStaff(Part):
     '''

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -13520,7 +13520,7 @@ class Part(Stream):
         '''
         Merge relevant attributes from the Other part
         into this one. Key attributes of difference: partName and partAbbreviation.
-        
+
         TODO: doc test
         '''
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1213,7 +1213,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         super().mergeAttributes(other)
 
         for attr in ('autoSort', 'isSorted', 'definesExplicitSystemBreaks',
-                     'definesExplicitPageBreaks', '_atSoundingPitch', '_mutable'):
+                     'definesExplicitPageBreaks', '_atSoundingPitch', '_mutable', '_partName', '_partAbbreviation'):
             if hasattr(other, attr):
                 setattr(self, attr, getattr(other, attr))
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -37,6 +37,7 @@ from music21 import metadata
 from music21 import meter
 from music21 import note
 from music21 import pitch
+from music21 import converter
 
 from music21.musicxml import m21ToXml
 
@@ -8587,6 +8588,15 @@ class Test(unittest.TestCase):
         self.assertIs(n.activeSite, s2)
         self.assertTrue(s1.notes)
         self.assertIs(n.activeSite, s2)
+
+    def test_expand_repeats(self):
+        # Test case provided by jacobtylerwalls on issue #1165
+        # https://github.com/cuthbertLab/music21/issues/1165#issuecomment-967293691
+        p = converter.parse('tinyNotation: c1 d e f')
+        p.measure(2).storeAtEnd(bar.Repeat(direction='end', times=1))
+        p.partName = 'mypartname'
+        exp = p.expandRepeats()
+        self.assertEqual(exp.partName, 'mypartname')
 
 # -----------------------------------------------------------------------------
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -37,7 +37,6 @@ from music21 import metadata
 from music21 import meter
 from music21 import note
 from music21 import pitch
-from music21 import converter
 
 from music21.musicxml import m21ToXml
 
@@ -8588,16 +8587,6 @@ class Test(unittest.TestCase):
         self.assertIs(n.activeSite, s2)
         self.assertTrue(s1.notes)
         self.assertIs(n.activeSite, s2)
-
-    def test_expand_repeats(self):
-        # Test case provided by jacobtylerwalls on issue #1165
-        # https://github.com/cuthbertLab/music21/issues/1165#issuecomment-967293691
-        p = converter.parse('tinyNotation: c1 d e f')
-        p.measure(2).storeAtEnd(bar.Repeat(direction='end', times=1))
-        p.partName = 'mypartname'
-        exp = p.expandRepeats()
-        self.assertEqual(exp.partName, 'mypartname')
-
 # -----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Changes are as follows:
1. Implementation of @jacobtylerwalls 's [code snippet](https://github.com/cuthbertLab/music21/issues/1165#issuecomment-967293691) as a test case
2. Adjusting `mergeAttributes()` in `stream/base.py` to also port over `_partName` and `_partAbbreviation`
3. Manually calling `mergeAttributes()` at the end of `expandRepeats()`

If there are any grievous styling/syntax problems let me know!