### PR TITLE
Fix repr() failure for Metadata

### DIFF
--- a/music21/base.py
+++ b/music21/base.py
@@ -631,7 +631,8 @@ class Music21Object(prebase.ProtoM21Object):
         >>> b._reprInternal()
         'id=hi'
         '''
-        if self.id == id(self):
+        # hasattr is here because of Metadata.__getattr__()
+        if not hasattr(self, 'id') or self.id == id(self):
             return super()._reprInternal()
         reprId = self.id
         try:


### PR DESCRIPTION
Fix test failing on master by reverting a small bit from 2f345d1407c96fa54851fb47e4361d5162eae255.