### PR TITLE
Cleanups for musicxml 4 TODO status

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -6,6 +6,38 @@
         <language minSize="100" name="Python" />
       </Languages>
     </inspection_tool>
+    <inspection_tool class="HttpUrlsUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredUrls">
+        <list>
+          <option value="http://localhost" />
+          <option value="http://127.0.0.1" />
+          <option value="http://0.0.0.0" />
+          <option value="http://www.w3.org/" />
+          <option value="http://json-schema.org/draft" />
+          <option value="http://java.sun.com/" />
+          <option value="http://xmlns.jcp.org/" />
+          <option value="http://javafx.com/javafx/" />
+          <option value="http://javafx.com/fxml" />
+          <option value="http://maven.apache.org/xsd/" />
+          <option value="http://maven.apache.org/POM/" />
+          <option value="http://www.springframework.org/schema/" />
+          <option value="http://www.springframework.org/tags" />
+          <option value="http://www.springframework.org/security/tags" />
+          <option value="http://www.thymeleaf.org" />
+          <option value="http://www.jboss.org/j2ee/schema/" />
+          <option value="http://www.jboss.com/xml/ns/" />
+          <option value="http://www.ibm.com/webservices/xsd" />
+          <option value="http://activemq.apache.org/schema/" />
+          <option value="http://schema.cloudfoundry.org/spring/" />
+          <option value="http://schemas.xmlsoap.org/" />
+          <option value="http://cxf.apache.org/schemas/" />
+          <option value="http://primefaces.org/ui" />
+          <option value="http://tiles.apache.org/" />
+          <option value="http://www.musicxml.org" />
+          <option value="http://www.datypic.com" />
+        </list>
+      </option>
+    </inspection_tool>
     <inspection_tool class="ProblematicWhitespace" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PyAbstractClassInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PyChainedComparisonsInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">

--- a/music21/base.py
+++ b/music21/base.py
@@ -652,7 +652,7 @@ class Music21Object(prebase.ProtoM21Object):
         return not (self._editorial is None)
 
     @property
-    def editorial(self) -> editorial.Editorial:
+    def editorial(self) -> 'music21.editorial.Editorial':
         '''
         a :class:`~music21.editorial.Editorial` object that stores editorial information
         (comments, footnotes, harmonic information, ficta).
@@ -668,13 +668,18 @@ class Music21Object(prebase.ProtoM21Object):
         >>> n.editorial
         <music21.editorial.Editorial {'ficta': <music21.pitch.Accidental sharp>}>
         '''
+        # Dev note: because property editorial shadows module editorial,
+        # typing has to be in quotes.
+
         # anytime something is changed here, change in style.StyleMixin and vice-versa
         if self._editorial is None:
             self._editorial = editorial.Editorial()
         return self._editorial
 
     @editorial.setter
-    def editorial(self, ed: editorial.Editorial):
+    def editorial(self, ed: 'music21.editorial.Editorial'):
+        # Dev note: because property editorial shadows module editorial,
+        # typing has to be in quotes.
         self._editorial = ed
 
     @property
@@ -700,7 +705,7 @@ class Music21Object(prebase.ProtoM21Object):
         return not (self._style is None)
 
     @property
-    def style(self) -> style.Style:
+    def style(self) -> 'music21.style.Style':
         '''
         Returns (or Creates and then Returns) the Style object
         associated with this object, or sets a new
@@ -722,6 +727,8 @@ class Music21Object(prebase.ProtoM21Object):
         >>> n.style.absoluteX is None
         True
         '''
+        # Dev note: because property style shadows module style,
+        # typing has to be in quotes.
         # anytime something is changed here, change in style.StyleMixin and vice-versa
         if not self.hasStyleInformation:
             StyleClass = self._styleClass
@@ -729,7 +736,9 @@ class Music21Object(prebase.ProtoM21Object):
         return self._style
 
     @style.setter
-    def style(self, newStyle: Optional[style.Style]):
+    def style(self, newStyle: Optional['music21.style.Style']):
+        # Dev note: because property style shadows module style,
+        # typing has to be in quotes.
         self._style = newStyle
 
     # convenience.
@@ -3438,7 +3447,7 @@ class Music21Object(prebase.ProtoM21Object):
         '''
         ts: Optional['music21.meter.TimeSignature'] = self.getContextByClass(
             'TimeSignature',
-            getElementMethod=ElementSearch.BEFORE_OFFSET
+            getElementMethod=ElementSearch.AT_OR_BEFORE_OFFSET
         )
         if ts is None:
             raise Music21ObjectException('this object does not have a TimeSignature in Sites')

--- a/music21/base.py
+++ b/music21/base.py
@@ -985,7 +985,7 @@ class Music21Object(prebase.ProtoM21Object):
     def getOffsetInHierarchy(
         self,
         site: Optional['music21.stream.Stream']
-     ) -> Union[float, fractions.Fraction]:
+    ) -> Union[float, fractions.Fraction]:
         '''
         For an element which may not be in site, but might be in a Stream in site (or further
         in streams), find the cumulative offset of the element in that site.
@@ -1055,7 +1055,9 @@ class Music21Object(prebase.ProtoM21Object):
 
         raise SitesException(f'Element {self} is not in hierarchy of {site}')
 
-    def getSpannerSites(self, spannerClassList: Optional[Iterable] = None) -> List['music21.spanner.Spanner']:
+    def getSpannerSites(self,
+                        spannerClassList: Optional[Iterable] = None
+                        ) -> List['music21.spanner.Spanner']:
         '''
         Return a list of all :class:`~music21.spanner.Spanner` objects
         (or Spanner subclasses) that contain

--- a/music21/base.py
+++ b/music21/base.py
@@ -6,7 +6,7 @@
 # Authors:      Michael Scott Cuthbert
 #               Christopher Ariza
 #
-# Copyright:    Copyright © 2006-2021 Michael Scott Cuthbert and the music21
+# Copyright:    Copyright © 2006-2022 Michael Scott Cuthbert and the music21
 #               Project
 # License:      BSD, see license.txt
 # -----------------------------------------------------------------------------
@@ -276,7 +276,7 @@ class Music21Object(prebase.ProtoM21Object):
 
     All music21 objects have these pieces of information:
 
-    1.  id: identification string unique to the objects container (optional).
+    1.  id: identification string unique to the object's container (optional).
         Defaults to the `id()` of the element.
     2.  groups: a Groups object: which is a list of strings identifying
         internal sub-collections (voices, parts, selections) to which this
@@ -311,7 +311,7 @@ class Music21Object(prebase.ProtoM21Object):
 
     _styleClass: Type[style.Style] = style.Style
 
-    # define order to present names in documentation; use strings
+    # define order for presenting names in documentation; use strings
     _DOC_ORDER = []
 
     # documentation for all attributes (not properties or methods)
@@ -375,7 +375,7 @@ class Music21Object(prebase.ProtoM21Object):
         self._derivation: Optional[Derivation] = None
 
         self._style: Optional[style.Style] = None
-        self._editorial = None
+        self._editorial: Optional[editorial.Editorial] = None
 
         # private duration storage; managed by property
         self._duration: Optional[duration.Duration] = None
@@ -630,7 +630,7 @@ class Music21Object(prebase.ProtoM21Object):
     # --------------------------------------------------------------------------
 
     @property
-    def hasEditorialInformation(self):
+    def hasEditorialInformation(self) -> bool:
         '''
         Returns True if there is a :class:`~music21.editorial.Editorial` object
         already associated with this object, False otherwise.
@@ -648,10 +648,11 @@ class Music21Object(prebase.ProtoM21Object):
         >>> mObj.hasEditorialInformation
         True
         '''
+        # anytime something is changed here, change in style.StyleMixin and vice-versa
         return not (self._editorial is None)
 
     @property
-    def editorial(self) -> 'music21.editorial.Editorial':
+    def editorial(self) -> editorial.Editorial:
         '''
         a :class:`~music21.editorial.Editorial` object that stores editorial information
         (comments, footnotes, harmonic information, ficta).
@@ -667,12 +668,13 @@ class Music21Object(prebase.ProtoM21Object):
         >>> n.editorial
         <music21.editorial.Editorial {'ficta': <music21.pitch.Accidental sharp>}>
         '''
+        # anytime something is changed here, change in style.StyleMixin and vice-versa
         if self._editorial is None:
             self._editorial = editorial.Editorial()
         return self._editorial
 
     @editorial.setter
-    def editorial(self, ed: 'music21.editorial.Editorial'):
+    def editorial(self, ed: editorial.Editorial):
         self._editorial = ed
 
     @property
@@ -694,10 +696,11 @@ class Music21Object(prebase.ProtoM21Object):
         >>> mObj.hasStyleInformation
         True
         '''
+        # anytime something is changed here, change in style.StyleMixin and vice-versa
         return not (self._style is None)
 
     @property
-    def style(self) -> 'music21.style.Style':
+    def style(self) -> style.Style:
         '''
         Returns (or Creates and then Returns) the Style object
         associated with this object, or sets a new
@@ -719,22 +722,24 @@ class Music21Object(prebase.ProtoM21Object):
         >>> n.style.absoluteX is None
         True
         '''
+        # anytime something is changed here, change in style.StyleMixin and vice-versa
         if not self.hasStyleInformation:
             StyleClass = self._styleClass
             self._style = StyleClass()
         return self._style
 
     @style.setter
-    def style(self, newStyle: Optional['music21.style.Style']):
+    def style(self, newStyle: Optional[style.Style]):
         self._style = newStyle
 
-    # --------------------------
-    # convenience.  used to be in note.Note, but belongs everywhere:
+    # convenience.
 
     @property
     def quarterLength(self) -> OffsetQL:
         '''
         Set or Return the Duration as represented in Quarter Length, possibly as a fraction.
+
+        Same as setting `.duration.quarterLength`.
 
         >>> n = note.Note()
         >>> n.quarterLength = 2.0
@@ -977,7 +982,10 @@ class Music21Object(prebase.ProtoM21Object):
                 value = float(value)
             self._naiveOffset = value
 
-    def getOffsetInHierarchy(self, site) -> Union[float, fractions.Fraction]:
+    def getOffsetInHierarchy(
+        self,
+        site: Optional['music21.stream.Stream']
+     ) -> Union[float, fractions.Fraction]:
         '''
         For an element which may not be in site, but might be in a Stream in site (or further
         in streams), find the cumulative offset of the element in that site.
@@ -1047,7 +1055,7 @@ class Music21Object(prebase.ProtoM21Object):
 
         raise SitesException(f'Element {self} is not in hierarchy of {site}')
 
-    def getSpannerSites(self, spannerClassList=None) -> List['music21.spanner.Spanner']:
+    def getSpannerSites(self, spannerClassList: Optional[Iterable] = None) -> List['music21.spanner.Spanner']:
         '''
         Return a list of all :class:`~music21.spanner.Spanner` objects
         (or Spanner subclasses) that contain
@@ -1140,7 +1148,7 @@ class Music21Object(prebase.ProtoM21Object):
         A Music21Object may, due to deep copying or other reasons,
         have a site (with an offset) which
         no longer contains the Music21Object. These lingering sites
-        are called orphans. This methods gets rid of them.
+        are called orphans. This method gets rid of them.
 
         The `excludeStorageStreams` are SpannerStorage and VariantStorage.
         '''
@@ -1530,7 +1538,7 @@ class Music21Object(prebase.ProtoM21Object):
             of the last .activeSite (even if it is dead.  A lot of code depends on .offset
             still being available if .activeSite dies, so changing that is not an option for now).
             So its sortTuple is 0.0 <0.-31.3>. which has a .previous() of tb2 in s, which can
-            call previous can get tb1, etc. So with really bad timing of cache cleanups and
+            call previous can get tb1, etc. So with terrible timing of cache cleanups and
             garbage collecting, it's possible to get an infinite loop.
 
             There may be ways to set activeSite on .getContextByClass() call such that this routine
@@ -1542,7 +1550,7 @@ class Music21Object(prebase.ProtoM21Object):
             then in another stream context (a), created earlier,
             we have [tb0, tb1, tb2].  tb1 is set up with (b) as an activeSite. Finding nothing
             previous, it goes to (a) and finds tb2; it then discovers that in (a), tb2 is after
-            tb1 so it returns None for this context.  One might say, "wait a second, why
+            tb1, so it returns None for this context.  One might say, "wait a second, why
             isn't tb0 returned? It's going to be skipped." To this, I would answer, the original
             context in which .previous() or .getContextByClass() was called was (b). There is
             no absolute obligation to find what was previous in a different site context. It is
@@ -1701,7 +1709,7 @@ class Music21Object(prebase.ProtoM21Object):
         (<music21.stream.Part Alto>, '9.0 <0.-20...>', 'flatten')
         (<music21.stream.Score bach>, '9.0 <0.-20...>', 'elementsOnly')
 
-        Here we make a copy of the earlier measure and we see that its contextSites
+        Here we make a copy of the earlier measure, and we see that its contextSites
         follow the derivationChain from the original measure and still find the Part
         and Score of the original Measure 3 even though mCopy is not in any of these
         objects.
@@ -1766,7 +1774,7 @@ class Music21Object(prebase.ProtoM21Object):
         >>> p2.append(m2)
 
         The keys could have appeared in any order, but by default
-        we set set priorityTarget to activeSite.  So this is the same as omitting.
+        we set priorityTarget to activeSite.  So this is the same as omitting.
 
         >>> for y in n.contextSites(priorityTarget=n.activeSite):
         ...     print(y[0])
@@ -1871,7 +1879,7 @@ class Music21Object(prebase.ProtoM21Object):
 
                 positionInStream = st.modify(offset=newOffset)
             except SitesException:
-                continue  # not a valid site any more.  Could be caught in derivationChain
+                continue  # not a valid site anymore.  Could be caught in derivationChain
 
             recursionType = siteObj.recursionType
             if returnSortTuples:
@@ -1969,7 +1977,7 @@ class Music21Object(prebase.ProtoM21Object):
         el = self.getContextByClass(className)
         while el is not None:
             yield el
-            el = el.getContextByClass(className, getElementMethod='getElementBeforeOffset')
+            el = el.getContextByClass(className, getElementMethod=ElementSearch.BEFORE_OFFSET)
 
     # -------------------------------------------------------------------------
 
@@ -2139,15 +2147,16 @@ class Music21Object(prebase.ProtoM21Object):
         # maxRecurse = 20
 
         prevEl = self.getContextByClass(className=className,
-                                        getElementMethod='getElementBeforeNotSelf',
+                                        getElementMethod=ElementSearch.BEFORE_NOT_SELF,
                                         followDerivation=not activeSiteOnly,
                                         priorityTargetOnly=activeSiteOnly,
                                         )
 
         # for singleSiteContext, unused_positionInContext, unused_recurseType in allSiteContexts:
         #     if prevEl is singleSiteContext:
-        #         prevElPrev = prevEl.getContextByClass(prevEl.__class__,
-        #                                             getElementMethod='getElementBeforeNotSelf')
+        #         prevElPrev = prevEl.getContextByClass(
+        #                          prevEl.__class__,
+        #                          getElementMethod=ElementSearch.BEFORE_NOT_SELF)
         #         if prevElPrev and prevElPrev is not self:
         #             return prevElPrev
         isInPart = False
@@ -2445,7 +2454,7 @@ class Music21Object(prebase.ProtoM21Object):
 
         5) isNotGrace = {0, 1}; 0 = grace, 1 = normal. Grace notes sort before normal notes
 
-        6) The last tie breaker is the creation time (insertIndex) of the site object
+        6) The last tie-breaker is the creation time (insertIndex) of the site object
         represented by the activeSite.
 
         >>> n = note.Note()
@@ -2701,7 +2710,7 @@ class Music21Object(prebase.ProtoM21Object):
     def _reprText(self, **keywords):
         '''
         Return a text representation possible with line
-        breaks. This methods can be overridden by subclasses
+        breaks. This method can be overridden by subclasses
         to provide alternative text representations.
         '''
         return repr(self)
@@ -2709,7 +2718,7 @@ class Music21Object(prebase.ProtoM21Object):
     def _reprTextLine(self):
         '''
         Return a text representation without line breaks. This
-        methods can be overridden by subclasses to provide
+        method can be overridden by subclasses to provide
         alternative text representations.
         '''
         return repr(self)
@@ -2784,7 +2793,7 @@ class Music21Object(prebase.ProtoM21Object):
         Return a list of Stream subclasses that this object
         is contained within or (if followDerivation is set) is derived from.
 
-        This gives access to the hierarchy that contained or
+        This method gives access to the hierarchy that contained or
         created this object.
 
         >>> s = corpus.parse('bach/bwv66.6')
@@ -3057,7 +3066,7 @@ class Music21Object(prebase.ProtoM21Object):
                     # keep start  if already set
                     forceEndTieType = 'continue'
                 # a stop was ending a previous tie; we know that
-                # the first is now a continue
+                # the first is now a "continue" type
                 elif e.tie.type == 'stop':
                     forceEndTieType = 'stop'
                     e.tie.type = 'continue'
@@ -3084,7 +3093,7 @@ class Music21Object(prebase.ProtoM21Object):
                         # keep start  if already set
                         forceEndTieType = 'continue'
                     # a stop was ending a previous tie; we know that
-                    # the first is now a continue
+                    # the first is now a "continue" type
                     elif component.tie.type == 'stop':
                         forceEndTieType = 'stop'
                         component.tie.type = 'continue'
@@ -3320,7 +3329,7 @@ class Music21Object(prebase.ProtoM21Object):
         >>> n2.measureNumber
         0
 
-        This updates live if the measure number changes:
+        The property updates if the object's surrounding measure's number changes:
 
         >>> m2.number = 11
         >>> n2.measureNumber
@@ -3426,7 +3435,9 @@ class Music21Object(prebase.ProtoM21Object):
         extracted to make sure that all three of the routines use the same one.
         '''
         ts: Optional['music21.meter.TimeSignature'] = self.getContextByClass(
-            'TimeSignature', getElementMethod='getElementAtOrBeforeOffset')
+            'TimeSignature',
+            getElementMethod=ElementSearch.BEFORE_OFFSET
+        )
         if ts is None:
             raise Music21ObjectException('this object does not have a TimeSignature in Sites')
         return ts
@@ -4477,7 +4488,7 @@ class Test(unittest.TestCase):
         self.assertEqual(n1.beat, 1.0)
 
         # the Measure.padAsAnacrusis() method looks at the barDuration and,
-        # if the Measure is incomplete, assumes its an anacrusis and adds
+        # if the Measure is incomplete, assumes it is an anacrusis and adds
         # the appropriate padding
         m1.padAsAnacrusis()
         # app values are the same except _getMeasureOffset()
@@ -4659,9 +4670,14 @@ class Test(unittest.TestCase):
                          '<music21.tempo.MetronomeMark Eighth=150>')
         # if we provide the getElementMethod parameter, we can use
         # getElementBeforeOffset
-        self.assertEqual(str(mm2.getContextByClass('MetronomeMark',
-                                                   getElementMethod='getElementBeforeOffset')),
-                         '<music21.tempo.MetronomeMark lento 16th=50>')
+        self.assertEqual(
+            str(
+                mm2.getContextByClass(
+                    'MetronomeMark',
+                    getElementMethod=ElementSearch.BEFORE_OFFSET
+                )
+            ),
+            '<music21.tempo.MetronomeMark lento 16th=50>')
 
     def testElementWrapperOffsetAccess(self):
         from music21 import stream
@@ -5006,7 +5022,7 @@ class Test(unittest.TestCase):
         self.assertEqual(set(n2.getSpannerSites(['Slur', 'Diminuendo'])), {sp1, sp3})
 
         # The order spanners are returned is generally the order that they were
-        # added, but that is not guaranteed, so for safety sake, use set comparisons:
+        # added, but that is not guaranteed, so for safety's sake, use set comparisons:
 
         self.assertEqual(set(n2.getSpannerSites(['Slur', 'Diminuendo'])), {sp3, sp1})
 

--- a/music21/musicxml/archiveTools.py
+++ b/music21/musicxml/archiveTools.py
@@ -6,7 +6,7 @@
 # Authors:      Christopher Ariza
 #               Michael Scott Cuthbert
 #
-# Copyright:    Copyright © 2009, 2017 Michael Scott Cuthbert and the music21 Project
+# Copyright:    Copyright © 2009, 2017, 2022 Michael Scott Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # -----------------------------------------------------------------------------
 '''
@@ -116,7 +116,7 @@ def uncompressMXL(filename: Union[str, pathlib.Path],
     '''
     filename = str(filename)
     if not filename.endswith('.mxl') and strictMxlCheck:
-        return  # not a compressed musicXML file
+        return False  # not a compressed musicXML file
 
     fp: pathlib.Path = common.pathTools.cleanpath(filename, returnPathlib=True)
     environLocal.warn(f"Updating file: {fp}")
@@ -144,10 +144,10 @@ def uncompressMXL(filename: Union[str, pathlib.Path],
                         wrongName.rename(correctName)
                         found_one_file = True
 
-
     # Delete uncompressed xml file from system
     if deleteOriginal:
         fp.unlink()
+    return True
 
 
 if __name__ == '__main__':

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -3,10 +3,11 @@
 # Name:         musicxml/m21ToXml.py
 # Purpose:      Translate from music21 objects to musicxml representation
 #
-# Authors:      Christopher Ariza
-#               Michael Scott Cuthbert
+# Authors:      Michael Scott Cuthbert
+#               Christopher Ariza
+#               Jacob Tyler Walls
 #
-# Copyright:    Copyright © 2010-2012, 2015-19 Michael Scott Cuthbert and the music21 Project
+# Copyright:    Copyright © 2010-22 Michael Scott Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
@@ -228,7 +229,7 @@ def _setTagTextFromAttribute(
 
 def _setAttributeFromAttribute(m21El, xmlEl, xmlAttributeName, attributeName=None, transform=None):
     '''
-    If m21El has a at least one element of tag==tag with some text. If
+    If m21El has at least one element of tag==tag with some text. If
     it does, set the attribute either with the same name (with "foo-bar" changed to
     "fooBar") or with attributeName to the text contents.
 
@@ -571,7 +572,7 @@ class GeneralObjectExporter:
         Translate a music21 :class:`~music21.duration.Duration` into
         a complete MusicXML representation.
 
-        Rarely rarely used.  Only if you call .show() on a duration object
+        Rarely, rarely used.  Only if you call .show() on a duration object
         '''
         # make a copy, as we this process will change tuple types
         # not needed, since fromGeneralNote does it too.  but so
@@ -2356,8 +2357,8 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
                 mxSoftware = SubElement(mxEncoding, 'software')
                 mxSoftware.text = software
         else:
-            # there will not be a music21 software tag if no scoreMetadata
-            # if not for this.
+            # there will not be a music21 software tag if there was no scoreMetadata
+            # if not for these lines.
             mxSoftware = SubElement(mxEncoding, 'software')
             mxSoftware.text = defaults.software
 
@@ -2659,7 +2660,7 @@ class PartExporter(XMLExporterBase):
                     and thisInstrument.instrumentId in self.parent.instrumentIdList)):
                 thisInstrument.instrumentIdRandomize()
 
-            # add to lists for checking on next part
+            # add to the lists for checking on next part
             if self.parent is not None:
                 self.parent.instrumentIdList.append(thisInstrument.instrumentId)
                 if thisInstrument is self.firstInstrumentObject:
@@ -2671,7 +2672,7 @@ class PartExporter(XMLExporterBase):
 
         Does nothing in the normal case of single staves.
 
-        Returns whether or not instrument processing should short circuit,
+        Returns whether instrument processing should short circuit,
         which is False for the general case and True for subsequent
         PartStaff objects after the first in a group.
         '''
@@ -5886,7 +5887,7 @@ class MeasureExporter(XMLExporterBase):
 
         # not to be done: repeater (deprecated)
         self.setColor(mxBeam, beamObject)
-        # again, we pass the name 'fan' twice so we don't have to run
+        # again, we pass the name 'fan' twice, so we don't have to run
         # hyphenToCamelCase on it.
         self.setStyleAttributes(mxBeam, beamObject, 'fan', 'fan')
 
@@ -7039,10 +7040,10 @@ class Test(unittest.TestCase):
     def testExportChordSymbolsWithRealizedDurations(self):
         gex = GeneralObjectExporter()
 
-        def realizeDurationsAndAssertTags(m: stream.Measure, forwardTag=False, offsetTag=False):
-            m = copy.deepcopy(m)
-            harmony.realizeChordSymbolDurations(m)
-            obj = gex.fromGeneralObject(m)
+        def realizeDurationsAndAssertTags(mm: stream.Measure, forwardTag=False, offsetTag=False):
+            mm = copy.deepcopy(mm)
+            harmony.realizeChordSymbolDurations(mm)
+            obj = gex.fromGeneralObject(mm)
             tree = self.getET(obj)
             self.assertIs(bool(tree.findall('.//forward')), forwardTag)
             self.assertIs(bool(tree.findall('.//offset')), offsetTag)

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -13,7 +13,7 @@
 A mixin to ScoreExporter that includes the capabilities for producing a single
 MusicXML `<part>` from multiple music21 `PartStaff` objects.
 '''
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 import unittest
 import warnings
 from xml.etree.ElementTree import Element, SubElement, Comment

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -6,7 +6,7 @@
 # Authors:      Jacob Tyler Walls
 #               Michael Scott Cuthbert
 #
-# Copyright:    Copyright © 2020 Michael Scott Cuthbert and the music21 Project
+# Copyright:    Copyright © 2020-22 Michael Scott Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
@@ -135,6 +135,8 @@ class PartStaffExporterMixin:
         # starting with v.7, self.groupsToJoin is already set earlier,
         # but check to be safe
         if not self.groupsToJoin:
+            # this is done in the non-mixin class.
+            # noinspection PyAttributeOutsideInit
             self.groupsToJoin = self.joinableGroups()
         for group in self.groupsToJoin:
             self.addStaffTagsMultiStaffParts(group)
@@ -334,7 +336,7 @@ class PartStaffExporterMixin:
     def movePartStaffMeasureContents(self, group: StaffGroup):
         '''
         For every <part> after the first, find the corresponding measure in the initial
-        <part> and merge the contents by inserting all of the contained elements.
+        <part> and merge the contents by inserting all contained elements.
 
         Called by :meth:`joinPartStaffs`
 
@@ -374,8 +376,8 @@ class PartStaffExporterMixin:
         DIVIDER_COMMENT = '========================= Measure [NNN] =========================='
         PLACEHOLDER = '[NNN]'
 
-        def makeDivider(sourceNumber: int) -> Element:
-            return Comment(DIVIDER_COMMENT.replace(PLACEHOLDER, sourceNumber))
+        def makeDivider(inner_sourceNumber: Union[int, str]) -> Element:
+            return Comment(DIVIDER_COMMENT.replace(PLACEHOLDER, str(inner_sourceNumber)))
 
         sourceMeasures = iter(source.findall('measure'))
         sourceMeasure = None  # Set back to None when disposed of
@@ -521,7 +523,8 @@ class PartStaffExporterMixin:
             in the earliest staff where found (not necessarily the first) using `comparison`.
             '''
             initialM21Instance: Optional[m21Class] = None
-            for ps in group:
+            # noinspection PyShadowingNames
+            for ps in group:  # ps okay to reuse.
                 if initialM21Instance is None:
                     initialM21Instance = ps.recurse().getElementsByClass(m21Class).first()
                 else:

--- a/music21/musicxml/xmlObjects.py
+++ b/music21/musicxml/xmlObjects.py
@@ -6,7 +6,7 @@
 # Authors:      Christopher Ariza
 #               Michael Scott Cuthbert
 #
-# Copyright:    Copyright © 2009-2015 Michael Scott Cuthbert and the music21 Project
+# Copyright:    Copyright © 2009-2022 Michael Scott Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 import re
@@ -43,7 +43,7 @@ ARTICULATION_MARKS = OrderedDict(
      ('other-articulation', articulations.Articulation),
      ])
 
-# A reversed dictionary mapping classes to names, excepting Articulation
+# A reversed dictionary mapping class to name, excepting Articulation
 # which does not get mapped, and Staccato which must come after Staccatissimo,
 # and Accent which must come after StrongAccent
 ARTICULATION_MARKS_REV = OrderedDict([(v, k) for k, v in ARTICULATION_MARKS.items()])
@@ -67,7 +67,7 @@ TECHNICAL_MARKS = OrderedDict([('up-bow', articulations.UpBow),
                                ('string', articulations.StringIndication),
                                ('hammer-on', articulations.HammerOn),
                                ('pull-off', articulations.PullOff),
-                               # bend not implemented because it needs many sub components
+                               # bend not implemented because it needs many subcomponents
                                # ('bend', articulations.FretBend),
                                ('tap', articulations.FretTap),
                                ('fret', articulations.FretIndication),

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -5,11 +5,11 @@
 #
 # Authors:      Michael Scott Cuthbert
 #
-# Copyright:    Copyright © 2016 Michael Scott Cuthbert and the music21 Project
+# Copyright:    Copyright © 2016-22 Michael Scott Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
-Methods for converting <sound> tag to the many different music21
+Methods for converting <sound> tag to the many music21
 objects that this tag might represent.
 
 Pulled out because xmlToM21 is getting way too big.
@@ -26,5 +26,9 @@ class SoundTagMixin:
         # pylint: disable=unused-variable
         tempoNum = mxSound.get('tempo')  # @UnusedVariable
         dynamicsNum = mxSound.get('dynamics')  # @UnusedVariable
+
+        # TODO: musicxml4: swing: straight or first/second/swing-type, swing-style
+        # TODO: musicxml4: instrument-change: instrument-sound, solo or ensemble or none
+        #                                     virtual-instrument
 
         return soundObjs

--- a/music21/style.py
+++ b/music21/style.py
@@ -572,7 +572,7 @@ class StyleMixin(common.SlottedObjectMixin):
     def __init__(self):
         #  no need to call super().__init__() on SlottedObjectMixin
         self._style: Optional[Style] = None
-        self._editorial: Optional[editorial.Editorial] = None
+        self._editorial: Optional['music21.editorial.Editorial'] = None
 
     @property
     def hasStyleInformation(self) -> bool:
@@ -655,7 +655,7 @@ class StyleMixin(common.SlottedObjectMixin):
         return not (self._editorial is None)
 
     @property
-    def editorial(self) -> editorial.Editorial:
+    def editorial(self) -> 'music21.editorial.Editorial':
         '''
         a :class:`~music21.editorial.Editorial` object that stores editorial information
         (comments, footnotes, harmonic information, ficta).
@@ -678,7 +678,7 @@ class StyleMixin(common.SlottedObjectMixin):
         return self._editorial
 
     @editorial.setter
-    def editorial(self, ed: editorial.Editorial):
+    def editorial(self, ed: 'music21.editorial.Editorial'):
         self._editorial = ed
 
 

--- a/music21/style.py
+++ b/music21/style.py
@@ -150,7 +150,6 @@ class Style(ProtoM21Object):
 
         OMIT_FROM_DOCS
 
-
         Similarly for non-strings:
 
         >>> tst.enclosure = 4
@@ -330,7 +329,7 @@ class TextStyle(Style):
 
         Invalid values raise a TextFormatException
 
-        >>> te.justify = 'hello'
+        >>> tst.justify = 'hello'
         Traceback (most recent call last):
         music21.style.TextFormatException:
             Not a supported justification: 'hello'
@@ -359,7 +358,7 @@ class TextStyle(Style):
 
         Invalid values raise a TextFormatException
 
-        >>> te.fontStyle = 'hello'
+        >>> tst.fontStyle = 'hello'
         Traceback (most recent call last):
         music21.style.TextFormatException:
             Not a supported fontStyle: 'hello'

--- a/music21/style.py
+++ b/music21/style.py
@@ -5,7 +5,7 @@
 #
 # Authors:      Michael Scott Cuthbert
 #
-# Copyright:    Copyright © 2016 Michael Scott Cuthbert and the music21
+# Copyright:    Copyright © 2016-22 Michael Scott Cuthbert and the music21
 #               Project
 # License:      BSD, see license.txt
 # -----------------------------------------------------------------------------
@@ -39,6 +39,7 @@ class Enclosure(common.StrEnum):
     OCTAGON = 'octagon'
     NONAGON = 'nonagon'
     DECAGON = 'decagon'
+    INVERTED_BRACKET = 'inverted-bracket'
     NONE = 'none'  # special -- sets to None.
 
 
@@ -99,12 +100,12 @@ class Style(ProtoM21Object):
             try:
                 enc_value = Enclosure(value.lower())
             except ValueError as ve:
-                raise TextFormatException(f'Not a supported enclosure: {value}') from ve
+                raise TextFormatException(f'Not a supported enclosure: {value!r}') from ve
 
             self._enclosure = enc_value
 
         else:
-            raise TextFormatException(f'Not a supported enclosure: {value}')
+            raise TextFormatException(f'Not a supported enclosure: {value!r}')
 
     enclosure = property(_getEnclosure,
                          _setEnclosure,
@@ -112,9 +113,19 @@ class Style(ProtoM21Object):
         Get or set the enclosure as a style.Enclosure enum or None.
 
         Valid names are
-        rectangle, square, oval, circle, bracket, triangle, diamond,
+        "rectangle"/style.Enclosure.RECTANGLE,
+        "square"/style.Enclosure.SQUARE,
+        "oval"/style.Enclosure.OVAL,
+        "circle"/style.Enclosure.CIRCLE,
+        "bracket"/style.Enclosure.BRACKET,
+        "inverted-bracket"/style.Enclosure.INVERTED_BRACKET (output in musicxml 4 only)
+        None/"none"/style.Enclosure.NONE (returns Python None object)
+
+        or the following other shapes with their ALLCAPS Enclosure equivalents:
+
+        triangle, diamond,
         pentagon, hexagon, heptagon, octagon,
-        nonagon, decagon or None.
+        nonagon, or decagon.
 
         >>> tst = style.TextStyle()
         >>> tst.enclosure = None
@@ -128,6 +139,24 @@ class Style(ProtoM21Object):
         >>> tst.enclosure = 'octagon'
         >>> tst.enclosure
         <Enclosure.OCTAGON>
+
+        Setting an invalid enclosure raises a TextFormatException
+
+        >>> tst.enclosure = 'parabola'
+        Traceback (most recent call last):
+        music21.style.TextFormatException:
+            Not a supported enclosure: 'parabola'
+
+
+        OMIT_FROM_DOCS
+
+
+        Similarly for non-strings:
+
+        >>> tst.enclosure = 4
+        Traceback (most recent call last):
+        music21.style.TextFormatException:
+            Not a supported enclosure: 4
         ''')
 
     def _getAbsoluteY(self):
@@ -136,7 +165,7 @@ class Style(ProtoM21Object):
     def _setAbsoluteY(self, value):
         if value is None:
             self._absoluteY = None
-        elif value == 'above':
+        elif value == 'above':  # TODO: convert to Enum and keep it
             self._absoluteY = 10
         elif value == 'below':
             self._absoluteY = -70
@@ -158,6 +187,7 @@ class Style(ProtoM21Object):
         Other legal positions are 'above' and 'below' which
         are synonyms for 10 and -70 respectively (for 5-line
         staves; other staves are not yet implemented)
+        This behavior may change in music21 v.8 or after.
 
         >>> te = style.Style()
         >>> te.absoluteY = 10
@@ -167,6 +197,13 @@ class Style(ProtoM21Object):
         >>> te.absoluteY = 'below'
         >>> te.absoluteY
         -70
+
+        Setting an invalid position raises a TextFormatException
+
+        >>> te.absoluteY = 'hello'
+        Traceback (most recent call last):
+        music21.style.TextFormatException:
+            Not a supported absoluteY position: 'hello'
         ''')
 
 
@@ -216,10 +253,11 @@ class TextStyle(Style):
         return self._alignVertical
 
     def _setAlignVertical(self, value):
+        # TODO: convert to StrEnum
         if value in (None, 'top', 'middle', 'bottom', 'baseline'):
             self._alignVertical = value
         else:
-            raise TextFormatException(f'invalid vertical align: {value}')
+            raise TextFormatException(f'Invalid vertical align: {value!r}')
 
     alignVertical = property(_getAlignVertical,
                              _setAlignVertical,
@@ -231,6 +269,13 @@ class TextStyle(Style):
         >>> te.alignVertical = 'top'
         >>> te.alignVertical
         'top'
+
+        Invalid vertical aligns raise a TextFormatException:
+
+        >>> te.alignVertical = 'hello'
+        Traceback (most recent call last):
+        music21.style.TextFormatException:
+            Invalid vertical align: 'hello'
         ''')
 
     def _getAlignHorizontal(self):
@@ -240,7 +285,7 @@ class TextStyle(Style):
         if value in (None, 'left', 'right', 'center'):
             self._alignHorizontal = value
         else:
-            raise TextFormatException(f'invalid horizontal align: {value}')
+            raise TextFormatException(f'Invalid horizontal align: {value!r}')
 
     alignHorizontal = property(_getAlignHorizontal,
                                _setAlignHorizontal,
@@ -252,6 +297,13 @@ class TextStyle(Style):
         >>> te.alignHorizontal = 'right'
         >>> te.alignHorizontal
         'right'
+
+        Invalid horizontal aligns raise a TextFormatException:
+
+        >>> te.alignHorizontal = 'hello'
+        Traceback (most recent call last):
+        music21.style.TextFormatException:
+            Invalid horizontal align: 'hello'
         ''')
 
     def _getJustify(self):
@@ -262,7 +314,7 @@ class TextStyle(Style):
             self._justify = None
         else:
             if value.lower() not in ('left', 'center', 'right', 'full'):
-                raise TextFormatException(f'Not a supported justification: {value}')
+                raise TextFormatException(f'Not a supported justification: {value!r}')
             self._justify = value.lower()
 
     justify = property(_getJustify,
@@ -275,6 +327,13 @@ class TextStyle(Style):
         >>> tst.justify = 'center'
         >>> tst.justify
         'center'
+
+        Invalid values raise a TextFormatException
+
+        >>> te.justify = 'hello'
+        Traceback (most recent call last):
+        music21.style.TextFormatException:
+            Not a supported justification: 'hello'
         ''')
 
     def _getStyle(self):
@@ -285,7 +344,7 @@ class TextStyle(Style):
             self._fontStyle = None
         else:
             if value.lower() not in ('italic', 'normal', 'bold', 'bolditalic'):
-                raise TextFormatException(f'Not a supported fontStyle: {value}')
+                raise TextFormatException(f'Not a supported fontStyle: {value!r}')
             self._fontStyle = value.lower()
 
     fontStyle = property(_getStyle,
@@ -297,6 +356,13 @@ class TextStyle(Style):
         >>> tst.fontStyle = 'bold'
         >>> tst.fontStyle
         'bold'
+
+        Invalid values raise a TextFormatException
+
+        >>> te.fontStyle = 'hello'
+        Traceback (most recent call last):
+        music21.style.TextFormatException:
+            Not a supported fontStyle: 'hello'
         ''')
 
     def _getWeight(self):
@@ -309,6 +375,8 @@ class TextStyle(Style):
             if value.lower() not in ('normal', 'bold'):
                 raise TextFormatException(f'Not a supported fontWeight: {value}')
             self._fontWeight = value.lower()
+
+    # TODO: figure out if we want to use fontStyle for all weights.
 
     fontWeight = property(_getWeight,
                           _setWeight,
@@ -496,17 +564,18 @@ class StyleMixin(common.SlottedObjectMixin):
     Not used by Music21Objects because of the added trouble in copying etc. so
     there is code duplication with base.Music21Object
     '''
+    # anytime something is changed here, change in base.Music21Object and vice-versa
     _styleClass = Style
 
     __slots__ = ('_style', '_editorial')
 
     def __init__(self):
         #  no need to call super().__init__() on SlottedObjectMixin
-        self._style = None
-        self._editorial = None
+        self._style: Optional[Style] = None
+        self._editorial: Optional[editorial.Editorial] = None
 
     @property
-    def hasStyleInformation(self):
+    def hasStyleInformation(self) -> bool:
         '''
         Returns True if there is a :class:`~music21.style.Style` object
         already associated with this object, False otherwise.
@@ -532,7 +601,7 @@ class StyleMixin(common.SlottedObjectMixin):
         return not (self._style is None)
 
     @property
-    def style(self):
+    def style(self) -> Style:
         '''
         Returns (or Creates and then Returns) the Style object
         associated with this object, or sets a new
@@ -554,17 +623,18 @@ class StyleMixin(common.SlottedObjectMixin):
         >>> acc.style.absoluteX is None
         True
         '''
+        # anytime something is changed here, change in base.Music21Object and vice-versa
         if self._style is None:
             styleClass = self._styleClass
             self._style = styleClass()
         return self._style
 
     @style.setter
-    def style(self, newStyle):
+    def style(self, newStyle: Style):
         self._style = newStyle
 
     @property
-    def hasEditorialInformation(self):
+    def hasEditorialInformation(self) -> bool:
         '''
         Returns True if there is a :class:`~music21.editorial.Editorial` object
         already associated with this object, False otherwise.
@@ -585,7 +655,7 @@ class StyleMixin(common.SlottedObjectMixin):
         return not (self._editorial is None)
 
     @property
-    def editorial(self):
+    def editorial(self) -> editorial.Editorial:
         '''
         a :class:`~music21.editorial.Editorial` object that stores editorial information
         (comments, footnotes, harmonic information, ficta).
@@ -601,13 +671,14 @@ class StyleMixin(common.SlottedObjectMixin):
         >>> acc.editorial
         <music21.editorial.Editorial {'ficta': <music21.pitch.Accidental sharp>}>
         '''
+        # anytime something is changed here, change in base.Music21Object and vice-versa
         from music21 import editorial
         if self._editorial is None:
             self._editorial = editorial.Editorial()
         return self._editorial
 
     @editorial.setter
-    def editorial(self, ed):
+    def editorial(self, ed: editorial.Editorial):
         self._editorial = ed
 
 


### PR DESCRIPTION
Also fix some typos and errors noticed by PyCharm

Fixes #1271  -- does not implement musicxml 4, but puts notes where changes should go.

Change order of authors in a few places where substantial work has been done by others since original version was released