### PR TITLE
V8 -- cleanup 1

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -42,7 +42,7 @@ When changing, update the single test case in base.py.
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
 
-__version_info__ = (7, 3, 2)  # can be 4-tuple: (7, 0, 5, 'a2')
+__version_info__ = (8, 0, 0, 'a1')  # can be 4-tuple: (7, 0, 5, 'a2')
 
 v = '.'.join(str(x) for x in __version_info__[0:3])
 if len(__version_info__) > 3 and __version_info__[3]:  # type: ignore

--- a/music21/base.py
+++ b/music21/base.py
@@ -28,7 +28,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'7.3.2'
+'8.0.0a1'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -10,7 +10,7 @@
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
-This module defines the Chord object, a sub-class of :class:`~music21.note.GeneralNote`
+This module defines the Chord object, a subclass of :class:`~music21.note.GeneralNote`
 as well as other methods, functions, and objects related to chords.
 '''
 __all__ = ['tables', 'Chord', 'ChordException', 'fromIntervalVector', 'fromForteClass']
@@ -86,7 +86,7 @@ class ChordBase(note.NotRest):
                 notes = [notes]
 
         # the list of pitch objects is managed by a property; this permits
-        # only updating the _chordTablesAddress when pitches has changed
+        # only updating the _chordTablesAddress when ".pitches" has changed
 
         # duration looks at _notes to get first duration of a pitch
         # if no other pitches are defined
@@ -163,7 +163,7 @@ class ChordBase(note.NotRest):
 
     def __deepcopy__(self: _ChordType, memo=None) -> _ChordType:
         '''As Chord objects have one or more Volume, objects, and Volume
-        objects store weak refs to the to client object, need to specialize
+        objects store weak refs to the client object, need to specialize
         deepcopy handling depending on if the chord has its own volume object.
         '''
         # environLocal.printDebug(['calling NotRest.__deepcopy__', self])
@@ -204,7 +204,7 @@ class ChordBase(note.NotRest):
         as can use it -- it's all an optimization step to create as few duration objects
         as is necessary.
 
-        Also requires that notes be an iterable.
+        Also requires that notes be iterable.
         '''
         # quickDuration specifies whether the duration object for the chord
         # should be taken from the first note of the list.
@@ -257,7 +257,7 @@ class ChordBase(note.NotRest):
     ) -> None:
         '''
         Add a note, pitch, the notes of another chord, or string representing a pitch,
-        or a list of any of the above to a Chord or PercussionChord.
+        or a list of any-of-the-above types to a Chord or PercussionChord.
 
         If runSort is True (default=True) then after appending, the
         chord will be sorted.
@@ -301,7 +301,7 @@ class ChordBase(note.NotRest):
         '''
         Removes a note or pitch from the chord.  Must be a pitch
         equal to a pitch in the chord or a string specifying the pitch
-        name with octave or the a note from a chord.  If not found,
+        name with octave or a note from a chord.  If not found,
         raises a ValueError
 
         >>> c = chord.Chord('C4 E4 G4')
@@ -579,7 +579,7 @@ class Chord(ChordBase):
 
     Chord has the ability to determine the root of a chord, as well as the bass note of a chord.
     In addition, Chord is capable of determining what type of chord a particular chord is, whether
-    it is a triad or a seventh, major or minor, etc, as well as what inversion the chord is in.
+    it is a triad or a seventh, major or minor, etc., as well as what inversion the chord is in.
 
     A chord can also be created from pitch class numbers:
 
@@ -656,7 +656,7 @@ class Chord(ChordBase):
     # CLASS VARIABLES #
     isChord = True
 
-    # define order to present names in documentation; use strings
+    # define order of presenting names in documentation; use strings
     _DOC_ORDER = ['pitches']
     # documentation for all attributes (not properties or methods)
     _DOC_ATTR = {
@@ -1003,7 +1003,7 @@ class Chord(ChordBase):
     ) -> None:
         '''
         Add a note, pitch, the notes of another chord, or string representing a pitch,
-        or a list of any of the above to a Chord.
+        or a list of any-of-the-above types to a Chord.
 
         If `runSort` is True (default=True) then after appending, the
         chord will be sorted.
@@ -1062,7 +1062,7 @@ class Chord(ChordBase):
         Add lyrics to the chord that show the distance of each note from
         the bass.  If returnList is True, a list of the intervals is returned instead.
 
-        By default we show only the generic interval:
+        By default, we show only the generic interval:
 
         >>> c1 = chord.Chord(['C2', 'E2', 'G2', 'C3'])
         >>> c2 = c1.annotateIntervals(inPlace=False)
@@ -1074,7 +1074,7 @@ class Chord(ChordBase):
         >>> [ly.text for ly in c2.lyrics]
         ['8', '5', '3']
 
-        The `stripSpecifiers` parameter can be used to show only the intervals size (3, 5, etc)
+        The `stripSpecifiers` parameter can be used to show only the intervals size (3, 5, etc.)
         or the complete interval specification (m3, P5, etc.)
 
         >>> c3 = c1.annotateIntervals(inPlace=False, stripSpecifiers=False)
@@ -1186,7 +1186,9 @@ class Chord(ChordBase):
     def bass(self,
              newbass: Union[bool, str, pitch.Pitch, note.Note] = None,
              *,
-             find: Union[bool, None] = None):
+             find: Union[bool, None] = None,
+             allow_add: bool = False,
+             ):
         '''
         Generally used to find and return the bass Pitch:
 
@@ -1204,14 +1206,32 @@ class Chord(ChordBase):
         >>> cmin_inv.bass()
         <music21.pitch.Pitch E-3>
 
-        Can also be used in rare occasions to set the bass note to a new Pitch.
+        Can also be used in rare occasions to set the bass note to a new Pitch,
+        so long as that note is found in the chord:
 
-        Note that overriding the bass currently will add the bass to the
-        chord itself.  This behavior differs from root() and
-        may change in subsequent versions without a deprecation cycle.  It is
-        better to explicitly add the bass to the chord.
+        >>> strange_chord = chord.Chord('E##4 F-4 C5')
+        >>> strange_chord.bass()
+        <music21.pitch.Pitch E##4>
+        >>> strange_chord.bass('F-4')
+        >>> strange_chord.bass()
+        <music21.pitch.Pitch F-4>
 
-        By default if nothing has been overridden, this method uses a
+        If the note assigned to the bass is not found, it will default to raising a
+        ChordException:
+
+        >>> strange_chord.bass('G--4')
+        Traceback (most recent call last):
+        music21.chord.ChordException: Pitch G--4 not found in chord
+
+        For the purposes of initializing from a ChordSymbol and in other cases,
+        a new bass can be added to the chord by setting `allow_add = True`:
+
+        >>> strange_chord.bass('G--4', allow_add=True)
+        >>> strange_chord.bass()
+        <music21.pitch.Pitch G--4>
+
+
+        By default, if nothing has been overridden, this method uses a
         quick algorithm to find the bass among the
         chord's pitches, if no bass has been previously specified. If this is
         not intended, set find to False when calling this method, and 'None'
@@ -1220,6 +1240,9 @@ class Chord(ChordBase):
         >>> em = chord.Chord(['E3', 'G3', 'B4'])
         >>> print(em.bass(find=False))
         None
+
+        Changed in v8: raise an exception if setting a new bass
+        to a pitch not in the chord, unless new keyword `allow_add` is `True`.
 
         OMIT_FROM_DOCS
 
@@ -1280,8 +1303,10 @@ class Chord(ChordBase):
                         break
 
             if not foundBassInChord:  # it's not there, needs to be added
-                self.pitches = (newbass, *(p for p in self.pitches))
-            # raise exception in v8 -- do not add this bass to the chord itself.
+                if not allow_add:
+                    raise ChordException(f'Pitch {newbass} not found in chord')
+                else:
+                    self.pitches = (newbass, *(p for p in self.pitches))
 
             self._overrides['bass'] = newbass
             self._cache['bass'] = newbass
@@ -2482,12 +2507,15 @@ class Chord(ChordBase):
         if it contains only notes that are
         either in unison with the root, a major third above the root,
         or an augmented fifth above the
-        root. Additionally, must contain at least one of each third and fifth above the root.
-        Chord might NOT seem to have to be spelled correctly
-        because incorrectly spelled Augmented Triads are
+        root. Additionally, the Chord must contain at least one of each third and
+        fifth above the root.
+
+        The chord might not seem to need to be spelled correctly
+        since incorrectly spelled Augmented Triads are
         usually augmented triads in some other inversion
-        (e.g. C-E-Ab is a 2nd inversion aug triad; C-Fb-Ab
-        is 1st inversion).  However, B#-Fb-Ab does return False as expected).
+        (e.g. C-E-Ab is a second-inversion augmented triad; C-Fb-Ab
+        is in first inversion).  However, B#-Fb-Ab does return False as it is not a
+        stack of two major thirds in any inversion.
 
         Returns False if is not an augmented triad.
 
@@ -2499,6 +2527,7 @@ class Chord(ChordBase):
         False
 
         Other spellings will give other roots!
+
         >>> c = chord.Chord(['C4', 'E4', 'A-4'])
         >>> c.isAugmentedTriad()
         True
@@ -2755,7 +2784,7 @@ class Chord(ChordBase):
         Returns True if the chord is a French augmented sixth chord
         (flat 6th scale degree in bass, tonic, second scale degree, and raised 4th).
 
-        N.B. The root() method of music21.chord Chord determines
+        N.B. The root() method of music21.chord.Chord determines
         the root based on the note with
         the most thirds above it. However, under this definition, a
         1st-inversion french augmented sixth chord
@@ -2763,7 +2792,7 @@ class Chord(ChordBase):
         subdominant chord it is based
         upon. We fix this by adjusting the root. First, however, we
         check to see if the chord is
-        in second inversion to begin with, otherwise its not
+        in second inversion to begin with, otherwise it is not
         a Fr+6 chord. This is to avoid ChordException errors.
 
         >>> fr6a = chord.Chord(['A-3', 'C4', 'D4', 'F#4'])
@@ -3225,14 +3254,17 @@ class Chord(ChordBase):
         and end up with the same pitch-classes.  Like the dyad F-B can have each
         note transposed up 6 semitones and get another B-F = F-B dyad.
 
-        A tonally-focused way of looking at this would be are we unable
-        to distinguish root position vs. some inversion of the chord by ear alone?
-        For instance, we can see that C-Eb-Gb-Bbb is in root position, while
-        Eb-Gb-Bbb-C is in first inversion.  But only hearing the chord in isolation
-        it would not be possible to tell.
+        A tonally-focused way of looking at this would be to ask, "Are we unable
+        to distinguish root position vs. some inversion of the basic chord by ear alone?"
+        For instance, we can see (visually) that C-Eb-Gb-Bbb is a diminished-seventh
+        chord in root position, while
+        Eb-Gb-Bbb-C is a diminished-seventh in first inversion.
+        But if the chord were heard in isolation
+        it would not be possible to tell the inversion at all, since diminished-sevenths
+        are transpositionally symmetrical.
 
         With either way of looking at it,
-        fourteen set classes of 2-10 pitch classes have this property,
+        there are fourteen set classes of 2-10 pitch classes have this property,
         including the augmented triad:
 
         >>> chord.Chord('C E G#').isTranspositionallySymmetrical()
@@ -3635,7 +3667,7 @@ class Chord(ChordBase):
 
         >>> aDim7no3rd = chord.Chord(['A3', 'E-4', 'G4'])
 
-        ...could be considered an type of E-flat 11 chord with a 3rd, but no 5th,
+        ...could be considered a type of E-flat 11 chord with a 3rd, but no 5th,
         7th, or 9th, in 5th inversion.  That doesn't make sense, so we should
         call it an A dim 7th chord
         with no 3rd.
@@ -3703,7 +3735,7 @@ class Chord(ChordBase):
         >>> [p.nameWithOctave for p in vo9.pitches]
         ['B3', 'D4', 'F4', 'A-4']
 
-        By default this method uses an algorithm to find the root among the
+        By default, this method uses an algorithm to find the root among the
         chord's pitches, if no root has been previously specified.  If a root
         has been explicitly specified, as in the Csus4 chord above, it can be
         returned to the original root() by setting find explicitly to True:
@@ -4040,7 +4072,7 @@ class Chord(ChordBase):
         'normal'
         'diamond'
 
-        By default assigns to first pitch:
+        By default, assigns to first pitch:
 
         >>> c3 = chord.Chord('C3 F4')
         >>> c3.setNotehead('slash', None)
@@ -4185,7 +4217,7 @@ class Chord(ChordBase):
         unspecified
         double
 
-        By default assigns to first pitch:
+        By default, assigns to first pitch:
 
         >>> c3 = chord.Chord('C3 F4')
         >>> c3.setStemDirection('down', None)
@@ -5042,7 +5074,7 @@ class Chord(ChordBase):
         >>> c1
         <music21.chord.Chord D#4 C#4>
 
-        Notice that the notes are not sorted by default -- this is a property for
+        Notice that the notes set this way are not sorted -- this is a property for
         power users who want complete control.
 
         Any incorrect assignment raises a TypeError:
@@ -5055,8 +5087,8 @@ class Chord(ChordBase):
         Traceback (most recent call last):
         TypeError: every element of notes must be a note.Note object
 
-        In case of an error, the previous notes are not changed.  (For this reason,
-        `.notes` cannot take a generator expression.
+        In case of an error, the previous notes are not changed (for this reason,
+        `.notes` cannot take a generator expression).
 
         >>> c1
         <music21.chord.Chord D#4 C#4>
@@ -5180,7 +5212,7 @@ class Chord(ChordBase):
     @property
     def orderedPitchClasses(self) -> List[int]:
         '''
-        Return an list of pitch class integers, ordered form lowest to highest.
+        Return a list of pitch class integers, ordered form lowest to highest.
 
         >>> c1 = chord.Chord(['D4', 'A4', 'F#5', 'D6'])
         >>> c1.orderedPitchClasses
@@ -5208,7 +5240,7 @@ class Chord(ChordBase):
     @property
     def pitchClassCardinality(self) -> int:
         '''
-        Return a the cardinality of pitch classes, or the number of unique
+        Return the cardinality of pitch classes, or the number of unique
         pitch classes, in the Chord:
 
         >>> c1 = chord.Chord(['D4', 'A4', 'F#5', 'D6'])
@@ -5750,7 +5782,7 @@ def fromForteClass(notation):
                 f'cannot extract set-class representation from string: {notation}')
     elif common.isListLike(notation):
         if len(notation) <= 3:
-            # assume its a set-class representation
+            # assume it's a set-class representation
             if notation:
                 card = notation[0]
             if len(notation) > 1:
@@ -5788,7 +5820,7 @@ def fromIntervalVector(notation, getZRelation=False):
     '''
     addressList = None
     if common.isListLike(notation):
-        if len(notation) == 6:  # assume its an interval vector
+        if len(notation) == 6:  # assume it's an interval vector
             addressList = tables.intervalVectorToAddress(notation)
     if addressList is None:
         raise ChordException(f'cannot handle specified notation: {notation}')

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -1188,7 +1188,7 @@ class Chord(ChordBase):
              *,
              find: Union[bool, None] = None,
              allow_add: bool = False,
-             ):
+             ) -> Optional[pitch.Pitch]:
         '''
         Generally used to find and return the bass Pitch:
 
@@ -1305,8 +1305,8 @@ class Chord(ChordBase):
             if not foundBassInChord:  # it's not there, needs to be added
                 if not allow_add:
                     raise ChordException(f'Pitch {newbass} not found in chord')
-                else:
-                    self.pitches = (newbass, *(p for p in self.pitches))
+
+                self.pitches = (newbass, *(p for p in self.pitches))
 
             self._overrides['bass'] = newbass
             self._cache['bass'] = newbass
@@ -3646,7 +3646,8 @@ class Chord(ChordBase):
     def root(self,
              newroot: Union[None, str, pitch.Pitch, note.Note] = None,
              *,
-             find: Union[bool, None] = None):
+             find: Union[bool, None] = None
+             ) -> Optional[pitch.Pitch]:
         # noinspection PyShadowingNames
         '''
         Returns the root of the chord.  Or if given a Pitch as the

--- a/music21/chord/tables.py
+++ b/music21/chord/tables.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
-# Name:          chord.tables.py
-# Purpose:       data and tables for chord and set class processing.
+# Name:         chord.tables.py
+# Purpose:      data and tables for chord and set class processing.
 #
-# Authors:       Christopher Ariza
+# Authors:      Christopher Ariza
+#               Michael Scott Asato Cuthbert
 #
 # Copyright:    Copyright © 2001-2011 Christopher Ariza
-# Copyright:    Copyright © 2011 Michael Scott Cuthbert and the music21 Project
+# Copyright:    Copyright © 2011-22 Michael Scott Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 
@@ -335,11 +336,11 @@ FORTE = (None, monad, diad, trichord, tetrachord, pentachord,
          hexachord, septachord, octachord,
          nonachord, decachord, undecachord, dodecachord)
 
-# this defines the pitch classes to return for the inversion of a given
+# This dictionary defines the pitch classes to return for the inversion of a given
 # forte number.  For instance (3, 11): (0, 4, 7) indicates that for the
 # inverted form of Forte class 3-11 (minor/major triad) return 0, 2, 3
-# (the zero could be assumed, but it makes my brain easier to have it there.
-# faster to store this than recompute every time.
+# (the zero could be assumed, but it makes my brain easier to have it there).
+# It is faster to store this than to recompute it every time.
 inversionDefaultPitchClasses = {
     (3, 2): (0, 2, 3),
     (3, 3): (0, 3, 4),
@@ -913,7 +914,7 @@ forteNumberWithInversionToTnIndex = {
 # some changes:
 # unison preferred to monad
 # v7.3 -- Roma preferred.  Gypsy only in parentheses.
-#      TODO: more removing and/or deemphasizing of ethnic-stereotype names.
+#      TODO: more removing and/or de-emphasizing of ethnic-stereotype names.
 
 tnIndexToChordInfo = {
     (1,  1,  0): {'name': ('unison',
@@ -1175,9 +1176,8 @@ tnIndexToChordInfo = {
                            'combinatorial I (I1, I7)')},
     (6, 31,  1): {'name': ('combinatorial I (I7)',)},
     (6, 31, -1): {'name': ('combinatorial I (I11)',)},
-    (6, 32,  0): {'name': ('C all combinatorial (P6, I3, RI9)',
-                           'Guidon/Arezzo',
-                           'Arezzo major diatonic',
+    (6, 32,  0): {'name': ('Guidonian hexachord',
+                           'C all combinatorial (P6, I3, RI9)',
                            'major hexamirror',
                            'quartal hexamirror',
                            'first-order all combinatorial')},
@@ -1292,10 +1292,11 @@ tnIndexToChordInfo = {
     (7, 31, -1): {'name': ('diminished scale',
                            'alternating heptachord')},
     (7, 32,  1): {'name': ('harmonic minor scale',
+                           'harmonic minor collection',
                            'Spanish Roma (Gypsy)',
                            'mela Kiravani')},
-    (7, 32, -1): {'name': ('harmonic major scale',
-                           'harmonic minor inverse',
+    (7, 32, -1): {'name': ('harmonic major scale (inverted)',
+                           'harmonic minor collection (inverted)',
                            'mela Cakravana',
                            'quasi raga Ahir Bhairav')},
     (7, 33,  0): {'name': ('Neapolitan-major mode',
@@ -1560,7 +1561,7 @@ def addressToIntervalVector(address):
     (0, 0, 1, 1, 1, 0)
 
     Inversion can be omitted or None without causing an error (or, of course,
-    changing the output
+    changing the output)
 
     >>> chord.tables.addressToIntervalVector((4, 29))
     (1, 1, 1, 1, 1, 1)
@@ -1614,7 +1615,7 @@ def intervalVectorToAddress(vector):
         for num, sc in enumerate(FORTE[card]):
             if sc is None:
                 continue  # first, used for spacing
-            # index 1 is vector
+            # index 1 is the vector
             if sc[1] == vector:
                 post.append(ChordTableAddress(card, num, None, None))
     return post
@@ -1680,7 +1681,7 @@ def addressToCommonNames(address):
 
 def addressToForteName(address, classification='tn'):
     '''
-    Given an address, return the set-class name as a string.  By default
+    Given an address, return the set-class name as a string.  By default,
     A and B are appended to chords without inversional equivalence:
 
     >>> octachord_address = chord.tables.ChordTableAddress(8, 15, -1, 10)
@@ -1689,7 +1690,7 @@ def addressToForteName(address, classification='tn'):
     >>> chord.tables.addressToForteName((8, 15))
     '8-15A'
 
-    The augmented triad is invariant under inversion so it gets no designation:
+    The augmented triad is invariant under inversion, so it gets no designation:
 
     >>> chord.tables.addressToForteName((3, 12))
     '3-12'
@@ -1723,7 +1724,7 @@ def seekChordTablesAddress(c):
 
     Table addresses are a ChordTableAddress named-tuple giving
     the cardinality, the Forte-index-number, the inversion, and the original
-    pitch class that matched (may be arbitrary for a symmetrical chord like
+    pitch class that matched (it may be arbitrary for a symmetrical chord like
     the diminished seventh chord).
 
     Inversion is either 0 (for symmetrical under inversion) or -1, 1
@@ -1768,7 +1769,7 @@ def seekChordTablesAddress(c):
     music21.chord.tables.ChordTablesException: cannot access chord tables address
         for Chord with 0 pitches
 
-    NOTE: this was once a time consuming operation, though it is
+    NOTE: this was once a time-consuming operation, though it is
     now quite a bit faster than before (order of 100 microseconds).  Nonetheless
     should only be run when necessary.  Methods that call this should
     try (as chord.Chord does) to cache the result.
@@ -1793,7 +1794,7 @@ def seekChordTablesAddress(c):
     card = len(pcSet)
     if card == 1:  # it is a singleton: return it
         return ChordTableAddress(1, 1, 0, pcSet[0])
-    elif card == 12:  # its the aggregate
+    elif card == 12:  # it is the aggregate
         return ChordTableAddress(12, 1, 0, 0)
 
     # go through each rotation of pcSet

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -1015,7 +1015,7 @@ class Iterator:
     bach/bwv358
     bach/bwv319
 
-    The numberList, which by default includes all chorales in the chosen numberingSystem,
+    The numberList, which, by default, includes all chorales in the chosen numberingSystem,
     can be set like the titleList. In the following example,
     note that the first chorale in the given
     numberList will not be part of the iteration because the

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         checker.py
-# Purpose:      music21 class which can parse a stream of parts and check your homework
+# Purpose:      checks figured basses for following voice-leading rules
 # Authors:      Jose Cabal-Ugaz
 #
 # Copyright:    Copyright © 2012 Michael Scott Cuthbert and the music21 Project
@@ -68,6 +68,7 @@ def getVoiceLeadingMoments(music21Stream):
 
 
 def extractHarmonies(music21Stream):
+    # noinspection PyShadowingNames
     '''
     Takes in a :class:`~music21.stream.Stream` and returns a dictionary whose values
     are the voice leading moments of the :class:`~music21.stream.Stream` and whose
@@ -148,6 +149,7 @@ def createOffsetMapping(music21Part):
 
 
 def correlateHarmonies(currentMapping, music21Part):
+    # noinspection PyShadowingNames
     '''
     Adds a new :class:`~music21.stream.Part` to an existing offset mapping.
 
@@ -204,6 +206,7 @@ def correlateHarmonies(currentMapping, music21Part):
 
 
 def checkSinglePossibilities(music21Stream, functionToApply, color="#FF0000", debug=False):
+    # noinspection PyShadowingNames
     '''
     Takes in a :class:`~music21.stream.Score` and a functionToApply which takes in a possibility
     instance, a tuple with pitches or rests comprising a vertical sonority. Changes the color of
@@ -268,6 +271,7 @@ def checkSinglePossibilities(music21Stream, functionToApply, color="#FF0000", de
 
 
 def checkConsecutivePossibilities(music21Stream, functionToApply, color="#FF0000", debug=False):
+    # noinspection PyShadowingNames
     '''
     Takes in a :class:`~music21.stream.Score` and a functionToApply which takes in two consecutive
     possibility instances, each a tuple with pitches or rests comprising a vertical sonority.
@@ -351,8 +355,8 @@ def checkConsecutivePossibilities(music21Stream, functionToApply, color="#FF0000
 def voiceCrossing(possibA):
     '''
     Returns a list of (partNumberA, partNumberB) pairs, each representing
-    two voices which form a voice crossing. The parts from lowest part to
-    highest part (right to left) must correspond to increasingly higher
+    two voices which form a voice crossing. The parts from the lowest part to
+    the highest part (right to left) must correspond to increasingly higher
     pitches in order for there to be no voice crossing. Comparisons between
     pitches are done using pitch comparison methods, which are based on pitch
     space values (see :class:`~music21.pitch.Pitch`).

--- a/music21/figuredBass/examples.py
+++ b/music21/figuredBass/examples.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         examples.py
-# Purpose:      music21 class which allows running of test cases
+# Purpose:      Figured bass test cases
 # Authors:      Jose Cabal-Ugaz
 #
 # Copyright:    Copyright © 2010-2011 Michael Scott Cuthbert and the music21 Project
@@ -94,7 +94,6 @@ def exampleD():
     The following is a realization of fbLine in four parts using the default rules set.
     The soprano part is limited to stepwise motion, and the alto and tenor parts are
     limited to motions within a perfect octave.
-
 
     >>> from music21.figuredBass import rules
     >>> fbRules = rules.Rules()
@@ -367,17 +366,11 @@ def italianA6ResolutionExample():
 
 def twelveBarBlues():
     '''
-    This is an progression in Bb major based on the twelve bar blues. The progression used is:
+    This is a progression in Bb major based on the twelve bar blues. The progression used is:
 
-
-    I  |  IV  |  I  |  I7
-
-
-    IV |  IV  |  I  |  I7
-
-
-    V7 |  IV6 |  I  |  I
-
+        I  |  IV  |  I  |  I7
+        IV |  IV  |  I  |  I7
+        V7 |  IV6 |  I  |  I
 
     >>> from music21.figuredBass import examples
     >>> from music21.figuredBass import rules

--- a/music21/figuredBass/notation.py
+++ b/music21/figuredBass/notation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         notation.py
-# Purpose:      music21 class for conveniently representing figured bass notation
+# Purpose:      representations of figured bass notation
 # Authors:      Jose Cabal-Ugaz
 #
 # Copyright:    Copyright © 2011 Michael Scott Cuthbert and the music21 Project
@@ -590,8 +590,8 @@ def convertToPitch(pitchString):
     Converts a pitchString to a :class:`~music21.pitch.Pitch`, only if necessary.
 
     >>> from music21.figuredBass import notation
-    >>> pitchString = 'C5'
-    >>> notation.convertToPitch(pitchString)
+    >>> pitchStr = 'C5'
+    >>> notation.convertToPitch(pitchStr)
     <music21.pitch.Pitch C5>
     >>> notation.convertToPitch(pitch.Pitch('E4'))  # does nothing
     <music21.pitch.Pitch E4>

--- a/music21/figuredBass/possibility.py
+++ b/music21/figuredBass/possibility.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         possibility.py
-# Purpose:      music21 class to define rule checking methods for a possibility
-#                represented as a tuple.
+# Purpose:      rule checking methods for a possibility represented as a tuple.
 # Authors:      Jose Cabal-Ugaz
 #
 # Copyright:    Copyright © 2011 Michael Scott Cuthbert and the music21 Project
@@ -12,7 +11,7 @@
 A possibility is a tuple with pitches, and is intended to encapsulate a possible
 solution to a :class:`~music21.figuredBass.segment.Segment`. Unlike a :class:`~music21.chord.Chord`,
 the ordering of a possibility does matter. The assumption throughout fbRealizer
-is that a possibility is always in order from highest part to lowest part, and
+is that a possibility is always in order from the highest part to the lowest part, and
 the last element of each possibility is the bass.
 
 
@@ -83,7 +82,7 @@ from music21 import voiceLeading
 def voiceCrossing(possibA):
     '''
     Returns True if there is voice crossing present between any two parts
-    in possibA. The parts from lowest part to highest part (right to left)
+    in possibA. The parts from the lowest part to the highest part (right to left)
     must correspond to increasingly higher pitches in order for there to
     be no voice crossing. Comparisons between pitches are done using pitch
     comparison methods, which are based on pitch space values
@@ -662,18 +661,17 @@ def voiceOverlap(possibA, possibB):
 
 
 def partMovementsWithinLimits(possibA, possibB, partMovementLimits=None):
+    # noinspection PyShadowingNames
     '''
     Returns True if all movements between shared parts of possibA and possibB
     are within limits, as specified by list partMovementLimits, which consists of
     (partNumber, maxSeparation) tuples.
-
 
     * partNumber: Specified from 1 to n, where 1 is the soprano or
       highest part and n is the bass or lowest part.
 
     * maxSeparation: For a given part, the maximum separation to allow
       between a pitch in possibA and a corresponding pitch in possibB, in semitones.
-
 
     >>> from music21 import pitch
     >>> from music21.figuredBass import possibility
@@ -686,13 +684,11 @@ def partMovementsWithinLimits(possibA, possibB, partMovementLimits=None):
     >>> B4 = pitch.Pitch('B4')
     >>> C5 = pitch.Pitch('C5')
 
-
     Here, we limit the soprano part to motion of two semitones,
     enharmonically equivalent to a major second.
     Moving from C5 to B4 is allowed because it constitutes stepwise
     motion, but moving to A4 is not allowed
     because the distance between A4 and C5 is three semitones.
-
 
     >>> partMovementLimits = [(1, 2)]
     >>> possibA1 = (C5, G4, E4, C4)
@@ -813,7 +809,7 @@ def couldBeItalianA6Resolution(possibA, possibB, threePartChordInfo=None, restri
 
 
     A PossibilityException is raised if possibA is not an Italian A6 chord, but this only
-    applies only if threePartChordInfo = None, because otherwise the chord information is
+    applies if `threePartChordInfo=None`, because otherwise the chord information is
     coming from :class:`~music21.figuredBass.segment.Segment` and the fact that possibA is
     an It+6 chord is assumed.
 
@@ -992,7 +988,7 @@ consequentPossibilityMethods = [parallelFifths, parallelOctaves,
                                 couldBeItalianA6Resolution]
 # consequentPossibilityMethods.sort(None, lambda x: x.__name__)
 
-_DOC_ORDER = singlePossibilityMethods + [partPairs] + consequentPossibilityMethods
+_DOC_ORDER = [*singlePossibilityMethods, partPairs, *consequentPossibilityMethods]
 
 
 class PossibilityException(exceptions21.Music21Exception):

--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         realizer.py
-# Purpose:      music21 class to define a figured bass line, consisting of notes
+# Purpose:      figured bass lines, consisting of notes
 #                and figures in a given key.
 # Authors:      Jose Cabal-Ugaz
 #
@@ -66,6 +66,7 @@ _MOD = 'figuredBass.realizer'
 
 
 def figuredBassFromStream(streamPart):
+    # noinspection PyShadowingNames
     '''
     Takes a :class:`~music21.stream.Part` (or another :class:`~music21.stream.Stream` subclass)
     and returns a :class:`~music21.figuredBass.realizer.FiguredBassLine` object whose bass notes
@@ -117,6 +118,7 @@ def figuredBassFromStream(streamPart):
         if paddingLeft != 0.0:
             fb._paddingLeft = paddingLeft
 
+    # noinspection PyShadowingNames
     def updateAnnotationString(annotationString: str, inputText: str) -> str:
         '''
         Continue building the working `annotationString` based on some `inputText`
@@ -238,7 +240,7 @@ class FiguredBassLine:
         self._fbScale = realizerScale.FiguredBassScale(inKey.pitchFromDegree(1), inKey.mode)
         self._fbList = []
 
-    def addElement(self, bassObject, notationString=None):
+    def addElement(self, bassObject: note.Note, notationString=None):
         '''
         Use this method to add (bassNote, notationString) pairs to the bass line. Elements
         are realized in the order they are added.
@@ -258,6 +260,7 @@ class FiguredBassLine:
             :width: 200
 
         OMIT_FROM_DOCS
+
         >>> fbLine = realizer.FiguredBassLine(key.Key('C'), meter.TimeSignature('4/4'))
         >>> fbLine.addElement(harmony.ChordSymbol('C'))
         >>> fbLine.addElement(harmony.ChordSymbol('G'))
@@ -266,7 +269,7 @@ class FiguredBassLine:
         >>> fbLine.addElement(roman.RomanNumeral('I'))
         >>> fbLine.addElement(roman.RomanNumeral('V'))
         '''
-        bassObject.notationString = notationString
+        bassObject.editorial.notationString = notationString
         c = bassObject.classes
         if 'Note' in c:
             self._fbList.append((bassObject, notationString))  # a bass note, and a notationString
@@ -358,7 +361,7 @@ class FiguredBassLine:
         bassNoteIndex = 0
         previousBassNote = bassLine[bassNoteIndex]
         bassNote = currentMapping[allKeys[0]][-1]
-        previousSegment = segment.OverlaidSegment(bassNote, bassNote.notationString,
+        previousSegment = segment.OverlaidSegment(bassNote, bassNote.editorial.notationString,
                                                    self._fbScale,
                                                    fbRules, numParts, maxPitch)
         previousSegment.quarterLength = previousBassNote.quarterLength
@@ -366,7 +369,7 @@ class FiguredBassLine:
         for k in allKeys[1:]:
             (startTime, unused_endTime) = k
             bassNote = currentMapping[k][-1]
-            currentSegment = segment.OverlaidSegment(bassNote, bassNote.notationString,
+            currentSegment = segment.OverlaidSegment(bassNote, bassNote.editorial.notationString,
                                                       self._fbScale,
                                                       fbRules, numParts, maxPitch)
             for partNumber in range(1, len(currentMapping[k])):
@@ -390,6 +393,7 @@ class FiguredBassLine:
         self._overlaidParts.append(music21Part)
 
     def realize(self, fbRules=None, numParts=4, maxPitch=None):
+        # noinspection PyShadowingNames
         '''
         Creates a :class:`~music21.figuredBass.segment.Segment`
         for each (bassNote, notationString) pair
@@ -401,8 +405,7 @@ class FiguredBassLine:
         likewise be controlled through maxPitch.
         Returns a :class:`~music21.figuredBass.realizer.Realization`.
 
-
-        If this methods is called without having provided any (bassNote, notationString) pairs,
+        If this method is called without having provided any (bassNote, notationString) pairs,
         a FiguredBassLineException is raised. If only one pair is provided, the Realization will
         contain :meth:`~music21.figuredBass.segment.Segment.allCorrectConsecutivePossibilities`
         for the one note.
@@ -410,8 +413,6 @@ class FiguredBassLine:
         if `fbRules` is None, creates a new rules.Rules() object
 
         if `maxPitch` is None, uses pitch.Pitch('B5')
-
-
 
         >>> from music21.figuredBass import realizer
         >>> from music21.figuredBass import rules
@@ -836,27 +837,27 @@ class Test(unittest.TestCase):
         third_note = s[note.Note][2]
         self.assertEqual(third_note.lyric, '64')
         unused_fb = figuredBassFromStream(s)
-        self.assertEqual(third_note.notationString, '6, 4')
+        self.assertEqual(third_note.editorial.notationString, '6, 4')
 
         third_note.lyric = '#6#42'
         unused_fb = figuredBassFromStream(s)
-        self.assertEqual(third_note.notationString, '#6, #4, 2')
+        self.assertEqual(third_note.editorial.notationString, '#6, #4, 2')
 
         third_note.lyric = '#64#2'
         unused_fb = figuredBassFromStream(s)
-        self.assertEqual(third_note.notationString, '#6, 4, #2')
+        self.assertEqual(third_note.editorial.notationString, '#6, 4, #2')
 
         # original case
         third_note.lyric = '6\n4'
         unused_fb = figuredBassFromStream(s)
-        self.assertEqual(third_note.notationString, '6, 4')
+        self.assertEqual(third_note.editorial.notationString, '6, 4')
 
         # single accidental
         for single_symbol in '+#bn':
             with self.subTest(single_symbol=single_symbol):
                 third_note.lyric = single_symbol
                 unused_fb = figuredBassFromStream(s)
-                self.assertEqual(third_note.notationString, single_symbol)
+                self.assertEqual(third_note.editorial.notationString, single_symbol)
 
 
 if __name__ == '__main__':

--- a/music21/figuredBass/realizerScale.py
+++ b/music21/figuredBass/realizerScale.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         realizerScale.py
-# Purpose:      music21 class for conveniently representing the concept of
-#                a figured bass scale
+# Purpose:      a figured bass scale
 # Authors:      Jose Cabal-Ugaz
 #
 # Copyright:    Copyright © 2010-2011 Michael Scott Cuthbert and the music21 Project

--- a/music21/figuredBass/rules.py
+++ b/music21/figuredBass/rules.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         rules.py
-# Purpose:      music21 class to define rules used in realization
+# Purpose:      Define rules used in realization
 # Authors:      Jose Cabal-Ugaz
 #
 # Copyright:    Copyright © 2010 Michael Scott Cuthbert and the music21 Project

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         segment.py
-# Purpose:      music21 class representing a figured bass note and notation
-#                realization.
+# Purpose:      figured bass note and notational realization.
 # Authors:      Jose Cabal-Ugaz
 #
 # Copyright:    Copyright © 2011 Michael Scott Cuthbert and the music21 Project
@@ -81,7 +80,7 @@ class Segment:
         Realizations of a Segment are represented
         as possibility tuples (see :mod:`~music21.figuredBass.possibility` for more details).
 
-        Methods in Python's `itertools <http://docs.python.org/library/itertools.html>`_
+        Methods in Python's `itertools`
         module are used extensively. Methods
         which generate possibilities or possibility progressions return iterators,
         which are turned into lists in the examples
@@ -118,7 +117,7 @@ class Segment:
         if fbScale is None:
             if _defaultRealizerScale['scale'] is None:
                 _defaultRealizerScale['scale'] = realizerScale.FiguredBassScale()
-            fbScale = _defaultRealizerScale['scale']  # save making it
+            fbScale = _defaultRealizerScale['scale']  # save the time of making it
         assert fbScale is not None  # tells mypy that we have it now
 
         if fbRules is None:
@@ -151,6 +150,7 @@ class Segment:
     # EXTERNAL METHODS
 
     def singlePossibilityRules(self, fbRules=None):
+        # noinspection PyShadowingNames
         '''
         A framework for storing single possibility rules and methods to be applied
         in :meth:`~music21.figuredBass.segment.Segment.allCorrectSinglePossibilities`.
@@ -159,9 +159,7 @@ class Segment:
 
         Items are added within this method in the following form:
 
-
         (willRunOnlyIfTrue, methodToRun, keepSolutionsWhichReturn, optionalArgs)
-
 
         These items are compiled internally when
         :meth:`~music21.figuredBass.segment.Segment.allCorrectSinglePossibilities`
@@ -177,9 +175,7 @@ class Segment:
         True       upperPartsWithinLimit         True                          12
         True       voiceCrossing                 False                         None
 
-
         Here, a modified fbRules is provided, which allows for incomplete possibilities.
-
 
         >>> from music21.figuredBass import rules
         >>> fbRules = rules.Rules()
@@ -211,18 +207,16 @@ class Segment:
         return singlePossibRules
 
     def consecutivePossibilityRules(self, fbRules=None):
+        # noinspection PyShadowingNames
         '''
         A framework for storing consecutive possibility rules and methods to be applied
         in :meth:`~music21.figuredBass.segment.Segment.allCorrectConsecutivePossibilities`.
         Takes in a :class:`~music21.figuredBass.rules.Rules` object, fbRules; if None
         then a new rules.Rules() object is created.
 
-
         Items are added within this method in the following form:
 
-
-        (willRunOnlyIfTrue, methodToRun, keepSolutionsWhichReturn, optionalArgs)
-
+            (willRunOnlyIfTrue, methodToRun, keepSolutionsWhichReturn, optionalArgs)
 
         These items are compiled internally when
         :meth:`~music21.figuredBass.segment.Segment.allCorrectConsecutivePossibilities`
@@ -248,10 +242,8 @@ class Segment:
                                                                  <music21.pitch.Pitch E3>,
                                                                  <music21.pitch.Pitch G3>], True
 
-
         Now, a modified fbRules is provided, allowing hidden octaves and
         voice overlap, and limiting the soprano line to stepwise motion.
-
 
         >>> from music21.figuredBass import rules
         >>> fbRules = rules.Rules()
@@ -328,9 +320,7 @@ class Segment:
         False      resolveDiminishedSeventhSegment  False
         False      resolveAugmentedSixthSegment     None
 
-
         Dominant Seventh Segment:
-
 
         >>> from music21 import note
         >>> segmentA = segment.Segment(bassNote=note.Note('B2'), notationString='6,5')
@@ -341,9 +331,7 @@ class Segment:
         False      resolveDiminishedSeventhSegment  False
         False      resolveAugmentedSixthSegment     None
 
-
         Fully-Diminished Seventh Segment:
-
 
         >>> segmentA = segment.Segment(bassNote=note.Note('B2'), notationString='-7')
         >>> allSpecialResRules = segmentA.specialResolutionRules()
@@ -353,9 +341,7 @@ class Segment:
         True       resolveDiminishedSeventhSegment  False
         False      resolveAugmentedSixthSegment     None
 
-
         Augmented Sixth Segment:
-
 
         >>> segmentA = segment.Segment(bassNote=note.Note('A-2'), notationString='#6,b5')
         >>> allSpecialResRules = segmentA.specialResolutionRules()
@@ -385,12 +371,12 @@ class Segment:
         return specialResRules
 
     def resolveDominantSeventhSegment(self, segmentB):
+        # noinspection PyShadowingNames
         '''
         Can resolve a Segment whose :attr:`~music21.figuredBass.segment.Segment.segmentChord`
         spells out a dominant seventh chord. If no applicable method in
         :mod:`~music21.figuredBass.resolution` can be used, the Segment is resolved
         as an ordinary Segment.
-
 
         >>> from music21.figuredBass import segment
         >>> from music21 import note
@@ -411,7 +397,6 @@ class Segment:
 
         >>> [p.nameWithOctave for p in allDomPossibList[7]]
         ['B5', 'F5', 'D5', 'G2']
-
 
         >>> segmentB = segment.Segment(bassNote=note.Note('C3'), notationString='')
         >>> domResPairs = segmentA.resolveDominantSeventhSegment(segmentB)
@@ -445,7 +430,7 @@ class Segment:
         if (domChord.inversion() == 0
                 and resChord.root().name == tonic.name
                 and (resChord.isMajorTriad() or resChord.isMinorTriad())):
-            # V7 to I resolutions are always incomplete, with a missing fifth.
+            # "V7 to I" resolutions are always incomplete, with a missing fifth.
             segmentB.fbRules.forbidIncompletePossibilities = False
 
         dominantResolutionMethods = [
@@ -486,6 +471,7 @@ class Segment:
             return self._resolveOrdinarySegment(segmentB)
 
     def resolveDiminishedSeventhSegment(self, segmentB, doubledRoot=False):
+        # noinspection PyShadowingNames
         '''
         Can resolve a Segment whose :attr:`~music21.figuredBass.segment.Segment.segmentChord`
         spells out a diminished seventh chord. If no applicable method in
@@ -503,7 +489,6 @@ class Segment:
         ['D5', 'A-4', 'F4', 'B2']
         >>> [p.nameWithOctave for p in allDimPossibList[6]]
         ['A-5', 'F5', 'D5', 'B2']
-
 
         >>> segmentB = segment.Segment(bassNote=note.Note('C3'), notationString='')
         >>> dimResPairs = segmentA.resolveDiminishedSeventhSegment(segmentB)
@@ -558,6 +543,7 @@ class Segment:
             return self._resolveOrdinarySegment(segmentB)
 
     def resolveAugmentedSixthSegment(self, segmentB):
+        # noinspection PyShadowingNames
         '''
         Can resolve a Segment whose :attr:`~music21.figuredBass.segment.Segment.segmentChord`
         spells out a
@@ -584,7 +570,6 @@ class Segment:
         (<music21.pitch.Pitch C4>, <music21.pitch.Pitch F#3>, <...E-3>, <...A-2>)
         >>> allAugSixthPossibList[4]
         (<music21.pitch.Pitch C5>, <music21.pitch.Pitch F#4>, <...E-4>, <...A-2>)
-
 
         >>> segmentB = segment.Segment(bassNote=note.Note('G2'), notationString='')
         >>> allAugResPossibPairs = segmentA.resolveAugmentedSixthSegment(segmentB)
@@ -722,30 +707,26 @@ class Segment:
         return [possibA for possibA in allA if self._isCorrectSinglePossibility(possibA)]
 
     def allCorrectConsecutivePossibilities(self, segmentB):
+        # noinspection PyShadowingNames
         '''
         Returns an iterator through correct (possibA, possibB) pairs.
-
 
         * If segmentA (self) is a special Segment, meaning that one of the Segment
           resolution methods in :meth:`~music21.figuredBass.segment.Segment.specialResolutionRules`
           needs to be applied, then this method returns every correct possibility of segmentA
           matched up with exactly one resolution possibility.
 
-
         * If segmentA is an ordinary, non-special Segment, then this method returns every
           combination of correct possibilities of segmentA and correct possibilities of segmentB
           which passes all filters
           in :meth:`~music21.figuredBass.segment.Segment.consecutivePossibilityRules`.
 
-
         Two notes on segmentA being a special Segment:
 
-
-        1. By default resolution possibilities are not filtered
+        1. By default, resolution possibilities are not filtered
            using :meth:`~music21.figuredBass.segment.Segment.singlePossibilityRules`
            rules of segmentB. Filter by setting
            :attr:`~music21.figuredBass.rules.Rules.applySinglePossibRulesToResolution` to True.
-
 
         2. By default, (possibA, possibB) pairs are not filtered
            using :meth:`~music21.figuredBass.segment.Segment.consecutivePossibilityRules`
@@ -758,9 +739,7 @@ class Segment:
         >>> segmentA = segment.Segment(bassNote=note.Note('C3'), notationString='')
         >>> segmentB = segment.Segment(bassNote=note.Note('D3'), notationString='4,3')
 
-
         Here, an ordinary resolution is being executed, because segmentA is an ordinary Segment.
-
 
         >>> consecutivePairs1 = segmentA.allCorrectConsecutivePossibilities(segmentB)
         >>> consecutivePairsList1 = list(consecutivePairs1)
@@ -769,10 +748,8 @@ class Segment:
         >>> consecutivePairsList1[29]
         ((<...G5>, <...G5>, <...E5>, <...C3>), (<...G5>, <...F5>, <...B4>, <...D3>))
 
-
         Here, a special resolution is being executed, because segmentA below is a
         special Segment.
-
 
         >>> segmentA = segment.Segment(bassNote=note.Note('D3'), notationString='4,3')
         >>> segmentB = segment.Segment(bassNote=note.Note('C3'), notationString='')

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -290,7 +290,7 @@ class Graph(prebase.ProtoM21Object):
         ValueRange is a two-element tuple of the lowest
         number and the highest.
 
-        By default there is a padding of 10% of the range
+        By default, there is a padding of 10% of the range
         in either direction.  Set paddingFraction = 0 to
         eliminate this shift
         '''

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -208,8 +208,8 @@ class Harmony(chord.Chord):
 
     def __init__(self,
                  figure: Optional[str] = None,
-                 root: Optional[pitch.Pitch] = None,
-                 bass: Optional[pitch.Pitch] = None,
+                 root: Union[str, pitch.Pitch, None] = None,
+                 bass: Union[str, pitch.Pitch, None] = None,
                  inversion: Optional[int] = None,
                  updatePitches: bool = True,
                  **keywords

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -3,11 +3,12 @@
 # Name:         harmony.py
 # Purpose:      music21 classes for representing harmonies and chord symbols
 #
-# Authors:      Beth Hadley
+# Authors:      Michael Scott Cuthbert
+#               Beth Hadley
 #               Christopher Ariza
-#               Michael Scott Cuthbert
+#               Jacob Tyler Walls
 #
-# Copyright:    Copyright © 2011-2012, 2016 Michael Scott Cuthbert and the music21 Project
+# Copyright:    Copyright © 2011-2022, Michael Scott Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
@@ -19,7 +20,7 @@ import copy
 import re
 import unittest
 
-from typing import Dict, List, Optional, Tuple, TypeVar
+from typing import Dict, List, Optional, Tuple, TypeVar, Union
 
 from music21 import base
 from music21 import chord
@@ -46,7 +47,7 @@ NCT = TypeVar('NCT', bound='NoChord')
 # Y indicates this chord_type is an official XML chord type
 # N indicates XML does not support this chord type
 # Y : 'some string' indicates XML supports the chord type, but
-#      uses a name different than what I use in this dictionary
+#      uses a name different from what I use in this dictionary
 #      I mostly used XML's nomenclature, but for a few of the sevenths
 #      I just couldn't stand to adopt their names because they aren't consistent
 # sorry, you can't use '-' for minor, cause that's a flat in music21
@@ -143,20 +144,38 @@ class Harmony(chord.Chord):
     score as a chord (with pitches realized) or with just the
     figure (as in Chord Symbols).
 
+    Most users should start with the ChordSymbol class or the RomanNumeral
+    class.  The Harmony object is primarily a base object for defining other
+    sorts of objects:
+
+    >>> c6 = harmony.ChordSymbol('C/E')
+    >>> c6
+    <music21.harmony.ChordSymbol C/E>
+
+    By default, Harmony objects just float above the score and are a sort of
+    analytical object.  To make them also count as pitches in a score, use
+    `writeAsChord=True`
+
+    >>> c6.writeAsChord = True
+    >>> c6
+    <music21.harmony.ChordSymbol C/E: E G C>
+
+    Or individual components can be specified:
+
+    >>> c6_again = harmony.ChordSymbol(root='C', bass='E', kind='major')
+    >>> c6_again
+    <music21.harmony.ChordSymbol C/E>
+
+    It is also possible to instantiate an empty Harmony object and
+    then set components later, but this is an advanced and delicate operation:
+
     >>> h = harmony.ChordSymbol()
     >>> h.root('B-3')
-    >>> h.bass('D')
+    >>> h.bass('D', allow_add=True)
     >>> h.inversion(1, transposeOnSet=False)
     >>> h.addChordStepModification(harmony.ChordStepModification('add', 4))
     >>> h
     <music21.harmony.ChordSymbol B-/D add 4>
-
-    >>> c6 = harmony.ChordSymbol(root='C', bass='E', kind = 'major')
-    >>> c6
-    <music21.harmony.ChordSymbol C/E>
-    >>> c6.writeAsChord = True
-    >>> c6
-    <music21.harmony.ChordSymbol C/E: E G C>
 
     >>> h = harmony.ChordSymbol('C7/E')
     >>> h.root()
@@ -178,8 +197,8 @@ class Harmony(chord.Chord):
     >>> sus.root()
     <music21.pitch.Pitch D3>
 
-    Accepts a keyword 'updatePitches'. By default it
-    is True, but can be set to False to initialize faster if pitches are not needed.
+    Accepts a keyword 'updatePitches'. By default, it
+    is `True`, but can be set to `False` to initialize faster if pitches are not needed.
     '''
     # sort harmony just before notes and chords and other default objects
     classSortOrder = base.Music21Object.classSortOrder - 1
@@ -222,7 +241,7 @@ class Harmony(chord.Chord):
         # assume the bass and root are identical and
         # assign the values accordingly
         if 'bass' not in self._overrides and 'root' in self._overrides:
-            self.bass(self._overrides['root'])
+            self.bass(self._overrides['root'], allow_add=True)
 
         if (updatePitches
                 and self._figure  # == '' or is not None
@@ -264,7 +283,7 @@ class Harmony(chord.Chord):
         '''
         This method must be called twice, once before the pitches
         are rendered, and once after. This is because after the pitches
-        are rendered, the root() and bass() becomes reset by the chord class
+        are rendered, the root() and bass() becomes reset by the chord class,
         but we want the objects to retain their initial root, bass, and inversion.
         '''
         if root and isinstance(root, str):
@@ -274,9 +293,9 @@ class Harmony(chord.Chord):
             self.root(root)
         if bass and isinstance(bass, str):
             bass = common.cleanedFlatNotation(bass)
-            self.bass(pitch.Pitch(bass, octave=3))
+            self.bass(pitch.Pitch(bass, octave=3), allow_add=True)
         elif bass is not None:
-            self.bass(bass)
+            self.bass(bass, allow_add=True)
         if inversion is not None:
             self.inversion(inversion, transposeOnSet=True)
 
@@ -526,9 +545,9 @@ class ChordStepModification(prebase.ProtoM21Object):
     - degree-alter: indicates semitone alteration of degree, positive and
       negative integers only
     - degree-type: add, alter, or subtract
-        - if add: degree-alter is relative to a dominant chord (major and
+        - if `add`: degree-alter is relative to a dominant chord (major and
           perfect intervals except for a minor seventh)
-        - if alter or subtract: degree-alter is relative to degree already in
+        - if `alter` or `subtract`: degree-alter is relative to degree already in
           the chord based on its kind element
 
     >>> hd = harmony.ChordStepModification('add', 4)
@@ -546,11 +565,11 @@ class ChordStepModification(prebase.ProtoM21Object):
     # is a number indicating the degree of the chord (1 for
     # the root, 3 for third, etc). The degree-alter element
     # is like the alter element in notes: 1 for sharp, -1 for
-    # flat, etc. The degree-type element can be add, alter, or
-    # subtract. If the degree-type is alter or subtract, the
+    # flat, etc. The degree-type element can be `add`, `alter`, or
+    # `subtract`. If the degree-type is alter or subtract, the
     # degree-alter is relative to the degree already in the
     # chord based on its kind element. If the degree-type is
-    # add, the degree-alter is relative to a dominant chord
+    # `add`, the degree-alter is relative to a dominant chord
     # (major and perfect intervals except for a minor
     # seventh). The print-object attribute can be used to
     # keep the degree from printing separately when it has
@@ -558,7 +577,7 @@ class ChordStepModification(prebase.ProtoM21Object):
     # the kind element. The plus-minus attribute is used to
     # indicate if plus and minus symbols should be used
     # instead of sharp and flat symbols to display the degree
-    # alteration; it is no by default. The degree-value and
+    # alteration; it is `no` by default. The degree-value and
     # degree-type text attributes specify how the value and
     # type of the degree should be displayed.
     #
@@ -993,7 +1012,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
 
     if the algorithm matches the chord, but omissions or subtractions are present,
     the chord symbol attempts to indicate this (although there is no standard way of doing
-    this so the notation might be different than what you're familiar with.
+    this so the notation might be different from what you're familiar with).
 
     An example of using this algorithm for identifying chords "in the wild":
 
@@ -1097,11 +1116,13 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
         a '/' if the chord is in an inversion, and the chord's bass
 
     The chord symbol nomenclature is not entirely standardized. There are several
-    different ways to write each Abbreviation
-    For example, an augmented triad might be symbolized with '+' or 'aug'
-    Thus, by default the returned symbol is the first (element 0) in the CHORD_TYPES list
-    For example (Eb minor eleventh chord, second inversion)
-    root + chord-type-str + '/' + bass = 'Ebmin11/Bb'
+    ways to write each abbreviation.
+
+    For example, an augmented triad might be symbolized with '+' or 'aug'.
+    Thus, by default the returned symbol is the first (element 0) in the CHORD_TYPES list.
+    For example (Eb minor eleventh chord, second inversion):
+
+        root + chord-type-str + '/' + bass = 'Ebmin11/Bb'
 
     Users who wish to change these defaults can simply change that
     entry in the CHORD_TYPES dictionary.
@@ -1150,7 +1171,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
         to determine if it could be a match for inChord
 
         the corresponding semitones are compared, and if they do not match it is determined
-        whether or not this is a permitted omission, etc.
+        whether this is a permitted omission, etc.
 
         '''
         m = len(givenChordNums)
@@ -1544,7 +1565,7 @@ class ChordSymbol(Harmony):
     >>> cs
     <music21.harmony.ChordSymbol>
     >>> cs.root('E-')
-    >>> cs.bass('B-')
+    >>> cs.bass('B-', allow_add=True)
 
     important: we are not asking for transposition, merely specifying the inversion that
     the chord should be read in (transposeOnSet = False)
@@ -1562,8 +1583,8 @@ class ChordSymbol(Harmony):
 
     def __init__(self,
                  figure=None,
-                 root: Optional[pitch.Pitch] = None,
-                 bass: Optional[pitch.Pitch] = None,
+                 root: Union[pitch.Pitch, str, None] = None,
+                 bass: Union[pitch.Pitch, str, None] = None,
                  inversion: Optional[int] = None,
                  kind='',
                  kindStr='',
@@ -1612,12 +1633,14 @@ class ChordSymbol(Harmony):
     def _adjustPitchesForChordStepModifications(self, pitches):
         '''
         degree-value element: indicates degree in chord, positive integers only
+
         degree-alter: indicates semitone alteration of degree, positive and negative integers only
-        degree-type: add, alter, or subtract
-            if add:
+
+        degree-type: `add`, `alter`, or `subtract`:
+            if `add`:
                 degree-alter is relative to a dominant chord (major and perfect
                 intervals except for a minor seventh)
-            if alter or subtract:
+            if `alter` or `subtract`:
                 degree-alter is relative to degree already in the chord based on its kind element
 
 
@@ -1628,11 +1651,11 @@ class ChordSymbol(Harmony):
         is a number indicating the degree of the chord (1 for
         the root, 3 for third, etc). The degree-alter element
         is like the alter element in notes: 1 for sharp, -1 for
-        flat, etc. The degree-type element can be add, alter, or
-        subtract. If the degree-type is alter or subtract, the
+        flat, etc. The degree-type element can be `add`, `alter`, or
+        `subtract`. If the degree-type is `alter` or `subtract`, the
         degree-alter is relative to the degree already in the
         chord based on its kind element. If the degree-type is
-        add, the degree-alter is relative to a dominant chord
+        `add`, the degree-alter is relative to a dominant chord
         (major and perfect intervals except for a minor
         seventh). The print-object attribute can be used to
         keep the degree from printing separately when it has
@@ -1640,7 +1663,7 @@ class ChordSymbol(Harmony):
         the kind element. The plus-minus attribute is used to
         indicate if plus and minus symbols should be used
         instead of sharp and flat symbols to display the degree
-        alteration; it is no by default. The degree-value and
+        alteration; it is `no` by default. The degree-value and
         degree-type text attributes specify how the value and
         type of the degree should be displayed.
 
@@ -1890,7 +1913,7 @@ class ChordSymbol(Harmony):
             st = st.replace(root, '')
             prelimFigure = prelimFigure.replace(',', '')
         else:
-            m1 = re.match(r'[A-Ga-g][#-]*', prelimFigure)  # match not case sensitive,
+            m1 = re.match(r'[A-Ga-g][#-]*', prelimFigure)  # match not case-sensitive,
             if m1:
                 root = m1.group()
                 # remove the root and bass from the string and any additions/omissions/alterations/
@@ -1903,12 +1926,12 @@ class ChordSymbol(Harmony):
             self.root(pitch.Pitch(root))
 
         # Get optional Bass:
-        m2 = re.search(r'/[A-Ga-g][#-]*', prelimFigure)  # match not case sensitive
+        m2 = re.search(r'/[A-Ga-g][#-]*', prelimFigure)  # match not case-sensitive
         remaining = st
         if m2:
             bass = m2.group()
             bass = bass.replace('/', '')
-            self.bass(bass)
+            self.bass(bass, allow_add=True)
             # remove the root and bass from the string
             remaining = st.replace(m2.group(), '')
 
@@ -2127,7 +2150,7 @@ class ChordSymbol(Harmony):
 
         # set overrides to be pitches in the harmony
         # self._overrides = {}  # JTW: was wiping legit overrides such as root=C from 'C6'
-        self.bass(self.bass())
+        self.bass(self.bass(), allow_add=True)
         self.root(self.root())
 
     # PUBLIC METHODS #
@@ -2414,11 +2437,11 @@ class NoChord(ChordSymbol):
             self._figure = self.chordKindStr
 
     def root(self, newroot=None, *, find=None):
-        # Ignore newroot, and set find to False to always return None
+        # Ignore newroot, and set find to "False" to always return None
         return None
 
-    def bass(self, newbass=None, *, find=None):
-        # Ignore newbass, and set find to False to always return None
+    def bass(self, newbass=None, *, find=None, allow_add=False):
+        # Ignore newbass, and set find to "False" to always return None
         return None
 
     def _parseFigure(self):
@@ -2492,7 +2515,7 @@ def realizeChordSymbolDurations(piece):
 
     If a ChordSymbol object exists followed by many notes, duration represents
     all those notes (how else can the computer know to end the chord? if
-    there's not chord following it other than end the chord at the end of the
+    there's no chord following it other than end the chord at the end of the
     piece?).
 
     >>> s = stream.Score()
@@ -2570,7 +2593,7 @@ class Test(unittest.TestCase):
         from music21 import harmony
         cs = harmony.ChordSymbol()
         cs.root('E-')
-        cs.bass('B-')
+        cs.bass('B-', allow_add=True)
         cs.inversion(2, transposeOnSet=False)
         cs.romanNumeral = 'I64'
         cs.chordKind = 'major'
@@ -2697,13 +2720,15 @@ class Test(unittest.TestCase):
 
 
     def runTestOnChord(self, xmlString, figure, pitches):
-        """
+        '''
         Run a series of tests on the given chord.
 
-        :param xmlString: an XML harmony object
-        :param figure: the equivalent figure representation
-        :param pitches: the list of pitches of the chord
-        """
+        xmlString: an XML harmony object
+
+        figure: the equivalent figure representation
+
+        pitches: the list of pitches of the chord
+        '''
         from xml.etree.ElementTree import fromstring as EL
         from music21 import musicxml
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5050,7 +5050,7 @@ class MeasureExporter(XMLExporterBase):
 
         >>> cs = harmony.ChordSymbol()
         >>> cs.root('E-')
-        >>> cs.bass('B-')
+        >>> cs.bass('B-', allow_add=True)
         >>> cs.inversion(2, transposeOnSet=False)
         >>> cs.chordKind = 'major'
         >>> cs.chordKindStr = 'M'

--- a/music21/note.py
+++ b/music21/note.py
@@ -982,7 +982,7 @@ class NotRest(GeneralNote):
         ('double', 'down', 'noStem', 'none', 'unspecified', 'up')
         >>> n = note.Note()
 
-        By default a Note's stemDirection is 'unspecified'
+        By default, a Note's stemDirection is 'unspecified'
         meaning that it is unknown:
 
         >>> n.stemDirection
@@ -1776,7 +1776,7 @@ class Unpitched(NotRest):
 class Rest(GeneralNote):
     '''
     Rests are represented in music21 as GeneralNote objects that do not have
-    a pitch object attached to them.  By default they have length 1.0 (Quarter Rest)
+    a pitch object attached to them.  By default, they have length 1.0 (Quarter Rest)
 
     Calling :attr:`~music21.stream.Stream.notes` on a Stream does not get rests.
     However, the property :attr:`~music21.stream.Stream.notesAndRests` of Streams

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4597,7 +4597,7 @@ class Pitch(prebase.ProtoM21Object):
         different octave.  The sharp must always be displayed.
 
         If `overrideStatus` is True, this method will ignore any current
-        `displayStatus` setting found on the Accidental. By default this does
+        `displayStatus` setting found on the Accidental. By default, this does
         not happen. If `displayStatus` is set to None, the Accidental's
         `displayStatus` is set.
 

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -80,7 +80,7 @@ def _getKeyFromCache(keyStr: str) -> key.Key:
     create a new key and put it in the cache and return it.
     '''
     if keyStr in _keyCache:
-        # adding copy.copy will at least prevent small errors at a cost of only 3 nano-seconds
+        # adding copy.copy will at least prevent small errors at a cost of only 3 nanoseconds
         # of added time.  A deepcopy, unfortunately, take 2.8ms, which is longer than not
         # caching at all.  And not caching at all really slows down things like RomanText.
         # This at least will prevent what happens if `.key.mode` is changed
@@ -277,14 +277,14 @@ def correctSuffixForChordQuality(chordObj, inversionString):
         if seventhType == 10 and qualityName == 'o':
             qualityName = 'ø'
         elif seventhType != 9:
-            pass  # do something for odd odd chords built on diminished triad.
+            pass  # do something for extremely odd chords built on diminished triad.
     # print(inversionString, fifthName)
     return qualityName + inversionString
 
 
 def postFigureFromChordAndKey(chordObj, keyObj=None):
     '''
-    Returns the post RN figure for a given chord in a given key.
+    Returns the post-RN figure for a given chord in a given key.
 
     If keyObj is none, it uses the root as a major key:
 
@@ -1628,8 +1628,8 @@ class RomanNumeral(harmony.Harmony):
 
 
     The RomanNumeral constructor accepts a keyword 'updatePitches' which is
-    passed to harmony.Harmony. By default it
-    is True, but can be set to False to initialize faster if pitches are not needed.
+    passed to harmony.Harmony. By default, it
+    is `True`, but can be set to `False` to initialize faster if pitches are not needed.
 
     >>> r = roman.RomanNumeral('vio', em, updatePitches=False)
     >>> r.pitches
@@ -2103,7 +2103,7 @@ class RomanNumeral(harmony.Harmony):
     def __init__(
         self,
         figure: Union[str, int] = '',
-        keyOrScale: Optional[Union[key.Key, scale.Scale]] = None,
+        keyOrScale: Optional[Union[key.Key, scale.Scale, str]] = None,
         *,
         caseMatters=True,
         updatePitches=True,
@@ -3129,7 +3129,6 @@ class RomanNumeral(harmony.Harmony):
                     _keyCache[keyOrScale.tonicPitchNameWithCase] = keyOrScale
             elif 'Scale' in keyClasses:
                 if keyOrScale.name in _scaleCache:
-                    # use stored scale as already has cache
                     keyOrScale = _scaleCache[keyOrScale.name]
                 else:
                     _scaleCache[keyOrScale.name] = keyOrScale
@@ -3370,11 +3369,11 @@ class RomanNumeral(harmony.Harmony):
         '''
         Checks if a RomanNumeral is an instance of 'modal mixture' in which the chord is
         not diatonic in the key specified, but
-        would be would be in the parallel (German: variant) major / minor
+        would be in the parallel (German: variant) major / minor
         and can therefore be thought of as a 'mixture' of major and minor modes, or
         as a 'borrowing' from the one to the other.
 
-        Examples include i in major or I in minor (*sic*).
+        Examples include "i" in major or "I" in minor (*sic*).
 
         Specifically, this method returns True for all and only the following cases in any
         inversion:
@@ -3395,7 +3394,7 @@ class RomanNumeral(harmony.Harmony):
 
         * scale degree b7 and triad quality major (Bb); and
 
-        * scale degree 7 and it's a diminished seventh specifically (b-d-f-ab).
+        * scale degree 7, and it is a diminished seventh (specifically b-d-f-ab).
 
         Minor context (example of c minor):
 
@@ -3409,7 +3408,7 @@ class RomanNumeral(harmony.Harmony):
 
         * scale degree #6 and triad quality minor (a); and
 
-        * scale degree 7 and it's a half diminished seventh specifically (b-d-f-a).
+        * scale degree 7, and it is a half-diminished seventh (specifically b-d-f-a).
 
         This list is broadly consistent with (and limited to) borrowing between the major and
         natural minor, except for excluding V (G-B-D) and viio (B-D-F) in minor.
@@ -3482,12 +3481,12 @@ class RomanNumeral(harmony.Harmony):
         False
 
         (That specific example of bIII+ in major is a borderline case that
-        arguably ought to be included and may be added in future.)
+        arguably ought to be included and may be added later without a deprecation cycle.)
 
         Naturally, really extended usages such as scale degrees beyond 7 (in the
         Octatonic mode, for instance) also return False.
 
-        The evaluateSecondaryNumeral parameter allows users to chose whether to consider
+        The evaluateSecondaryNumeral parameter allows users to choose whether to consider
         secondary Roman numerals (like V/vi) or to ignore them.
         When considered, exactly the same rules apply but recasting the comparison on
         the secondaryRomanNumeral.

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -1760,8 +1760,8 @@ class ConcreteScale(Scale):
         For a given pitch, return the appropriate scale degree.
         If no scale degree is available, None is returned.
 
-        Note -- by default it will find based on note name not on
-        PitchClass because this is used so commonly by tonal functions.
+        Note: by default it will use a find algorithm that is based on the note's
+        `.name` not on `.pitchClass` because this is used so commonly by tonal functions.
         So if it's important that D# and E- are the same, set the
         comparisonAttribute to `pitchClass`
 

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -362,7 +362,7 @@ def unitNormStep(step, a=0, b=1, normalized=True):
     to fill step through inclusive a,b, then return a unit interval list of values
     necessary to cover region.
 
-    Note that returned values are by default normalized within the unit interval.
+    Note that returned values are, by default, normalized within the unit interval.
 
 
     >>> sieve.unitNormStep(0.5, 0, 1)

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -4040,7 +4040,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         That is, a request for measures 4 through 10 will return 7 Measures, numbers 4 through 10.
 
         Additionally, any number of associated classes can be gathered from the context
-        and put into the measure.  By default we collect the Clef, TimeSignature, KeySignature,
+        and put into the measure.  By default, we collect the Clef, TimeSignature, KeySignature,
         and Instrument so that there is enough context to perform.  (See getContextByClass()
         and .previous() for definitions of the context)
 
@@ -6056,10 +6056,10 @@ class Stream(core.StreamCoreMixin, base.Music21Object):
         returned. If a flat Stream of notes, or a Score of such
         Streams is provided, no Measures will be returned.
 
-        If using chordify with chord symbols, ensure that the chord symbols
-        have durations (by default the duration of a chord symbol object is 0, unlike
-        a chord object). If harmony objects are not provided a duration, they
-        will not be included in the chordified output pitches but may appear as chord symbol
+        If using chordify with chord symbols, ensure that the ChordSymbol objects
+        have durations (by default, the duration of a ChordSymbol object is 0, unlike
+        a Chord object). If Harmony objects are not provided a duration, they
+        will not be included in the chordified output pitches but may appear as chord symbols
         in notation on the score. To realize the chord symbol durations on a score, call
         :meth:`music21.harmony.realizeChordSymbolDurations` and pass in the score.
 

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -602,8 +602,8 @@ class StreamCoreMixin:
         {1.0} <music21.note.Note D>
 
 
-        Now we'll remove the second note so not all elements of the slur
-        are present, which by default will not insert the Slur:
+        Now we'll remove the second note so not all elements of the Slur
+        are present. This, by default, will not insert the Slur:
 
         >>> s = getStream()
         >>> s.remove(s[-1])


### PR DESCRIPTION
master/main is now on v8.  A m21_7 branch has been created for any backward changes to put in v7.

* Update version number
* Chord.bass('new_bass') throws exception if new_bass is not in the chord, unless allow_add=True
* FiguredBass realizer stores notation objects in the note's Editorial not on the note object itself (typing cleanup)
* Change some obscure chord table names to things that make more sense to me
* Grammar fixes