### PR TITLE
Fix MIDI in Google Colab Notebooks

### DIFF
--- a/documentation/docbuild/writers.py
+++ b/documentation/docbuild/writers.py
@@ -263,7 +263,7 @@ class IPythonNotebookReSTWriter(ReSTWriter):
         ipFilePaths = [x for x in self.ipythonNotebookFilePaths if 'usersGuide' in x.name]
         if not ipFilePaths:
             raise DocumentationWritersException(
-                'No iPythonNotebook files were converted; '
+                'No Jupyter Notebook files were converted; '
                 + 'you probably have a problem with pandoc or nbconvert not being installed.'
             )
         usersGuideDir = self.notebookFilePathToRstFilePath(ipFilePaths[0]).parent
@@ -325,7 +325,7 @@ class IPythonNotebookReSTWriter(ReSTWriter):
     def notebookFilePathToRstFilePath(self, ipythonNotebookFilePath):
         if not ipythonNotebookFilePath.exists():
             raise DocumentationWritersException(
-                f'No iPythonNotebook with filePath {ipythonNotebookFilePath}')
+                f'No Jupyter Notebook with filePath {ipythonNotebookFilePath}')
         notebookFileNameWithoutExtension = ipythonNotebookFilePath.stem
         notebookParentDirectoryPath = ipythonNotebookFilePath.parent
         rstFileName = notebookFileNameWithoutExtension + '.rst'

--- a/music21/common/misc.py
+++ b/music21/common/misc.py
@@ -192,25 +192,26 @@ def sortModules(moduleList: Iterable[Any]) -> List[object]:
 def pitchList(pitchL):
     '''
     utility method that replicates the previous behavior of
-    lists of pitches
+    lists of pitches.
+
+    May be moved in v8 or later to a common.testing or test.X module.
     '''
     return '[' + ', '.join([x.nameWithOctave for x in pitchL]) + ']'
 
 
 def runningUnderIPython() -> bool:
     '''
-    return bool if we are running under iPython Notebook (not iPython)
+    return bool if we are running under IPython Notebook (not IPython terminal)
+    or Google Colabatory (colab).
 
-    (no tests, since will be different)
-
-    This post:
+    Methods based on:
 
     https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook
 
-    says not to do this, but really, I can't think of another way
-    to have different output as default.
+    (No tests provided here, since results will differ depending on environment)
 
-    Returns True also for Google Colab
+    May be moved in v8 or later to the ipython21 module.  Implementation may
+    change.
     '''
     if sys.stderr.__class__.__name__ == 'OutStream':
         return True

--- a/music21/ipython21/__init__.py
+++ b/music21/ipython21/__init__.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         ipython21/__init__.py
-# Purpose:      music21 iPython Notebook support
+# Purpose:      music21 IPython Notebook support
 #
-# Authors:      Michael Scott Cuthbert
+# Authors:      Michael Scott Asato Cuthbert
 #
-# Copyright:    Copyright © 2013-15 Michael Scott Cuthbert and the music21 Project
+# Copyright:    Copyright © 2013-22 Michael Scott Asato Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
-iPython extension to music21.  In IPython Notebook call:
+IPython extension to music21.  In Jupyter Notebook call:
 
    %load_ext music21.ipython21
 
-and show will take place inside the browser
+and show will take place inside the browser.  But currently not needed.
 '''
 __all__ = ['ipExtension', 'objects', 'loadNoMagic', 'load_ipython_extension']
 
@@ -25,7 +25,7 @@ from music21 import common
 
 def loadNoMagic():
     '''
-    Load the magic functions when running iPython
+    Load the magic functions of load_ipython_extension when running IPython
     '''
     if common.runningUnderIPython():
         # noinspection PyPackageRequirements
@@ -35,7 +35,18 @@ def loadNoMagic():
             load_ipython_extension(localIP)
 
 
-# if we are imported in an IPython environment, then load magic after half a second
+def inGoogleColabNotebook():
+    if not common.runningUnderIPython():
+        return False
+    try:
+        # get_ipython is loaded into global scope in IPython and Google Colab
+        # because we already returned False above, the NameError should never
+        # be triggered, but better safe than sorry.  And helps type checkers.
+        return get_ipython().__class__.__module__ == "google.colab._shell"
+    except NameError:
+        return False
+
+# if we are imported in an IPython environment, then load magic after two seconds
 if common.runningUnderIPython():
     from threading import Timer
     t = Timer(2, loadNoMagic)

--- a/music21/ipython21/__init__.py
+++ b/music21/ipython21/__init__.py
@@ -46,6 +46,7 @@ def inGoogleColabNotebook():
     except NameError:
         return False
 
+
 # if we are imported in an IPython environment, then load magic after two seconds
 if common.runningUnderIPython():
     from threading import Timer

--- a/music21/ipython21/ipExtension.py
+++ b/music21/ipython21/ipExtension.py
@@ -7,16 +7,18 @@ _DOC_IGNORE_MODULE_OR_PACKAGE = True
 
 def load_ipython_extension(ip):
     '''
-    Special method to automatically make PNG objects display inline.
+    Load any necessary notebook extensions.  Currently just
+    sets matplotlib to interactive mode.
 
-    MAY 2017: everything happens in converter.subConverters
+    Formerly set image/png to display properly, but we now use the default
+    display(Image(data)) in Jupyter.
     '''
     # pngFormatter = ip.display_formatter.formatters['image/png']
     # pngFormatter.for_type(music21.ipython21.objects.IPythonPNGObject,
     #                       music21.ipython21.objects.IPythonPNGObject.getData)
     try:
         from matplotlib import pyplot as plt  # type: ignore
-        plt.ion()
+        plt.ion()  # enable interactive mode
         # get retina figures in matplotlib
         ip.run_line_magic('config', "InlineBackend.figure_format = 'retina'")
     except ImportError:

--- a/music21/ipython21/objects.py
+++ b/music21/ipython21/objects.py
@@ -7,8 +7,9 @@ _DOC_IGNORE_MODULE_OR_PACKAGE = True
 
 class IPythonPNGObject:
     '''
-    we need to define a certain type of object that when encountered we
-    can handle. see ipExtension.
+    Given a filepath to a PNG file, have one method to read it and delete the
+    file.  This class may be removed, renamed, or otherwise altered in v8 --
+    it no longer has anything special to PNGs.
     '''
     def __init__(self, fp=None):
         self.fp = fp


### PR DESCRIPTION
Jupyter Notebook comes with the require.js script for loading other modules already included.  Google Colab does not.  Showing MIDI in the notebook needs to have require.js around.  Google Colab runs each cell in its own WebWorker; thus the loading of require.js and music21j must happen in each cell -- no global variables.

Since Google Colab is still running Python 3.7 (and selecting another core is a PAIN!) and music21 v8 will be 3.8+ only, this functionality is being backported to v7 and a 7.3.2 version will be released.