### PR TITLE
v8: makeRests(inPlace=True) returns None for scores

### DIFF
--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -829,6 +829,8 @@ def makeRests(
       - `inPlace` defaults False
       - Recurses into parts, measures, voices
       - Gave priority to `timeRangeFromBarDuration` over `refStreamOrTimeRange`
+
+    Changed in v8: scores (or other streams having parts) edited `inPlace` return `None`.
     '''
     from music21 import stream
 
@@ -846,7 +848,10 @@ def makeRests(
                 refStreamOrTimeRange=refStreamOrTimeRange,
                 timeRangeFromBarDuration=timeRangeFromBarDuration,
             )
-        return returnObj
+        if inPlace:
+            return
+        else:
+            return returnObj
 
     def oHighTargetForMeasure(
         m: Optional[stream.Measure] = None,


### PR DESCRIPTION
Let `makeRests(inPlace=True)` return None for consistency with other methods (and with itself).