### PR TITLE
Use more classes in getElementsByClass

### DIFF
--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -660,7 +660,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s.parts[1].flatten().notesAndRests), 127)
 
         # chords are defined in second part here
-        self.assertEqual(len(s.parts[1].flatten().getElementsByClass('Chord')), 32)
+        self.assertEqual(len(s.parts[1][chord.Chord]), 32)
 
         # check pitches in chords; sharps are applied due to key signature
         match = [p.nameWithOctave for p in s.parts[1].flatten().getElementsByClass(
@@ -944,13 +944,13 @@ class Test(unittest.TestCase):
         # s.show()
         # one start, one end
         # s.parts[0].show('t')
-        self.assertEqual(len(s.flatten().getElementsByClass('Repeat')), 2)
+        self.assertEqual(len(s['Repeat']), 2)
         # s.show()
 
         # this has a 1 note pickup
         # has three repeat bars; first one is implied
         s = converter.parse(testFiles.draughtOfAle)
-        self.assertEqual(len(s.flatten().getElementsByClass('Repeat')), 3)
+        self.assertEqual(len(s['Repeat']), 3)
         self.assertEqual(s.parts[0].getElementsByClass(
             'Measure')[0].notes[0].pitch.nameWithOctave, 'D4')
 
@@ -965,14 +965,14 @@ class Test(unittest.TestCase):
         from music21 import corpus
         s = converter.parse(testFiles.morrisonsJig)
         # TODO: get
-        self.assertEqual(len(s.flatten().getElementsByClass(spanner.RepeatBracket)), 2)
+        self.assertEqual(len(s[spanner.RepeatBracket]), 2)
         # s.show()
         # four repeat brackets here; 2 at beginning, 2 at end
         s = converter.parse(testFiles.hectorTheHero)
-        self.assertEqual(len(s.flatten().getElementsByClass(spanner.RepeatBracket)), 4)
+        self.assertEqual(len(s[spanner.RepeatBracket]), 4)
 
         s = corpus.parse('JollyTinkersReel')
-        self.assertEqual(len(s.flatten().getElementsByClass(spanner.RepeatBracket)), 4)
+        self.assertEqual(len(s[spanner.RepeatBracket]), 4)
 
     def testMetronomeMarkA(self):
         from music21.abcFormat import testFiles

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -196,7 +196,7 @@ def abcToStreamPart(abcHandler, inputM21=None, spannerBundle=None):
         pass
     # clefs are not typically defined, but if so, are set to the first measure
     # following the meta data, or in the open stream
-    if not clefSet and not p.recurse().getElementsByClass('Clef'):
+    if not clefSet and not p[clef.Clef]:
         if useMeasures:  # assume at start of measures
             p.getElementsByClass(stream.Measure).first().clef = clef.bestClef(p, recurse=True)
         else:

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -205,7 +205,7 @@ def abcToStreamPart(abcHandler, inputM21=None, spannerBundle=None):
     if postTransposition != 0:
         p.transpose(postTransposition, inPlace=True)
 
-    if useMeasures and p.recurse().getElementsByClass('TimeSignature'):
+    if useMeasures and p[meter.TimeSignature]:
         # call make beams for now; later, import beams
         # environLocal.printDebug(['abcToStreamPart: calling makeBeams'])
         try:
@@ -850,16 +850,16 @@ class Test(unittest.TestCase):
         p1 = o.getScoreByNumber(81).parts[0]
         self.assertEqual(p1.offset, 0.0)
         self.assertEqual(len(p1.flatten().notesAndRests), 77)
-        self.assertEqual(len(list(p1.flatten().getElementsByClass('ChordSymbol'))), 25)
+        self.assertEqual(len(list(p1.flatten().getElementsByClass(harmony.ChordSymbol))), 25)
         # Am/C
-        self.assertEqual(list(p1.flatten().getElementsByClass('ChordSymbol'))[7].root(),
+        self.assertEqual(list(p1.flatten().getElementsByClass(harmony.ChordSymbol))[7].root(),
                          pitch.Pitch('A3'))
-        self.assertEqual(list(p1.flatten().getElementsByClass('ChordSymbol'))[7].bass(),
+        self.assertEqual(list(p1.flatten().getElementsByClass(harmony.ChordSymbol))[7].bass(),
                          pitch.Pitch('C3'))
         # G7/B
-        self.assertEqual(list(p1.flatten().getElementsByClass('ChordSymbol'))[14].root(),
+        self.assertEqual(list(p1.flatten().getElementsByClass(harmony.ChordSymbol))[14].root(),
                          pitch.Pitch('G3'))
-        self.assertEqual(list(p1.flatten().getElementsByClass('ChordSymbol'))[14].bass(),
+        self.assertEqual(list(p1.flatten().getElementsByClass(harmony.ChordSymbol))[14].bass(),
                          pitch.Pitch('B2'))
 
     def testNoChord(self):
@@ -884,9 +884,9 @@ class Test(unittest.TestCase):
 
         score = harmony.realizeChordSymbolDurations(score)
 
-        self.assertEqual(8, score.getElementsByClass('ChordSymbol')[
+        self.assertEqual(8, score.getElementsByClass(harmony.ChordSymbol)[
             -1].quarterLength)
-        self.assertEqual(4, score.getElementsByClass('ChordSymbol')[
+        self.assertEqual(4, score.getElementsByClass(harmony.ChordSymbol)[
             0].quarterLength)
 
     def testAbcKeyImport(self):
@@ -965,14 +965,14 @@ class Test(unittest.TestCase):
         from music21 import corpus
         s = converter.parse(testFiles.morrisonsJig)
         # TODO: get
-        self.assertEqual(len(s.flatten().getElementsByClass('RepeatBracket')), 2)
+        self.assertEqual(len(s.flatten().getElementsByClass(spanner.RepeatBracket)), 2)
         # s.show()
         # four repeat brackets here; 2 at beginning, 2 at end
         s = converter.parse(testFiles.hectorTheHero)
-        self.assertEqual(len(s.flatten().getElementsByClass('RepeatBracket')), 4)
+        self.assertEqual(len(s.flatten().getElementsByClass(spanner.RepeatBracket)), 4)
 
         s = corpus.parse('JollyTinkersReel')
-        self.assertEqual(len(s.flatten().getElementsByClass('RepeatBracket')), 4)
+        self.assertEqual(len(s.flatten().getElementsByClass(spanner.RepeatBracket)), 4)
 
     def testMetronomeMarkA(self):
         from music21.abcFormat import testFiles

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -1240,7 +1240,7 @@ class MelodicIntervalDiversity(DiscreteAnalysis):
         for p in procList:
             # get only Notes for now, skipping rests and chords
             # flatten to reach notes contained in measures
-            noteStream = p.flatten().stripTies(inPlace=False).getElementsByClass('Note').stream()
+            noteStream = p.flatten().stripTies(inPlace=False).getElementsByClass(note.Note).stream()
             # noteStream.show()
             for i, n in enumerate(noteStream):
                 if i <= len(noteStream) - 2:

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -129,7 +129,7 @@ class DiscreteAnalysis:
 
     def getColorsUsed(self):
         '''
-        Based on solutions found so far with with this processor,
+        Based on solutions found so far with this processor,
         return the colors that have been used.
         '''
         post = []
@@ -140,7 +140,7 @@ class DiscreteAnalysis:
 
     def getSolutionsUsed(self):
         '''
-        Based on solutions found so far with with this processor,
+        Based on solutions found so far with this processor,
         return the solutions that have been used.
         '''
         post = []
@@ -167,7 +167,7 @@ class DiscreteAnalysis:
 
     def solutionToColor(self, solution):
         '''
-        Given a analysis specific result, return the appropriate color.
+        Given an analysis specific result, return the appropriate color.
         Must be able to handle None in the case that there is no result.
         '''
         pass
@@ -305,7 +305,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
         >>> p._getSharpFlatCount(s.flatten())
         (87, 0)
         '''
-        # pitches gets a flat representation
+        # ".pitches" gets a flat representation
         flatCount = 0
         sharpCount = 0
         for p in subStream.pitches:
@@ -496,7 +496,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
                 if keyPitch.name not in valid:
                     mask = True
                 if mask:
-                    # set as white so as to maintain spacing
+                    # set as white to maintain spacing
                     color = '#ffffff'
                     keyStr = ''
                 else:
@@ -583,7 +583,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
 
         flipEnharmonic = False
 #         if pitchObj.accidental is not None:
-#             # if we have a sharp key and we need to favor flat, get enharmonic
+#             # if we have a sharp key, and we need to favor flat, get enharmonic
 #             if pitchObj.accidental.alter > 0 and favor == 'flat':
 #                 flipEnharmonic = True
 #             elif pitchObj.accidental.alter < 0 and favor == 'sharp':
@@ -635,7 +635,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
         #    mode = None
         #    solution = (None, mode, 0)
 
-        # see which has a higher correlation coefficient, the first major or the
+        # see which has a higher correlation coefficient, the first major or
         # the first minor
         if likelyKeysMajor is not None:
             sortList = [(coefficient, p, 'major') for
@@ -1227,6 +1227,7 @@ class MelodicIntervalDiversity(DiscreteAnalysis):
         # note that Stream.findConsecutiveNotes() and Stream.melodicIntervals()
         # offer similar approaches, but return Streams and manage offsets and durations,
         # components not needed here
+        from music21 import stream
 
         if found is None:
             found = {}

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -1233,7 +1233,7 @@ class MelodicIntervalDiversity(DiscreteAnalysis):
 
         # if this has parts, need to move through each at a time
         if sStream.hasPartLikeStreams():
-            procList = list(sStream.getElementsByClass('Stream'))
+            procList = list(sStream.getElementsByClass(stream.Stream))
         else:  # assume a single list of notes, or sStream is a part
             procList = [sStream]
 

--- a/music21/analysis/elements.py
+++ b/music21/analysis/elements.py
@@ -19,7 +19,7 @@ def attributeCount(streamOrStreamIter, attrName='quarterLength') -> collections.
 
     >>> from music21 import corpus
     >>> bach = corpus.parse('bach/bwv324.xml')
-    >>> bachIter = bach.parts[0].recurse().getElementsByClass('Note')
+    >>> bachIter = bach.parts[0].recurse().getElementsByClass(note.Note)
     >>> qlCount = analysis.elements.attributeCount(bachIter, 'quarterLength')
     >>> qlCount.most_common(3)
     [(1.0, 12), (2.0, 11), (4.0, 2)]

--- a/music21/analysis/metrical.py
+++ b/music21/analysis/metrical.py
@@ -86,7 +86,7 @@ def thomassenMelodicAccent(streamIn):
     .. _melac: https://www.humdrum.org/Humdrum/commands/melac.html
 
     Takes in a Stream of :class:`~music21.note.Note` objects (use `.flatten().notes` to get it, or
-    better `.flatten().getElementsByClass('Note')` to filter out chords) and adds the attribute to
+    better `.flatten().getElementsByClass(note.Note)` to filter out chords) and adds the attribute to
     each.  Note that Huron and Royal's work suggests that melodic accent has a correlation
     with metrical accent only for solo works/passages; even treble passages do not have a
     strong correlation. (Gregorian chants were found to have a strong ''negative'' correlation

--- a/music21/analysis/metrical.py
+++ b/music21/analysis/metrical.py
@@ -86,7 +86,8 @@ def thomassenMelodicAccent(streamIn):
     .. _melac: https://www.humdrum.org/Humdrum/commands/melac.html
 
     Takes in a Stream of :class:`~music21.note.Note` objects (use `.flatten().notes` to get it, or
-    better `.flatten().getElementsByClass(note.Note)` to filter out chords) and adds the attribute to
+    better `.flatten().getElementsByClass(note.Note)` to filter out chords)
+    and adds the attribute to
     each.  Note that Huron and Royal's work suggests that melodic accent has a correlation
     with metrical accent only for solo works/passages; even treble passages do not have a
     strong correlation. (Gregorian chants were found to have a strong ''negative'' correlation

--- a/music21/analysis/reduceChords.py
+++ b/music21/analysis/reduceChords.py
@@ -142,7 +142,7 @@ class ChordReducer:
         reduction.append(chordifiedPart)
 
         if closedPosition:
-            for x in reduction.recurse().getElementsByClass('Chord'):
+            for x in reduction[chord.Chord]:
                 x.closedPosition(forceOctave=4, inPlace=True)
 
         return reduction

--- a/music21/analysis/reduceChordsOld.py
+++ b/music21/analysis/reduceChordsOld.py
@@ -369,7 +369,7 @@ class TestExternal(unittest.TestCase):
         from music21 import key
         from music21 import roman
         cm = key.Key('G')
-        for thisChord in p.recurse().getElementsByClass('Chord'):
+        for thisChord in p[chord.Chord]:
             thisChord.lyric = roman.romanNumeralFromChord(thisChord,
                                                           cm,
                                                           preferSecondaryDominants=True).figure

--- a/music21/analysis/reduceChordsOld.py
+++ b/music21/analysis/reduceChordsOld.py
@@ -355,7 +355,7 @@ class TestExternal(unittest.TestCase):
         fixClef = True
         if fixClef:
             startClefs = c.parts[1].getElementsByClass(stream.Measure
-                                                       ).first().getElementsByClass('Clef')
+                                                       ).first().getElementsByClass(clef.Clef)
             if startClefs:
                 clef1 = startClefs[0]
                 c.parts[1].getElementsByClass(stream.Measure).first().remove(clef1)

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -399,7 +399,7 @@ class ScoreReduction:
                         v.makeRests(fillGaps=True, inPlace=True)
                 m.flattenUnnecessaryVoices(inPlace=True)
                 # hide all rests in all containers
-                for r in m.recurse().getElementsByClass('Rest'):
+                for r in m[note.Rest]:
                     r.style.hideObjectOnPrint = True
                 # m.show('t')
             # add to score

--- a/music21/base.py
+++ b/music21/base.py
@@ -3877,14 +3877,14 @@ class ElementWrapper(Music21Object):
     ...    el = music21.ElementWrapper(soundFile)
     ...    s.insert(i, el)
 
-    >>> for j in s.getElementsByClass('ElementWrapper'):
+    >>> for j in s.getElementsByClass(base.ElementWrapper):
     ...    if j.beatStrength > 0.4:
     ...        (j.offset, j.beatStrength, j.getnchannels(), j.fileName)
     (0.0, 1.0, 2, 'thisSound_1.wav')
     (3.0, 1.0, 2, 'thisSound_16.wav')
     (6.0, 1.0, 2, 'thisSound_12.wav')
     (9.0, 1.0, 2, 'thisSound_8.wav')
-    >>> for j in s.getElementsByClass('ElementWrapper'):
+    >>> for j in s.getElementsByClass(base.ElementWrapper):
     ...    if j.beatStrength > 0.4:
     ...        (j.offset, j.beatStrength, j.getnchannels() + 1, j.fileName)
     (0.0, 1.0, 3, 'thisSound_1.wav')
@@ -3894,7 +3894,7 @@ class ElementWrapper(Music21Object):
 
     Test representation of an ElementWrapper
 
-    >>> for i, j in enumerate(s.getElementsByClass('ElementWrapper')):
+    >>> for i, j in enumerate(s.getElementsByClass(base.ElementWrapper)):
     ...     if i == 2:
     ...         j.id = None
     ...     else:
@@ -4575,15 +4575,15 @@ class Test(unittest.TestCase):
         s3.append(n3)
 
         # only get n1 here, as that is only level available
-        self.assertEqual(s1.recurse().getElementsByClass('Note').first(), n1)
-        self.assertEqual(s2.recurse().getElementsByClass('Note').first(), n2)
+        self.assertEqual(s1.recurse().getElementsByClass(note.Note).first(), n1)
+        self.assertEqual(s2.recurse().getElementsByClass(note.Note).first(), n2)
         self.assertEqual(s1.recurse().getElementsByClass('Clef').first(), c1)
         self.assertEqual(s2.recurse().getElementsByClass('Clef').first(), c2)
 
         # attach s2 to s1
         s2.append(s1)
         # stream 1 gets both notes
-        self.assertEqual(list(s2.recurse().getElementsByClass('Note')), [n2, n1])
+        self.assertEqual(list(s2.recurse().getElementsByClass(note.Note)), [n2, n1])
 
     def testSetEditorial(self):
         b2 = Music21Object()
@@ -4697,7 +4697,7 @@ class Test(unittest.TestCase):
         matchBeatStrength = []
         matchAudioChannels = []
 
-        for j in s.getElementsByClass('ElementWrapper'):
+        for j in s.getElementsByClass(ElementWrapper):
             matchOffset.append(j.offset)
             matchBeatStrength.append(j.beatStrength)
             matchAudioChannels.append(j.getnchannels())

--- a/music21/base.py
+++ b/music21/base.py
@@ -4577,8 +4577,8 @@ class Test(unittest.TestCase):
         # only get n1 here, as that is only level available
         self.assertEqual(s1.recurse().getElementsByClass(note.Note).first(), n1)
         self.assertEqual(s2.recurse().getElementsByClass(note.Note).first(), n2)
-        self.assertEqual(s1.recurse().getElementsByClass('Clef').first(), c1)
-        self.assertEqual(s2.recurse().getElementsByClass('Clef').first(), c2)
+        self.assertEqual(s1[clef.Clef].first(), c1)
+        self.assertEqual(s2[clef.Clef].first(), c2)
 
         # attach s2 to s1
         s2.append(s1)
@@ -4697,7 +4697,7 @@ class Test(unittest.TestCase):
         matchBeatStrength = []
         matchAudioChannels = []
 
-        for j in s.getElementsByClass(ElementWrapper):
+        for j in s.getElementsByClass(base.ElementWrapper):
             matchOffset.append(j.offset)
             matchBeatStrength.append(j.beatStrength)
             matchAudioChannels.append(j.getnchannels())

--- a/music21/base.py
+++ b/music21/base.py
@@ -4301,8 +4301,12 @@ class Test(unittest.TestCase):
     def testBeatAccess(self):
         '''Test getting beat data from various Music21Objects.
         '''
+        from music21 import clef
         from music21 import corpus
+        from music21 import key
+        from music21 import meter
         from music21 import stream
+
         s = corpus.parse('bach/bwv66.6.xml')
         p1 = s.parts['Soprano']
 
@@ -4311,18 +4315,18 @@ class Test(unittest.TestCase):
 
         # clef/ks can get its beat; these objects are in a pickup,
         # and this give their bar offset relative to the bar
-        eClef = p1.flatten().getElementsByClass('Clef').first()
+        eClef = p1.flatten().getElementsByClass(clef.Clef).first()
         self.assertEqual(eClef.beat, 4.0)
         self.assertEqual(eClef.beatDuration.quarterLength, 1.0)
         self.assertEqual(eClef.beatStrength, 0.25)
 
-        eKS = p1.flatten().getElementsByClass('KeySignature').first()
+        eKS = p1.flatten().getElementsByClass(key.KeySignature).first()
         self.assertEqual(eKS.beat, 4.0)
         self.assertEqual(eKS.beatDuration.quarterLength, 1.0)
         self.assertEqual(eKS.beatStrength, 0.25)
 
         # ts can get beatStrength, beatDuration
-        eTS = p1.flatten().getElementsByClass('TimeSignature').first()
+        eTS = p1.flatten().getElementsByClass(meter.TimeSignature).first()
         self.assertEqual(eTS.beatDuration.quarterLength, 1.0)
         self.assertEqual(eTS.beatStrength, 0.25)
 

--- a/music21/braille/test.py
+++ b/music21/braille/test.py
@@ -2124,7 +2124,7 @@ class Test(unittest.TestCase):
         bm.insert(0, tempo.TempoText('Con brio'))
         bm.insert(25.0, clef.TrebleClef())
         bm.insert(32.0, clef.BassClef())
-        bm.recurse().getElementsByClass('TimeSignature').first().symbol = 'common'
+        bm[meter.TimeSignature].first().symbol = 'common'
         bm.makeNotation(inPlace=True, cautionaryNotImmediateRepeat=False)
         m = bm.getElementsByClass(stream.Measure)
         m[0].padAsAnacrusis(useInitialRests=True)

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -22,6 +22,7 @@ import unittest
 import zipfile
 
 from io import StringIO
+from typing import List, Optional
 
 from music21 import bar
 from music21 import chord
@@ -29,6 +30,7 @@ from music21 import clef
 from music21 import common
 from music21 import duration
 from music21 import exceptions21
+from music21 import layout
 from music21 import key
 from music21 import meter
 from music21 import note
@@ -84,7 +86,7 @@ class CapellaImportException(exceptions21.Music21Exception):
 class CapellaImporter:
     '''
     Object for importing .capx, CapellaXML files into music21 (from which they can be
-    converted to musicxml, MIDI, lilypond, etc.
+    converted to musicxml, MIDI, lilypond, etc.)
 
     Note that Capella stores files closer to their printed versions -- that is to say,
     Systems enclose all the parts for that system and have new clefs etc.
@@ -194,7 +196,7 @@ class CapellaImporter:
                 newPart.coreElementsChanged()
         newScore = stream.Score()
         # ORDERED DICT
-        parts = [None for i in range(len(partDictById))]
+        parts: List[Optional['music21.stream.Part']] = [None for i in range(len(partDictById))]
         for partId in partDictById:
             partDict = partDictById[partId]
             parts[partDict['number']] = partDict['part']

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -175,13 +175,13 @@ class CapellaImporter:
         '''
         # this line is redundant currently, since all we have in systemScore
         # are Systems, but later there will be other things.
-        systemStream = systemScore.getElementsByClass('System')
+        systemStream = systemScore.getElementsByClass(layout.System)
         partDictById = {}
         for thisSystem in systemStream:
             # this line is redundant currently, since all we have in
             # thisSystem are Parts, but later there will be other things.
             systemOffset = systemScore.elementOffset(thisSystem)
-            partStream = thisSystem.getElementsByClass('Part')
+            partStream = thisSystem.getElementsByClass(stream.Part)
             for j, thisPart in enumerate(partStream):
                 if thisPart.id not in partDictById:
                     newPart = stream.Part()

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -203,7 +203,7 @@ class CapellaImporter:
             if p is None:
                 print('part entries do not match partDict!')
                 continue
-            clefs = p.getElementsByClass('Clef')
+            clefs = p.getElementsByClass(clef.Clef)
             keySignatures = p.getElementsByClass('KeySignature')
             lastClef = None
             lastKeySignature = None
@@ -219,7 +219,7 @@ class CapellaImporter:
                     lastKeySignature = ks
             p.makeMeasures(inPlace=True)
             # for m in p.getElementsByClass(stream.Measure):
-            #    barLines = m.getElementsByClass('Barline')
+            #    barLines = m.getElementsByClass(bar.Barline)
             #    for bl in barLines:
             #        blOffset = bl.offset
             #        if blOffset == 0.0:

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -6343,9 +6343,10 @@ class Test(unittest.TestCase):
 
     def testTiesA(self):
         # test creating independent ties for each Pitch
+        from music21 import chord
         from music21.musicxml import m21ToXml
 
-        c1 = Chord(['c', 'd', 'b'])
+        c1 = chord.Chord(['c', 'd', 'b'])
         # as this is a subclass of Note, we have a .tie attribute already
         # here, it is managed by a property
         self.assertEqual(c1.tie, None)
@@ -6379,7 +6380,7 @@ class Test(unittest.TestCase):
         from music21.musicxml import testPrimitive
         from music21 import converter
         s = converter.parse(testPrimitive.chordIndependentTies)
-        chords = s.flatten().getElementsByClass('Chord')
+        chords = s.flatten().getElementsByClass(chord.Chord)
         # the middle pitch should have a tie
         self.assertEqual(chords[0].getTie(pitch.Pitch('a4')).type, 'start')
         self.assertEqual(chords[0].getTie(pitch.Pitch('c5')), None)

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -64,27 +64,26 @@ musicOrdinals[22] = 'Triple-octave'
 
 
 @deprecated('v7.3', 'v9', 'Use common.opFrac(num) instead')
-def cleanupFloat(floatNum, maxDenominator=defaults.limitOffsetDenominator):
+def cleanupFloat(floatNum, maxDenominator=defaults.limitOffsetDenominator):  # pragma: no cover
     '''
     Cleans up a floating point number by converting
     it to a fractions.Fraction object limited to
     a denominator of maxDenominator
 
-    >>> common.cleanupFloat(0.33333327824)
+    common.cleanupFloat(0.33333327824)
     0.333333333333...
 
-    >>> common.cleanupFloat(0.142857)
+    common.cleanupFloat(0.142857)
     0.1428571428571...
 
-    >>> common.cleanupFloat(1.5)
+    common.cleanupFloat(1.5)
     1.5
 
     Fractions are passed through silently...
 
-    >>> import fractions
-    >>> common.cleanupFloat(fractions.Fraction(4, 3))
+    import fractions
+    common.cleanupFloat(fractions.Fraction(4, 3))
     Fraction(4, 3)
-
     '''
     if isinstance(floatNum, Fraction):
         return floatNum  # do nothing to fractions

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1947,6 +1947,8 @@ class Test(unittest.TestCase):
         Here is a filename with an incorrect extension (.txt for .rnText).  Make sure that
         it is not cached the second time...
         '''
+        from music21 import harmony
+
         fp = common.getSourceFilePath() / 'converter' / 'incorrectExtension.txt'
         pf = PickleFilter(fp)
         pf.removePickle()
@@ -1955,7 +1957,7 @@ class Test(unittest.TestCase):
             parse(fp)
 
         c = parse(fp, format='romantext')
-        self.assertEqual(len(c.recurse().getElementsByClass('Harmony')), 1)
+        self.assertEqual(len(c[harmony.Harmony]), 1)
 
     def testConverterFromPath(self):
         fp = common.getSourceFilePath() / 'corpus' / 'bach' / 'bwv66.6.mxl'

--- a/music21/derivation.py
+++ b/music21/derivation.py
@@ -222,9 +222,9 @@ class Derivation(SlottedObjectMixin):
         >>> s1.id = 's1'
         >>> s1.repeatAppend(note.Note(), 10)
         >>> s1.repeatAppend(note.Rest(), 10)
-        >>> s2 = s1.getElementsByClass('GeneralNote').stream()
+        >>> s2 = s1.notesAndRests.stream()
         >>> s2.id = 's2'
-        >>> s3 = s2.getElementsByClass('Note').stream()
+        >>> s3 = s2.getElementsByClass(note.Note).stream()
         >>> s3.id = 's3'
         >>> for y in s3.derivation.chain():
         ...     print(y)
@@ -308,8 +308,8 @@ class Derivation(SlottedObjectMixin):
         >>> s1 = stream.Stream()
         >>> s1.repeatAppend(note.Note(), 10)
         >>> s1.repeatAppend(note.Rest(), 10)
-        >>> s2 = s1.getElementsByClass('GeneralNote').stream()
-        >>> s3 = s2.getElementsByClass('Note').stream()
+        >>> s2 = s1.notesAndRests.stream()
+        >>> s3 = s2.getElementsByClass(note.Note).stream()
         >>> s3.derivation.rootDerivation is s1
         True
         '''

--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -451,11 +451,13 @@ class Test(unittest.TestCase):
 
     def testCorpusDynamicsWedge(self):
         from music21 import corpus
+        from music21 import dynamics
+
         a = corpus.parse('opus41no1/movement2')  # has dynamics!
-        b = a.parts[0].flatten().getElementsByClass('Dynamic')
+        b = a.parts[0].flatten().getElementsByClass(dynamics.Dynamic)
         self.assertEqual(len(b), 35)
 
-        b = a.parts[0].flatten().getElementsByClass('DynamicWedge')
+        b = a.parts[0].flatten().getElementsByClass(dynamics.DynamicWedge)
         self.assertEqual(len(b), 2)
 
     def testMusicxmlOutput(self):

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -608,7 +608,7 @@ class DataInstance:
         else:
             self.partsCount = 0
 
-        for v in self.stream.recurse().getElementsByClass('Voice'):
+        for v in self.stream[stream.Voice]:
             self.formsByPart.append(StreamForms(v))
 
     def setClassLabel(self, classLabel, classValue=None):

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -141,7 +141,7 @@ def createOffsetMapping(music21Part):
     (11.0, 12.0)   [<music21.note.Note A> ]
     '''
     currentMapping = collections.defaultdict(list)
-    for music21GeneralNote in music21Part.flatten().getElementsByClass('GeneralNote'):
+    for music21GeneralNote in music21Part.flatten().notesAndRests:
         initOffset = music21GeneralNote.offset
         endTime = initOffset + music21GeneralNote.quarterLength
         currentMapping[(initOffset, endTime)].append(music21GeneralNote)
@@ -183,7 +183,7 @@ def correlateHarmonies(currentMapping, music21Part):
 
     for offsets in sorted(currentMapping.keys()):
         (initOffset, endTime) = offsets
-        notesInRange = music21Part.flatten().getElementsByClass('GeneralNote').getElementsByOffset(
+        notesInRange = music21Part.flatten().notesAndRests.getElementsByOffset(
             initOffset, offsetEnd=endTime,
             includeEndBoundary=False, mustFinishInSpan=False,
             mustBeginInSpan=False, includeElementsThatEndAtStart=False)

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -45,7 +45,7 @@ def getVoiceLeadingMoments(music21Stream):
             :width: 700
     '''
     allHarmonies = extractHarmonies(music21Stream)
-    allParts = music21Stream.getElementsByClass('Part').stream()
+    allParts = music21Stream.getElementsByClass(stream.Part).stream()
     newParts = [allParts[i].flatten().getElementsNotOfClass('GeneralNote').stream()
                 for i in range(len(allParts))]
     paddingLeft = allParts[0].getElementsByClass(stream.Measure).first().paddingLeft
@@ -107,7 +107,7 @@ def extractHarmonies(music21Stream):
     (11.0, 11.5)   [<music21.note.Note A>  <music21.note.Note F>  <music21.note.Note D> ]
     (11.5, 12.0)   [<music21.note.Note A>  <music21.note.Note F>  <music21.note.Note A> ]
     '''
-    allParts = music21Stream.getElementsByClass('Part')
+    allParts = music21Stream.getElementsByClass(stream.Part)
     if len(allParts) < 2:
         raise Music21Exception('There must be at least two parts to extract harmonies')
     allHarmonies = createOffsetMapping(allParts[0])
@@ -247,7 +247,7 @@ def checkSinglePossibilities(music21Stream, functionToApply, color="#FF0000", de
         debugInfo.append(f"{'(Offset, End Time):'!s:25}Part Numbers:")
 
     allHarmonies = sorted(list(extractHarmonies(music21Stream).items()))
-    allParts = [p.flatten() for p in music21Stream.getElementsByClass('Part')]
+    allParts = [p.flatten() for p in music21Stream.getElementsByClass(stream.Part)]
     for (offsets, notes) in allHarmonies:
         vlm = [generalNoteToPitch(n) for n in notes]
         vlm_violations = functionToApply(vlm)
@@ -314,7 +314,7 @@ def checkConsecutivePossibilities(music21Stream, functionToApply, color="#FF0000
         debugInfo.append('(Offset A, End Time A):  (Offset B, End Time B): Part Numbers:')
 
     allHarmonies = sorted(extractHarmonies(music21Stream).items())
-    allParts = [p.flatten() for p in music21Stream.getElementsByClass('Part')]
+    allParts = [p.flatten() for p in music21Stream.getElementsByClass(stream.Part)]
     (previousOffsets, previousNotes) = allHarmonies[0]
     vlmA = [generalNoteToPitch(n) for n in previousNotes]
     initOffsetA = previousOffsets[0]

--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -333,7 +333,7 @@ class FiguredBassLine:
         bl2 = bassLine.makeNotation(inPlace=False, cautionaryNotImmediateRepeat=False)
         if r is not None:
             m0 = bl2.getElementsByClass(stream.Measure).first()
-            m0.remove(m0.getElementsByClass('Rest').first())
+            m0.remove(m0.getElementsByClass(note.Rest).first())
             m0.padAsAnacrusis()
         return bl2
 

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -592,7 +592,7 @@ class StreamFreezer(StreamFreezeThawBase):
             streamIds += spannerBundle.getSpannerStorageIds()
 
         if getVariants is True:
-            for el in streamObj.recurse(includeSelf=True).getElementsByClass('Variant'):
+            for el in streamObj.recurse(includeSelf=True).getElementsByClass(variant.Variant):
                 streamIds += self.findActiveStreamIdsInHierarchy(el._stream)
 
         # should not happen that there are duplicates, but possible with spanners...
@@ -1162,7 +1162,7 @@ class Test(unittest.TestCase):
                            variantName='rhythmic_switch', replacementDuration=3.0)
 
         # test Variant is in stream
-        unused_v1 = c.parts.first().getElementsByClass('Variant').first()
+        unused_v1 = c.parts.first().getElementsByClass(variant.Variant).first()
 
         sf = freezeThaw.StreamFreezer(c, fastButUnsafe=True)
         # sf.v = v
@@ -1176,7 +1176,7 @@ class Test(unittest.TestCase):
         s = st.stream
         # s.show('lily.pdf')
         p0 = s.parts[0]
-        variants = p0.getElementsByClass('Variant')
+        variants = p0.getElementsByClass(variant.Variant)
         v2 = variants[0]
         self.assertEqual(v2._stream[0][1].offset, 0.5)
         # v2.show('t')

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -1198,11 +1198,13 @@ class Dolan(HorizontalBarWeighted):
         Examine the instruments in the Score and determine if there
         is a good match for a default configuration of parts.
         '''
+        from music21 import instrument
+
         if self.partGroups:
             return  # keep what the user set
         if self.streamObj:
             return None
-        instStream = self.streamObj.flatten().getElementsByClass('Instrument')
+        instStream = self.streamObj.flatten().getElementsByClass(instrument.Instrument)
         if not instStream:
             return  # do not set anything
 

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1931,7 +1931,7 @@ class SpineCollection(prebase.ProtoM21Object):
 
             stavesAppliedTo = []
             prioritiesToSearch = {}
-            for tandem in thisSpine.stream.recurse().getElementsByClass('MiscTandem'):
+            for tandem in thisSpine.stream[MiscTandem]:
                 if tandem.tandem.startswith('*staff'):
                     staffInfo = tandem.tandem[6:]  # could be multiple staves
                     stavesAppliedTo = [int(x) for x in staffInfo.split('/')]

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -773,7 +773,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         s.metadata = md
         grToRemove = []
 
-        for gr in s.recurse().getElementsByClass('GlobalReference'):
+        for gr in s[GlobalReference]:
             wasParsed = gr.updateMetadata(md)
             if wasParsed:
                 grToRemove.append(gr)

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -91,7 +91,7 @@ import copy
 import unittest
 
 from collections import namedtuple
-from typing import Tuple, Optional
+from typing import Tuple, Optional, List
 
 from music21 import base
 from music21 import exceptions21

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -703,7 +703,7 @@ def divideByPages(scoreIn, printUpdates=False, fastMeasures=False):
 
                 staffObject.elements = p
                 thisSystem.replace(p, staffObject)
-                allStaffLayouts = p[StaffLayout]
+                allStaffLayouts: List[StaffLayout] = p.recurse().getElementsByClass('StaffLayout')
                 if not allStaffLayouts:
                     continue
                 # else:
@@ -1323,7 +1323,7 @@ class LayoutScore(stream.Opus):
         self,
         pageId: int,
         systemId: int
-    ) -> Tuple[Optional[int], Optional[int]]:
+    ) -> Tuple[Optional[int], int]:
         # noinspection PyShadowingNames
         '''
         given a pageId and systemId, get the (pageId, systemId) for the previous system.
@@ -1337,16 +1337,16 @@ class LayoutScore(stream.Opus):
         >>> ls = layout.divideByPages(lt, fastMeasures = True)
         >>> systemId = 1
         >>> pageId = 2  # last system, last page
-        >>> while systemId is not None:
+        >>> while pageId is not None:
         ...    pageId, systemId = ls.getSystemBeforeThis(pageId, systemId)
         ...    (pageId, systemId)
-        (2, 0) (1, 2) (1, 1) (1, 0) (0, 4) (0, 3) (0, 2) (0, 1) (0, 0) (None, None)
+        (2, 0) (1, 2) (1, 1) (1, 0) (0, 4) (0, 3) (0, 2) (0, 1) (0, 0) (None, -1)
         '''
         if systemId > 0:
             return pageId, systemId - 1
         else:
             if pageId == 0:
-                return (None, None)
+                return (None, -1)
             previousPageId = pageId - 1
             numSystems = len(self.pages[previousPageId].systems)
             return previousPageId, numSystems - 1

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -2148,7 +2148,7 @@ class LilypondConverter:
 
         musicList = []
 
-        varFilter = [r for r in variantObject.getElementsByClass('Rest')
+        varFilter = [r for r in variantObject.getElementsByClass(note.Rest)
                      if r.style.hideObjectOnPrint]
 
         if varFilter:

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2323,7 +2323,7 @@ def channelInstrumentData(
     # Music tracks
     for subs in substreamList:
         # get a first instrument; iterate over rest
-        instrumentStream = subs.recurse().getElementsByClass('Instrument')
+        instrumentStream = subs[instrument.Instrument]
         setAnInstrument = False
         for inst in instrumentStream:
             if inst.midiChannel is not None and inst.midiProgram not in channelByInstrument:
@@ -3587,6 +3587,7 @@ class Test(unittest.TestCase):
 
     def testMidiTempoImportB(self):
         from music21 import converter
+        from music21 import tempo
 
         dirLib = common.getSourceFilePath() / 'midi' / 'testPrimitive'
         # a file with three tracks and one conductor track with four tempo marks
@@ -3595,15 +3596,15 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s.parts), 3)
         # metronome marks propagate to every staff, but are hidden on subsequent staffs
         self.assertEqual(
-            [mm.numberImplicit for mm in s.parts[0].recurse().getElementsByClass('MetronomeMark')],
+            [mm.numberImplicit for mm in s.parts[0][tempo.MetronomeMark]],
             [False, False, False, False]
         )
         self.assertEqual(
-            [mm.numberImplicit for mm in s.parts[1].recurse().getElementsByClass('MetronomeMark')],
+            [mm.numberImplicit for mm in s.parts[1][tempo.MetronomeMark]],
             [True, True, True, True]
         )
         self.assertEqual(
-            [mm.numberImplicit for mm in s.parts[2].recurse().getElementsByClass('MetronomeMark')],
+            [mm.numberImplicit for mm in s.parts[2][tempo.MetronomeMark]],
             [True, True, True, True]
         )
 

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3849,7 +3849,7 @@ class Test(unittest.TestCase):
         fp = dirLib / 'test14.mid'
         s = converter.parse(fp)
         # three chords will be created, as well as two voices
-        self.assertEqual(len(s.flatten().getElementsByClass('Chord')), 3)
+        self.assertEqual(len(s[chord.Chord]), 3)
         self.assertEqual(len(s.parts.first().measure(3).voices), 2)
 
     def testImportChordsA(self):
@@ -3861,7 +3861,7 @@ class Test(unittest.TestCase):
         # a simple file created in athenacl
         s = converter.parse(fp)
         # s.show('t')
-        self.assertEqual(len(s.flatten().getElementsByClass('Chord')), 5)
+        self.assertEqual(len(s[chord.Chord]), 5)
 
     def testMidiEventsImported(self):
         self.maxDiff = None
@@ -4017,7 +4017,7 @@ class Test(unittest.TestCase):
         inn = converter.parse(fp)
 
         self.assertEqual(
-            len(inn.parts[1].measure(3).voices.last().getElementsByClass('Rest')), 1)
+            len(inn.parts[1].measure(3).voices.last().getElementsByClass(note.Rest)), 1)
 
     def testRestsMadeInMeasures(self):
         from music21 import converter

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2165,7 +2165,7 @@ def prepareStreamForMidi(s) -> stream.Stream:
         # this assumes that dynamics in a part/stream apply to all components
         # of that part stream
         # this sets the cachedRealized value for each Volume
-        for p in s.getElementsByClass('Stream'):
+        for p in s.getElementsByClass(stream.Stream):
             volume.realizeVolume(p)
 
         s.insert(0, conductor)
@@ -2224,7 +2224,7 @@ def conductorStream(s: stream.Stream) -> stream.Part:
     '''
     from music21 import tempo
     from music21 import meter
-    partsList = list(s.getElementsByClass('Stream').getElementsByOffset(0))
+    partsList = list(s.getElementsByClass(stream.Stream).getElementsByOffset(0))
     minPriority = min(p.priority for p in partsList) if partsList else 0
     conductorPriority = minPriority - 1
 
@@ -2310,7 +2310,7 @@ def channelInstrumentData(
     # store streams in uniform list
     substreamList = []
     if s.hasPartLikeStreams():
-        for obj in s.getElementsByClass('Stream'):
+        for obj in s.getElementsByClass(stream.Stream):
             # Conductor track: don't consume a channel
             if (not obj[note.GeneralNote]) and obj[Conductor]:
                 continue
@@ -2546,7 +2546,7 @@ def streamHierarchyToMidiTracks(
 
     # store streams in uniform list: prepareStreamForMidi() ensures there are substreams
     substreamList = []
-    for obj in s.getElementsByClass('Stream'):
+    for obj in s.getElementsByClass(stream.Stream):
         # prepareStreamForMidi() supplies defaults for these
         if obj.getElementsByClass(('MetronomeMark', 'TimeSignature')):
             # Ensure conductor track is first

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -531,7 +531,7 @@ class GeneralObjectExporter:
             st2 = stream.Part()
             st2.mergeAttributes(st)
             st2.elements = copy.deepcopy(st)
-            if not st.getElementsByClass('Clef').getElementsByOffset(0.0):
+            if not st.getElementsByClass(clef.Clef).getElementsByOffset(0.0):
                 st2.clef = clef.bestClef(st2)
             st2.makeNotation(inPlace=True)
             st2.metadata = copy.deepcopy(getMetadataFromContext(st))
@@ -549,7 +549,7 @@ class GeneralObjectExporter:
             st2 = stream.Part()
             st2.mergeAttributes(st)
             st2.elements = copy.deepcopy(st)
-            if not st.getElementsByClass('Clef').getElementsByOffset(0.0):
+            if not st.getElementsByClass(clef.Clef).getElementsByOffset(0.0):
                 bestClef = True
             else:
                 bestClef = False
@@ -559,7 +559,7 @@ class GeneralObjectExporter:
 
         else:
             # probably a problem? or a voice...
-            if not st.getElementsByClass('Clef').getElementsByOffset(0.0):
+            if not st.getElementsByClass(clef.Clef).getElementsByOffset(0.0):
                 bestClef = True
             else:
                 bestClef = False
@@ -2751,7 +2751,7 @@ class PartExporter(XMLExporterBase):
         # that place key/clef information in the containing stream
         if hasattr(first_measure, 'clef') and first_measure.clef is None:
             first_measure.makeMutable()  # must mutate
-            outerClefs = part.getElementsByClass('Clef')
+            outerClefs = part.getElementsByClass(clef.Clef)
             if outerClefs:
                 first_measure.clef = outerClefs.first()
 
@@ -6107,7 +6107,7 @@ class MeasureExporter(XMLExporterBase):
         mxMeasureStyle = None
         mxMultipleRest = None
 
-        rests = m.getElementsByClass('Rest')
+        rests = m.getElementsByClass(note.Rest)
         if rests:
             hasMMR = rests[0].getSpannerSites('MultiMeasureRest')
             if hasMMR:

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -545,7 +545,7 @@ class GeneralObjectExporter:
             st2.metadata = copy.deepcopy(getMetadataFromContext(st))
             return self.fromScore(st2)
 
-        elif st.getElementsByClass('Stream').first().isFlat:  # like a part w/ measures...
+        elif st.getElementsByClass(stream.Stream).first().isFlat:  # like a part w/ measures...
             st2 = stream.Part()
             st2.mergeAttributes(st)
             st2.elements = copy.deepcopy(st)
@@ -1572,7 +1572,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         '''
         s = self.stream
         # environLocal.printDebug('streamToMx(): interpreting multipart')
-        streamOfStreams = s.getElementsByClass('Stream')
+        streamOfStreams = s.getElementsByClass(stream.Stream)
         for innerStream in streamOfStreams:
             # may need to copy element here
             # apply this stream's offset to elements
@@ -6490,11 +6490,11 @@ class MeasureExporter(XMLExporterBase):
             return
 
         mxPrint = None
-        found = m.getElementsByClass('PageLayout')
+        found = m.getElementsByClass(layout.PageLayout)
         if found:
             pl = found[0]  # assume only one per measure
             mxPrint = self.pageLayoutToXmlPrint(pl)
-        found = m.getElementsByClass('SystemLayout')
+        found = m.getElementsByClass(layout.SystemLayout)
         if found:
             sl = found[0]  # assume only one per measure
             if mxPrint is None:

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -225,7 +225,7 @@ class PartStaffExporterMixin:
          <music21.layout.StaffGroup <... p2a><... p2b>>,
          <music21.layout.StaffGroup <... p6a><... p6b>>]
         '''
-        staffGroups = self.stream.getElementsByClass('StaffGroup')
+        staffGroups = self.stream.getElementsByClass(spanner.StaffGroup)
         joinableGroups: List[StaffGroup] = []
         # Joinable groups must consist of only PartStaffs with Measures
         # and exist in self.stream

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -13,7 +13,7 @@
 A mixin to ScoreExporter that includes the capabilities for producing a single
 MusicXML `<part>` from multiple music21 `PartStaff` objects.
 '''
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Type
 import unittest
 import warnings
 from xml.etree.ElementTree import Element, SubElement, Comment
@@ -26,6 +26,7 @@ from music21.meter import TimeSignature
 from music21 import stream  # for typing
 from music21.musicxml import helpers
 from music21.musicxml.xmlObjects import MusicXMLExportException, MusicXMLWarning
+from music21 import spanner
 
 def addStaffTags(measure: Element, staffNumber: int, tagList: Optional[List[str]] = None):
     '''
@@ -225,7 +226,7 @@ class PartStaffExporterMixin:
          <music21.layout.StaffGroup <... p2a><... p2b>>,
          <music21.layout.StaffGroup <... p6a><... p6b>>]
         '''
-        staffGroups = self.stream.getElementsByClass(spanner.StaffGroup)
+        staffGroups = self.stream.getElementsByClass(StaffGroup)
         joinableGroups: List[StaffGroup] = []
         # Joinable groups must consist of only PartStaffs with Measures
         # and exist in self.stream
@@ -517,7 +518,7 @@ class PartStaffExporterMixin:
         </measure>
         '''
 
-        def isMultiAttribute(m21Class: M21ObjType,
+        def isMultiAttribute(m21Class: Type[M21ObjType],
                              comparison: str = '__eq__') -> bool:
             '''
             Return True if any first instance of m21Class in any subsequent staff

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -26,7 +26,6 @@ from music21.meter import TimeSignature
 from music21 import stream  # for typing
 from music21.musicxml import helpers
 from music21.musicxml.xmlObjects import MusicXMLExportException, MusicXMLWarning
-from music21 import spanner
 
 def addStaffTags(measure: Element, staffNumber: int, tagList: Optional[List[str]] = None):
     '''

--- a/music21/musicxml/testPrimitive.py
+++ b/music21/musicxml/testPrimitive.py
@@ -18221,13 +18221,13 @@ class Test(unittest.TestCase):
             orig_stream[1].append(item)
 
         orig_clefs = [staff.flatten().getElementsByClass(clef.Clef).stream() for staff in
-                      orig_stream.getElementsByClass('Part')]
+                      orig_stream.getElementsByClass(stream.Part)]
 
         xml = musicxml.m21ToXml.GeneralObjectExporter().parse(orig_stream)
 
         new_stream = converter.parse(xml.decode('utf-8'))
         new_clefs = [staff.flatten().getElementsByClass(clef.Clef).stream() for staff in
-                     new_stream.getElementsByClass('Part')]
+                     new_stream.getElementsByClass(stream.Part)]
 
         self.assertEqual([len(clefs) for clefs in new_clefs],
                          [len(clefs) for clefs in orig_clefs])

--- a/music21/musicxml/testPrimitive.py
+++ b/music21/musicxml/testPrimitive.py
@@ -18183,14 +18183,14 @@ class Test(unittest.TestCase):
         orig_stream.repeatAppend(note.Note('C4'), 2)
         orig_stream.append(clef.BassClef())
         orig_stream.repeatAppend(note.Note('C4'), 2)
-        orig_clefs = orig_stream.flatten().getElementsByClass('Clef')
+        orig_clefs = orig_stream.flatten().getElementsByClass(clef.Clef)
 
         xml = musicxml.m21ToXml.GeneralObjectExporter().parse(orig_stream)
         self.assertEqual(xml.count(b'<clef>'), 2)  # clefs got out
         self.assertEqual(xml.count(b'<measure'), 1)  # in one measure
 
         new_stream = converter.parse(xml)
-        new_clefs = new_stream.flatten().getElementsByClass('Clef')
+        new_clefs = new_stream.flatten().getElementsByClass(clef.Clef)
 
         self.assertEqual(len(new_clefs), len(orig_clefs))
         self.assertEqual([c.offset for c in new_clefs], [c.offset for c in orig_clefs])
@@ -18220,13 +18220,13 @@ class Test(unittest.TestCase):
                      clef.TrebleClef(), note.Note('C4')]:
             orig_stream[1].append(item)
 
-        orig_clefs = [staff.flatten().getElementsByClass('Clef').stream() for staff in
+        orig_clefs = [staff.flatten().getElementsByClass(clef.Clef).stream() for staff in
                       orig_stream.getElementsByClass('Part')]
 
         xml = musicxml.m21ToXml.GeneralObjectExporter().parse(orig_stream)
 
         new_stream = converter.parse(xml.decode('utf-8'))
-        new_clefs = [staff.flatten().getElementsByClass('Clef').stream() for staff in
+        new_clefs = [staff.flatten().getElementsByClass(clef.Clef).stream() for staff in
                      new_stream.getElementsByClass('Part')]
 
         self.assertEqual([len(clefs) for clefs in new_clefs],

--- a/music21/musicxml/test_m21ToXml.py
+++ b/music21/musicxml/test_m21ToXml.py
@@ -362,7 +362,7 @@ class Test(unittest.TestCase):
         self.assertEqual([e.get('number') for e in endings], ['1,2', '1,2', '3', '3'])
 
         # m21 represents lack of bracket numbers as 0; musicxml uses ''
-        s.parts[0].getElementsByClass('RepeatBracket').first().number = 0
+        s.parts[0].getElementsByClass(spanner.RepeatBracket).first().number = 0
         x = self.getET(s)
         endings = x.findall('.//ending')
         self.assertEqual([e.get('number') for e in endings], ['', '', '3', '3'])

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -277,7 +277,7 @@ class Test(unittest.TestCase):
         # has repeats in it; start with single measure
         s = corpus.parse('opus74no1', 3)
         # there are 2 for each part, totaling 8
-        self.assertEqual(len(s.flatten().getElementsByClass('RepeatBracket')), 8)
+        self.assertEqual(len(s.flatten().getElementsByClass(spanner.RepeatBracket)), 8)
         # can get for each part as spanners are stored in Part now
 
         # TODO: need to test getting repeat brackets after measure extraction
@@ -285,7 +285,7 @@ class Test(unittest.TestCase):
         sSub = s.parts[0].measures(72, 77)
         # 2 repeat brackets are gathered b/c they are stored at the Part by
         # default
-        rbSpanners = sSub.getElementsByClass('RepeatBracket')
+        rbSpanners = sSub.getElementsByClass(spanner.RepeatBracket)
         self.assertEqual(len(rbSpanners), 2)
 
     def testImportVoicesA(self):
@@ -513,21 +513,21 @@ class Test(unittest.TestCase):
         from music21 import corpus
 
         s = corpus.parse('leadSheet/berlinAlexandersRagtime.xml')
-        self.assertEqual(len(s.flatten().getElementsByClass('ChordSymbol')), 19)
+        self.assertEqual(len(s[harmony.ChordSymbol]), 19)
 
-        match = [h.chordKind for h in s.recurse().getElementsByClass('ChordSymbol')]
+        match = [h.chordKind for h in s[harmony.ChordSymbol]]
         self.assertEqual(match, ['major', 'dominant-seventh', 'major', 'major', 'major',
                                  'major', 'dominant-seventh', 'major', 'dominant-seventh',
                                  'major', 'dominant-seventh', 'major', 'dominant-seventh',
                                  'major', 'dominant-seventh', 'major', 'dominant-seventh',
                                  'major', 'major'])
 
-        match = [str(h.root()) for h in s.recurse().getElementsByClass('ChordSymbol')]
+        match = [str(h.root()) for h in s[harmony.ChordSymbol]]
 
         self.assertEqual(match, ['F3', 'C3', 'F3', 'B-2', 'F3', 'C3', 'G2', 'C3', 'C3',
                                  'F3', 'C3', 'F3', 'F2', 'B-2', 'F2', 'F3', 'C3', 'F3', 'C3'])
 
-        match = {str(h.figure) for h in s.recurse().getElementsByClass('ChordSymbol')}
+        match = {str(h.figure) for h in s[harmony.ChordSymbol]}
 
         self.assertEqual(match, {'F', 'F7', 'B-', 'C7', 'G7', 'C'})
 
@@ -644,8 +644,8 @@ class Test(unittest.TestCase):
         from music21.musicxml import testPrimitive
 
         s = converter.parse(testPrimitive.spanners33a)
-        self.assertEqual(len(s.recurse().getElementsByClass('Crescendo')), 1)
-        self.assertEqual(len(s.recurse().getElementsByClass('Diminuendo')), 1)
+        self.assertEqual(len(s[dynamics.Crescendo]), 1)
+        self.assertEqual(len(s[dynamics.Diminuendo]), 1)
 
     def testImportWedgeB(self):
         from music21 import converter
@@ -653,7 +653,7 @@ class Test(unittest.TestCase):
 
         # this produces a single component cresc
         s = converter.parse(testPrimitive.directions31a)
-        self.assertEqual(len(s.recurse().getElementsByClass('Crescendo')), 2)
+        self.assertEqual(len(s[dynamics.Crescendo]), 2)
 
     def testBracketImportB(self):
         from music21 import converter
@@ -661,21 +661,21 @@ class Test(unittest.TestCase):
 
         s = converter.parse(testPrimitive.spanners33a)
         # s.show()
-        self.assertEqual(len(s.recurse().getElementsByClass('Line')), 6)
+        self.assertEqual(len(s[spanner.Line]), 6)
 
     def testTrillExtensionImportA(self):
         from music21 import converter
         from music21.musicxml import testPrimitive
         s = converter.parse(testPrimitive.notations32a)
         # s.show()
-        self.assertEqual(len(s.recurse().getElementsByClass('TrillExtension')), 2)
+        self.assertEqual(len(s[expressions.TrillExtension]), 2)
 
     def testGlissandoImportA(self):
         from music21 import converter
         from music21.musicxml import testPrimitive
         s = converter.parse(testPrimitive.spanners33a)
         # s.show()
-        glisses = list(s.recurse().getElementsByClass('Glissando'))
+        glisses = list(s[spanner.Glissando])
         self.assertEqual(len(glisses), 2)
         self.assertEqual(glisses[0].slideType, 'chromatic')
         self.assertEqual(glisses[1].slideType, 'continuous')
@@ -686,7 +686,7 @@ class Test(unittest.TestCase):
         from music21.musicxml import testPrimitive
 
         s = converter.parse(testPrimitive.spanners33a, format='musicxml')
-        self.assertEqual(len(s.recurse().getElementsByClass('Line')), 6)
+        self.assertEqual(len(s[spanner.Line]), 6)
 
     def testImportGraceA(self):
         from music21 import converter
@@ -1017,7 +1017,7 @@ class Test(unittest.TestCase):
         from music21.musicxml import testPrimitive
 
         s = converter.parse(testPrimitive.directions31a)
-        rmIterator = s.recurse().getElementsByClass('RehearsalMark')
+        rmIterator = s[expressions.RehearsalMark]
         self.assertEqual(len(rmIterator), 4)
         self.assertEqual(rmIterator[0].content, 'A')
         self.assertEqual(rmIterator[1].content, 'B')
@@ -1032,17 +1032,17 @@ class Test(unittest.TestCase):
         testFp = thisDir / 'testNC.xml'
         s = converter.parse(testFp)
 
-        self.assertEqual(5, len(s.recurse().getElementsByClass('ChordSymbol')))
-        self.assertEqual(2, len(s.recurse().getElementsByClass('NoChord')))
+        self.assertEqual(5, len(s[harmony.ChordSymbol]))
+        self.assertEqual(2, len(s[harmony.NoChord]))
 
         self.assertEqual('augmented-seventh',
-                         s.recurse().getElementsByClass('ChordSymbol')[0].chordKind)
+                         s[harmony.ChordSymbol][0].chordKind)
         self.assertEqual('none',
-                         s.recurse().getElementsByClass('ChordSymbol')[1].chordKind)
+                         s[harmony.ChordSymbol][1].chordKind)
 
-        self.assertEqual('random', str(s.recurse().getElementsByClass('NoChord')[
+        self.assertEqual('random', str(s[harmony.NoChord][
                                        0].chordKindStr))
-        self.assertEqual('N.C.', str(s.recurse().getElementsByClass('NoChord')[
+        self.assertEqual('N.C.', str(s[harmony.NoChord][
                                      1].chordKindStr))
 
     def testChordAlias(self):
@@ -1067,7 +1067,7 @@ class Test(unittest.TestCase):
         s = converter.parse(testFp)
 
         offsets = [0.0, 2.0, 0.0, 2.0, 0.0, 2.0]
-        for ch, offset in zip(s.recurse().getElementsByClass('ChordSymbol'),
+        for ch, offset in zip(s[harmony.ChordSymbol],
                               offsets):
             self.assertEqual(ch.offset, offset)
 
@@ -1194,13 +1194,13 @@ class Test(unittest.TestCase):
         # Measure 3, left barline: <ending number="3" type="start"/>
         # Measure 3, right barline: <ending number="3" type="stop"/>
         score = converter.parse(testPrimitive.multiDigitEnding)
-        repeatBrackets = score.recurse().getElementsByClass('RepeatBracket')
+        repeatBrackets = score.recurse().getElementsByClass(spanner.RepeatBracket)
         self.assertListEqual(repeatBrackets[0].getNumberList(), [1, 2])
         self.assertListEqual(repeatBrackets[1].getNumberList(), [3])
 
         nonconformingInput = testPrimitive.multiDigitEnding.replace("1,2", "ad lib.")
         score2 = converter.parse(nonconformingInput)
-        repeatBracket = score2.recurse().getElementsByClass('RepeatBracket').first()
+        repeatBracket = score2.recurse().getElementsByClass(spanner.RepeatBracket).first()
         self.assertListEqual(repeatBracket.getNumberList(), [1])
 
     def testChordAlteration(self):
@@ -1269,12 +1269,12 @@ class Test(unittest.TestCase):
 
         # Dynamic
         s = converter.parse(testFiles.mozartTrioK581Excerpt)
-        dyn = s.recurse().getElementsByClass('Dynamic').first()
+        dyn = s[dynamics.Dynamic].first()
         self.assertEqual(dyn.style.relativeY, 6)
 
         # Coda/Segno
         s = converter.parse(testPrimitive.repeatExpressionsA)
-        seg = s.recurse().getElementsByClass('Segno').first()
+        seg = s[repeat.Segno].first()
         self.assertEqual(seg.style.relativeX, 10)
 
         # TextExpression
@@ -1301,7 +1301,7 @@ class Test(unittest.TestCase):
 
         # Metronome
         s = converter.parse(testFiles.tabTest)
-        metro = s.recurse().getElementsByClass('MetronomeMark').first()
+        metro = s[tempo.MetronomeMark].first()
         self.assertEqual(metro.style.absoluteY, 40)
         self.assertEqual(metro.placement, 'above')
 

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -66,7 +66,7 @@ class Test(unittest.TestCase):
         # this is a good example with repeats
         s = corpus.parse('k80/movement3')
         for p in s.parts:
-            post = p.recurse().getElementsByClass(bar.Repeat)
+            post = p[bar.Repeat]
             self.assertEqual(len(post), 6)
 
         # a = corpus.parse('opus41no1/movement3')
@@ -332,7 +332,7 @@ class Test(unittest.TestCase):
         # has metronome marks defined, not with sound tag
         s = converter.parse(testPrimitive.metronomeMarks31c)
         # get all tempo indications
-        mms = s.flatten().getElementsByClass('TempoIndication')
+        mms = s[meter.TempoIndication]
         self.assertGreater(len(mms), 3)
 
     def testImportMetronomeMarksB(self):
@@ -392,7 +392,7 @@ class Test(unittest.TestCase):
         from music21 import converter
 
         s = converter.parse(testPrimitive.staffGroupsNested41d)
-        staffGroups = s.getElementsByClass('StaffGroup')
+        staffGroups = s.getElementsByClass(spanner.StaffGroup)
         # staffGroups.show()
         self.assertEqual(len(staffGroups), 2)
 
@@ -411,7 +411,7 @@ class Test(unittest.TestCase):
         from music21 import converter
 
         s = converter.parse(testPrimitive.pianoStaff43a)
-        sgs = s.getElementsByClass('StaffGroup')
+        sgs = s.getElementsByClass(spanner.StaffGroup)
         self.assertEqual(len(sgs), 1)
         self.assertEqual(sgs[0].symbol, 'brace')
         self.assertIs(sgs[0].barTogether, True)
@@ -727,10 +727,10 @@ class Test(unittest.TestCase):
     def testStaffLayout(self):
         from music21 import corpus
         c = corpus.parse('demos/layoutTest.xml')
-        layouts = c.flatten().getElementsByClass('LayoutBase').stream()
-        systemLayouts = layouts.getElementsByClass('SystemLayout')
+        layouts = c.flatten().getElementsByClass(layout.LayoutBase).stream()
+        systemLayouts = layouts.getElementsByClass(layout.SystemLayout)
         self.assertEqual(len(systemLayouts), 42)
-        staffLayouts = layouts.getElementsByClass('StaffLayout')
+        staffLayouts = layouts.getElementsByClass(layout.StaffLayout)
         self.assertEqual(len(staffLayouts), 20)
         pageLayouts = layouts.getElementsByClass('PageLayout')
         self.assertEqual(len(pageLayouts), 10)
@@ -754,9 +754,9 @@ class Test(unittest.TestCase):
     def testStaffLayoutMore(self):
         from music21 import corpus
         c = corpus.parse('demos/layoutTestMore.xml')
-        layouts = c.flatten().getElementsByClass('LayoutBase').stream()
+        layouts = c.flatten().getElementsByClass(layout.LayoutBase).stream()
         self.assertEqual(len(layouts), 76)
-        systemLayouts = layouts.getElementsByClass('SystemLayout')
+        systemLayouts = layouts.getElementsByClass(layout.SystemLayout)
         sl0 = systemLayouts[0]
         self.assertEqual(sl0.distance, None)
         self.assertEqual(sl0.topDistance, 211.0)

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -95,7 +95,7 @@ class Test(unittest.TestCase):
 
         s = converter.parse(testPrimitive.spannersSlurs33c)
         # have 5 spanners
-        self.assertEqual(len(s.flatten().getElementsByClass(spanner.Spanner)), 5)
+        self.assertEqual(len(s[spanner.Spanner]), 5)
 
         # can get the same from a recurse search
         self.assertEqual(len(s.recurse().getElementsByClass(spanner.Spanner)), 5)
@@ -190,7 +190,7 @@ class Test(unittest.TestCase):
 
         s = converter.parse(testPrimitive.textExpressions)
         # s.show()
-        self.assertEqual(len(s.flatten().getElementsByClass(expressions.TextExpression)), 3)
+        self.assertEqual(len(s[expressions.TextExpression]), 3)
 
         p1 = s.parts[0]
         m1 = p1.getElementsByClass(stream.Measure)[0]
@@ -262,22 +262,22 @@ class Test(unittest.TestCase):
 
         # has one segno
         s = converter.parse(testPrimitive.repeatExpressionsA)
-        self.assertEqual(len(s.flatten().getElementsByClass(repeat.Segno)), 1)
-        self.assertEqual(len(s.flatten().getElementsByClass(repeat.Fine)), 1)
-        self.assertEqual(len(s.flatten().getElementsByClass(repeat.DalSegnoAlFine)), 1)
+        self.assertEqual(len(s[repeat.Segno]), 1)
+        self.assertEqual(len(s[repeat.Fine]), 1)
+        self.assertEqual(len(s[repeat.DalSegnoAlFine]), 1)
 
         # has two codas
         s = converter.parse(testPrimitive.repeatExpressionsB)
-        self.assertEqual(len(s.flatten().getElementsByClass(repeat.Coda)), 2)
+        self.assertEqual(len(s[repeat.Coda]), 2)
         # has one d.c.al coda
-        self.assertEqual(len(s.flatten().getElementsByClass(repeat.DaCapoAlCoda)), 1)
+        self.assertEqual(len(s[repeat.DaCapoAlCoda]), 1)
 
     def testImportRepeatBracketA(self):
         from music21 import corpus
         # has repeats in it; start with single measure
         s = corpus.parse('opus74no1', 3)
         # there are 2 for each part, totaling 8
-        self.assertEqual(len(s.flatten().getElementsByClass(spanner.RepeatBracket)), 8)
+        self.assertEqual(len(s[spanner.RepeatBracket]), 8)
         # can get for each part as spanners are stored in Part now
 
         # TODO: need to test getting repeat brackets after measure extraction
@@ -569,7 +569,7 @@ class Test(unittest.TestCase):
         s = converter.parse(testPrimitive.notations32a)
 
         # s.flatten().show('t')
-        num_tremolo_spanners = len(s.flatten().getElementsByClass('TremoloSpanner'))
+        num_tremolo_spanners = len(s['TremoloSpanner'])
         self.assertEqual(num_tremolo_spanners, 0)  # no spanned tremolos
 
         count = 0
@@ -781,7 +781,7 @@ class Test(unittest.TestCase):
         notesOrChords = (note.Note, chord.Chord)
         allNotesOrChords = c.flatten().getElementsByClass(notesOrChords)
         self.assertEqual(len(allNotesOrChords), 50)
-        allChords = c.flatten().getElementsByClass('Chord')
+        allChords = c[chord.Chord]
         self.assertEqual(len(allChords), 45)
         pCount = 0
         for cc in allChords:
@@ -810,7 +810,7 @@ class Test(unittest.TestCase):
         '''
         from music21 import corpus
         c = corpus.parse('luca/gloria')
-        r = c.parts[1].measure(99).getElementsByClass('Rest').first()
+        r = c.parts[1].measure(99).getElementsByClass(note.Rest).first()
         bracketAttachedToRest = r.getSpannerSites()[0]
         self.assertIn('Line', bracketAttachedToRest.classes)
         self.assertEqual(bracketAttachedToRest.idLocal, '1')
@@ -823,7 +823,7 @@ class Test(unittest.TestCase):
         c = corpus.parse('demos/voices_with_chords.xml')
         m1 = c.parts[0].measure(1)
         # m1.show('text')
-        firstChord = m1.voices.getElementById('2').getElementsByClass('Chord').first()
+        firstChord = m1.voices.getElementById('2').getElementsByClass(chord.Chord).first()
         self.assertEqual(repr(firstChord), '<music21.chord.Chord G4 B4>')
         self.assertEqual(firstChord.offset, 1.0)
 

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -332,7 +332,7 @@ class Test(unittest.TestCase):
         # has metronome marks defined, not with sound tag
         s = converter.parse(testPrimitive.metronomeMarks31c)
         # get all tempo indications
-        mms = s[meter.TempoIndication]
+        mms = s[tempo.TempoIndication]
         self.assertGreater(len(mms), 3)
 
     def testImportMetronomeMarksB(self):
@@ -392,7 +392,7 @@ class Test(unittest.TestCase):
         from music21 import converter
 
         s = converter.parse(testPrimitive.staffGroupsNested41d)
-        staffGroups = s.getElementsByClass(spanner.StaffGroup)
+        staffGroups = s.getElementsByClass(layout.StaffGroup)
         # staffGroups.show()
         self.assertEqual(len(staffGroups), 2)
 
@@ -411,7 +411,7 @@ class Test(unittest.TestCase):
         from music21 import converter
 
         s = converter.parse(testPrimitive.pianoStaff43a)
-        sgs = s.getElementsByClass(spanner.StaffGroup)
+        sgs = s.getElementsByClass(layout.StaffGroup)
         self.assertEqual(len(sgs), 1)
         self.assertEqual(sgs[0].symbol, 'brace')
         self.assertIs(sgs[0].barTogether, True)

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1928,7 +1928,7 @@ class PartParser(XMLParserBase):
         #     because it should happen on a voice level.
         if measureParser.fullMeasureRest is True:
             # recurse is necessary because it could be in voices...
-            r1 = m.recurse().getElementsByClass('Rest').first()
+            r1 = m[note.Rest].first()
             lastTSQl = self.lastTimeSignature.barDuration.quarterLength
             if (r1.fullMeasure is True  # set by xml measure='yes'
                                     or (r1.duration.quarterLength != lastTSQl

--- a/music21/omr/correctors.py
+++ b/music21/omr/correctors.py
@@ -314,7 +314,7 @@ class ScoreCorrector:
             self.singleParts[destinationVerticalIndex].measureStream[destinationHorizontalIndex])
         # Measure object
         correctMeasure = self.singleParts[sourceVerticalIndex].measureStream[sourceHorizontalIndex]
-        oldNotePitches = [n.pitch for n in incorrectMeasure.getElementsByClass('Note')]
+        oldNotePitches = [n.pitch for n in incorrectMeasure.getElementsByClass(note.Note)]
         for el in incorrectMeasure.elements:
             incorrectMeasure.remove(el)
 

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -3755,6 +3755,7 @@ class Test(unittest.TestCase):
 
         Also has grace notes, so it tests our importing of grace notes
         '''
+        from music21 import bar
         from music21 import corpus
         from music21 import stream
 

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -481,7 +481,7 @@ def insertRepeat(s, start, end, *, inPlace=False):
 
     >>> len(s.parts[0].flatten().getElementsByClass(bar.Repeat))
     2
-    >>> len(s.flatten().getElementsByClass(bar.Repeat))
+    >>> len(s[bar.Repeat])
     8
     >>> s.parts[0].measure(3).leftBarline.direction
     'start'
@@ -724,6 +724,7 @@ class Expander:
         run several setup routines.
         '''
         from music21 import stream
+
         # get and store the source measure count; this is presumed to
         # be a Stream with Measures
         self._srcMeasureStream = self._src.getElementsByClass(stream.Measure).stream()
@@ -3208,7 +3209,7 @@ class Test(unittest.TestCase):
             template.append(m)
         s = copy.deepcopy(template)
         s[3].insert(0, repeat.DaCapo())
-        self.assertEqual(len(s.flatten().getElementsByClass(repeat.DaCapo)), 1)
+        self.assertEqual(len(s[repeat.DaCapo]), 1)
 
         raw = GEX.parse(s).decode('utf-8')
 
@@ -3218,7 +3219,7 @@ class Test(unittest.TestCase):
         s = copy.deepcopy(template)
         s[0].timeSignature = meter.TimeSignature('4/4')
         s[3].insert(0, expressions.TextExpression('da capo'))
-        self.assertEqual(len(s.flatten().getElementsByClass(repeat.DaCapo)), 0)
+        self.assertEqual(len(s[repeat.DaCapo]), 0)
 
         raw = GEX.parse(s).decode('utf-8')
         self.assertGreater(raw.find('da capo'), 0, raw)
@@ -3754,23 +3755,23 @@ class Test(unittest.TestCase):
 
         Also has grace notes, so it tests our importing of grace notes
         '''
-
         from music21 import corpus
         from music21 import stream
+
         s = corpus.parse('ryansMammoth/BanjoReel')
         # s.show('text')
         self.assertEqual(len(s.parts), 1)
         self.assertEqual(len(s.parts[0].getElementsByClass(stream.Measure)), 11)
         self.assertEqual(len(s.parts[0].flatten().notes), 58)
 
-        bars = s.parts[0].flatten().getElementsByClass('Barline')
+        bars = s.parts[0][bar.Barline]
         self.assertEqual(len(bars), 3)
 
         s2 = s.expandRepeats()
         # s2.show('text')
 
         self.assertEqual(len(s2.parts[0].getElementsByClass(stream.Measure)), 20)
-        self.assertEqual(len(s2.parts[0].flatten().notes), 105)
+        self.assertEqual(len(s2.parts[0].recurse().notes), 105)
 
     def testExpandRepeatsImportedB(self):
         from music21 import corpus
@@ -3795,10 +3796,10 @@ class Test(unittest.TestCase):
         from music21 import converter
         from music21.musicxml import testPrimitive
         s = converter.parse(testPrimitive.repeatExpressionsA)
-        self.assertEqual(len(s.flatten().getElementsByClass('RepeatExpression')), 3)
+        self.assertEqual(len(s['RepeatExpression']), 3)
 
         s = converter.parse(testPrimitive.repeatExpressionsB)
-        self.assertEqual(len(s.flatten().getElementsByClass('RepeatExpression')), 3)
+        self.assertEqual(len(s['RepeatExpression']), 3)
 
         # s.show()
 

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -3685,7 +3685,7 @@ class Test(unittest.TestCase):
         s.append(p)
         targetCount = 1
         self.assertEqual(
-            len(s.flatten().getElementsByClass('KeySignature')),
+            len(s['KeySignature']),
             targetCount,
         )
         # through sequential iteration

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -986,7 +986,7 @@ class TestExternal(unittest.TestCase):
         #     txt = f.read()
         #
         #     s = clercqTemperley.CTSong(txt)
-        #     for chord in s.toScore().flatten().getElementsByClass('Chord'):
+        #     for chord in s.toScore().flatten().getElementsByClass(chord.Chord):
         #         try:
         #             x = chord.pitches
         #         except:

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -1287,7 +1287,7 @@ class Test(unittest.TestCase):
     def testMinor67set(self):
         from music21.romanText import testFiles
         s = romanTextToStreamScore(testFiles.testSetMinorRootParse)
-        chords = list(s.recurse().getElementsByClass('RomanNumeral'))
+        chords = list(s[roman.RomanNumeral])
 
         def pitchEqual(index, pitchStr):
             ch = chords[index]

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -443,7 +443,7 @@ class M21toTSV:
 
         tsvData = []
 
-        for thisRN in self.m21Stream.recurse().getElementsByClass('RomanNumeral'):
+        for thisRN in self.m21Stream[roman.RomanNumeral]:
 
             relativeroot = None
             if thisRN.secondaryRomanNumeral:

--- a/music21/romanText/writeRoman.py
+++ b/music21/romanText/writeRoman.py
@@ -167,7 +167,7 @@ class RnWriter(prebase.ProtoM21Object):
                              '']  # One blank line between metadata and analysis
         # Note: blank analyst and proofreader entries until supported within music21 metadata
 
-        if not self.container.recurse().getElementsByClass('TimeSignature'):
+        if not self.container[meter.TimeSignature]:
             self.container.insert(0, meter.TimeSignature('4/4'))  # Placeholder
 
         self.currentKeyString: str = ''

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -187,7 +187,7 @@ class LyricSearcher:
         iTextByIdentifier = OrderedDict()
         lastSyllabicByIdentifier = OrderedDict()
 
-        for n in s.recurse().getElementsByClass('NotRest'):
+        for n in s.recurse().notes:
             ls: List[note.Lyric] = n.lyrics
             if not ls:
                 continue

--- a/music21/search/serial.py
+++ b/music21/search/serial.py
@@ -596,7 +596,7 @@ class ContiguousSegmentSearcher:
         self.searchLength = length
         self.listOfContiguousSegments = []
         hasParts = True
-        partList = self.stream.recurse().getElementsByClass('Part')
+        partList = self.stream[stream.Part]
         if not partList:
             partList = [self.stream]
             hasParts = False

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -710,7 +710,7 @@ class TwelveToneRow(ToneRow):
         '''
         # note: do not want to return a TwelveToneRow() type, as this will
         # add again the same pitches to the elements list twice.
-        noteList = self.getElementsByClass('Note')
+        noteList = self.getElementsByClass(note.Note)
 
         i = [(12 - x.pitch.pitchClass) % 12 for x in noteList]
         matrix = [[(x.pitch.pitchClass + t) % 12 for x in noteList] for t in i]

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -100,7 +100,7 @@ class Spanner(base.Music21Object):
     <music21.note.Note E>
 
 
-    (2) we can get a stream of spanners (equiv. to getElementsByClass('Spanner'))
+    (2) we can get a stream of spanners (equiv. to getElementsByClass(spanner.Spanner))
         by calling the .spanner property on the stream.
 
     >>> spannerCollection = s.spanners  # a stream object

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -980,7 +980,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object, Generic[M21ObjType]):
         {0.0} <music21.clef.BassClef>
         {0.0} <music21.note.Note D#>
         '''
-        clefList = self.getElementsByClass('Clef').getElementsByOffset(0)
+        clefList = self.getElementsByClass(clef.Clef).getElementsByOffset(0)
         # casting to list added 20microseconds...
         return clefList.first()
 
@@ -5180,6 +5180,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object, Generic[M21ObjType]):
         v.3 -- inPlace defaults to False
         v.5 -- returns None if inPlace=True
         '''
+        from music21 import spanner
+
         if not inPlace:  # make a copy
             returnObj = self.coreCopyAsDerivation('toWrittenPitch')
         else:
@@ -5200,7 +5202,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object, Generic[M21ObjType]):
             for container in returnObj.recurse(streamsOnly=True, includeSelf=True):
                 container.atSoundingPitch = False
 
-        for ottava in returnObj.recurse().getElementsByClass('Ottava'):
+        for ottava in returnObj[spanner.Ottava]:
             ottava.undoTransposition()
 
         if not inPlace:
@@ -13395,7 +13397,7 @@ class Score(Stream):
         >>> lastChord
         <music21.chord.Chord E2 G3 B3 E4>
 
-        Note that we still do a .getElementsByClass('Chord') since many pieces end
+        Note that we still do a .getElementsByClass(chord.Chord) since many pieces end
         with nothing but a rest...
         '''
         if measureNumber < 0:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1157,10 +1157,11 @@ class Stream(core.StreamCoreMixin, base.Music21Object, Generic[M21ObjType]):
         >>> m.staffLines = 2
         >>> staffLayout.staffLines
         2
-
         '''
-        staffLayouts = self.recurse().getElementsByClass('StaffLayout')
-        sl: 'music21.layout.StaffLayout'
+        from music21 import layout
+
+        staffLayouts = self[layout.StaffLayout]
+        sl: layout.StaffLayout
         for sl in staffLayouts:
             if sl.getOffsetInHierarchy(self) > 0:
                 break
@@ -5964,7 +5965,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object, Generic[M21ObjType]):
 
         def consolidateRests(templateInner):
             consecutiveRests = []
-            for el in list(templateInner.getElementsByClass('GeneralNote')):
+            for el in list(templateInner.notesAndRests):
                 if not isinstance(el, note.Rest):
                     removeConsecutiveRests(templateInner, consecutiveRests)
                     consecutiveRests = []
@@ -9444,7 +9445,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object, Generic[M21ObjType]):
         if 'Measure' in self.classes or 'Voice' in self.classes:
             return True
         # all other Stream classes are not well-formed if they have "loose" notes
-        elif self.getElementsByClass('GeneralNote'):
+        elif self.notesAndRests:
             return False
         elif 'Part' in self.classes:
             if self.hasMeasures():
@@ -12751,7 +12752,7 @@ class Measure(Stream):
         '''
         if useInitialRests:
             removeList = []
-            for gn in self.getElementsByClass('GeneralNote'):
+            for gn in self.notesAndRests:
                 if not isinstance(gn, note.Rest):
                     break
                 removeList.append(gn)
@@ -13039,7 +13040,7 @@ class Part(Stream):
             return self._cache['_partName']
         else:
             pn = None
-            for e in self.recurse().getElementsByClass('Instrument'):
+            for e in self[instrument.Instrument]:
                 pn = e.partName
                 if pn is None:
                     pn = e.instrumentName
@@ -13093,7 +13094,7 @@ class Part(Stream):
             return self._cache['_partAbbreviation']
         else:
             pn = None
-            for e in self.recurse().getElementsByClass('Instrument'):
+            for e in self[instrument.Instrument]:
                 pn = e.partAbbreviation
                 if pn is None:
                     pn = e.instrumentAbbreviation
@@ -13388,7 +13389,7 @@ class Score(Stream):
             {0.0} <music21.chord.Chord E2 G3 B3 E4>
             {4.0} <music21.bar.Barline type=final>
 
-        >>> lastChord = excerptChords.recurse().getElementsByClass('Chord').last()
+        >>> lastChord = excerptChords[chord.Chord].last()
         >>> lastChord
         <music21.chord.Chord E2 G3 B3 E4>
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9032,7 +9032,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object, Generic[M21ObjType]):
             return returnObj  # exit
 
         if returnObj.hasPartLikeStreams():
-            for p in returnObj.getElementsByClass('Part'):
+            for p in returnObj.getElementsByClass(stream.Part):
                 p.sliceByQuarterLengths(quarterLengthList,
                                         target=target, addTies=addTies, inPlace=True)
             returnObj.coreElementsChanged()

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -5122,6 +5122,8 @@ class Stream(core.StreamCoreMixin, base.Music21Object, Generic[M21ObjType]):
         >>> sp.derivation.origin is p
         True
         '''
+        from music21 import spanner
+
         if not inPlace:  # make a copy
             returnObj = self.coreCopyAsDerivation('toSoundingPitch')
         else:
@@ -5142,7 +5144,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object, Generic[M21ObjType]):
             for container in returnObj.recurse(streamsOnly=True, includeSelf=True):
                 container.atSoundingPitch = True
 
-        for ottava in returnObj.recurse().getElementsByClass('Ottava'):
+        for ottava in returnObj[spanner.Ottava]:
             ottava.performTransposition()
 
         if not inPlace:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9032,7 +9032,7 @@ class Stream(core.StreamCoreMixin, base.Music21Object, Generic[M21ObjType]):
             return returnObj  # exit
 
         if returnObj.hasPartLikeStreams():
-            for p in returnObj.getElementsByClass(stream.Part):
+            for p in returnObj.getElementsByClass('Part'):
                 p.sliceByQuarterLengths(quarterLengthList,
                                         target=target, addTies=addTies, inPlace=True)
             returnObj.coreElementsChanged()

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -1581,7 +1581,7 @@ class OffsetIterator(StreamIterator[M21ObjType]):
 
 
 # -----------------------------------------------------------------------------
-class RecursiveIterator(StreamIterator[M21ObjType]):
+class RecursiveIterator(StreamIterator[M21ObjType], collections.abc.Sequence):
     '''
     One of the most powerful iterators in music21.  Generally not called
     directly, but created by being invoked on a stream with `Stream.recurse()`

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -458,14 +458,14 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], collections.ab
         >>> bool(iterator)
         True
 
-        >>> bool(iterator.getElementsByClass('Chord'))
+        >>> bool(iterator.getElementsByClass(chord.Chord))
         False
 
         test false cache:
 
-        >>> len(iterator.getElementsByClass('Chord'))
+        >>> len(iterator.getElementsByClass(chord.Chord))
         0
-        >>> bool(iterator.getElementsByClass('Chord'))
+        >>> bool(iterator.getElementsByClass(chord.Chord))
         False
 
         '''
@@ -809,7 +809,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], collections.ab
         >>> s3.elementOffset(b, returnSpecial=True)
         <OffsetSpecial.AT_END>
 
-        >>> s4 = s.iter().getElementsByClass('Barline').stream()
+        >>> s4 = s.iter().getElementsByClass(bar.Barline).stream()
         >>> s4.show('t')
         {0.0} <music21.bar.Barline type=regular>
 
@@ -1008,7 +1008,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], collections.ab
         >>> r = note.Rest()
         >>> s.append(r)
         >>> s.append(note.Note('D'))
-        >>> for el in s.iter().getElementsByClass('Rest'):
+        >>> for el in s.iter().getElementsByClass(note.Rest):
         ...     print(el)
         <music21.note.Rest quarter>
 
@@ -1020,7 +1020,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], collections.ab
         >>> r.activeSite.id
         's2'
 
-        >>> for el in s.iter().getElementsByClass('Rest'):
+        >>> for el in s.iter().getElementsByClass(note.Rest):
         ...     print(el.activeSite.id)
         s1
 
@@ -1515,7 +1515,7 @@ class OffsetIterator(StreamIterator[M21ObjType]):
     [<music21.note.Note E>]
     [<music21.note.Note F>, <music21.note.Note G>]
 
-    >>> for groupedElements in stream.iterator.OffsetIterator(s).getElementsByClass('Clef'):
+    >>> for groupedElements in stream.iterator.OffsetIterator(s).getElementsByClass(clef.Clef):
     ...     print(groupedElements)
     [<music21.clef.TrebleClef>]
     '''

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -514,12 +514,12 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], collections.ab
         >>> s = converter.parse('tinyNotation: 3/4 D4 E2 F4 r2 G2 r4')
         >>> s.recurse().notes.first()
         <music21.note.Note D>
-        >>> s.recurse().getElementsByClass('Rest').first()
+        >>> s[note.Rest].first()
         <music21.note.Rest half>
 
         If no elements match, returns None:
 
-        >>> print(s.recurse().getElementsByClass('Chord').first())
+        >>> print(s[chord.Chord].first())
         None
 
         New in v7.
@@ -565,7 +565,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], collections.ab
         >>> s = converter.parse('tinyNotation: 3/4 D4 E2 F4 r2 G2 r4')
         >>> s.recurse().notes.last()
         <music21.note.Note G>
-        >>> s.recurse().getElementsByClass('Rest').last()
+        >>> s[note.Rest].last()
         <music21.note.Rest quarter>
 
         New in v7.
@@ -790,7 +790,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], collections.ab
         >>> b = bar.Barline()
         >>> s.storeAtEnd(b)
 
-        >>> s2 = s.iter().getElementsByClass('Note').stream()
+        >>> s2 = s.iter().getElementsByClass(note.Note).stream()
         >>> s2.show('t')
         {0.0} <music21.note.Note C>
         {2.0} <music21.note.Note D>
@@ -2000,7 +2000,7 @@ class Test(unittest.TestCase):
         self.assertIs(r0, r)
 
         # adding a filter gives a new StreamIterator that restarts at 0
-        sIter2 = sIter.getElementsByClass('GeneralNote')  # this filter does nothing here.
+        sIter2 = sIter.notesAndRests  # this filter does nothing here.
         obj0 = next(sIter2)
         self.assertIs(obj0, r)
 

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -1762,7 +1762,7 @@ def iterateBeamGroups(
     iterator: 'music21.stream.iterator.StreamIterator' = s.recurse() if recurse else s.iter()
     current_beam_group: List[note.NotRest] = []
     in_beam_group: bool = False
-    for el in iterator.getElementsByClass('NotRest'):
+    for el in iterator.notes:
         first_el_type: Optional[str] = None
         if el.beams and el.beams.getByNumber(1):
             first_el_type = el.beams.getTypeByNumber(1)

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -489,7 +489,7 @@ def makeMeasures(
     # del clefList
     clefObj = srcObj.clef or srcObj.getContextByClass('Clef')
     if clefObj is None:
-        clefObj = srcObj.getElementsByClass('Clef').getElementsByOffset(0).first()
+        clefObj = srcObj.getElementsByClass(clef.Clef).getElementsByOffset(0).first()
         # only return clefs that have offset = 0.0
         if not clefObj:
             clefObj = clef.bestClef(srcObj, recurse=True)

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1433,7 +1433,7 @@ class Test(unittest.TestCase):
             m.append(c)
             p.append(m)
         p2 = p.stripTies(matchByPitch=True)
-        chordsOut = list(p2.flatten().getElementsByClass('Chord'))
+        chordsOut = list(p2.flatten().getElementsByClass(chord.Chord))
         self.assertEqual(len(chordsOut), 5)
         self.assertEqual(chordsOut[0].pitches, ch0.pitches)
         self.assertEqual(chordsOut[0].duration.quarterLength, 2.0)
@@ -2319,7 +2319,7 @@ class Test(unittest.TestCase):
         obj = expressions.TextExpression('FREEZE')
         s.insert(3, obj)
         s.makeMeasures(inPlace=True)
-        self.assertEqual(len(s.flatten().getElementsByClass('Expression')), 1)
+        self.assertEqual(len(s['Expression']), 1)
 
     def testRemove(self):
         '''Test removing components from a Stream.
@@ -2393,7 +2393,7 @@ class Test(unittest.TestCase):
         sBach = corpus.parse('bach/bwv324.xml')
         partSoprano = sBach.parts.first()
 
-        c1 = partSoprano.flatten().getElementsByClass('Clef').first()
+        c1 = partSoprano.flatten().getElementsByClass(clef.Clef).first()
         self.assertIsInstance(c1, clef.TrebleClef)
 
         # now, replace with a different clef
@@ -2401,7 +2401,7 @@ class Test(unittest.TestCase):
         partSoprano.flatten().replace(c1, c2, allDerived=True)
 
         # all views of the Stream have been updated
-        cTest = sBach.parts.first().flatten().getElementsByClass('Clef').first()
+        cTest = sBach.parts.first().flatten().getElementsByClass(clef.Clef).first()
         self.assertIsInstance(cTest, clef.AltoClef)
 
     def testReplaceB(self):
@@ -2650,7 +2650,7 @@ class Test(unittest.TestCase):
     def testMakeAccidentalsB(self):
         s = corpus.parse('monteverdi/madrigal.5.3.rntxt')
         m34 = s.parts[0].getElementsByClass(Measure)[33]
-        c = m34.getElementsByClass('Chord')
+        c = m34.getElementsByClass(chord.Chord)
         # assuming not showing accidental b/c of key
         self.assertEqual(str(c[1].pitches), '(<music21.pitch.Pitch B-4>, '
                             + '<music21.pitch.Pitch D5>, <music21.pitch.Pitch F5>)')
@@ -2659,7 +2659,7 @@ class Test(unittest.TestCase):
 
         s = corpus.parse('monteverdi/madrigal.5.4.rntxt')
         m74 = s.parts[0].getElementsByClass(Measure)[73]
-        c = m74.getElementsByClass('Chord')
+        c = m74.getElementsByClass(chord.Chord)
         # has correct pitches but natural not showing on C
         self.assertEqual(str(c[0].pitches),
                          '(<music21.pitch.Pitch C5>, <music21.pitch.Pitch E5>, '
@@ -4326,7 +4326,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(post.getElementsByClass(
             'Stream')[1].getElementsByClass(Measure)), 3)
         self.assertEqual(len(post.flatten().getElementsByClass('TimeSignature')), 2)
-        self.assertEqual(len(post.flatten().getElementsByClass('Clef')), 2)
+        self.assertEqual(len(post.flatten().getElementsByClass(clef.Clef)), 2)
 
     def testMakeNotationScoreB(self):
         '''Test makeNotation on Score objects
@@ -4356,7 +4356,7 @@ class Test(unittest.TestCase):
             'Stream')[1].getElementsByClass(Measure)), 4)
 
         self.assertEqual(len(post.flatten().getElementsByClass('TimeSignature')), 2)
-        self.assertEqual(len(post.flatten().getElementsByClass('Clef')), 2)
+        self.assertEqual(len(post.flatten().getElementsByClass(clef.Clef)), 2)
 
     def testMakeNotationScoreC(self):
         '''Test makeNotation on Score objects
@@ -4384,7 +4384,7 @@ class Test(unittest.TestCase):
             Stream)[1].getElementsByClass(Measure)), 3)
 
         self.assertEqual(len(post.flatten().getElementsByClass('TimeSignature')), 2)
-        self.assertEqual(len(post.flatten().getElementsByClass('Clef')), 2)
+        self.assertEqual(len(post.flatten().getElementsByClass(clef.Clef)), 2)
 
     def testMakeNotationKeySignatureOneVoice(self):
         '''
@@ -4641,17 +4641,17 @@ class Test(unittest.TestCase):
                     s.insert(o, n)
                 o += ql
             self.assertEqual(len(s), 9)
-            self.assertEqual(len(s.getElementsByClass('Chord')), 0)
+            self.assertEqual(len(s.getElementsByClass(chord.Chord)), 0)
 
             # do both in place and not in place, compare results
             sMod = s.chordify()
             s = s.chordify()
             for sEval in [s, sMod]:
-                self.assertEqual(len(sEval.getElementsByClass('Chord')), 3)
+                self.assertEqual(len(sEval.getElementsByClass(chord.Chord)), 3)
                 # make sure we have all the original pitches
                 for i in range(len(pitchCol)):
                     match = [p.nameWithOctave for p in
-                             sEval.getElementsByClass('Chord')[i].pitches]
+                             sEval.getElementsByClass(chord.Chord)[i].pitches]
                     self.assertEqual(match, list(pitchCol[i]))
         # print('post chordify')
         # s.show('t')
@@ -4682,7 +4682,7 @@ class Test(unittest.TestCase):
         s = s.chordify()
         for sEval in [s, sMod]:
             # of these 6 chords, only 2 have more than one note
-            self.assertEqual(len(sEval.getElementsByClass('Chord')), 6)
+            self.assertEqual(len(sEval.getElementsByClass(chord.Chord)), 6)
             self.assertEqual([c.offset for c in sEval], [0.0, 1.0, 1.5, 2.0, 3.0, 3.5])
 
         # do the same, but reverse the short/long duration relation
@@ -4733,19 +4733,25 @@ class Test(unittest.TestCase):
         s1.insert(0.5, n6)
 
         sMod = s1.chordify(removeRedundantPitches=True)
-        self.assertEqual([p.nameWithOctave for p in sMod.getElementsByClass('Chord')[0].pitches],
+        self.assertEqual([p.nameWithOctave
+                          for p in sMod.getElementsByClass(chord.Chord)[0].pitches],
                           ['C2', 'G2'])
 
-        self.assertEqual([p.nameWithOctave for p in sMod.getElementsByClass('Chord')[1].pitches],
+        self.assertEqual([p.nameWithOctave
+                          for p in sMod.getElementsByClass(chord.Chord)[1].pitches],
                           ['E4', 'F#4'])
 
         # without redundant pitch gathering
         sMod = s1.chordify(removeRedundantPitches=False)
-        self.assertEqual([p.nameWithOctave for p in sMod.getElementsByClass('Chord')[0].pitches],
-                          ['C2', 'C2', 'G2'])
+        self.assertEqual(
+            [p.nameWithOctave for p in sMod.getElementsByClass(chord.Chord)[0].pitches],
+            ['C2', 'C2', 'G2']
+        )
 
-        self.assertEqual([p.nameWithOctave for p in sMod.getElementsByClass('Chord')[1].pitches],
-                          ['E4', 'E4', 'F#4'])
+        self.assertEqual(
+            [p.nameWithOctave for p in sMod.getElementsByClass(chord.Chord)[1].pitches],
+            ['E4', 'E4', 'F#4']
+        )
 
     def testMakeChordsBuiltD(self):
         # attempt to isolate case
@@ -4776,8 +4782,8 @@ class Test(unittest.TestCase):
 
         post = s.flatten().chordify()
         # post.show('t')
-        self.assertEqual(len(post.getElementsByClass('Rest')), 1)
-        self.assertEqual(len(post.getElementsByClass('Chord')), 6)
+        self.assertEqual(len(post.getElementsByClass(note.Rest)), 1)
+        self.assertEqual(len(post.getElementsByClass(chord.Chord)), 6)
         # post.show()
 
     def testGetElementAtOrBeforeBarline(self):
@@ -4851,7 +4857,7 @@ class Test(unittest.TestCase):
         self.assertEqual(s.getElementAfterElement(n2), b1)
 
         # try to get elements by class
-        sub1 = s.getElementsByClass('Barline').stream()
+        sub1 = s.getElementsByClass(bar.Barline).stream()
         self.assertEqual(len(sub1), 1)
         # only found item is barline
         self.assertEqual(sub1[0], b1)
@@ -5350,7 +5356,7 @@ class Test(unittest.TestCase):
                           39.0, 40.0, 40.5, 41.0, 42.0, 43.5, 45.0, 45.5, 46.0, 46.5,
                            47.0, 47.5, 48.0, 49.5, 51.0, 51.5, 52.0, 52.5, 53.0, 53.5,
                            54.0, 54.5, 55.0, 55.5, 56.0, 56.5, 57.0, 58.5, 59.5])
-        self.assertEqual(len(post.flatten().getElementsByClass('Chord')), 71)
+        self.assertEqual(len(post[chord.Chord]), 71)
         # Careful! one version of the caching is screwing up m. 20 which definitely should
         # not have rests in it -- was creating 69 notes, not 71.
 
@@ -5429,8 +5435,8 @@ class Test(unittest.TestCase):
         s.insert(0, p1)
         s.insert(0, p2)
         post = s.chordify()
-        self.assertEqual(len(post.getElementsByClass('Chord')), 12)
-        self.assertEqual(str(post.getElementsByClass('Chord').first().pitches),
+        self.assertEqual(len(post.getElementsByClass(chord.Chord)), 12)
+        self.assertEqual(str(post.getElementsByClass(chord.Chord).first().pitches),
                          '(<music21.pitch.Pitch C4>, <music21.pitch.Pitch G4>)')
 
         p1 = Part()
@@ -5445,8 +5451,8 @@ class Test(unittest.TestCase):
         s.insert(0, p1)
         s.insert(0, p2)
         post = s.chordify()
-        self.assertEqual(len(post.getElementsByClass('Chord')), 2)
-        self.assertEqual(str(post.getElementsByClass('Chord').first().pitches),
+        self.assertEqual(len(post.getElementsByClass(chord.Chord)), 2)
+        self.assertEqual(str(post.getElementsByClass(chord.Chord).first().pitches),
                          '(<music21.pitch.Pitch C4>, <music21.pitch.Pitch G4>)')
         # post.show()
 
@@ -5511,7 +5517,7 @@ class Test(unittest.TestCase):
             self.assertFalse(m.hasVoices())
             match.append(len(m.pitches))
         self.assertEqual(match, [3, 9, 9, 25, 25, 21, 12, 6, 21, 29])
-        self.assertEqual(len(post.flatten().getElementsByClass('Rest')), 4)
+        self.assertEqual(len(post.flatten().getElementsByClass(note.Rest)), 4)
 
     def testChordifyD(self):
         # test on a Stream of Streams.
@@ -5524,7 +5530,7 @@ class Test(unittest.TestCase):
         s3.insert(0, s2)
 
         post = s3.chordify()
-        self.assertEqual(len(post.getElementsByClass('Chord')), 8)
+        self.assertEqual(len(post.getElementsByClass(chord.Chord)), 8)
 
     def testChordifyE(self):
         s1 = Stream()
@@ -5541,7 +5547,7 @@ class Test(unittest.TestCase):
         # s1.show()
         post = s1.chordify()
         # post.show()
-        self.assertEqual(len(post.flatten().getElementsByClass('Chord')), 8)
+        self.assertEqual(len(post[chord.Chord]), 8)
 
     # noinspection SpellCheckingInspection
     def testOpusSearch(self):
@@ -5775,7 +5781,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s1.parts), 2)
 
         p1 = s1.parts[0]
-        self.assertEqual(len(p1.flatten().getElementsByClass('Clef')), 1)
+        self.assertEqual(len(p1.flatten().getElementsByClass(clef.Clef)), 1)
         # p1.show('t')
 
         # look at individual measure; check counts; these should not
@@ -5793,7 +5799,7 @@ class Test(unittest.TestCase):
         # NOTE: we no longer get Clef here, as we return clefs in the
         # Part outside a Measure when using measures()
         # m = p1.measure(2)
-        # self.assertEqual(len(m1.flatten().getElementsByClass('Clef')), 1)
+        # self.assertEqual(len(m1.flatten().getElementsByClass(clef.Clef)), 1)
 
         # look at individual measure; check counts; these should not
         # change after measure extraction
@@ -5808,9 +5814,9 @@ class Test(unittest.TestCase):
 
         # m2Raw.show('t')
 
-        # self.assertEqual(len(m1.flatten().getElementsByClass('Clef')), 1)
+        # self.assertEqual(len(m1.flatten().getElementsByClass(clef.Clef)), 1)
         ex1 = p1.measures(1, 3)
-        self.assertEqual(len(ex1.flatten().getElementsByClass('Clef')), 1)
+        self.assertEqual(len(ex1.flatten().getElementsByClass(clef.Clef)), 1)
 
         # ex1.show()
 
@@ -6175,7 +6181,7 @@ class Test(unittest.TestCase):
         self.assertIs(s3.derivation.origin, s1)
         self.assertIsNot(s3.derivation.origin, s2)
 
-        s4 = s3.getElementsByClass('Chord').stream()
+        s4 = s3.getElementsByClass(chord.Chord).stream()
         self.assertEqual(len(s4), 10)
         self.assertIs(s4.derivation.origin, s3)
 
@@ -6223,7 +6229,10 @@ class Test(unittest.TestCase):
         self.assertEqual(mRange.derivation.rootDerivation, p1)
         self.assertEqual(mRange.flatten().notesAndRests.stream().derivation.rootDerivation, p1)
 
-        self.assertIs(s.flatten().getElementsByClass('Rest').stream().derivation.rootDerivation, s)
+        self.assertIs(
+            s.flatten().getElementsByClass(note.Rest).stream().derivation.rootDerivation,
+            s
+        )
 
         # As of v3, we CAN use the activeSite to get the Part from the Measure, as
         # the activeSite was not set when doing the getElementsByClass operation
@@ -6412,10 +6421,10 @@ class Test(unittest.TestCase):
     def testRecurseB(self):
 
         s = corpus.parse('madrigal.5.8.rntxt')
-        self.assertEqual(len(s.flatten().getElementsByClass('KeySignature')), 1)
+        self.assertEqual(len(s['KeySignature']), 1)
         for e in s.recurse(classFilter='KeySignature'):
             e.activeSite.remove(e)
-        self.assertEqual(len(s.flatten().getElementsByClass('KeySignature')), 0)
+        self.assertEqual(len(s['KeySignature']), 0)
 
     def testTransposeScore(self):
 
@@ -7191,7 +7200,7 @@ class Test(unittest.TestCase):
         # test that each note has its original group
         idA = []
         idB = []
-        for c in post.flatten().getElementsByClass('Chord'):
+        for c in post.flatten().getElementsByClass(chord.Chord):
             for p in c.pitches:
                 if 'a' in p.groups:
                     idA.append(p.name)
@@ -7208,7 +7217,7 @@ class Test(unittest.TestCase):
         idBass = []
 
         post = s.chordify(addPartIdAsGroup=True, removeRedundantPitches=False)
-        for c in post.flatten().getElementsByClass('Chord'):
+        for c in post.flatten().getElementsByClass(chord.Chord):
             for p in c.pitches:
                 if 'Soprano' in p.groups:
                     idSoprano.append(p.name)
@@ -7389,7 +7398,7 @@ class Test(unittest.TestCase):
         sChords = s.measures(9, 9).chordify()
         sChords.extendTies()
         post = []
-        for ch in sChords.flatten().getElementsByClass('Chord'):
+        for ch in sChords.flatten().getElementsByClass(chord.Chord):
             post.append([repr(n.tie) for n in ch])
 
         self.assertEqual(post,
@@ -7550,7 +7559,7 @@ class Test(unittest.TestCase):
         s = corpus.parse('bwv66.6')
         ex = s.parts[0].measures(3, 6)
 
-        self.assertEqual(str(ex.flatten().getElementsByClass('Clef')[0]),
+        self.assertEqual(str(ex.flatten().getElementsByClass(clef.Clef)[0]),
                          '<music21.clef.TrebleClef>')
         self.assertEqual(str(ex.flatten().getElementsByClass('Instrument')[0]),
                          'P1: Soprano: Instrument 1')
@@ -7567,7 +7576,7 @@ class Test(unittest.TestCase):
                     r = note.Rest(quarterLength=n.quarterLength)
                     m.insert(o, r)
         # s.parts[0].show()
-        self.assertEqual(len(ex.flatten().getElementsByClass('Rest')), 5)
+        self.assertEqual(len(ex[note.Rest]), 5)
 
     def testMeasuresB(self):
         s = corpus.parse('luca/gloria')
@@ -7602,7 +7611,7 @@ class Test(unittest.TestCase):
                 n.activeSite.remove(n)
                 r = note.Rest(quarterLength=n.quarterLength)
                 site.insert(o, r)
-        self.assertEqual(len(ex.flatten().getElementsByClass('Rest')), 5)
+        self.assertEqual(len(ex[note.Rest]), 5)
         # ex.show()
 
     def testMeasuresSuffix(self):
@@ -7700,7 +7709,7 @@ class Test(unittest.TestCase):
         # there should only be 2 tuplet indications in the produced chords: start and stop...
         self.assertEqual(raw.count('<tuplet '), 2, raw)
         # pitch grouping in measure index 1 was not allocated properly
-        # for c in chords.getElementsByClass('Chord'):
+        # for c in chords.getElementsByClass(chord.Chord):
         #    self.assertEqual(len(c), 2)
 
     def testChordifyG(self):
@@ -7710,7 +7719,7 @@ class Test(unittest.TestCase):
         s.insert(0, note.Note('C4', quarterLength=2))
         chords = s.chordify()
         # s.chordify().show('t')
-        for c in chords.getElementsByClass('Chord'):
+        for c in chords.getElementsByClass(chord.Chord):
             self.assertEqual(len(c), 2)
 
         # try with small divisions
@@ -7719,7 +7728,7 @@ class Test(unittest.TestCase):
         s.insert(0, note.Note('C4', quarterLength=2))
         chords = s.chordify()
         # s.chordify().show('t')
-        for c in chords.getElementsByClass('Chord'):
+        for c in chords.getElementsByClass(chord.Chord):
             self.assertEqual(len(c), 2)
 
         s = Stream()
@@ -7727,7 +7736,7 @@ class Test(unittest.TestCase):
         s.insert(0, note.Note('C4', quarterLength=2))
         chords = s.chordify()
         # s.chordify().show('t')
-        for c in chords.getElementsByClass('Chord'):
+        for c in chords.getElementsByClass(chord.Chord):
             self.assertEqual(len(c), 2)
 
         s = Stream()
@@ -7735,7 +7744,7 @@ class Test(unittest.TestCase):
         s.insert(0, note.Note('C4', quarterLength=2))
         chords = s.chordify()
         # s.chordify().show('t')
-        for c in chords.getElementsByClass('Chord'):
+        for c in chords.getElementsByClass(chord.Chord):
             self.assertEqual(len(c), 2)
 
     def testMakeVoicesA(self):

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -710,7 +710,7 @@ class Test(unittest.TestCase):
         a = converter.parse(corpus.getWork('corelli/opus3no1/1grave'))
         b = a.parts[1]
         c = b.flatten()
-        for thisNote in c.getElementsByClass('Note'):
+        for thisNote in c.getElementsByClass(note.Note):
             thisNote.lyric = thisNote.name
         textStr = text.assembleLyrics(b)
         self.assertEqual(textStr.startswith('A A G F E'),
@@ -6169,7 +6169,7 @@ class Test(unittest.TestCase):
         # for testing against
         s2 = Stream()
 
-        s3 = s1.getElementsByClass('GeneralNote').stream()
+        s3 = s1.notesAndRests.stream()
         self.assertEqual(len(s3), 20)
         # environLocal.printDebug(['s3.derivation.origin', s3.derivation.origin])
         self.assertIs(s3.derivation.origin, s1)
@@ -6260,7 +6260,7 @@ class Test(unittest.TestCase):
         self.assertIs(s1Flat.derivation.origin, s1)
         self.assertEqual(s1Flat.derivation.method, 'flat')
 
-        s1Elements = s1Flat.getElementsByClass('Note').stream()
+        s1Elements = s1Flat.getElementsByClass(note.Note).stream()
         self.assertEqual(s1Elements.derivation.method, 'getElementsByClass')
 
         s1 = converter.parse('tinyNotation: 4/4 C2 D2')
@@ -7365,7 +7365,7 @@ class Test(unittest.TestCase):
         s.append(chord.Chord(['c4', 'a5']))
         s.extendTies()
         post = []
-        for n in s.flatten().getElementsByClass('GeneralNote'):
+        for n in s.flatten().notesAndRests:
             if isinstance(n, chord.Chord):
                 post.append([repr(q.tie) for q in n])
             else:

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -106,7 +106,7 @@ def convertTempoByReferent(
     270.0
 
     '''
-    # find duration in seconds of of quarter length
+    # find duration in seconds of quarter length
     srcDurPerBeat = 60 / numberSrc
     # convert to dur for one quarter length
     dur = srcDurPerBeat / quarterLengthBeatSrc
@@ -276,7 +276,7 @@ class TempoText(TempoIndication):
 
     def applyTextFormatting(self, te=None, numberImplicit=False):
         '''
-        Apply the default text formatting to the text expression version of of this tempo mark
+        Apply the default text formatting to the text expression version of this tempo mark
         '''
         if te is None:  # use the stored version if possible
             te = self._textExpression
@@ -422,8 +422,8 @@ class MetronomeMark(TempoIndication):
         self._updateNumberFromText()
         self._updateTextFromNumber()
 
-        # need to store a sounding value for the case where where
-        # a sounding different is different than the number given in the MM
+        # need to store a sounding value for the case where
+        # a sounding different is different from the number given in the MM
         self._numberSounding = None
 
     def _reprInternal(self):
@@ -463,7 +463,7 @@ class MetronomeMark(TempoIndication):
         elif common.isNum(value) or isinstance(value, str):
             self._referent = duration.Duration(value)
         elif not isinstance(value, duration.Duration):
-            # try get duration object, like from Note
+            # try to get duration object, like from Note
             self._referent = value.duration
         elif 'Duration' in value.classes:
             self._referent = value
@@ -595,7 +595,7 @@ class MetronomeMark(TempoIndication):
     def setQuarterBPM(self, value, setNumber=True):
         '''
         Given a value in BPM, use it to set the value of this MetronomeMark.
-        BPM values are assumed to be refer only to quarter notes; different beat values,
+        BPM values are assumed to refer only to quarter notes; different beat values,
         if defined here, will be scaled
 
 
@@ -609,7 +609,7 @@ class MetronomeMark(TempoIndication):
         if not setNumber:
             # convert this to a quarter bpm
             self._numberSounding = value
-        else:  # go through property so as to set implicit status
+        else:  # go through property to set implicit status
             self.number = value
 
     def _getDefaultNumber(self, tempoText):
@@ -661,7 +661,7 @@ class MetronomeMark(TempoIndication):
             tempoNumber = number
         else:  # try to convert
             tempoNumber = float(number)
-        # get a items and sort
+        # get items and sort
         matches = []
         for tempoStr, tempoValue in defaultTempoValues.items():
             matches.append([tempoValue, tempoStr])
@@ -831,7 +831,7 @@ class MetricModulation(TempoIndication):
     '''
     A class for representing the relationship between two MetronomeMarks.
     Generally this relationship is one of equality, where the number is maintained but
-    the referent that number is applied to changes.
+    the referent that number is applied to each change.
 
     The basic definition of a MetricModulation is given by supplying two MetronomeMarks,
     one for the oldMetronome, the other for the newMetronome. High level properties,
@@ -1105,7 +1105,7 @@ class MetricModulation(TempoIndication):
                                       number=mmLast.number)
         if mmOld is not None:
             self._oldMetronome = mmOld
-        # if we have an a new referent, then update number
+        # if we have a new referent, then update number
         if (self._newMetronome is not None
                 and self._newMetronome.referent is not None
                 and self._oldMetronome.number is not None):
@@ -1151,7 +1151,7 @@ class MetricModulation(TempoIndication):
         Set the other side of the metric modulation not based on equality,
         but on a direct translation of the tempo value.
 
-        referent can be a string type or a int/float quarter length
+        referent can be a string type or an int/float quarter length
         '''
         if side is None:
             if self._oldMetronome is None:
@@ -1469,7 +1469,7 @@ class Test(unittest.TestCase):
         mmod1.oldMetronome = mm1
         mmod1.newMetronome = mm2
 
-        # this works, and new value is updated:
+        # this works and new value is updated:
         self.assertEqual(str(mmod1),
                          '<music21.tempo.MetricModulation '
                          + '<music21.tempo.MetronomeMark animato Eighth=120>='

--- a/music21/tinyNotation.py
+++ b/music21/tinyNotation.py
@@ -123,7 +123,7 @@ here we will set the "modifierStar" to change the color of notes:
 >>> tnc = tinyNotation.Converter('3/4 C4*pink* D4*green* E4*blue*')
 >>> tnc.modifierStar = ColorModifier
 >>> s = tnc.parse().stream
->>> for n in s.recurse().getElementsByClass('Note'):
+>>> for n in s.recurse().getElementsByClass(note.Note):
 ...     print(n.step, n.style.color)
 C pink
 D green
@@ -147,7 +147,7 @@ Or more usefully, and often desired:
     {2.0} <music21.harmony.ChordSymbol Dm>
     {3.0} <music21.harmony.ChordSymbol E-sus4>
     {4.0} <music21.bar.Barline type=final>
->>> for cs in s.recurse().getElementsByClass('ChordSymbol'):
+>>> for cs in s.recurse().getElementsByClass(harmony.ChordSymbol):
 ...     print([p.name for p in cs.pitches])
 ['C', 'E', 'G', 'B']
 ['D', 'F', 'A']

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -443,7 +443,7 @@ class Variant(base.Music21Object):
 
         if includeSpacers is True:
             spacerDuration = (self
-                              .getElementsByClass('Rest')
+                              .getElementsByClass(note.Rest)
                               .addFilter(spacerFilter)
                               .first().duration.quarterLength)
         else:

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -40,6 +40,539 @@ _MOD = 'variant'
 environLocal = environment.Environment(_MOD)
 
 
+# ------------------------------------------------------------------------------
+# classes
+
+
+class VariantException(exceptions21.Music21Exception):
+    pass
+
+
+class Variant(base.Music21Object):
+    '''
+    A Music21Object that stores elements like a Stream, but does not
+    represent itself externally to a Stream; i.e., the contents of a Variant are not flattened.
+
+    This is accomplished not by subclassing, but by object composition: similar to the Spanner,
+    the Variant contains a Stream as a private attribute. Calls to this Stream, for the Variant,
+    are automatically delegated by use of the __getattr__ method. Special cases are overridden
+    or managed as necessary: e.g., the Duration of a Variant is generally always zero.
+
+    To use Variants from a Stream, see the :func:`~music21.stream.Stream.activateVariants` method.
+
+
+    >>> v = variant.Variant()
+    >>> v.repeatAppend(note.Note(), 8)
+    >>> len(v.notes)
+    8
+    >>> v.highestTime
+    0.0
+    >>> v.containedHighestTime
+    8.0
+
+    >>> v.duration  # handled by Music21Object
+    <music21.duration.Duration 0.0>
+    >>> v.isStream
+    False
+
+    >>> s = stream.Stream()
+    >>> s.append(v)
+    >>> s.append(note.Note())
+    >>> s.highestTime
+    1.0
+    >>> s.show('t')
+    {0.0} <music21.variant.Variant object of length 8.0>
+    {0.0} <music21.note.Note C>
+    >>> s.flatten().show('t')
+    {0.0} <music21.variant.Variant object of length 8.0>
+    {0.0} <music21.note.Note C>
+    '''
+
+    classSortOrder = stream.Stream.classSortOrder - 2  # variants should always come first?
+
+    # this copies the init of Streams
+    def __init__(self, givenElements=None, *args, **keywords):
+        super().__init__()
+        self.exposeTime = False
+        self._stream = stream.VariantStorage(givenElements=givenElements,
+                                             *args, **keywords)
+
+        self._replacementDuration = None
+
+        if 'name' in keywords:
+            self.groups.append(keywords['name'])
+
+
+    def _deepcopySubclassable(self, memo=None, ignoreAttributes=None, removeFromIgnore=None):
+        '''
+        see __deepcopy__ on Spanner for tests and docs
+        '''
+        # NOTE: this is a performance critical operation
+        defaultIgnoreSet = {'_cache'}
+        if ignoreAttributes is None:
+            ignoreAttributes = defaultIgnoreSet
+        else:
+            ignoreAttributes = ignoreAttributes | defaultIgnoreSet
+
+        new = super()._deepcopySubclassable(memo, ignoreAttributes, removeFromIgnore)
+
+        return new
+
+    def __deepcopy__(self, memo=None):
+        return self._deepcopySubclassable(memo)
+
+    # --------------------------------------------------------------------------
+    # as _stream is a private Stream, unwrap/wrap methods need to override
+    # Music21Object to get at these objects
+    # this is the same as with Spanners
+
+    def purgeOrphans(self, excludeStorageStreams=True):
+        self._stream.purgeOrphans(excludeStorageStreams)
+        base.Music21Object.purgeOrphans(self, excludeStorageStreams)
+
+    def purgeLocations(self, rescanIsDead=False):
+        # must override Music21Object to purge locations from the contained
+        self._stream.purgeLocations(rescanIsDead=rescanIsDead)
+        base.Music21Object.purgeLocations(self, rescanIsDead=rescanIsDead)
+
+    def _reprInternal(self):
+        return 'object of length ' + str(self.containedHighestTime)
+
+    def __getattr__(self, attr):
+        '''
+        This defers all calls not defined in this Class to calls on the privately contained Stream.
+        '''
+        # environLocal.printDebug(['relaying unmatched attribute request '
+        #               + attr + ' to private Stream'])
+
+        # must mask pitches so as not to recurse
+        # TODO: check tt recurse does not go into this
+        if attr in ['flat', 'pitches']:
+            raise AttributeError
+
+        # needed for unpickling where ._stream doesn't exist until later...
+        if attr != '_stream' and hasattr(self, '_stream'):
+            return getattr(self._stream, attr)
+        else:
+            raise AttributeError
+
+    def __getitem__(self, key):
+        return self._stream.__getitem__(key)
+
+
+    def __len__(self):
+        return len(self._stream)
+
+    def __iter__(self):
+        return self._stream.__iter__()
+
+    def getElementIds(self):
+        if 'elementIds' not in self._cache or self._cache['elementIds'] is None:
+            self._cache['elementIds'] = [id(c) for c in self._stream._elements]
+        return self._cache['elementIds']
+
+
+    def replaceElement(self, old, new):
+        '''
+        When copying a Variant, we need to update the Variant with new
+        references for copied elements. Given the old element,
+        this method will replace the old with the new.
+
+        The `old` parameter can be either an object or object id.
+
+        This method is very similar to the replaceSpannedElement method on Spanner.
+        '''
+        if old is None:
+            return None  # do nothing
+        if common.isNum(old):
+            # this must be id(obj), not obj.id
+            e = self._stream.coreGetElementByMemoryLocation(old)
+            if e is not None:
+                self._stream.replace(e, new, allDerived=False)
+        else:
+            # do not do all Sites: only care about this one
+            self._stream.replace(old, new, allDerived=False)
+
+    # --------------------------------------------------------------------------
+    # Stream  simulation/overrides
+    @property
+    def highestTime(self):
+        '''
+        This property masks calls to Stream.highestTime. Assuming `exposeTime`
+        is False, this always returns zero, making the Variant always take zero time.
+
+        >>> v = variant.Variant()
+        >>> v.append(note.Note(quarterLength=4))
+        >>> v.highestTime
+        0.0
+        '''
+        if self.exposeTime:
+            return self._stream.highestTime
+        else:
+            return 0.0
+
+    @property
+    def highestOffset(self):
+        '''
+        This property masks calls to Stream.highestOffset. Assuming `exposeTime`
+        is False, this always returns zero, making the Variant always take zero time.
+
+        >>> v = variant.Variant()
+        >>> v.append(note.Note(quarterLength=4))
+        >>> v.highestOffset
+        0.0
+        '''
+        if self.exposeTime:
+            return self._stream.highestOffset
+        else:
+            return 0.0
+
+    def show(self, fmt=None, app=None):
+        '''
+        Call show() on the Stream contained by this Variant.
+
+        This method must be overridden, otherwise Music21Object.show() is called.
+
+
+        >>> v = variant.Variant()
+        >>> v.repeatAppend(note.Note(quarterLength=0.25), 8)
+        >>> v.show('t')
+        {0.0} <music21.note.Note C>
+        {0.25} <music21.note.Note C>
+        {0.5} <music21.note.Note C>
+        {0.75} <music21.note.Note C>
+        {1.0} <music21.note.Note C>
+        {1.25} <music21.note.Note C>
+        {1.5} <music21.note.Note C>
+        {1.75} <music21.note.Note C>
+        '''
+        self._stream.show(fmt=fmt, app=app)
+
+    # --------------------------------------------------------------------------
+    # properties particular to this class
+
+    @property
+    def containedHighestTime(self):
+        '''
+        This property calls the contained Stream.highestTime.
+
+        >>> v = variant.Variant()
+        >>> v.append(note.Note(quarterLength=4))
+        >>> v.containedHighestTime
+        4.0
+        '''
+        return self._stream.highestTime
+
+    @property
+    def containedHighestOffset(self):
+        '''
+        This property calls the contained Stream.highestOffset.
+
+        >>> v = variant.Variant()
+        >>> v.append(note.Note(quarterLength=4))
+        >>> v.append(note.Note())
+        >>> v.containedHighestOffset
+        4.0
+        '''
+        return self._stream.highestOffset
+
+    @property
+    def containedSite(self):
+        '''
+        Return the Stream contained in this Variant.
+        '''
+        return self._stream
+
+    def _getReplacementDuration(self):
+        if self._replacementDuration is None:
+            return self._stream.duration.quarterLength
+        else:
+            return self._replacementDuration
+
+    def _setReplacementDuration(self, value):
+        self._replacementDuration = value
+
+    replacementDuration = property(_getReplacementDuration, _setReplacementDuration, doc='''
+        Set or Return the quarterLength duration in the main stream which this variant
+        object replaces in the variant version of the stream. If replacementDuration is
+        not set, it is assumed to be the same length as the variant. If, it is set to 0,
+        the variant should be interpreted as an insertion. Setting replacementDuration
+        to None will return the value to the default which is the duration of the variant
+        itself.
+        ''')
+
+    @property
+    def lengthType(self):
+        '''
+        Returns 'deletion' if variant is shorter than the region it replaces, 'elongation'
+        if the variant is longer than the region it replaces, and 'replacement' if it is
+        the same length.
+        '''
+        lengthDifference = self.replacementDuration - self.containedHighestTime
+        if lengthDifference > 0.0:
+            return 'deletion'
+        elif lengthDifference < 0.0:
+            return 'elongation'
+        else:
+            return 'replacement'
+
+    def replacedElements(self, contextStream=None, classList=None,
+                         keepOriginalOffsets=False, includeSpacers=False):
+        # noinspection PyShadowingNames
+        '''
+        Returns a Stream containing the elements which this variant replaces in a
+        given context stream.
+        This Stream will have length self.replacementDuration.
+
+        In regions that are strictly replaced, only elements that share a class with
+        an element in the variant
+        are captured. Elsewhere, all elements are captured.
+
+        >>> s = converter.parse("tinynotation: 4/4 d4 e4 f4 g4   a2 b-4 a4    g4 a8 g8 f4 e4    d2 a2                  d4 e4 f4 g4    a2 b-4 a4    g4 a8 b-8 c'4 c4    f1", makeNotation=False)
+        >>> s.makeMeasures(inPlace=True)
+        >>> v1stream = converter.parse("tinynotation: 4/4        a2. b-8 a8", makeNotation=False)
+        >>> v2stream1 = converter.parse("tinynotation: 4/4                                       d4 f4 a2", makeNotation=False)
+        >>> v2stream2 = converter.parse("tinynotation: 4/4                                                  d4 f4 AA2", makeNotation=False)
+
+        >>> v1 = variant.Variant()
+        >>> v1measure = stream.Measure()
+        >>> v1.insert(0.0, v1measure)
+        >>> for e in v1stream.notesAndRests:
+        ...    v1measure.insert(e.offset, e)
+
+        >>> v2 = variant.Variant()
+        >>> v2measure1 = stream.Measure()
+        >>> v2measure2 = stream.Measure()
+        >>> v2.insert(0.0, v2measure1)
+        >>> v2.insert(4.0, v2measure2)
+        >>> for e in v2stream1.notesAndRests:
+        ...    v2measure1.insert(e.offset, e)
+        >>> for e in v2stream2.notesAndRests:
+        ...    v2measure2.insert(e.offset, e)
+
+        >>> v3 = variant.Variant()
+        >>> v2.replacementDuration = 4.0
+        >>> v3.replacementDuration = 4.0
+
+        >>> s.insert(4.0, v1)    # replacement variant
+        >>> s.insert(12.0, v2)  # insertion variant (2 bars replace 1 bar)
+        >>> s.insert(20.0, v3)  # deletion variant (0 bars replace 1 bar)
+
+        >>> v1.replacedElements(s).show('text')
+        {0.0} <music21.stream.Measure 2 offset=0.0>
+            {0.0} <music21.note.Note A>
+            {2.0} <music21.note.Note B->
+            {3.0} <music21.note.Note A>
+
+        >>> v2.replacedElements(s).show('text')
+        {0.0} <music21.stream.Measure 4 offset=0.0>
+            {0.0} <music21.note.Note D>
+            {2.0} <music21.note.Note A>
+
+        >>> v3.replacedElements(s).show('text')
+        {0.0} <music21.stream.Measure 6 offset=0.0>
+            {0.0} <music21.note.Note A>
+            {2.0} <music21.note.Note B->
+            {3.0} <music21.note.Note A>
+
+        >>> v3.replacedElements(s, keepOriginalOffsets=True).show('text')
+        {20.0} <music21.stream.Measure 6 offset=20.0>
+            {0.0} <music21.note.Note A>
+            {2.0} <music21.note.Note B->
+            {3.0} <music21.note.Note A>
+
+
+        A second example:
+
+
+        >>> v = variant.Variant()
+        >>> variantDataM1 = [('b', 'eighth'), ('c', 'eighth'), ('a', 'quarter'),
+        ...                  ('a', 'quarter'),('b', 'quarter')]
+        >>> variantDataM2 = [('c', 'quarter'), ('d', 'quarter'),
+        ...                  ('e', 'quarter'), ('e', 'quarter')]
+        >>> variantData = [variantDataM1, variantDataM2]
+        >>> for d in variantData:
+        ...    m = stream.Measure()
+        ...    for pitchName, durType in d:
+        ...        n = note.Note(pitchName)
+        ...        n.duration.type = durType
+        ...        m.append(n)
+        ...    v.append(m)
+        >>> v.groups = ['paris']
+        >>> v.replacementDuration = 4.0
+
+        >>> s = stream.Stream()
+        >>> streamDataM1 = [('a', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('g', 'quarter')]
+        >>> streamDataM2 = [('b', 'eighth'), ('c', 'quarter'),
+        ...                 ('a', 'eighth'), ('a', 'quarter'), ('b', 'quarter')]
+        >>> streamDataM3 = [('c', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('a', 'quarter')]
+        >>> streamDataM4 = [('c', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('a', 'quarter')]
+        >>> streamData = [streamDataM1, streamDataM2, streamDataM3, streamDataM4]
+        >>> for d in streamData:
+        ...    m = stream.Measure()
+        ...    for pitchName, durType in d:
+        ...        n = note.Note(pitchName)
+        ...        n.duration.type = durType
+        ...        m.append(n)
+        ...    s.append(m)
+        >>> s.insert(4.0, v)
+
+        >>> v.replacedElements(s).show('t')
+        {0.0} <music21.stream.Measure 0 offset=0.0>
+            {0.0} <music21.note.Note B>
+            {0.5} <music21.note.Note C>
+            {1.5} <music21.note.Note A>
+            {2.0} <music21.note.Note A>
+            {3.0} <music21.note.Note B>
+        '''
+        spacerFilter = lambda r: r.hasStyleInformation and r.style.hideObjectOnPrint
+
+        if contextStream is None:
+            contextStream = self.activeSite
+            if contextStream is None:
+                environLocal.printDebug(
+                    'No contextStream or activeSite, finding most recently added site (dangerous)')
+                contextStream = self.getContextByClass('Stream')
+                if contextStream is None:
+                    raise VariantException('Cannot find a Stream context for this object...')
+
+        if self not in contextStream.getElementsByClass(self.__class__):
+            raise VariantException(f'Variant not found in stream {contextStream}')
+
+        vStart = self.getOffsetBySite(contextStream)
+
+        if includeSpacers is True:
+            spacerDuration = (self
+                              .getElementsByClass('Rest')
+                              .addFilter(spacerFilter)
+                              .first().duration.quarterLength)
+        else:
+            spacerDuration = 0.0
+
+
+        if self.lengthType in ('replacement', 'elongation'):
+            vEnd = vStart + self.replacementDuration + spacerDuration
+            classes = []
+            for e in self.elements:
+                classes.append(e.classes[0])
+            if classList is not None:
+                classes.extend(classList)
+            returnStream = contextStream.getElementsByOffset(vStart, vEnd,
+                includeEndBoundary=False,
+                mustFinishInSpan=False,
+                mustBeginInSpan=True,
+                classList=classes).stream()
+
+        elif self.lengthType == 'deletion':
+            vMiddle = vStart + self.containedHighestTime
+            vEnd = vStart + self.replacementDuration
+            classes = []  # collect all classes found in this variant
+            for e in self.elements:
+                classes.append(e.classes[0])
+            if classList is not None:
+                classes.extend(classList)
+            returnPart1 = contextStream.getElementsByOffset(vStart, vMiddle,
+                includeEndBoundary=False,
+                mustFinishInSpan=False,
+                mustBeginInSpan=True,
+                classList=classes).stream()
+            returnPart2 = contextStream.getElementsByOffset(vMiddle, vEnd,
+                includeEndBoundary=False,
+                mustFinishInSpan=False,
+                mustBeginInSpan=True).stream()
+
+            returnStream = returnPart1
+            for e in returnPart2.elements:
+                oInPart = e.getOffsetBySite(returnPart2)
+                returnStream.insert(vMiddle - vStart + oInPart, e)
+        else:
+            raise VariantException('lengthType must be replacement, elongation, or deletion')
+
+        if self in returnStream:
+            returnStream.remove(self)
+
+        # This probably makes sense to do, but activateVariants
+        #    for example only uses the offset in the original.
+        #    Also, we are not changing measure numbers and should
+        #    not as that will cause activateVariants to fail.
+        if keepOriginalOffsets is False:
+            for e in returnStream:
+                e.setOffsetBySite(returnStream, e.getOffsetBySite(returnStream) - vStart)
+
+        return returnStream
+
+    def removeReplacedElementsFromStream(self, referenceStream=None, classList=None):
+        '''
+        remove replaced elements from a referenceStream or activeSite
+
+
+        >>> v = variant.Variant()
+        >>> variantDataM1 = [('b', 'eighth'), ('c', 'eighth'), ('a', 'quarter'),
+        ...                  ('a', 'quarter'),('b', 'quarter')]
+        >>> variantDataM2 = [('c', 'quarter'), ('d', 'quarter'), ('e', 'quarter'), ('e', 'quarter')]
+        >>> variantData = [variantDataM1, variantDataM2]
+        >>> for d in variantData:
+        ...    m = stream.Measure()
+        ...    for pitchName, durType in d:
+        ...        n = note.Note(pitchName)
+        ...        n.duration.type = durType
+        ...        m.append(n)
+        ...    v.append(m)
+        >>> v.groups = ['paris']
+        >>> v.replacementDuration = 4.0
+
+        >>> s = stream.Stream()
+        >>> streamDataM1 = [('a', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('g', 'quarter')]
+        >>> streamDataM2 = [('b', 'eighth'), ('c', 'quarter'), ('a', 'eighth'),
+        ...                 ('a', 'quarter'), ('b', 'quarter')]
+        >>> streamDataM3 = [('c', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('a', 'quarter')]
+        >>> streamDataM4 = [('c', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('a', 'quarter')]
+        >>> streamData = [streamDataM1, streamDataM2, streamDataM3, streamDataM4]
+        >>> for d in streamData:
+        ...    m = stream.Measure()
+        ...    for pitchName, durType in d:
+        ...        n = note.Note(pitchName)
+        ...        n.duration.type = durType
+        ...        m.append(n)
+        ...    s.append(m)
+        >>> s.insert(4.0, v)
+
+        >>> v.removeReplacedElementsFromStream(s)
+        >>> s.show('t')
+        {0.0} <music21.stream.Measure 0 offset=0.0>
+            {0.0} <music21.note.Note A>
+            {1.0} <music21.note.Note B>
+            {2.0} <music21.note.Note A>
+            {3.0} <music21.note.Note G>
+        {4.0} <music21.variant.Variant object of length 8.0>
+        {8.0} <music21.stream.Measure 0 offset=8.0>
+            {0.0} <music21.note.Note C>
+            {1.0} <music21.note.Note B>
+            {2.0} <music21.note.Note A>
+            {3.0} <music21.note.Note A>
+        {12.0} <music21.stream.Measure 0 offset=12.0>
+            {0.0} <music21.note.Note C>
+            {1.0} <music21.note.Note B>
+            {2.0} <music21.note.Note A>
+            {3.0} <music21.note.Note A>
+        '''
+        if referenceStream is None:
+            referenceStream = self.activeSite
+            if referenceStream is None:
+                environLocal.printDebug('No referenceStream or activeSite, '
+                                        + 'finding most recently added site (dangerous)')
+                referenceStream = self.getContextByClass('Stream')
+                if referenceStream is None:
+                    raise VariantException('Cannot find a Stream context for this object...')
+        if self not in referenceStream.getElementsByClass(self.__class__):
+            raise VariantException(f'Variant not found in stream {referenceStream}')
+
+        replacedElements = self.replacedElements(referenceStream, classList)
+        for el in replacedElements:
+            referenceStream.remove(el)
+
+
+
 # ------Public Merge Functions
 def mergeVariants(streamX, streamY, variantName='variant', *, inPlace=False):
     # noinspection PyShadowingNames
@@ -66,7 +599,7 @@ def mergeVariants(streamX, streamY, variantName='variant', *, inPlace=False):
     {3.0} <music21.variant.Variant object of length 1.0>
     {3.0} <music21.note.Note D>
 
-    >>> v0 = mergedStream.getElementsByClass('Variant').first()
+    >>> v0 = mergedStream.getElementsByClass(variant.Variant).first()
     >>> v0
     <music21.variant.Variant object of length 1.0>
     >>> v0.first()
@@ -848,7 +1381,7 @@ def mergePartAsOssia(mainPart, ossiaPart, ossiaName,
 def addVariant(
     s: stream.Stream,
     startOffset: Union[int, float],
-    sVariant: Union[stream.Stream, 'Variant'],
+    sVariant: Union[stream.Stream, Variant],
     variantName=None,
     variantGroups=None,
     replacementDuration=None
@@ -1036,17 +1569,17 @@ def refineVariant(s, sVariant, *, inPlace=False):
 
     '''
     # stream that will be returned
-    if sVariant not in s.getElementsByClass('Variant'):
+    if sVariant not in s.getElementsByClass(Variant):
         raise VariantException(f'{sVariant} not found in stream {s}.')
 
     if inPlace is True:
         returnObject = s
         variantRegion = sVariant
     else:
-        sVariantIndex = s.getElementsByClass('Variant').index(sVariant)
+        sVariantIndex = s.getElementsByClass(Variant).index(sVariant)
 
         returnObject = s.coreCopyAsDerivation('refineVariant')
-        variantRegion = returnObject.getElementsByClass('Variant')(sVariantIndex)
+        variantRegion = returnObject.getElementsByClass(Variant)(sVariantIndex)
 
 
     # useful parameters from variant and its location
@@ -1764,7 +2297,7 @@ def _doVariantFixingOnStream(s, variantNames=None):
     (4.0, 'deletion', 5.0, 1.0)
     '''
 
-    for v in s.getElementsByClass('Variant'):
+    for v in s.getElementsByClass(Variant):
         if isinstance(variantNames, list):  # If variantNames are controlled
             if set(v.groups) and not set(variantNames):
                 # and if this variant is not in the controlled list
@@ -1977,536 +2510,6 @@ def _getPreviousElement(s, v):
     return returnElement
 
 
-# ------------------------------------------------------------------------------
-# classes
-
-
-class VariantException(exceptions21.Music21Exception):
-    pass
-
-
-class Variant(base.Music21Object):
-    '''
-    A Music21Object that stores elements like a Stream, but does not
-    represent itself externally to a Stream; i.e., the contents of a Variant are not flattened.
-
-    This is accomplished not by subclassing, but by object composition: similar to the Spanner,
-    the Variant contains a Stream as a private attribute. Calls to this Stream, for the Variant,
-    are automatically delegated by use of the __getattr__ method. Special cases are overridden
-    or managed as necessary: e.g., the Duration of a Variant is generally always zero.
-
-    To use Variants from a Stream, see the :func:`~music21.stream.Stream.activateVariants` method.
-
-
-    >>> v = variant.Variant()
-    >>> v.repeatAppend(note.Note(), 8)
-    >>> len(v.notes)
-    8
-    >>> v.highestTime
-    0.0
-    >>> v.containedHighestTime
-    8.0
-
-    >>> v.duration  # handled by Music21Object
-    <music21.duration.Duration 0.0>
-    >>> v.isStream
-    False
-
-    >>> s = stream.Stream()
-    >>> s.append(v)
-    >>> s.append(note.Note())
-    >>> s.highestTime
-    1.0
-    >>> s.show('t')
-    {0.0} <music21.variant.Variant object of length 8.0>
-    {0.0} <music21.note.Note C>
-    >>> s.flatten().show('t')
-    {0.0} <music21.variant.Variant object of length 8.0>
-    {0.0} <music21.note.Note C>
-    '''
-
-    classSortOrder = stream.Stream.classSortOrder - 2  # variants should always come first?
-
-    # this copies the init of Streams
-    def __init__(self, givenElements=None, *args, **keywords):
-        super().__init__()
-        self.exposeTime = False
-        self._stream = stream.VariantStorage(givenElements=givenElements,
-                                             *args, **keywords)
-
-        self._replacementDuration = None
-
-        if 'name' in keywords:
-            self.groups.append(keywords['name'])
-
-
-    def _deepcopySubclassable(self, memo=None, ignoreAttributes=None, removeFromIgnore=None):
-        '''
-        see __deepcopy__ on Spanner for tests and docs
-        '''
-        # NOTE: this is a performance critical operation
-        defaultIgnoreSet = {'_cache'}
-        if ignoreAttributes is None:
-            ignoreAttributes = defaultIgnoreSet
-        else:
-            ignoreAttributes = ignoreAttributes | defaultIgnoreSet
-
-        new = super()._deepcopySubclassable(memo, ignoreAttributes, removeFromIgnore)
-
-        return new
-
-    def __deepcopy__(self, memo=None):
-        return self._deepcopySubclassable(memo)
-
-    # --------------------------------------------------------------------------
-    # as _stream is a private Stream, unwrap/wrap methods need to override
-    # Music21Object to get at these objects
-    # this is the same as with Spanners
-
-    def purgeOrphans(self, excludeStorageStreams=True):
-        self._stream.purgeOrphans(excludeStorageStreams)
-        base.Music21Object.purgeOrphans(self, excludeStorageStreams)
-
-    def purgeLocations(self, rescanIsDead=False):
-        # must override Music21Object to purge locations from the contained
-        self._stream.purgeLocations(rescanIsDead=rescanIsDead)
-        base.Music21Object.purgeLocations(self, rescanIsDead=rescanIsDead)
-
-    def _reprInternal(self):
-        return 'object of length ' + str(self.containedHighestTime)
-
-    def __getattr__(self, attr):
-        '''
-        This defers all calls not defined in this Class to calls on the privately contained Stream.
-        '''
-        # environLocal.printDebug(['relaying unmatched attribute request '
-        #               + attr + ' to private Stream'])
-
-        # must mask pitches so as not to recurse
-        # TODO: check tt recurse does not go into this
-        if attr in ['flat', 'pitches']:
-            raise AttributeError
-
-        # needed for unpickling where ._stream doesn't exist until later...
-        if attr != '_stream' and hasattr(self, '_stream'):
-            return getattr(self._stream, attr)
-        else:
-            raise AttributeError
-
-    def __getitem__(self, key):
-        return self._stream.__getitem__(key)
-
-
-    def __len__(self):
-        return len(self._stream)
-
-    def __iter__(self):
-        return self._stream.__iter__()
-
-    def getElementIds(self):
-        if 'elementIds' not in self._cache or self._cache['elementIds'] is None:
-            self._cache['elementIds'] = [id(c) for c in self._stream._elements]
-        return self._cache['elementIds']
-
-
-    def replaceElement(self, old, new):
-        '''
-        When copying a Variant, we need to update the Variant with new
-        references for copied elements. Given the old element,
-        this method will replace the old with the new.
-
-        The `old` parameter can be either an object or object id.
-
-        This method is very similar to the replaceSpannedElement method on Spanner.
-        '''
-        if old is None:
-            return None  # do nothing
-        if common.isNum(old):
-            # this must be id(obj), not obj.id
-            e = self._stream.coreGetElementByMemoryLocation(old)
-            if e is not None:
-                self._stream.replace(e, new, allDerived=False)
-        else:
-            # do not do all Sites: only care about this one
-            self._stream.replace(old, new, allDerived=False)
-
-    # --------------------------------------------------------------------------
-    # Stream  simulation/overrides
-    @property
-    def highestTime(self):
-        '''
-        This property masks calls to Stream.highestTime. Assuming `exposeTime`
-        is False, this always returns zero, making the Variant always take zero time.
-
-        >>> v = variant.Variant()
-        >>> v.append(note.Note(quarterLength=4))
-        >>> v.highestTime
-        0.0
-        '''
-        if self.exposeTime:
-            return self._stream.highestTime
-        else:
-            return 0.0
-
-    @property
-    def highestOffset(self):
-        '''
-        This property masks calls to Stream.highestOffset. Assuming `exposeTime`
-        is False, this always returns zero, making the Variant always take zero time.
-
-        >>> v = variant.Variant()
-        >>> v.append(note.Note(quarterLength=4))
-        >>> v.highestOffset
-        0.0
-        '''
-        if self.exposeTime:
-            return self._stream.highestOffset
-        else:
-            return 0.0
-
-    def show(self, fmt=None, app=None):
-        '''
-        Call show() on the Stream contained by this Variant.
-
-        This method must be overridden, otherwise Music21Object.show() is called.
-
-
-        >>> v = variant.Variant()
-        >>> v.repeatAppend(note.Note(quarterLength=0.25), 8)
-        >>> v.show('t')
-        {0.0} <music21.note.Note C>
-        {0.25} <music21.note.Note C>
-        {0.5} <music21.note.Note C>
-        {0.75} <music21.note.Note C>
-        {1.0} <music21.note.Note C>
-        {1.25} <music21.note.Note C>
-        {1.5} <music21.note.Note C>
-        {1.75} <music21.note.Note C>
-        '''
-        self._stream.show(fmt=fmt, app=app)
-
-    # --------------------------------------------------------------------------
-    # properties particular to this class
-
-    @property
-    def containedHighestTime(self):
-        '''
-        This property calls the contained Stream.highestTime.
-
-        >>> v = variant.Variant()
-        >>> v.append(note.Note(quarterLength=4))
-        >>> v.containedHighestTime
-        4.0
-        '''
-        return self._stream.highestTime
-
-    @property
-    def containedHighestOffset(self):
-        '''
-        This property calls the contained Stream.highestOffset.
-
-        >>> v = variant.Variant()
-        >>> v.append(note.Note(quarterLength=4))
-        >>> v.append(note.Note())
-        >>> v.containedHighestOffset
-        4.0
-        '''
-        return self._stream.highestOffset
-
-    @property
-    def containedSite(self):
-        '''
-        Return the Stream contained in this Variant.
-        '''
-        return self._stream
-
-    def _getReplacementDuration(self):
-        if self._replacementDuration is None:
-            return self._stream.duration.quarterLength
-        else:
-            return self._replacementDuration
-
-    def _setReplacementDuration(self, value):
-        self._replacementDuration = value
-
-    replacementDuration = property(_getReplacementDuration, _setReplacementDuration, doc='''
-        Set or Return the quarterLength duration in the main stream which this variant
-        object replaces in the variant version of the stream. If replacementDuration is
-        not set, it is assumed to be the same length as the variant. If, it is set to 0,
-        the variant should be interpreted as an insertion. Setting replacementDuration
-        to None will return the value to the default which is the duration of the variant
-        itself.
-        ''')
-
-    @property
-    def lengthType(self):
-        '''
-        Returns 'deletion' if variant is shorter than the region it replaces, 'elongation'
-        if the variant is longer than the region it replaces, and 'replacement' if it is
-        the same length.
-        '''
-        lengthDifference = self.replacementDuration - self.containedHighestTime
-        if lengthDifference > 0.0:
-            return 'deletion'
-        elif lengthDifference < 0.0:
-            return 'elongation'
-        else:
-            return 'replacement'
-
-    def replacedElements(self, contextStream=None, classList=None,
-                         keepOriginalOffsets=False, includeSpacers=False):
-        # noinspection PyShadowingNames
-        '''
-        Returns a Stream containing the elements which this variant replaces in a
-        given context stream.
-        This Stream will have length self.replacementDuration.
-
-        In regions that are strictly replaced, only elements that share a class with
-        an element in the variant
-        are captured. Elsewhere, all elements are captured.
-
-        >>> s = converter.parse("tinynotation: 4/4 d4 e4 f4 g4   a2 b-4 a4    g4 a8 g8 f4 e4    d2 a2                  d4 e4 f4 g4    a2 b-4 a4    g4 a8 b-8 c'4 c4    f1", makeNotation=False)
-        >>> s.makeMeasures(inPlace=True)
-        >>> v1stream = converter.parse("tinynotation: 4/4        a2. b-8 a8", makeNotation=False)
-        >>> v2stream1 = converter.parse("tinynotation: 4/4                                       d4 f4 a2", makeNotation=False)
-        >>> v2stream2 = converter.parse("tinynotation: 4/4                                                  d4 f4 AA2", makeNotation=False)
-
-        >>> v1 = variant.Variant()
-        >>> v1measure = stream.Measure()
-        >>> v1.insert(0.0, v1measure)
-        >>> for e in v1stream.notesAndRests:
-        ...    v1measure.insert(e.offset, e)
-
-        >>> v2 = variant.Variant()
-        >>> v2measure1 = stream.Measure()
-        >>> v2measure2 = stream.Measure()
-        >>> v2.insert(0.0, v2measure1)
-        >>> v2.insert(4.0, v2measure2)
-        >>> for e in v2stream1.notesAndRests:
-        ...    v2measure1.insert(e.offset, e)
-        >>> for e in v2stream2.notesAndRests:
-        ...    v2measure2.insert(e.offset, e)
-
-        >>> v3 = variant.Variant()
-        >>> v2.replacementDuration = 4.0
-        >>> v3.replacementDuration = 4.0
-
-        >>> s.insert(4.0, v1)    # replacement variant
-        >>> s.insert(12.0, v2)  # insertion variant (2 bars replace 1 bar)
-        >>> s.insert(20.0, v3)  # deletion variant (0 bars replace 1 bar)
-
-        >>> v1.replacedElements(s).show('text')
-        {0.0} <music21.stream.Measure 2 offset=0.0>
-            {0.0} <music21.note.Note A>
-            {2.0} <music21.note.Note B->
-            {3.0} <music21.note.Note A>
-
-        >>> v2.replacedElements(s).show('text')
-        {0.0} <music21.stream.Measure 4 offset=0.0>
-            {0.0} <music21.note.Note D>
-            {2.0} <music21.note.Note A>
-
-        >>> v3.replacedElements(s).show('text')
-        {0.0} <music21.stream.Measure 6 offset=0.0>
-            {0.0} <music21.note.Note A>
-            {2.0} <music21.note.Note B->
-            {3.0} <music21.note.Note A>
-
-        >>> v3.replacedElements(s, keepOriginalOffsets=True).show('text')
-        {20.0} <music21.stream.Measure 6 offset=20.0>
-            {0.0} <music21.note.Note A>
-            {2.0} <music21.note.Note B->
-            {3.0} <music21.note.Note A>
-
-
-        A second example:
-
-
-        >>> v = variant.Variant()
-        >>> variantDataM1 = [('b', 'eighth'), ('c', 'eighth'), ('a', 'quarter'),
-        ...                  ('a', 'quarter'),('b', 'quarter')]
-        >>> variantDataM2 = [('c', 'quarter'), ('d', 'quarter'),
-        ...                  ('e', 'quarter'), ('e', 'quarter')]
-        >>> variantData = [variantDataM1, variantDataM2]
-        >>> for d in variantData:
-        ...    m = stream.Measure()
-        ...    for pitchName, durType in d:
-        ...        n = note.Note(pitchName)
-        ...        n.duration.type = durType
-        ...        m.append(n)
-        ...    v.append(m)
-        >>> v.groups = ['paris']
-        >>> v.replacementDuration = 4.0
-
-        >>> s = stream.Stream()
-        >>> streamDataM1 = [('a', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('g', 'quarter')]
-        >>> streamDataM2 = [('b', 'eighth'), ('c', 'quarter'),
-        ...                 ('a', 'eighth'), ('a', 'quarter'), ('b', 'quarter')]
-        >>> streamDataM3 = [('c', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('a', 'quarter')]
-        >>> streamDataM4 = [('c', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('a', 'quarter')]
-        >>> streamData = [streamDataM1, streamDataM2, streamDataM3, streamDataM4]
-        >>> for d in streamData:
-        ...    m = stream.Measure()
-        ...    for pitchName, durType in d:
-        ...        n = note.Note(pitchName)
-        ...        n.duration.type = durType
-        ...        m.append(n)
-        ...    s.append(m)
-        >>> s.insert(4.0, v)
-
-        >>> v.replacedElements(s).show('t')
-        {0.0} <music21.stream.Measure 0 offset=0.0>
-            {0.0} <music21.note.Note B>
-            {0.5} <music21.note.Note C>
-            {1.5} <music21.note.Note A>
-            {2.0} <music21.note.Note A>
-            {3.0} <music21.note.Note B>
-        '''
-        spacerFilter = lambda r: r.hasStyleInformation and r.style.hideObjectOnPrint
-
-        if contextStream is None:
-            contextStream = self.activeSite
-            if contextStream is None:
-                environLocal.printDebug(
-                    'No contextStream or activeSite, finding most recently added site (dangerous)')
-                contextStream = self.getContextByClass('Stream')
-                if contextStream is None:
-                    raise VariantException('Cannot find a Stream context for this object...')
-
-        if self not in contextStream.getElementsByClass('Variant'):
-            raise VariantException(f'Variant not found in stream {contextStream}')
-
-        vStart = self.getOffsetBySite(contextStream)
-
-        if includeSpacers is True:
-            spacerDuration = (self
-                              .getElementsByClass('Rest')
-                              .addFilter(spacerFilter)
-                              .first().duration.quarterLength)
-        else:
-            spacerDuration = 0.0
-
-
-        if self.lengthType in ('replacement', 'elongation'):
-            vEnd = vStart + self.replacementDuration + spacerDuration
-            classes = []
-            for e in self.elements:
-                classes.append(e.classes[0])
-            if classList is not None:
-                classes.extend(classList)
-            returnStream = contextStream.getElementsByOffset(vStart, vEnd,
-                includeEndBoundary=False,
-                mustFinishInSpan=False,
-                mustBeginInSpan=True,
-                classList=classes).stream()
-
-        elif self.lengthType == 'deletion':
-            vMiddle = vStart + self.containedHighestTime
-            vEnd = vStart + self.replacementDuration
-            classes = []  # collect all classes found in this variant
-            for e in self.elements:
-                classes.append(e.classes[0])
-            if classList is not None:
-                classes.extend(classList)
-            returnPart1 = contextStream.getElementsByOffset(vStart, vMiddle,
-                includeEndBoundary=False,
-                mustFinishInSpan=False,
-                mustBeginInSpan=True,
-                classList=classes).stream()
-            returnPart2 = contextStream.getElementsByOffset(vMiddle, vEnd,
-                includeEndBoundary=False,
-                mustFinishInSpan=False,
-                mustBeginInSpan=True).stream()
-
-            returnStream = returnPart1
-            for e in returnPart2.elements:
-                oInPart = e.getOffsetBySite(returnPart2)
-                returnStream.insert(vMiddle - vStart + oInPart, e)
-        else:
-            raise VariantException('lengthType must be replacement, elongation, or deletion')
-
-        if self in returnStream:
-            returnStream.remove(self)
-
-        # This probably makes sense to do, but activateVariants
-        #    for example only uses the offset in the original.
-        #    Also, we are not changing measure numbers and should
-        #    not as that will cause activateVariants to fail.
-        if keepOriginalOffsets is False:
-            for e in returnStream:
-                e.setOffsetBySite(returnStream, e.getOffsetBySite(returnStream) - vStart)
-
-        return returnStream
-
-    def removeReplacedElementsFromStream(self, referenceStream=None, classList=None):
-        '''
-        remove replaced elements from a referenceStream or activeSite
-
-
-        >>> v = variant.Variant()
-        >>> variantDataM1 = [('b', 'eighth'), ('c', 'eighth'), ('a', 'quarter'),
-        ...                  ('a', 'quarter'),('b', 'quarter')]
-        >>> variantDataM2 = [('c', 'quarter'), ('d', 'quarter'), ('e', 'quarter'), ('e', 'quarter')]
-        >>> variantData = [variantDataM1, variantDataM2]
-        >>> for d in variantData:
-        ...    m = stream.Measure()
-        ...    for pitchName, durType in d:
-        ...        n = note.Note(pitchName)
-        ...        n.duration.type = durType
-        ...        m.append(n)
-        ...    v.append(m)
-        >>> v.groups = ['paris']
-        >>> v.replacementDuration = 4.0
-
-        >>> s = stream.Stream()
-        >>> streamDataM1 = [('a', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('g', 'quarter')]
-        >>> streamDataM2 = [('b', 'eighth'), ('c', 'quarter'), ('a', 'eighth'),
-        ...                 ('a', 'quarter'), ('b', 'quarter')]
-        >>> streamDataM3 = [('c', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('a', 'quarter')]
-        >>> streamDataM4 = [('c', 'quarter'), ('b', 'quarter'), ('a', 'quarter'), ('a', 'quarter')]
-        >>> streamData = [streamDataM1, streamDataM2, streamDataM3, streamDataM4]
-        >>> for d in streamData:
-        ...    m = stream.Measure()
-        ...    for pitchName, durType in d:
-        ...        n = note.Note(pitchName)
-        ...        n.duration.type = durType
-        ...        m.append(n)
-        ...    s.append(m)
-        >>> s.insert(4.0, v)
-
-        >>> v.removeReplacedElementsFromStream(s)
-        >>> s.show('t')
-        {0.0} <music21.stream.Measure 0 offset=0.0>
-            {0.0} <music21.note.Note A>
-            {1.0} <music21.note.Note B>
-            {2.0} <music21.note.Note A>
-            {3.0} <music21.note.Note G>
-        {4.0} <music21.variant.Variant object of length 8.0>
-        {8.0} <music21.stream.Measure 0 offset=8.0>
-            {0.0} <music21.note.Note C>
-            {1.0} <music21.note.Note B>
-            {2.0} <music21.note.Note A>
-            {3.0} <music21.note.Note A>
-        {12.0} <music21.stream.Measure 0 offset=12.0>
-            {0.0} <music21.note.Note C>
-            {1.0} <music21.note.Note B>
-            {2.0} <music21.note.Note A>
-            {3.0} <music21.note.Note A>
-        '''
-        if referenceStream is None:
-            referenceStream = self.activeSite
-            if referenceStream is None:
-                environLocal.printDebug('No referenceStream or activeSite, '
-                                        + 'finding most recently added site (dangerous)')
-                referenceStream = self.getContextByClass('Stream')
-                if referenceStream is None:
-                    raise VariantException('Cannot find a Stream context for this object...')
-        if self not in referenceStream.getElementsByClass('Variant'):
-            raise VariantException(f'Variant not found in stream {referenceStream}')
-
-        replacedElements = self.replacedElements(referenceStream, classList)
-        for el in replacedElements:
-            referenceStream.remove(el)
 
 
 # ------------------------------------------------------------------------------
@@ -2572,8 +2575,8 @@ class Test(unittest.TestCase):
 
         self.assertIn('Variant', v1.classes)
 
-        self.assertFalse(v1.hasElementOfClass('Variant'))
-        self.assertTrue(v1.hasElementOfClass('Measure'))
+        self.assertFalse(v1.hasElementOfClass(Variant))
+        self.assertTrue(v1.hasElementOfClass(stream.Measure))
 
     def testDeepCopyVariantA(self):
         s = stream.Stream()
@@ -2601,7 +2604,7 @@ class Test(unittest.TestCase):
 
         # test functionality on a deepcopy
         sCopy = copy.deepcopy(s)
-        self.assertEqual(len(sCopy.getElementsByClass('Variant')), 1)
+        self.assertEqual(len(sCopy.getElementsByClass(Variant)), 1)
         self.assertEqual(self.pitchOut(sCopy.pitches),
             '[G4, G4, G4, G4, G4, G4, G4, G4]')
         sCopy.activateVariants(inPlace=True)


### PR DESCRIPTION
Removing Strings, substituting types, and fixing errors that arise from doing so.