### PR TITLE
import typing as t

### DIFF
--- a/documentation/docbuild/documenters.py
+++ b/documentation/docbuild/documenters.py
@@ -14,7 +14,7 @@
 import inspect
 import re
 import types
-from typing import List
+import typing as t
 import unittest
 
 from music21 import common
@@ -97,7 +97,7 @@ class ObjectDocumenter(Documenter):
         return ''
 
     @property
-    def rstAutodocDirectiveFormat(self) -> List[str]:
+    def rstAutodocDirectiveFormat(self) -> t.List[str]:
         return []
 
     @property
@@ -168,7 +168,6 @@ class FunctionDocumenter(ObjectDocumenter):
         return path.replace('.__init__', '')
 
     @property
-    def rstAutodocDirectiveFormat(self) -> List[str]:
         '''
         >>> function = common.opFrac
         >>> documenter = FunctionDocumenter(function)

--- a/documentation/docbuild/documenters.py
+++ b/documentation/docbuild/documenters.py
@@ -168,6 +168,7 @@ class FunctionDocumenter(ObjectDocumenter):
         return path.replace('.__init__', '')
 
     @property
+    def rstAutodocDirectiveFormat(self) -> t.List[str]:
         '''
         >>> function = common.opFrac
         >>> documenter = FunctionDocumenter(function)

--- a/documentation/testDocumentation.py
+++ b/documentation/testDocumentation.py
@@ -18,7 +18,7 @@ import os.path
 import sys
 import doctest
 import io
-from typing import Union
+import typing as t
 
 from collections import namedtuple
 # noinspection PyPackageRequirements
@@ -187,7 +187,7 @@ def getDocumentationFiles(runOne=False):
     return allModules
 
 
-def main(runOne: Union[str, bool] = False):
+def main(runOne: t.Union[str, bool] = False):
     if runOne is False:
         nbvalNotebook.runAll()
     totalTests = 0

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -59,8 +59,7 @@ __all__ = [
 import io
 import re
 import unittest
-from typing import (Union, Optional, List, Tuple, Any, TypeVar, Sequence, Literal, Dict,
-                    TYPE_CHECKING)
+import typing as t
 
 from music21 import common
 from music21 import environment
@@ -69,7 +68,7 @@ from music21 import prebase
 
 from music21.abcFormat import translate
 
-_T = TypeVar('_T')
+_T = t.TypeVar('_T')
 environLocal = environment.Environment('abcFormat')
 
 # for implementation
@@ -97,7 +96,7 @@ ABC_BARS = [
 # store a mapping of ABC representation to pitch values
 # key is (srcStr, carriedAccidental, str(keySignature)
 # value is (pitchName (m21), accidentalDisplayStatus)
-_pitchTranslationCache: Dict[Tuple[str, str, str], Tuple[str, Union[bool, None]]] = {}
+_pitchTranslationCache: t.Dict[t.Tuple[str, str, str], t.Tuple[str, t.Union[bool, None]]] = {}
 
 
 # ------------------------------------------------------------------------------
@@ -323,7 +322,7 @@ class ABCMetadata(ABCToken):
             return True
         return False
 
-    def getTimeSignatureParameters(self) -> Optional[Tuple[int, int, str]]:
+    def getTimeSignatureParameters(self) -> t.Optional[t.Tuple[int, int, str]]:
         '''
         If there is a time signature representation available,
         get a numerator, denominator and an abbreviation symbol.
@@ -375,7 +374,7 @@ class ABCMetadata(ABCToken):
             symbol = 'normal'  # m21 compat
         return n, d, symbol
 
-    def getTimeSignatureObject(self) -> Optional['music21.meter.TimeSignature']:
+    def getTimeSignatureObject(self) -> t.Optional['music21.meter.TimeSignature']:
         '''
         Return a music21 :class:`~music21.meter.TimeSignature`
         object for this metadata tag, if isMeter is True, otherwise raise exception.
@@ -409,7 +408,7 @@ class ABCMetadata(ABCToken):
             numerator, denominator, unused_symbol = parameters
             return meter.TimeSignature(f'{numerator}/{denominator}')
 
-    def getKeySignatureParameters(self) -> Tuple[int, Optional[str]]:
+    def getKeySignatureParameters(self) -> t.Tuple[int, t.Optional[str]]:
         # noinspection SpellCheckingInspection
         '''
         Extract key signature parameters,
@@ -530,7 +529,7 @@ class ABCMetadata(ABCToken):
         # (key of D) but then mark every  c  as  natural
         return key.pitchToSharps(standardKeyStr, mode), mode
 
-    def getKeySignatureObject(self) -> Union['music21.key.Key',
+    def getKeySignatureObject(self) -> t.Union['music21.key.Key',
                                              'music21.key.KeySignature',
                                              None]:
         # noinspection SpellCheckingInspection,PyShadowingNames
@@ -575,7 +574,7 @@ class ABCMetadata(ABCToken):
         else:
             return ks.asKey(mode)
 
-    def getClefObject(self) -> Tuple[Optional['music21.clef.Clef'], Optional[int]]:
+    def getClefObject(self) -> t.Tuple[t.Optional['music21.clef.Clef'], t.Optional[int]]:
         '''
         Extract any clef parameters stored in the key metadata token.
         Assume that a clef definition suggests a transposition.
@@ -594,20 +593,20 @@ class ABCMetadata(ABCToken):
 
         # placing this import in method for now; clef.py may import this module UNLIKELY
         from music21 import clef
-        clefObj: Optional[clef.Clef] = None
-        t = None
+        clefObj: t.Optional[clef.Clef] = None
+        transposeSemitones = None
 
         if '-8va' in self.data.lower():
             clefObj = clef.Treble8vbClef()
-            t = -12
+            transposeSemitones = -12
         elif 'bass' in self.data.lower():
             clefObj = clef.BassClef()
-            t = -24
+            transposeSemitones = -24
 
         # if not defined, returns None, None
-        return clefObj, t
+        return clefObj, transposeSemitones
 
-    def getMetronomeMarkObject(self) -> Optional['music21.tempo.MetronomeMark']:
+    def getMetronomeMarkObject(self) -> t.Optional['music21.tempo.MetronomeMark']:
         '''
         Extract any tempo parameters stored in a tempo metadata token.
 
@@ -664,7 +663,7 @@ class ABCMetadata(ABCToken):
 
         # get a symbolic and numerical value if available
         number: float = -1  # sentinel = None
-        referent: Optional[float] = None
+        referent: t.Optional[float] = None
         if nonText:
             if '=' in nonText:
                 durs, numberStr = nonText.split('=')
@@ -861,7 +860,7 @@ class ABCBar(ABCToken):
         else:
             return False
 
-    def isRepeatBracket(self) -> Union[int, Literal[False]]:
+    def isRepeatBracket(self) -> t.Union[int, t.Literal[False]]:
         '''
         Return a number if this defines a repeat bracket for an alternate ending
         otherwise returns False.
@@ -880,7 +879,7 @@ class ABCBar(ABCToken):
         else:
             return False
 
-    def getBarObject(self) -> Optional['music21.bar.Barline']:
+    def getBarObject(self) -> t.Optional['music21.bar.Barline']:
         '''
         Return a music21 bar object
 
@@ -891,7 +890,7 @@ class ABCBar(ABCToken):
          <music21.bar.Repeat direction=start>
         '''
         from music21 import bar
-        m21bar: Optional[bar.Barline]
+        m21bar: t.Optional[bar.Barline]
         if self.isRepeat():
             if self.repeatForm in ('end', 'start'):
                 m21bar = bar.Repeat(direction=self.repeatForm)
@@ -932,9 +931,12 @@ class ABCTuplet(ABCToken):
         self.numberNotesNormal: int = 1
 
         # store an m21 tuplet object
-        self.tupletObj: Optional['music21.duration.Tuplet'] = None
+        self.tupletObj: t.Optional['music21.duration.Tuplet'] = None
 
-    def updateRatio(self, timeSignatureObj: Optional['music21.meter.TimeSignature'] = None) -> None:
+    def updateRatio(
+        self,
+        timeSignatureObj: t.Optional['music21.meter.TimeSignature'] = None
+    ) -> None:
         # noinspection PyShadowingNames
         '''
         Cannot be called until local meter context
@@ -1017,7 +1019,7 @@ class ABCTuplet(ABCToken):
         splitTuplet = self.src.strip().split(':')
 
         tupletNumber = splitTuplet[0]
-        normalNotes: Optional[int] = None
+        normalNotes: t.Optional[int] = None
 
         if len(splitTuplet) >= 2 and splitTuplet[1] != '':
             normalNotes = int(splitTuplet[1])
@@ -1116,7 +1118,7 @@ class ABCSlurStart(ABCToken):
     '''
     def __init__(self, src=''):
         super().__init__(src)
-        self.slurObj: Optional['music21.spanner.Slur'] = None
+        self.slurObj: t.Optional['music21.spanner.Slur'] = None
 
     def fillSlur(self):
         '''
@@ -1143,7 +1145,7 @@ class ABCCrescStart(ABCToken):
 
     def __init__(self, src=''):
         super().__init__(src)
-        self.crescObj: Optional['music21.dynamics.Crescendo'] = None
+        self.crescObj: t.Optional['music21.dynamics.Crescendo'] = None
 
     def fillCresc(self):
         from music21 import dynamics
@@ -1157,7 +1159,7 @@ class ABCDimStart(ABCToken):
     '''
     def __init__(self, src=''):
         super().__init__(src)
-        self.dimObj: Optional['music21.dynamics.Diminuendo'] = None
+        self.dimObj: t.Optional['music21.dynamics.Diminuendo'] = None
 
     def fillDim(self):
         from music21 import dynamics
@@ -1226,7 +1228,7 @@ class ABCBrokenRhythmMarker(ABCToken):
     '''
     def __init__(self, src=''):
         super().__init__(src)
-        self.data: Optional[str] = None
+        self.data: t.Optional[str] = None
 
     def preParse(self):
         '''Called before context adjustments: need to have access to data
@@ -1264,7 +1266,7 @@ class ABCNote(ABCToken):
         self.carriedAccidental: str = carriedAccidental
 
         # store chord string if connected to this note
-        self.chordSymbols: List[str] = []
+        self.chordSymbols: t.List[str] = []
 
         # context attributes
         self.inBar = None
@@ -1272,7 +1274,7 @@ class ABCNote(ABCToken):
         self.inGrace = None
 
         # provide default duration from handler; may change during piece
-        self.activeDefaultQuarterLength: Optional[float] = None
+        self.activeDefaultQuarterLength: t.Optional[float] = None
         # store if a broken symbol applies; a pair of symbols, position (left, right)
         self.brokenRhythmMarker = None
 
@@ -1283,28 +1285,28 @@ class ABCNote(ABCToken):
         self.activeTuplet = None
 
         # store a spanner if active
-        self.applicableSpanners: List['music21.spanner.Spanner'] = []
+        self.applicableSpanners: t.List['music21.spanner.Spanner'] = []
 
         # store a tie if active
         self.tie = None
 
         # store articulations if active
-        self.articulations: List[str] = []
+        self.articulations: t.List[str] = []
 
         # set to True if a modification of key signature
         # set to False if an altered tone part of a Key
-        self.accidentalDisplayStatus: Union[bool, None] = None
+        self.accidentalDisplayStatus: t.Union[bool, None] = None
 
         # determined during parse() based on if pitch chars are present
         self.isRest: bool = False
 
         # Pitch and duration attributes for m21 conversion
         # they are set via parse() based on other contextual information.
-        self.pitchName: Optional[str] = None  # if None, a rest or chord
+        self.pitchName: t.Optional[str] = None  # if None, a rest or chord
         self.quarterLength: float = 0.0
 
     @staticmethod
-    def _splitChordSymbols(strSrc: str) -> Tuple[List[str], str]:
+    def _splitChordSymbols(strSrc: str) -> t.Tuple[t.List[str], str]:
         '''
         Splits chord symbols from other string characteristics.
         Returns a 2-tuple of a list of chord symbols, and clean remaining chars
@@ -1334,7 +1336,7 @@ class ABCNote(ABCToken):
         self,
         strSrc: str,
         forceKeySignature=None
-    ) -> Tuple[Optional[str], Union[bool, None]]:
+    ) -> t.Tuple[t.Optional[str], t.Union[bool, None]]:
         '''
         Given a note or rest string without a chord symbol,
         return a music21 pitch string or None (if a rest),
@@ -1450,7 +1452,7 @@ class ABCNote(ABCToken):
             raise ABCHandlerException('Carried accidentals not rendered moot.')
         # if there is an explicit accidental, regardless of key, it should
         # be shown: this will work for naturals well
-        accidentalDisplayStatus: Union[bool, None]
+        accidentalDisplayStatus: t.Union[bool, None]
         if carriedAccString:
             # An accidental carrying through the measure is supposed to be applied.
             # This will be set iff no explicit accidental is attached to the note.
@@ -1495,7 +1497,7 @@ class ABCNote(ABCToken):
 
     def getQuarterLength(self,
                          strSrc: str,
-                         forceDefaultQuarterLength: Optional[float] = None) -> float:
+                         forceDefaultQuarterLength: t.Optional[float] = None) -> float:
         '''
         Called with parse(), after context processing, to calculate duration
 
@@ -1543,7 +1545,7 @@ class ABCNote(ABCToken):
         >>> an.getQuarterLength('A', forceDefaultQuarterLength=1.0)
         1.875
         '''
-        activeDefaultQuarterLength: Optional[float]
+        activeDefaultQuarterLength: t.Optional[float]
         if forceDefaultQuarterLength is not None:
             activeDefaultQuarterLength = forceDefaultQuarterLength
         else:  # may be None
@@ -1588,7 +1590,7 @@ class ABCNote(ABCToken):
         # assume we have a complete fraction
         elif '/' in numStr:
             nStr, dStr = numStr.split('/')
-            if TYPE_CHECKING:
+            if t.TYPE_CHECKING:
                 assert nStr is not None
                 assert dStr is not None
             n = int(nStr.strip())
@@ -1625,16 +1627,16 @@ class ABCNote(ABCToken):
 
     def parse(
         self,
-        forceDefaultQuarterLength: Optional[float] = None,
-        forceKeySignature: Optional['music21.key.KeySignature'] = None
+        forceDefaultQuarterLength: t.Optional[float] = None,
+        forceKeySignature: t.Optional['music21.key.KeySignature'] = None
     ) -> None:
         # environLocal.printDebug(['parse', self.src])
         self.chordSymbols, nonChordSymStr = self._splitChordSymbols(self.src)
         # get pitch name form remaining string
         # rests will have a pitch name of None
 
-        pn: Optional[str]
-        accDisp: Union[bool, None]
+        pn: t.Optional[str]
+        accDisp: t.Union[bool, None]
         try:
             pn, accDisp = self.getPitchName(nonChordSymStr,
                                             forceKeySignature=forceKeySignature)
@@ -1669,7 +1671,7 @@ class ABCChord(ABCNote):
     def __init__(self, src: str = ''):
         super().__init__(src)
         # store a list of component objects
-        self.subTokens: List[ABCToken] = []
+        self.subTokens: t.List[ABCToken] = []
 
     def parse(self, forceKeySignature=None, forceDefaultQuarterLength=None):
         '''
@@ -1714,24 +1716,24 @@ class ABCChord(ABCNote):
 
         inner_quarterLength = 0
         # tokens contained here are each ABCNote instances
-        for t in ah.tokens:
+        for token in ah.tokens:
             # environLocal.printDebug(['ABCChord: subTokens', t])
             # parse any tokens individually, supply local data as necessary
-            if isinstance(t, ABCNote):
-                t.parse(
+            if isinstance(token, ABCNote):
+                token.parse(
                     forceDefaultQuarterLength=self.activeDefaultQuarterLength,
                     forceKeySignature=activeKeySignature)
 
-                if t.isRest:
+                if token.isRest:
                     continue
 
                 # get the quarter length from the sub-tokens
                 # All the notes within a chord should normally have the same length,
                 # but if not, the chord duration is that of the first note.
                 if not inner_quarterLength:
-                    inner_quarterLength = t.quarterLength
+                    inner_quarterLength = token.quarterLength
 
-                self.subTokens.append(t)
+                self.subTokens.append(token)
 
 
         # When both inside and outside the chord length modifiers are used,
@@ -1755,14 +1757,14 @@ class ABCHandler:
     New in v6.3 -- lineBreaksDefinePhrases -- does not yet do anything
     '''
     def __init__(self,
-                 abcVersion: Optional[Tuple[int, ...]] = None,
+                 abcVersion: t.Optional[t.Tuple[int, ...]] = None,
                  lineBreaksDefinePhrases=False):
         # tokens are ABC objects import n a linear stream
-        self.abcVersion: Optional[Tuple[int, ...]] = abcVersion
-        self.abcDirectives: Dict[str, str] = {}
-        self.tokens: List[ABCToken] = []
-        self.activeParens: List[str] = []  # e.g. ['Crescendo', 'Slur']
-        self.activeSpanners: List['music21.spanner.Spanner'] = []
+        self.abcVersion: t.Optional[t.Tuple[int, ...]] = abcVersion
+        self.abcDirectives: t.Dict[str, str] = {}
+        self.tokens: t.List[ABCToken] = []
+        self.activeParens: t.List[str] = []  # e.g. ['Crescendo', 'Slur']
+        self.activeSpanners: t.List['music21.spanner.Spanner'] = []
         self.lineBreaksDefinePhrases: bool = lineBreaksDefinePhrases
         self.pos = -1
         self.skipAhead = 0
@@ -1772,8 +1774,8 @@ class ABCHandler:
         self.currentCollectStr = ''
 
     @staticmethod
-    def _getLinearContext(source: Sequence[_T],
-                          i: int) -> Tuple[Optional[_T], _T, Optional[_T], Optional[_T]]:
+    def _getLinearContext(source: t.Sequence[_T],
+                          i: int) -> t.Tuple[t.Optional[_T], _T, t.Optional[_T], t.Optional[_T]]:
         '''
         Find the local context of a string or iterable of objects
         beginning at a particular index.
@@ -1852,7 +1854,7 @@ class ABCHandler:
         return lastIndex + 1
 
     @staticmethod
-    def barlineTokenFilter(token: str) -> List[ABCBar]:
+    def barlineTokenFilter(token: str) -> t.List[ABCBar]:
         '''
         Some single barline tokens are better replaced
         with two tokens. This method, given a token,
@@ -1876,7 +1878,7 @@ class ABCHandler:
         >>> abcFormat.ABCHandler.barlineTokenFilter('hi')
         [<music21.abcFormat.ABCBar 'hi'>]
         '''
-        barTokens: List[ABCBar] = []
+        barTokens: t.List[ABCBar] = []
         if token == '::':
             # create a start and an end
             barTokens.append(ABCBar(':|'))
@@ -1996,8 +1998,8 @@ class ABCHandler:
 
     @staticmethod
     def startsMetadata(c: str,
-                       cNext: Optional[str],
-                       cNextNext: Optional[str]) -> bool:
+                       cNext: t.Optional[str],
+                       cNextNext: t.Optional[str]) -> bool:
         '''
         Returns True if this context describes the start of a metadata section, like
 
@@ -2089,7 +2091,7 @@ class ABCHandler:
         accidentals = '^=_'
 
         activeChordSymbol = ''  # accumulate, then prepend
-        accidentalized: Dict[str, str] = {}
+        accidentalized: t.Dict[str, str] = {}
         accidental: str = ''
         abcPitch: str = ''  # ABC substring defining any pitch within the current token
         self.isFirstComment = True
@@ -2445,17 +2447,17 @@ class ABCHandler:
         # pre-parse : call on objects that need preliminary processing
         # metadata, for example, is parsed
         # lastTimeSignature = None
-        for t in self.tokens:
-            # environLocal.printDebug(['tokenProcess: calling preParse()', t.src])
-            t.preParse()
+        for token in self.tokens:
+            # environLocal.printDebug(['tokenProcess: calling preParse()', token.src])
+            token.preParse()
 
         # context: iterate through tokens, supplying contextual data
         # as necessary to appropriate objects
         lastDefaultQL = None
         lastKeySignature = None
         lastTimeSignatureObj = None  # an m21 object
-        lastTupletToken: Optional[ABCTuplet] = None  # a token obj; keeps count of usage
-        lastTieToken: Optional[ABCTie] = None
+        lastTupletToken: t.Optional[ABCTuplet] = None  # a token obj; keeps count of usage
+        lastTieToken: t.Optional[ABCTie] = None
         lastStaccToken = None
         lastUpToken = None
         lastDownToken = None
@@ -2468,138 +2470,138 @@ class ABCHandler:
         for i in range(len(self.tokens)):
             # get context of tokens
             q = self._getLinearContext(self.tokens, i)
-            tPrev, t, tNext, unused_tNextNext = q
+            tPrev, token, tNext, unused_tNextNext = q
             # tPrevNotSpace, tPrev, t, tNext, tNextNotSpace, tNextNext = q
             # environLocal.printDebug(['tokenProcess: calling parse()', t])
 
-            if isinstance(t, ABCMetadata):
-                if t.isMeter():
-                    lastTimeSignatureObj = t.getTimeSignatureObject()
+            if isinstance(token, ABCMetadata):
+                if token.isMeter():
+                    lastTimeSignatureObj = token.getTimeSignatureObject()
                 # restart matching conditions; match meter twice ok
-                if t.isDefaultNoteLength() or (t.isMeter() and lastDefaultQL is None):
-                    lastDefaultQL = t.getDefaultQuarterLength()
-                elif t.isKey():
-                    sharpCount, mode = t.getKeySignatureParameters()
+                if token.isDefaultNoteLength() or (token.isMeter() and lastDefaultQL is None):
+                    lastDefaultQL = token.getDefaultQuarterLength()
+                elif token.isKey():
+                    sharpCount, mode = token.getKeySignatureParameters()
                     lastKeySignature = key.KeySignature(sharpCount)
                     if mode not in (None, ''):
                         lastKeySignature = lastKeySignature.asKey(mode)
 
-                if t.isReferenceNumber():
+                if token.isReferenceNumber():
                     # reset any spanners or parens at the end of any piece
                     # in case they aren't closed.
                     self.activeParens = []
                     self.activeSpanners = []
                 continue
             # broken rhythms need to be applied to previous and next notes
-            if isinstance(t, ABCBrokenRhythmMarker):
+            if isinstance(token, ABCBrokenRhythmMarker):
                 if (isinstance(tPrev, ABCNote)
                         and isinstance(tNext, ABCNote)):
                     # environLocal.printDebug(['tokenProcess: got broken rhythm marker', t.src])
-                    tPrev.brokenRhythmMarker = (t.data, 'left')
-                    tNext.brokenRhythmMarker = (t.data, 'right')
+                    tPrev.brokenRhythmMarker = (token.data, 'left')
+                    tNext.brokenRhythmMarker = (token.data, 'right')
                 else:
                     environLocal.printDebug(
                         ['broken rhythm marker '
-                         + f'({t.src}) not positioned between two notes or chords'])
+                         + f'({token.src}) not positioned between two notes or chords'])
 
             # need to update tuplets with currently active meter
-            if isinstance(t, ABCTuplet):
-                t.updateRatio(lastTimeSignatureObj)
+            if isinstance(token, ABCTuplet):
+                token.updateRatio(lastTimeSignatureObj)
                 # set number of notes that will be altered
                 # might need to do this with ql values, or look ahead to nxt
                 # token
-                t.updateNoteCount()
-                lastTupletToken = t
+                token.updateNoteCount()
+                lastTupletToken = token
                 self.activeParens.append('Tuplet')
 
             # notes within slur marks need to be added to the spanner
-            if isinstance(t, ABCSlurStart):
-                t.fillSlur()
-                self.activeSpanners.append(t.slurObj)
+            if isinstance(token, ABCSlurStart):
+                token.fillSlur()
+                self.activeSpanners.append(token.slurObj)
                 self.activeParens.append('Slur')
-            elif isinstance(t, ABCParenStop):
+            elif isinstance(token, ABCParenStop):
                 if self.activeParens:
                     p = self.activeParens.pop()
                     if p in ('Slur', 'Crescendo', 'Diminuendo'):
                         self.activeSpanners.pop()
 
-            if isinstance(t, ABCTie):
+            if isinstance(token, ABCTie):
                 # tPrev is usually an ABCNote but may be a GraceStop.
                 if lastNoteToken and lastNoteToken.tie == 'stop':
                     lastNoteToken.tie = 'continue'
                 elif lastNoteToken:
                     lastNoteToken.tie = 'start'
-                lastTieToken = t
+                lastTieToken = token
 
-            if isinstance(t, ABCStaccato):
-                lastStaccToken = t
+            if isinstance(token, ABCStaccato):
+                lastStaccToken = token
 
-            if isinstance(t, ABCUpbow):
-                lastUpToken = t
+            if isinstance(token, ABCUpbow):
+                lastUpToken = token
 
-            if isinstance(t, ABCDownbow):
-                lastDownToken = t
+            if isinstance(token, ABCDownbow):
+                lastDownToken = token
 
-            if isinstance(t, ABCAccent):
-                lastAccToken = t
+            if isinstance(token, ABCAccent):
+                lastAccToken = token
 
-            if isinstance(t, ABCStraccent):
-                lastStrAccToken = t
+            if isinstance(token, ABCStraccent):
+                lastStrAccToken = token
 
-            if isinstance(t, ABCTenuto):
-                lastTenutoToken = t
+            if isinstance(token, ABCTenuto):
+                lastTenutoToken = token
 
-            if isinstance(t, ABCCrescStart):
-                t.fillCresc()
-                self.activeSpanners.append(t.crescObj)
+            if isinstance(token, ABCCrescStart):
+                token.fillCresc()
+                self.activeSpanners.append(token.crescObj)
                 self.activeParens.append('Crescendo')
 
-            if isinstance(t, ABCDimStart):
-                t.fillDim()
-                self.activeSpanners.append(t.dimObj)
+            if isinstance(token, ABCDimStart):
+                token.fillDim()
+                self.activeSpanners.append(token.dimObj)
                 self.activeParens.append('Diminuendo')
 
-            if isinstance(t, ABCGraceStart):
-                lastGraceToken = t
+            if isinstance(token, ABCGraceStart):
+                lastGraceToken = token
 
-            if isinstance(t, ABCGraceStop):
+            if isinstance(token, ABCGraceStop):
                 lastGraceToken = None
 
             # ABCChord inherits ABCNote, thus getting note is enough for both
-            if isinstance(t, (ABCNote, ABCChord)):
+            if isinstance(token, (ABCNote, ABCChord)):
                 if lastDefaultQL is None:
                     raise ABCHandlerException(
                         'no active default note length provided for note processing. '
-                        + f'tPrev: {tPrev}, t: {t}, tNext: {tNext}'
+                        + f'tPrev: {tPrev}, token: {token}, tNext: {tNext}'
                     )
-                t.activeDefaultQuarterLength = lastDefaultQL
-                t.activeKeySignature = lastKeySignature
-                t.applicableSpanners = self.activeSpanners[:]  # fast copy of a list
+                token.activeDefaultQuarterLength = lastDefaultQL
+                token.activeKeySignature = lastKeySignature
+                token.applicableSpanners = self.activeSpanners[:]  # fast copy of a list
 
                 # This block ends tie objects one note after they begin
                 if lastTieToken is not None:
-                    t.tie = 'stop'
+                    token.tie = 'stop'
                     lastTieToken = None
                 if lastStaccToken is not None:
-                    t.articulations.append('staccato')
+                    token.articulations.append('staccato')
                     lastStaccToken = None
                 if lastUpToken is not None:
-                    t.articulations.append('upbow')
+                    token.articulations.append('upbow')
                     lastUpToken = None
                 if lastDownToken is not None:
-                    t.articulations.append('downbow')
+                    token.articulations.append('downbow')
                     lastDownToken = None
                 if lastAccToken is not None:
-                    t.articulations.append('accent')
+                    token.articulations.append('accent')
                     lastAccToken = None
                 if lastStrAccToken is not None:
-                    t.articulations.append('strongaccent')
+                    token.articulations.append('strongaccent')
                     lastStrAccToken = None
                 if lastTenutoToken is not None:
-                    t.articulations.append('tenuto')
+                    token.articulations.append('tenuto')
                     lastTenutoToken = None
                 if lastGraceToken is not None:
-                    t.inGrace = True
+                    token.inGrace = True
                 if lastTupletToken is None:
                     pass
                 elif lastTupletToken.noteCount == 0:
@@ -2607,13 +2609,13 @@ class ABCHandler:
                 else:
                     lastTupletToken.noteCount -= 1  # decrement
                     # add a reference to the note
-                    t.activeTuplet = lastTupletToken.tupletObj
-                lastNoteToken = t
+                    token.activeTuplet = lastTupletToken.tupletObj
+                lastNoteToken = token
 
         # parse : call methods to set attributes and parse abc string
-        for t in self.tokens:
+        for token in self.tokens:
             # environLocal.printDebug(['tokenProcess: calling parse()', t])
-            t.parse()
+            token.parse()
 
     def process(self, strSrc: str) -> None:
         self.tokens = []
@@ -2691,9 +2693,9 @@ class ABCHandler:
             raise ABCHandlerException('must process tokens before calling split')
         count = 0
         for i in range(len(self.tokens)):
-            t = self.tokens[i]
-            if isinstance(t, ABCMetadata):
-                if t.isReferenceNumber():
+            token = self.tokens[i]
+            if isinstance(token, ABCMetadata):
+                if token.isReferenceNumber():
                     count += 1
                     if count > 1:
                         return True
@@ -2762,19 +2764,19 @@ class ABCHandler:
         activeTokens = []
         currentABCHandler = None
 
-        for i, t in enumerate(self.tokens):
-            if isinstance(t, ABCMetadata) and t.isReferenceNumber():
+        for i, token in enumerate(self.tokens):
+            if isinstance(token, ABCMetadata) and token.isReferenceNumber():
                 if currentABCHandler is not None:
                     currentABCHandler.tokens = activeTokens
                     activeTokens = []
                 currentABCHandler = ABCHandler()
-                referenceNumber = int(t.data)
+                referenceNumber = int(token.data)
                 ahDict[referenceNumber] = currentABCHandler
 
             if currentABCHandler is None:
-                prependToAllList.append(t)
+                prependToAllList.append(token)
             else:
-                activeTokens.append(t)
+                activeTokens.append(token)
 
         if currentABCHandler is not None:
             currentABCHandler.tokens = activeTokens
@@ -2801,10 +2803,10 @@ class ABCHandler:
         '''
         if not self.tokens:
             raise ABCHandlerException('must process tokens before calling split')
-        for t in self.tokens:
-            if isinstance(t, ABCMetadata):
-                if t.isReferenceNumber():
-                    return t.data
+        for token in self.tokens:
+            if isinstance(token, ABCMetadata):
+                if token.isReferenceNumber():
+                    return token.data
         return None
 
     def definesMeasures(self):
@@ -2831,18 +2833,18 @@ class ABCHandler:
             raise ABCHandlerException('must process tokens before calling split')
         count = 0
         for i in range(len(self.tokens)):
-            t = self.tokens[i]
-            if isinstance(t, ABCBar):
+            token = self.tokens[i]
+            if isinstance(token, ABCBar):
                 # must define at least 2 regular barlines
                 # this leave out cases where only double bars are given
-                if t.isRegular():
+                if token.isRegular():
                     count += 1
                     # forcing the inclusion of two measures to count
                     if count >= 2:
                         return True
         return False
 
-    def splitByVoice(self) -> List['ABCHandler']:
+    def splitByVoice(self) -> t.List['ABCHandler']:
         # noinspection PyShadowingNames
         '''
         Given a processed token list, look for voices. If voices exist,
@@ -2862,18 +2864,23 @@ class ABCHandler:
 
         Common headers are first
 
-        >>> [t.src for t in tokenColls[0].tokens]
+        >>> [token.src for token in tokenColls[0].tokens]
         ['M:6/8', 'L:1/8', 'K:G']
 
         Then each voice
 
-        >>> [t.src for t in tokenColls[1].tokens]
-        ['V:1 name="Whistle" snm="wh"', 'B3', 'A3', '|', 'G6', '|', 'B3', 'A3', '|', 'G6', '||']
-        >>> [t.src for t in tokenColls[2].tokens]
-        ['V:2 name="violin" snm="v"', 'B', 'd', 'B', 'A', 'c', 'A', '|',
-         'G', 'A', 'G', 'D3', '|', 'B', 'd', 'B', 'A', 'c', 'A', '|', 'G', 'A', 'G', 'D6', '||']
-        >>> [t.src for t in tokenColls[3].tokens]
-        ['V:3 name="Bass" snm="b" clef=bass', 'D3', 'D3', '|', 'D6', '|',
+        >>> [token.src for token in tokenColls[1].tokens]
+        ['V:1 name="Whistle" snm="wh"',
+         'B3', 'A3', '|', 'G6', '|', 'B3', 'A3', '|', 'G6', '||']
+        >>> [token.src for token in tokenColls[2].tokens]
+        ['V:2 name="violin" snm="v"',
+         'B', 'd', 'B', 'A', 'c', 'A', '|',
+         'G', 'A', 'G', 'D3', '|',
+         'B', 'd', 'B', 'A', 'c', 'A', '|',
+         'G', 'A', 'G', 'D6', '||']
+        >>> [token.src for token in tokenColls[3].tokens]
+        ['V:3 name="Bass" snm="b" clef=bass',
+         'D3', 'D3', '|', 'D6', '|',
          'D3', 'D3', '|', 'D6', '||']
 
         Then later the metadata can be merged at the start of each voice...
@@ -2881,9 +2888,10 @@ class ABCHandler:
         >>> mergedTokens = tokenColls[0] + tokenColls[1]
         >>> mergedTokens
         <music21.abcFormat.ABCHandler object at 0x...>
-        >>> [t.src for t in mergedTokens.tokens]
+        >>> [token.src for token in mergedTokens.tokens]
         ['M:6/8', 'L:1/8', 'K:G', 'V:1 name="Whistle" snm="wh"',
-         'B3', 'A3', '|', 'G6', '|', 'B3', 'A3', '|', 'G6', '||']
+         'B3', 'A3', '|', 'G6', '|',
+         'B3', 'A3', '|', 'G6', '||']
         '''
         # TODO: this procedure should also be responsible for
         #     breaking the passage into voice/lyric pairs
@@ -2894,12 +2902,12 @@ class ABCHandler:
         voiceCount = 0
         pos = []
         for i in range(len(self.tokens)):
-            t = self.tokens[i]
-            if isinstance(t, ABCMetadata):
-                if t.isVoice():
+            token = self.tokens[i]
+            if isinstance(token, ABCMetadata):
+                if token.isVoice():
                     # if first char is a number
                     # can be V:3 name="Bass" snm="b" clef=bass
-                    if t.data and t.data[0].isdigit():
+                    if token.data and token.data[0].isdigit():
                         pos.append(i)  # store position
                         voiceCount += 1
 
@@ -2932,9 +2940,9 @@ class ABCHandler:
 
     @staticmethod
     def _buildMeasureBoundaryIndices(
-        positionList: List[int],
+        positionList: t.List[int],
         lastValidIndex: int
-    ) -> List[List[int]]:
+    ) -> t.List[t.List[int]]:
         '''
         Staticmethod
 
@@ -2983,7 +2991,7 @@ class ABCHandler:
         # environLocal.printDebug(['splitByMeasure(); pairs pre filter', pairs])
         return pairs
 
-    def splitByMeasure(self) -> List['ABCHandlerBar']:
+    def splitByMeasure(self) -> t.List['ABCHandlerBar']:
         '''
         Divide a token list by Measures, also
         defining start and end bars of each Measure.
@@ -3090,18 +3098,18 @@ class ABCHandler:
         #     environLocal.printDebug(['concluded splitByMeasure:', sub,
         #            'leftBarToken', sub.leftBarToken, 'rightBarToken', sub.rightBarToken,
         #            'len(sub)', len(sub), 'sub.hasNotes()', sub.hasNotes()])
-        #     for t in sub.tokens:
-        #         print('\t', t)
+        #     for token in sub.tokens:
+        #         print('\t', token)
         return abcBarHandlers
 
-    def tokensToBarIndices(self) -> List[int]:
+    def tokensToBarIndices(self) -> t.List[int]:
         '''
         Return a list of indices indicating which tokens in self.tokens are
         bar lines or the last piece of metadata before a note or chord.
         '''
         barIndices = []
         tNext = None
-        for i, t in enumerate(self.tokens):
+        for i, token in enumerate(self.tokens):
             try:
                 tNext = self.tokens[i + 1]
             except IndexError:
@@ -3109,13 +3117,13 @@ class ABCHandler:
 
             # either we get a bar, or we just complete metadata and
             # possibly encounter a note (a pickup)
-            if isinstance(t, ABCBar):  # or (barCount == 0 and noteCount > 0):
-                # environLocal.printDebug(['splitByMeasure()', 'found bar', t])
+            if isinstance(token, ABCBar):  # or (barCount == 0 and noteCount > 0):
+                # environLocal.printDebug(['splitByMeasure()', 'found bar', token])
                 barIndices.append(i)  # store position
                 # barCount += 1  # not used
             # case of end of metadata and start of notes in a pickup
             # tag the last metadata as the end
-            elif (isinstance(t, ABCMetadata)
+            elif (isinstance(token, ABCMetadata)
                   and tNext is not None
                   and isinstance(tNext, (ABCNote, ABCChord))):
                 barIndices.append(i)  # store position
@@ -3143,8 +3151,8 @@ class ABCHandler:
         if not self.tokens:
             raise ABCHandlerException('must process tokens before calling')
         count = 0
-        for t in self.tokens:
-            if isinstance(t, (ABCNote, ABCChord)):
+        for token in self.tokens:
+            if isinstance(token, (ABCNote, ABCChord)):
                 count += 1
         # environLocal.printDebug(['hasNotes', count])
         if count > 0:
@@ -3152,7 +3160,7 @@ class ABCHandler:
         else:
             return False
 
-    def getTitle(self) -> Optional[str]:
+    def getTitle(self) -> t.Optional[str]:
         '''
         Get the first title tag. Used for testing.
 
@@ -3160,10 +3168,10 @@ class ABCHandler:
         '''
         if not self.tokens:
             raise ABCHandlerException('must process tokens before calling split')
-        for t in self.tokens:
-            if isinstance(t, ABCMetadata):
-                if t.isTitle():
-                    return t.data
+        for token in self.tokens:
+            if isinstance(token, ABCMetadata):
+                if token.isTitle():
+                    return token.data
         return None
 
 
@@ -3179,8 +3187,8 @@ class ABCHandlerBar(ABCHandler):
         # tokens are ABC objects in a linear stream
         super().__init__()
 
-        self.leftBarToken: Optional[ABCBar] = None
-        self.rightBarToken: Optional[ABCBar] = None
+        self.leftBarToken: t.Optional[ABCBar] = None
+        self.rightBarToken: t.Optional[ABCBar] = None
 
     def __add__(self, other):
         ah = self.__class__()  # will get the same class type
@@ -3210,7 +3218,7 @@ class ABCHandlerBar(ABCHandler):
         return ah
 
 
-def mergeLeadingMetaData(barHandlers: List[ABCHandlerBar]) -> List[ABCHandlerBar]:
+def mergeLeadingMetaData(barHandlers: t.List[ABCHandlerBar]) -> t.List[ABCHandlerBar]:
     '''
     Given a list of ABCHandlerBar objects, return a list of ABCHandlerBar
     objects where leading metadata is merged, if possible,
@@ -3370,7 +3378,7 @@ class ABCFile(prebase.ProtoM21Object):
         referenceNumbers = '\n'.join(collect)
         return referenceNumbers
 
-    def readstr(self, strSrc: str, number: Optional[int] = None) -> ABCHandler:
+    def readstr(self, strSrc: str, number: t.Optional[int] = None) -> ABCHandler:
         '''
         Read a string and process all Tokens.
         Returns a ABCHandler instance.
@@ -3458,14 +3466,14 @@ class Test(unittest.TestCase):
             handler.tokenProcess()
 
             tokens = handler.tokens  # get private for testing
-            for t in tokens:
-                if isinstance(t, ABCMetadata):
-                    if t.tag == 'T':
-                        self.assertEqual(t.data, titleEncoded)
-                    elif t.tag == 'M':
-                        self.assertEqual(t.data, meterEncoded)
-                    elif t.tag == 'K':
-                        self.assertEqual(t.data, keyEncoded)
+            for token in tokens:
+                if isinstance(token, ABCMetadata):
+                    if token.tag == 'T':
+                        self.assertEqual(token.data, titleEncoded)
+                    elif token.tag == 'M':
+                        self.assertEqual(token.data, meterEncoded)
+                    elif token.tag == 'K':
+                        self.assertEqual(token.data, keyEncoded)
 
     def testTokenProcess(self):
         from music21.abcFormat import testFiles
@@ -3711,8 +3719,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(ah), 75)
         tokens = ah.tokens
         i = 0
-        for t in tokens:
-            if isinstance(t, ABCCrescStart):
+        for token in tokens:
+            if isinstance(token, ABCCrescStart):
                 i += 1
         self.assertEqual(i, 1)
 
@@ -3723,8 +3731,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(ah), 75)
         tokens = ah.tokens
         i = 0
-        for t in tokens:
-            if isinstance(t, ABCDimStart):
+        for token in tokens:
+            if isinstance(token, ABCDimStart):
                 i += 1
         self.assertEqual(i, 1)
 
@@ -3740,15 +3748,15 @@ class Test(unittest.TestCase):
         ah.process(testFiles.bowTest)
         self.assertEqual(len(ah), 83)
         tokens = ah.tokens
-        i = 0
-        j = 0
-        for t in tokens:
-            if isinstance(t, ABCUpbow):
-                i += 1
-            elif isinstance(t, ABCDownbow):
-                j += 1
-        self.assertEqual(i, 2)
-        self.assertEqual(j, 1)
+        upBows = 0
+        downBows = 0
+        for token in tokens:
+            if isinstance(token, ABCUpbow):
+                upBows += 1
+            elif isinstance(token, ABCDownbow):
+                downBows += 1
+        self.assertEqual(upBows, 2)
+        self.assertEqual(downBows, 1)
 
     def testAcc(self):
         from music21.abcFormat import testFiles
@@ -3851,12 +3859,12 @@ class Test(unittest.TestCase):
         i = 0
         j = 0
         k = 0
-        for t in tokens:
-            if isinstance(t, abcFormat.ABCAccent):
+        for token in tokens:
+            if isinstance(token, abcFormat.ABCAccent):
                 i += 1
-            elif isinstance(t, abcFormat.ABCStraccent):
+            elif isinstance(token, abcFormat.ABCStraccent):
                 j += 1
-            elif isinstance(t, abcFormat.ABCTenuto):
+            elif isinstance(token, abcFormat.ABCTenuto):
                 k += 1
         self.assertEqual(i, 2)
         self.assertEqual(j, 2)

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -530,8 +530,8 @@ class ABCMetadata(ABCToken):
         return key.pitchToSharps(standardKeyStr, mode), mode
 
     def getKeySignatureObject(self) -> t.Union['music21.key.Key',
-                                             'music21.key.KeySignature',
-                                             None]:
+                                               'music21.key.KeySignature',
+                                               None]:
         # noinspection SpellCheckingInspection,PyShadowingNames
         '''
         Return a music21 :class:`~music21.key.KeySignature` or :class:`~music21.key.Key`

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -1081,4 +1081,3 @@ if __name__ == '__main__':
     import music21
     music21.mainTest(Test)
 
-

--- a/music21/alpha/analysis/fixer.py
+++ b/music21/alpha/analysis/fixer.py
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 import unittest
 from copy import deepcopy
-from typing import Optional
+import typing as t
 
 from music21.alpha.analysis import aligner
 from music21.alpha.analysis import ornamentRecognizer
@@ -350,7 +350,7 @@ class OrnamentFixer(OMRMidiFixer):
             self.recognizers = recognizers
         self.markChangeColor = markChangeColor
 
-    def findOrnament(self, busyNotes, simpleNotes) -> Optional[expressions.Ornament]:
+    def findOrnament(self, busyNotes, simpleNotes) -> t.Optional[expressions.Ornament]:
         '''
         Finds an ornament in busyNotes based from simpleNote
         using provided recognizers.
@@ -389,7 +389,7 @@ class OrnamentFixer(OMRMidiFixer):
             return True
         return False
 
-    def fix(self, *, show=False, inPlace=True) -> Optional[OMRMidiFixer]:
+    def fix(self, *, show=False, inPlace=True) -> t.Optional[OMRMidiFixer]:
         '''
         Corrects missed ornaments in omrStream according to midiStream
         :param show: Whether to show results
@@ -397,7 +397,7 @@ class OrnamentFixer(OMRMidiFixer):
         return a new OrnamentFixer with changes
         '''
         changes = self.changes
-        sa: Optional[aligner.StreamAligner] = None
+        sa: t.Optional[aligner.StreamAligner] = None
         omrNotesLabeledOrnament = []
         midiNotesAlreadyFixedForOrnament = []
 

--- a/music21/alpha/analysis/ornamentRecognizer.py
+++ b/music21/alpha/analysis/ornamentRecognizer.py
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 import unittest
 from copy import deepcopy
-from typing import List, Optional, Union
+import typing as t
 
 from music21.common.numberTools import opFrac
 from music21.common.types import OffsetQL
@@ -46,8 +46,8 @@ class OrnamentRecognizer:
 
     def calculateOrnamentTotalQl(
         self,
-        busyNotes: List[note.GeneralNote],
-        simpleNotes: Optional[List[note.GeneralNote]] = None
+        busyNotes: t.List[note.GeneralNote],
+        simpleNotes: t.Optional[t.List[note.GeneralNote]] = None
     ) -> OffsetQL:
         '''
         Returns total length of trill assuming busy notes are all an expanded trill.
@@ -76,7 +76,7 @@ class TrillRecognizer(OrnamentRecognizer):
         self.acceptableInterval = 3
         self.minimumLengthForNachschlag = 5
 
-    def recognize(self, busyNotes, simpleNotes=None) -> Union[bool, expressions.Trill]:
+    def recognize(self, busyNotes, simpleNotes=None) -> t.Union[bool, expressions.Trill]:
         '''
         Tries to identify the busy notes as a trill.
 
@@ -176,7 +176,7 @@ class TurnRecognizer(OrnamentRecognizer):
         self,
         busyNotes,
         simpleNotes=None,
-    ) -> Union[bool, expressions.Turn, expressions.InvertedTurn]:
+    ) -> t.Union[bool, expressions.Turn, expressions.InvertedTurn]:
         '''
         Tries to identify the busy notes as a turn or inverted turn.
 

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -26,7 +26,7 @@ The :class:`music21.analysis.discrete.KrumhanslSchmuckler`
 #     range and key modules in analysis
 
 import unittest
-from typing import Union, List, Any, Tuple, Iterable, Optional, Sequence
+import typing as t
 
 from collections import OrderedDict
 from music21 import exceptions21
@@ -58,7 +58,7 @@ class DiscreteAnalysis:
     '''
     # define in subclass
     name = ''
-    identifiers: List[str] = []
+    identifiers: t.List[str] = []
 
     def __init__(self, referenceStream=None):
         # store a reference stream if needed
@@ -73,7 +73,7 @@ class DiscreteAnalysis:
         # store alternative solutions, which may be sorted or not
         self.alternativeSolutions = []
 
-    def _rgbToHex(self, rgb: Sequence[Union[float, int]]) -> str:
+    def _rgbToHex(self, rgb: t.Sequence[t.Union[float, int]]) -> str:
         '''
         Utility conversion method
 
@@ -85,7 +85,7 @@ class DiscreteAnalysis:
         rgb = round(rgb[0]), round(rgb[1]), round(rgb[2])
         return f'#{rgb[0]:02x}{rgb[1]:02x}{rgb[2]:02x}'
 
-    def _hexToRgb(self, value: str) -> List[int]:
+    def _hexToRgb(self, value: str) -> t.List[int]:
         '''
         Utility conversion method for six-digit hex values to RGB lists.
 
@@ -293,7 +293,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
                 # add to dictionary
                 dst[validKey.name] = self._rgbToHex(rgbStep)
 
-    def _getSharpFlatCount(self, subStream) -> Tuple[int, int]:
+    def _getSharpFlatCount(self, subStream) -> t.Tuple[int, int]:
         # noinspection PyShadowingNames
         '''
         Determine count of sharps and flats in a Stream
@@ -314,7 +314,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
                     sharpCount += 1
         return sharpCount, flatCount
 
-    def getWeights(self, weightType='major') -> List[float]:
+    def getWeights(self, weightType='major') -> t.List[float]:
         '''
         Returns the key weights. To provide different key weights,
         subclass and override this method. The defaults here are KrumhanslSchmuckler.
@@ -392,7 +392,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
         if keyResults is None:
             return None
 
-        likelyKeys: List[Any] = [0] * 12
+        likelyKeys: t.List[t.Any] = [0] * 12
         a = sorted((result, pc) for (pc, result) in enumerate(keyResults))
         a.reverse()
 
@@ -410,7 +410,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
         if keyResults is None:
             return None
 
-        solution: List[Union[int, float]] = [0.0] * 12
+        solution: t.List[t.Union[int, float]] = [0.0] * 12
         top = [0.0] * 12
         bottomRight = [0.0] * 12
         bottomLeft = [0.0] * 12
@@ -948,8 +948,8 @@ class Ambitus(DiscreteAnalysis):
         super().__init__(referenceStream=referenceStream)
         # Store the min and max Pitch instances for referenceStream
         # set by getPitchSpan(), which is called by _generateColors()
-        self.minPitchObj: Optional[pitch.Pitch] = None
-        self.maxPitchObj: Optional[pitch.Pitch] = None
+        self.minPitchObj: t.Optional[pitch.Pitch] = None
+        self.maxPitchObj: t.Optional[pitch.Pitch] = None
 
         self._pitchSpanColors = OrderedDict()
         self._generateColors()
@@ -994,7 +994,7 @@ class Ambitus(DiscreteAnalysis):
 
         # environLocal.printDebug([self._pitchSpanColors])
 
-    def getPitchSpan(self, subStream) -> Optional[Tuple[pitch.Pitch, pitch.Pitch]]:
+    def getPitchSpan(self, subStream) -> t.Optional[t.Tuple[pitch.Pitch, pitch.Pitch]]:
         '''
         For a given subStream, return a tuple consisting of the two pitches
         with the minimum and maximum pitch space value.
@@ -1041,11 +1041,11 @@ class Ambitus(DiscreteAnalysis):
             return None
 
         # find the min and max pitch space value for all pitches
-        psFound: List[float] = []
-        pitchesFound: List[pitch.Pitch] = []
+        psFound: t.List[float] = []
+        pitchesFound: t.List[pitch.Pitch] = []
         for n in justNotes:
             # environLocal.printDebug([n])
-            pitches: Iterable[pitch.Pitch] = ()
+            pitches: t.Iterable[pitch.Pitch] = ()
             if isinstance(n, note.GeneralNote) and not isinstance(n, harmony.ChordSymbol):
                 pitches = n.pitches
             psFound += [p.ps for p in pitches]

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -21,7 +21,7 @@ and :class:`music21.analysis.discrete.Ambitus` (for pitch range analysis) classe
 '''
 import unittest
 import warnings
-from typing import Union
+import typing as t
 
 from music21 import exceptions21
 
@@ -244,9 +244,9 @@ class WindowedAnalysis:
 
 
     def process(self,
-                minWindow: Union[int, None] = 1,
-                maxWindow: Union[int, None] = 1,
-                windowStepSize: Union[int, str] = 1,
+                minWindow: t.Union[int, None] = 1,
+                maxWindow: t.Union[int, None] = 1,
+                windowStepSize: t.Union[int, str] = 1,
                 windowType='overlap',
                 includeTotalWindow=True):
         # noinspection PyShadowingNames

--- a/music21/articulations.py
+++ b/music21/articulations.py
@@ -78,7 +78,7 @@ A longer test showing the utility of the module:
     :width: 628
 
 '''
-from typing import Optional, Type
+import typing as t
 import unittest
 
 from music21 import base
@@ -106,7 +106,7 @@ class Articulation(base.Music21Object):
     >>> x.displayText = '>'
 
     '''
-    _styleClass: Type[style.Style] = style.TextStyle
+    _styleClass: t.Type[style.Style] = style.TextStyle
 
     def __init__(self):
         super().__init__()
@@ -115,7 +115,7 @@ class Articulation(base.Music21Object):
         self._volumeShift: float = 0.0
         self.lengthShift: float = 1.0
         self.tieAttach: str = 'first'  # attach to first or last or all notes after split
-        self.displayText: Optional[str] = None
+        self.displayText: t.Optional[str] = None
 
     def _reprInternal(self):
         return ''

--- a/music21/audioSearch/__init__.py
+++ b/music21/audioSearch/__init__.py
@@ -41,7 +41,7 @@ import wave
 import warnings
 import unittest
 
-from typing import List, Union
+import typing as t
 
 # cannot call this base, because when audioSearch.__init__.py
 # imports * from base, it overwrites audioSearch!
@@ -525,11 +525,11 @@ def detectPitchFrequencies(freqFromAQList, useScale=None):
 
 
 def smoothFrequencies(
-    frequencyList: List[Union[int, float]],
+    frequencyList: t.List[t.Union[int, float]],
     *,
     smoothLevels=7,
     inPlace=False
-) -> List[int]:
+) -> t.List[int]:
     '''
     Smooths the shape of the signal in order to avoid false detections in the fundamental
     frequency.  Takes in a list of ints or floats.
@@ -605,7 +605,7 @@ def smoothFrequencies(
         )
 
     dpf = frequencyList
-    detectedPitchesFreq: List[float]
+    detectedPitchesFreq: t.List[float]
     if inPlace:
         detectedPitchesFreq = [float(f) for f in dpf]
     else:
@@ -628,12 +628,12 @@ def smoothFrequencies(
         elif i > numFreqs - int(math.ceil(smoothLevels / 2.0)) - 1:
             detectedPitchesFreq[i] = int(ends)
         else:
-            t = 0.0
+            change = 0.0
             for j in range(smoothLevels):
-                t += detectedPitchesFreq[i + j - int(math.floor(smoothLevels / 2.0))]
-            detectedPitchesFreq[i] = t / smoothLevels
+                change += detectedPitchesFreq[i + j - int(math.floor(smoothLevels / 2.0))]
+            detectedPitchesFreq[i] = change / smoothLevels
 
-    out: List[int] = [int(round(f)) for f in detectedPitchesFreq]
+    out: t.List[int] = [int(round(f)) for f in detectedPitchesFreq]
     if not inPlace:
         return out
     else:
@@ -1003,7 +1003,7 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 
 if __name__ == '__main__':

--- a/music21/bar.py
+++ b/music21/bar.py
@@ -13,7 +13,7 @@
 Object models of barlines, including repeat barlines.
 '''
 import unittest
-from typing import Optional
+import typing as t
 
 from music21 import base
 from music21 import exceptions21
@@ -273,8 +273,8 @@ class Repeat(repeat.RepeatMark, Barline):
             barType = 'final'
         Barline.__init__(self, type=barType)
 
-        self._direction: Optional[str] = None  # either start or end
-        self._times: Optional[int] = None  # if an end, how many repeats
+        self._direction: t.Optional[str] = None  # either start or end
+        self._times: t.Optional[int] = None  # if an end, how many repeats
 
         # start is forward, end is backward in musicxml
         self.direction = direction  # start, end
@@ -310,7 +310,7 @@ class Repeat(repeat.RepeatMark, Barline):
             raise BarException(f'cannot set repeat direction to: {value}')
 
     @property
-    def times(self) -> Optional[int]:
+    def times(self) -> t.Optional[int]:
         '''
         Get or set the "times" property of this barline. This
         defines how many times the repeat happens. A standard repeat

--- a/music21/base.py
+++ b/music21/base.py
@@ -49,21 +49,8 @@ from importlib.util import find_spec
 
 # for type annotation only
 import fractions
-from typing import (
-    Any,
-    Dict,
-    FrozenSet,
-    Iterable,
-    List,
-    Literal,
-    Optional,
-    Union,
-    Tuple,
-    Type,
-    TypeVar,
-    cast,
-    overload,
-)
+import typing as t
+from typing import overload
 
 from music21 import common
 from music21.common.enums import ElementSearch, OffsetSpecial
@@ -86,7 +73,7 @@ from music21._version import __version__, __version_info__
 from music21.test.testRunner import mainTest
 
 
-_M21T = TypeVar('_M21T', bound='music21.base.Music21Object')
+_M21T = t.TypeVar('_M21T', bound='music21.base.Music21Object')
 
 # all other music21 modules below...
 
@@ -307,14 +294,14 @@ class Music21Object(prebase.ProtoM21Object):
     within Note)
     '''
 
-    classSortOrder: Union[int, float] = 20  # default classSortOrder
+    classSortOrder: t.Union[int, float] = 20  # default classSortOrder
     # these values permit fast class comparisons for performance critical cases
     isStream = False
 
-    _styleClass: Type[style.Style] = style.Style
+    _styleClass: t.Type[style.Style] = style.Style
 
     # define order for presenting names in documentation; use strings
-    _DOC_ORDER: List[str] = []
+    _DOC_ORDER: t.List[str] = []
 
     # documentation for all attributes (not properties or methods)
     _DOC_ATTR = {
@@ -361,28 +348,28 @@ class Music21Object(prebase.ProtoM21Object):
         # do not call super().__init__() since it just wastes time
         self._id = None
         # None is stored as the internal location of an obj w/o any sites
-        self._activeSite: Optional['music21.stream.Stream'] = None
+        self._activeSite: t.Optional['music21.stream.Stream'] = None
         # offset when no activeSite is available
-        self._naiveOffset: Union[float, fractions.Fraction] = 0.0
+        self._naiveOffset: t.Union[float, fractions.Fraction] = 0.0
 
         # offset when activeSite is already garbage collected/dead,
         # as in short-lived sites
         # like .getElementsByClass().stream()
-        self._activeSiteStoredOffset: Union[float, fractions.Fraction, None] = None
+        self._activeSiteStoredOffset: t.Union[float, fractions.Fraction, None] = None
 
         # store a derivation object to track derivations from other Streams
         # pass a reference to this object
-        self._derivation: Optional[Derivation] = None
+        self._derivation: t.Optional[Derivation] = None
 
-        self._style: Optional[style.Style] = None
-        self._editorial: Optional[editorial.Editorial] = None
+        self._style: t.Optional[style.Style] = None
+        self._editorial: t.Optional[editorial.Editorial] = None
 
         # private duration storage; managed by property
-        self._duration: Optional[duration.Duration] = None
+        self._duration: t.Optional[duration.Duration] = None
         self._priority = 0  # default is zero
 
         # store cached values here:
-        self._cache: Dict[str, Any] = {}
+        self._cache: t.Dict[str, t.Any] = {}
 
         if 'id' in keywords:
             self._id = keywords['id']
@@ -409,7 +396,7 @@ class Music21Object(prebase.ProtoM21Object):
             self.editorial = keywords['editorial']
 
     @property
-    def id(self) -> Union[int, str]:
+    def id(self) -> t.Union[int, str]:
         '''
         A unique identification string or int; not to be confused with Python's
         built-in `id()` method. However, if not set, will return
@@ -425,7 +412,7 @@ class Music21Object(prebase.ProtoM21Object):
         return id(self)
 
     @id.setter
-    def id(self, new_id: Union[int, str]):
+    def id(self, new_id: t.Union[int, str]):
         if isinstance(new_id, int) and new_id > defaults.minIdNumberToConsiderMemoryLocation:
             msg = 'Setting an ID that could be mistaken for a memory location '
             msg += f'is discouraged: got {new_id}'
@@ -565,7 +552,7 @@ class Music21Object(prebase.ProtoM21Object):
 
         return new
 
-    def __deepcopy__(self: _M21T, memo: Optional[Dict[int, Any]] = None) -> _M21T:
+    def __deepcopy__(self: _M21T, memo: t.Optional[t.Dict[int, t.Any]] = None) -> _M21T:
         '''
         Helper method to copy.py's deepcopy function.  Call it from there.
 
@@ -611,13 +598,13 @@ class Music21Object(prebase.ProtoM21Object):
         # environLocal.printDebug([self, 'end deepcopy', 'self._activeSite', self._activeSite])
         return new
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> t.Dict[str, t.Any]:
         state = self.__dict__.copy()
         state['_derivation'] = None
         state['_activeSite'] = None
         return state
 
-    def __setstate__(self, state: Dict[str, Any]):
+    def __setstate__(self, state: t.Dict[str, t.Any]):
         # defining self.__dict__ upon initialization currently breaks everything
         self.__dict__ = state  # pylint: disable=attribute-defined-outside-init
 
@@ -752,7 +739,7 @@ class Music21Object(prebase.ProtoM21Object):
         return self._style
 
     @style.setter
-    def style(self, newStyle: Optional['music21.style.Style']):
+    def style(self, newStyle: t.Optional['music21.style.Style']):
         # Dev note: because property style shadows module style,
         # typing has to be in quotes.
         self._style = newStyle
@@ -811,7 +798,7 @@ class Music21Object(prebase.ProtoM21Object):
         return self._derivation
 
     @derivation.setter
-    def derivation(self, newDerivation: Optional[Derivation]) -> None:
+    def derivation(self, newDerivation: t.Optional[Derivation]) -> None:
         self._derivation = newDerivation
 
     def clearCache(self, **keywords):
@@ -834,33 +821,33 @@ class Music21Object(prebase.ProtoM21Object):
         '''
         # do not replace with self._cache.clear() -- leaves terrible
         # state for shallow copies.
-        self._cache: Dict[str, Any] = {}
+        self._cache: t.Dict[str, t.Any] = {}
 
     @overload
     def getOffsetBySite(
         self,
-        site: Union['music21.stream.Stream', None],
+        site: t.Union['music21.stream.Stream', None],
         *,
-        returnSpecial: Literal[False] = False,
-    ) -> Union[float, fractions.Fraction]:
+        returnSpecial: t.Literal[False] = False,
+    ) -> t.Union[float, fractions.Fraction]:
         return 0.0  # dummy until Astroid #1015 is fixed.  Replace with ...
 
     @overload
     def getOffsetBySite(
         self,
-        site: Union['music21.stream.Stream', None],
+        site: t.Union['music21.stream.Stream', None],
         *,
         returnSpecial: bool = False,
-    ) -> Union[float, fractions.Fraction, str]:
+    ) -> t.Union[float, fractions.Fraction, str]:
         return 0.0  # dummy until Astroid #1015 is fixed.  Replace with ...
-        # using bool instead of Literal[True] because of
+        # using bool instead of t.Literal[True] because of
 
     def getOffsetBySite(
         self,
-        site: Union['music21.stream.Stream', None],
+        site: t.Union['music21.stream.Stream', None],
         *,
         returnSpecial: bool = False,
-    ) -> Union[float, fractions.Fraction, str]:
+    ) -> t.Union[float, fractions.Fraction, str]:
         '''
         If this class has been registered in a container such as a Stream,
         that container can be provided here, and the offset in that object
@@ -975,7 +962,7 @@ class Music21Object(prebase.ProtoM21Object):
             ) from se
 
     def setOffsetBySite(self,
-                        site: Optional['music21.stream.Stream'],
+                        site: t.Optional['music21.stream.Stream'],
                         value: OffsetQLIn):
         '''
         Change the offset for a site.  These are equivalent:
@@ -1029,8 +1016,8 @@ class Music21Object(prebase.ProtoM21Object):
 
     def getOffsetInHierarchy(
         self,
-        site: Optional['music21.stream.Stream']
-    ) -> Union[float, fractions.Fraction]:
+        site: t.Optional['music21.stream.Stream']
+    ) -> t.Union[float, fractions.Fraction]:
         '''
         For an element which may not be in site, but might be in a Stream in site (or further
         in streams), find the cumulative offset of the element in that site.
@@ -1101,8 +1088,8 @@ class Music21Object(prebase.ProtoM21Object):
         raise SitesException(f'Element {self} is not in hierarchy of {site}')
 
     def getSpannerSites(self,
-                        spannerClassList: Optional[Iterable] = None
-                        ) -> List['music21.spanner.Spanner']:
+                        spannerClassList: t.Optional[t.Iterable] = None
+                        ) -> t.List['music21.spanner.Spanner']:
         '''
         Return a list of all :class:`~music21.spanner.Spanner` objects
         (or Spanner subclasses) that contain
@@ -1237,37 +1224,37 @@ class Music21Object(prebase.ProtoM21Object):
     @overload
     def getContextByClass(
         self,
-        className: Type[_M21T],
+        className: t.Type[_M21T],
         *,
         getElementMethod=ElementSearch.AT_OR_BEFORE,
         sortByCreationTime=False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> Union[_M21T, None]:
+    ) -> t.Union[_M21T, None]:
         return None  # until Astroid #1015
 
     @overload
     def getContextByClass(
         self,
-        className: Union[str, None],
+        className: t.Union[str, None],
         *,
         getElementMethod=ElementSearch.AT_OR_BEFORE,
         sortByCreationTime=False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> Union[Music21Object, None]:
+    ) -> t.Union[Music21Object, None]:
         return None  # until Astroid #1015
 
 
     def getContextByClass(
         self,
-        className: Union[Type[_M21T], str, None],
+        className: t.Union[t.Type[_M21T], str, None],
         *,
         getElementMethod: ElementSearch = ElementSearch.AT_OR_BEFORE,
         sortByCreationTime=False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> Union[_M21T, Music21Object, None]:
+    ) -> t.Union[_M21T, Music21Object, None]:
         # noinspection PyShadowingNames
         '''
         A very powerful method in music21 of fundamental importance: Returns
@@ -1733,7 +1720,7 @@ class Music21Object(prebase.ProtoM21Object):
         callerFirst=None,
         memo=None,
         offsetAppend=0.0,
-        sortByCreationTime: Union[str, bool] = False,
+        sortByCreationTime: t.Union[str, bool] = False,
         priorityTarget=None,
         returnSortTuples=False,
         followDerivation=True,
@@ -1922,7 +1909,7 @@ class Music21Object(prebase.ProtoM21Object):
         if callerFirst is None:
             callerFirst = self
             if self.isStream and self not in memo:
-                streamSelf = cast('music21.stream.Stream', self)
+                streamSelf = t.cast('music21.stream.Stream', self)
                 recursionType = streamSelf.recursionType
                 environLocal.printDebug(
                     f'Caller first is {callerFirst} with offsetAppend {offsetAppend}')
@@ -2066,7 +2053,7 @@ class Music21Object(prebase.ProtoM21Object):
     # -------------------------------------------------------------------------
 
     def next(self,
-             className: Union[Type[Music21Object], str, None] = None,
+             className: t.Union[t.Type[Music21Object], str, None] = None,
              *,
              activeSiteOnly=False):
         '''
@@ -2166,7 +2153,7 @@ class Music21Object(prebase.ProtoM21Object):
             callContinue = False
             for singleSiteContext, unused_positionInContext, unused_recurseType in allSiteContexts:
                 if nextEl is singleSiteContext:
-                    nextEl = cast('music21.stream.Stream', nextEl)
+                    nextEl = t.cast('music21.stream.Stream', nextEl)
                     if nextEl and nextEl[0] is not self:  # has elements
                         return nextEl[0]
 
@@ -2186,7 +2173,7 @@ class Music21Object(prebase.ProtoM21Object):
             raise Music21Exception('Maximum recursion!')
 
     def previous(self,
-                 className: Union[Type[Music21Object], str, None] = None,
+                 className: t.Union[t.Type[Music21Object], str, None] = None,
                  *,
                  activeSiteOnly=False):
         '''
@@ -2293,7 +2280,7 @@ class Music21Object(prebase.ProtoM21Object):
         else:  # pragma: no cover
             return self._activeSite
 
-    def _setActiveSite(self, site: Union['music21.stream.Stream', None]):
+    def _setActiveSite(self, site: t.Union['music21.stream.Stream', None]):
         # environLocal.printDebug(['_setActiveSite() called:', 'self', self, 'site', site])
 
         # NOTE: this is a performance intensive call
@@ -2635,7 +2622,7 @@ class Music21Object(prebase.ProtoM21Object):
                           self.classSortOrder, isNotGrace, insertIndex)
 
     # -----------------------------------------------------------------
-    def _getDuration(self) -> Optional[duration.Duration]:
+    def _getDuration(self) -> t.Optional[duration.Duration]:
         '''
         Gets the DurationObject of the object or None
         '''
@@ -3075,7 +3062,7 @@ class Music21Object(prebase.ProtoM21Object):
 
         # clear lyrics from remaining parts
         if isinstance(eRemain, note.GeneralNote):
-            emptyLyrics: List['music21.note.Lyric'] = []
+            emptyLyrics: t.List['music21.note.Lyric'] = []
             # not sure why isinstance check is not picking this up.
             eRemain.lyrics = emptyLyrics  # pylint: disable=attribute-defined-outside-init
 
@@ -3201,7 +3188,7 @@ class Music21Object(prebase.ProtoM21Object):
 
     def splitByQuarterLengths(
         self,
-        quarterLengthList: List[Union[int, float]],
+        quarterLengthList: t.List[t.Union[int, float]],
         addTies=True,
         displayTiedAccidentals=False
     ) -> _SplitTuple:
@@ -3326,8 +3313,8 @@ class Music21Object(prebase.ProtoM21Object):
 
         >>> n = note.Note()
         >>> n.duration.quarterLength = 0.5 + 0.0625  # eighth + 64th
-        >>> t = duration.Tuplet(4, 3)
-        >>> n.duration.appendTuplet(t)
+        >>> tup = duration.Tuplet(4, 3)
+        >>> n.duration.appendTuplet(tup)
         >>> first, last = n.splitAtDurations()
         >>> (first.duration, last.duration)
         (<music21.duration.Duration 0.375>, <music21.duration.Duration 0.046875>)
@@ -3343,8 +3330,8 @@ class Music21Object(prebase.ProtoM21Object):
 
         >>> n = note.Note()
         >>> n.duration.quarterLength = 0.5 + 0.0625  # eighth + 64th
-        >>> t = duration.Tuplet(3, 2, 'eighth')
-        >>> n.duration.appendTuplet(t)
+        >>> tup = duration.Tuplet(3, 2, 'eighth')
+        >>> n.duration.appendTuplet(tup)
         >>> (n.duration.type, n.duration.dots, n.duration.tuplets)
         ('complex', 0, (<music21.duration.Tuplet 3/2/eighth>,))
 
@@ -3369,7 +3356,7 @@ class Music21Object(prebase.ProtoM21Object):
     # temporal and beat based positioning
 
     @property
-    def measureNumber(self) -> Optional[int]:
+    def measureNumber(self) -> t.Optional[int]:
         # noinspection PyShadowingNames
         '''
         Return the measure number of a :class:`~music21.stream.Measure` that contains this
@@ -3441,7 +3428,7 @@ class Music21Object(prebase.ProtoM21Object):
                     mNumber = m.number
         return mNumber
 
-    def _getMeasureOffset(self, includeMeasurePadding=True) -> Union[float, fractions.Fraction]:
+    def _getMeasureOffset(self, includeMeasurePadding=True) -> t.Union[float, fractions.Fraction]:
         # noinspection PyShadowingNames
         '''
         Try to obtain the nearest Measure that contains this object,
@@ -3509,7 +3496,7 @@ class Music21Object(prebase.ProtoM21Object):
         extracted to make sure that all three of the routines use the same one.
         '''
         from music21 import meter
-        ts: Optional[meter.TimeSignature] = self.getContextByClass(
+        ts: t.Optional[meter.TimeSignature] = self.getContextByClass(
             meter.TimeSignature,
             getElementMethod=ElementSearch.AT_OR_BEFORE_OFFSET
         )
@@ -3518,7 +3505,7 @@ class Music21Object(prebase.ProtoM21Object):
         return ts
 
     @property
-    def beat(self) -> Union[fractions.Fraction, float]:
+    def beat(self) -> t.Union[fractions.Fraction, float]:
         # noinspection PyShadowingNames
         '''
         Return the beat of this object as found in the most
@@ -3822,7 +3809,7 @@ class Music21Object(prebase.ProtoM21Object):
         # once we have mm, simply pass in this duration
         return mm.durationToSeconds(self.duration)
 
-    def _setSeconds(self, value: Union[int, float]) -> None:
+    def _setSeconds(self, value: t.Union[int, float]) -> None:
         from music21 import tempo
         ti = self.getContextByClass(tempo.TempoIndication)
         if ti is None:
@@ -4041,7 +4028,7 @@ class ElementWrapper(Music21Object):
         else:
             return False
 
-    def __setattr__(self, name: str, value: Any) -> None:
+    def __setattr__(self, name: str, value: t.Any) -> None:
         # environLocal.printDebug(['calling __setattr__ of ElementWrapper', name, value])
 
         # if in the ElementWrapper already, set that first
@@ -4058,7 +4045,7 @@ class ElementWrapper(Music21Object):
         else:
             object.__setattr__(self, name, value)
 
-    def __getattr__(self, name: str) -> Any:
+    def __getattr__(self, name: str) -> t.Any:
         '''This method is only called when __getattribute__() fails.
         Using this also avoids the potential recursion problems of subclassing
         __getattribute__()_
@@ -5259,8 +5246,8 @@ class Test(unittest.TestCase):
         s.insert(1, e2)
         self.assertIs(e2.previous(), e1)
         self.assertIs(s[1].previous(), e1)
-        t = copy.deepcopy(s)
-        self.assertIs(t[1].previous(), t[0])
+        s2 = copy.deepcopy(s)
+        self.assertIs(s2[1].previous(), s2[0])
 
         e1 = note.Note('C')
         e2 = note.Note('D')
@@ -5304,17 +5291,6 @@ class Test(unittest.TestCase):
 # ------------------------------------------------------------------------------
 # define presented order in documentation
 _DOC_ORDER = [Music21Object, ElementWrapper]
-
-del (Any,
-     Dict,
-     FrozenSet,
-     Iterable,
-     List,
-     Optional,
-     Union,
-     Tuple,
-     TypeVar)
-
 
 # -----------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -72,7 +72,7 @@ To get rid of beams on a note do:
 
 >>> n2.beams.beamsList = []
 '''
-from typing import Iterable, List, Optional, Union
+import typing as t
 import unittest
 
 from music21 import exceptions21
@@ -240,7 +240,7 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
     # STATIC METHODS #
 
     @staticmethod
-    def naiveBeams(srcList: Iterable['music21.base.Music21Object']):
+    def naiveBeams(srcList: t.Iterable['music21.base.Music21Object']):
         # noinspection PyShadowingNames
         '''
         Given a list or iterator of elements, return a list of None or Beams for
@@ -261,7 +261,7 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
                      2/None>/<music21.beam.Beam 3/None>>,
          None]
         '''
-        beamsList: List[Optional[Beams]] = []
+        beamsList: t.List[t.Optional[Beams]] = []
         for el in srcList:
             # if a dur cannot be beamable under any circumstance, replace
             # it with None; this includes Rests
@@ -280,7 +280,7 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
         return beamsList
 
     @staticmethod
-    def removeSandwichedUnbeamables(beamsList: List[Union['Beams', None]]):
+    def removeSandwichedUnbeamables(beamsList: t.List[t.Union['Beams', None]]):
         # noinspection PyShadowingNames
         '''
         Go through the naiveBeamsList and remove beams from objects surrounded

--- a/music21/braille/basic.py
+++ b/music21/braille/basic.py
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 
 import unittest
-from typing import List, Dict
+import typing as t
 
 # from music21 import articulations
 from music21 import articulations
@@ -34,7 +34,7 @@ symbols = lookup.symbols
 
 environRules = environment.Environment('basic.py')
 
-beamStatus: Dict[str, bool] = {}
+beamStatus: t.Dict[str, bool] = {}
 
 # Attributes that the translator currently sets on Music21Objects
 # that should be cleaned up after transcription
@@ -689,7 +689,7 @@ def noteToBraille(
         except AttributeError:
             beamStatus[keyword] = False
 
-    noteTrans: List[str] = []
+    noteTrans: t.List[str] = []
     # opening double slur (before second note, after first note)
     # opening bracket slur
     # closing bracket slur (if also beginning of next long slur)
@@ -847,7 +847,7 @@ def handlePitchWithAccidental(music21Pitch, pitchTrans, brailleEnglish):
             brailleEnglish.append(f'Parenthesis {ps}')
 
 
-def handleArticulations(music21Note, noteTrans: List[str], upperFirstInFingering=True):
+def handleArticulations(music21Note, noteTrans: t.List[str], upperFirstInFingering=True):
     # finger mark
     # -----------
     try:
@@ -863,7 +863,7 @@ def handleArticulations(music21Note, noteTrans: List[str], upperFirstInFingering
             + 'cannot be transcribed to braille.')
 
 
-def handleExpressions(music21Note: note.GeneralNote, noteTrans: List[str]):
+def handleExpressions(music21Note: note.GeneralNote, noteTrans: t.List[str]):
     '''
     Transcribe the expressions for a note.GeneralNote.
     '''
@@ -959,13 +959,13 @@ def tempoTextToBraille(
     ⠛⠗⠁⠵⠊⠕⠎⠕⠀⠍⠁⠀
     ⠉⠁⠝⠞⠁⠃⠊⠇⠑⠲
     '''
-    newBrailleEnglish: List[str] = []
+    newBrailleEnglish: t.List[str] = []
     music21TempoText.editorial.brailleEnglish = newBrailleEnglish
     allPhrases = music21TempoText.text.split(',')
     braillePhrases = []
     for samplePhrase in allPhrases:
         allWords = samplePhrase.split()
-        phraseTrans: List[str] = []
+        phraseTrans: t.List[str] = []
         for sampleWord in allWords:
             try:
                 brailleWord = wordToBraille(sampleWord)

--- a/music21/braille/lookup.py
+++ b/music21/braille/lookup.py
@@ -24,7 +24,7 @@ A place where other signs are found generally is
 New International Manual of Braille Music Notation (by Bettye Krolick), which we will cite as
 "Krolick" or "krolick".
 '''
-from typing import Dict
+import typing as t
 import itertools
 
 _DOC_IGNORE_MODULE_OR_PACKAGE = True
@@ -189,7 +189,7 @@ naturals = {0: '',
             6: _B[3456] + _B[124] + _B[16],
             7: _B[3456] + _B[1245] + _B[16]}
 
-numbersUpper: Dict[int, str] = {
+numbersUpper: t.Dict[int, str] = {
     0: _B[245],
     1: _B[1],
     2: _B[12],
@@ -201,7 +201,7 @@ numbersUpper: Dict[int, str] = {
     8: _B[125],
     9: _B[24],
 }
-numbersLower: Dict[int, str] = {
+numbersLower: t.Dict[int, str] = {
     0: _B[356],
     1: _B[2],
     2: _B[23],
@@ -214,7 +214,7 @@ numbersLower: Dict[int, str] = {
     9: _B[35],
 }
 
-rests: Dict[str, str] = {
+rests: t.Dict[str, str] = {
     'dummy': _B[3],
     '128th': _B[1346],
     '64th': _B[1236],
@@ -228,21 +228,21 @@ rests: Dict[str, str] = {
     'longa': _B[134] + _B[45] + _B[14] + _B[45] + _B[14] + _B[134],
 }
 
-lengthPrefixes: Dict[str, str] = {
+lengthPrefixes: t.Dict[str, str] = {
     'larger': _B[45] + _B[126] + _B[2],  # whole to eighth inclusive + longer (degarmo 15)
     'smaller': _B[6] + _B[126] + _B[2],  # 16th to 128th inclusive
     'xsmall': _B[56] + _B[126] + _B[2],  # 256th notes + presumably shorter?
 
 }
 
-barlines: Dict[str, str] = {
+barlines: t.Dict[str, str] = {
     'final': _B[126] + _B[13],
     'double': _B[126] + _B[13] + _B[3],
     'dashed': _B[13],
     'heavy': _B[123],  # use "unusual circumstances barline
 }
 
-fingerMarks: Dict[str, str] = {
+fingerMarks: t.Dict[str, str] = {
     '1': _B[1],
     '2': _B[12],
     '3': _B[123],
@@ -302,7 +302,7 @@ textExpressions = {
     'decr.': _B[345] + _B[145] + _B[15] + _B[14] + _B[1235] + _B[3],
 }
 
-alphabet: Dict[str, str] = {
+alphabet: t.Dict[str, str] = {
     'a': _B[1],
     'b': _B[12],
     'c': _B[14],

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -21,7 +21,7 @@ import collections
 import copy
 import enum
 import unittest
-from typing import Optional, Union, TypedDict, List, Tuple, Type, Dict
+import typing as t
 
 from music21 import bar
 from music21 import base
@@ -85,7 +85,7 @@ CSO_MMARK = 4
 CSO_VOICE = 10
 
 # (music21Object, affinity code, Braille classSortOrder)
-affinityCodes: List[Tuple[Type[base.Music21Object], Affinity, int]] = [
+affinityCodes: t.List[t.Tuple[t.Type[base.Music21Object], Affinity, int]] = [
     (note.Note, Affinity.NOTEGROUP, CSO_NOTE),
     (note.Rest, Affinity.NOTEGROUP, CSO_REST),
     (chord.Chord, Affinity.NOTEGROUP, CSO_CHORD),
@@ -99,7 +99,7 @@ affinityCodes: List[Tuple[Type[base.Music21Object], Affinity, int]] = [
     (stream.Voice, Affinity.INACCORD, CSO_VOICE),
 ]
 
-affinityNames: Dict[Affinity, str] = {
+affinityNames: t.Dict[Affinity, str] = {
     Affinity.SIGNATURE: 'Signature Grouping',
     Affinity.TTEXT: 'Tempo Text Grouping',
     Affinity.MMARK: 'Metronome Mark Grouping',
@@ -110,16 +110,16 @@ affinityNames: Dict[Affinity, str] = {
     Affinity.SPLIT2_NOTEGROUP: 'Split Note Grouping B',
 }
 
-excludeFromBrailleElements: List[Type[base.Music21Object]] = [
+excludeFromBrailleElements: t.List[t.Type[base.Music21Object]] = [
     spanner.Slur,
     layout.SystemLayout,
     layout.PageLayout,
     layout.StaffLayout,
 ]
 
-class GroupingGlobals(TypedDict):
-    keySignature: Optional[key.KeySignature]
-    timeSignature: Optional[meter.TimeSignature]
+class GroupingGlobals(t.TypedDict):
+    keySignature: t.Optional[key.KeySignature]
+    timeSignature: t.Optional[meter.TimeSignature]
 
 
 GROUPING_GLOBALS: GroupingGlobals = {
@@ -355,11 +355,11 @@ class BrailleSegment(text.BrailleText):
         ---end segment---
         '''
         super().__init__(lineLength=lineLength)
-        self._groupingDict: Dict[SegmentKey, BrailleElementGrouping] = {}
+        self._groupingDict: t.Dict[SegmentKey, BrailleElementGrouping] = {}
 
-        self.groupingKeysToProcess: List[SegmentKey] = []
-        self.currentGroupingKey: Optional[SegmentKey] = None
-        self.previousGroupingKey: Optional[SegmentKey] = None
+        self.groupingKeysToProcess: t.List[SegmentKey] = []
+        self.currentGroupingKey: t.Optional[SegmentKey] = None
+        self.previousGroupingKey: t.Optional[SegmentKey] = None
         self.lastNote = None
 
         self.showClefSigns: bool = False
@@ -592,7 +592,7 @@ class BrailleSegment(text.BrailleText):
 
     def extractInaccordGrouping(self):
         inaccords = self._groupingDict.get(self.currentGroupingKey)
-        last_clef: Optional[clef.Clef] = None
+        last_clef: t.Optional[clef.Clef] = None
         seen_voice: bool = False
         for music21VoiceOrClef in inaccords:
             if isinstance(music21VoiceOrClef, clef.Clef):
@@ -1091,8 +1091,8 @@ class BrailleGrandSegment(BrailleSegment, text.BrailleKeyboard):
     def __init__(self, lineLength: int = 40):
         BrailleSegment.__init__(self, lineLength=lineLength)
         text.BrailleKeyboard.__init__(self, lineLength=lineLength)
-        self.allKeyPairs: List[Tuple[Optional[SegmentKey],
-                                     Optional[SegmentKey]]] = []
+        self.allKeyPairs: t.List[t.Tuple[t.Optional[SegmentKey],
+                                     t.Optional[SegmentKey]]] = []
         self.previousGroupingPair = None
         self.currentGroupingPair = None
 
@@ -1402,7 +1402,7 @@ def findSegments(music21Part,
                  showFirstMeasureNumber=True,
                  showHand=None,
                  showHeading=True,
-                 showLongSlursAndTiesTogether: Optional[bool] = None,
+                 showLongSlursAndTiesTogether: t.Optional[bool] = None,
                  showShortSlursAndTiesTogether=False,
                  slurLongPhraseWithBrackets=True,
                  suppressOctaveMarks=False,
@@ -1578,7 +1578,7 @@ def prepareSlurredNotes(music21Part,
                         *,
                         slurLongPhraseWithBrackets=True,
                         showShortSlursAndTiesTogether=False,
-                        showLongSlursAndTiesTogether: Optional[bool] = None,
+                        showLongSlursAndTiesTogether: t.Optional[bool] = None,
                         ):
     '''
     Takes in a :class:`~music21.stream.Part` and three keywords:
@@ -1979,7 +1979,7 @@ def getRawSegments(music21Part,
     return allSegments
 
 
-def extractBrailleElements(music21MeasureOrVoice: Union[stream.Measure, stream.Voice]):
+def extractBrailleElements(music21MeasureOrVoice: t.Union[stream.Measure, stream.Voice]):
     '''
     Takes in a :class:`~music21.stream.Measure` or :class:`~music21.stream.Voice`
     and returns a :class:`~music21.braille.segment.BrailleElementGrouping` of correctly ordered
@@ -2023,7 +2023,7 @@ def extractBrailleElements(music21MeasureOrVoice: Union[stream.Measure, stream.V
     <music21.bar.Barline type=final>
     '''
     allElements = BrailleElementGrouping()
-    last_clef: Optional[clef.Clef] = None
+    last_clef: t.Optional[clef.Clef] = None
     for music21Object in music21MeasureOrVoice:
         # Hold the clef in memory in case the next object is a voice
         if isinstance(music21Object, clef.Clef):

--- a/music21/braille/text.py
+++ b/music21/braille/text.py
@@ -118,10 +118,6 @@ class BrailleText(prebase.ProtoM21Object):
         '''
         Adds an expression long enough that it is split at
         each space symbol such that line wrapping could occur.
-
-
-        >>> bt = braille.text.BrailleText(lineLength=10)
-        >>>
         '''
         for brailleExpr in longExpr.split(symbols['space']):
             self.appendOrInsertCurrent(brailleExpr)

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -92,7 +92,7 @@ memorization" (BMTM, 71). Some of these keywords are changed automatically in co
 import re
 import unittest
 
-from typing import Optional, Union
+import typing as t
 
 from music21 import base
 from music21 import exceptions21
@@ -118,7 +118,7 @@ def objectToBraille(music21Obj: base.Music21Object,
                     showFirstMeasureNumber=True,
                     showHand=None,
                     showHeading=True,
-                    showLongSlursAndTiesTogether: Optional[bool] = None,
+                    showLongSlursAndTiesTogether: t.Optional[bool] = None,
                     showShortSlursAndTiesTogether=False,
                     slurLongPhraseWithBrackets=True,
                     suppressOctaveMarks=False,
@@ -221,7 +221,7 @@ def objectToBraille(music21Obj: base.Music21Object,
                                 upperFirstInNoteFingering=upperFirstInNoteFingering,
                                 )
 
-def streamToBraille(music21Stream: Union[stream.Measure, stream.Part, stream.Score, stream.Opus],
+def streamToBraille(music21Stream: t.Union[stream.Measure, stream.Part, stream.Score, stream.Opus],
                     *,
                     inPlace=False,
                     debug=False,
@@ -234,7 +234,7 @@ def streamToBraille(music21Stream: Union[stream.Measure, stream.Part, stream.Sco
                     showFirstMeasureNumber=True,
                     showHand=None,
                     showHeading=True,
-                    showLongSlursAndTiesTogether: Optional[bool] = None,
+                    showLongSlursAndTiesTogether: t.Optional[bool] = None,
                     showShortSlursAndTiesTogether=False,
                     slurLongPhraseWithBrackets=True,
                     suppressOctaveMarks=False,
@@ -369,7 +369,7 @@ def scoreToBraille(music21Score,
                    showFirstMeasureNumber=True,
                    showHand=None,
                    showHeading=True,
-                   showLongSlursAndTiesTogether: Optional[bool] = None,
+                   showLongSlursAndTiesTogether: t.Optional[bool] = None,
                    showShortSlursAndTiesTogether=False,
                    slurLongPhraseWithBrackets=True,
                    suppressOctaveMarks=False,
@@ -382,7 +382,7 @@ def scoreToBraille(music21Score,
     for music21Metadata in music21Score.getElementsByClass(metadata.Metadata):
         allBrailleLines.append(metadataToString(music21Metadata, returnBrailleUnicode=not debug))
 
-    unprocessed_partStaff: Optional[stream.PartStaff] = None
+    unprocessed_partStaff: t.Optional[stream.PartStaff] = None
 
     def process_unmatched_part_staff_as_single_part():
         nonlocal unprocessed_partStaff
@@ -506,7 +506,7 @@ def opusToBraille(music21Opus,
                   showFirstMeasureNumber=True,
                   showHand=None,
                   showHeading=True,
-                  showLongSlursAndTiesTogether: Optional[bool] = None,
+                  showLongSlursAndTiesTogether: t.Optional[bool] = None,
                   showShortSlursAndTiesTogether=False,
                   slurLongPhraseWithBrackets=True,
                   suppressOctaveMarks=False,
@@ -553,7 +553,7 @@ def measureToBraille(music21Measure,
                      showFirstMeasureNumber=False,  # observe False!
                      showHand=None,
                      showHeading=False,  # observe False!
-                     showLongSlursAndTiesTogether: Optional[bool] = None,
+                     showLongSlursAndTiesTogether: t.Optional[bool] = None,
                      showShortSlursAndTiesTogether=False,
                      slurLongPhraseWithBrackets=True,
                      suppressOctaveMarks=False,
@@ -615,7 +615,7 @@ def partToBraille(music21Part,
                   showFirstMeasureNumber=True,
                   showHand=None,
                   showHeading=True,
-                  showLongSlursAndTiesTogether: Optional[bool] = None,
+                  showLongSlursAndTiesTogether: t.Optional[bool] = None,
                   showShortSlursAndTiesTogether=False,
                   slurLongPhraseWithBrackets=True,
                   suppressOctaveMarks=False,
@@ -675,7 +675,7 @@ def keyboardPartsToBraille(keyboardScore,
                            showFirstMeasureNumber=True,
                            showHand=None,
                            showHeading=True,
-                           showLongSlursAndTiesTogether: Optional[bool] = None,
+                           showLongSlursAndTiesTogether: t.Optional[bool] = None,
                            showShortSlursAndTiesTogether=False,
                            slurLongPhraseWithBrackets=True,
                            suppressOctaveMarks=False,

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -22,7 +22,7 @@ import unittest
 import zipfile
 
 from io import StringIO
-from typing import List, Optional
+import typing as t
 
 from music21 import bar
 from music21 import chord
@@ -196,7 +196,7 @@ class CapellaImporter:
                 newPart.coreElementsChanged()
         newScore = stream.Score()
         # ORDERED DICT
-        parts: List[Optional['music21.stream.Part']] = [None for i in range(len(partDictById))]
+        parts: t.List[t.Optional['music21.stream.Part']] = [None for i in range(len(partDictById))]
         for partId in partDictById:
             partDict = partDictById[partId]
             parts[partDict['number']] = partDict['part']
@@ -329,13 +329,12 @@ class CapellaImporter:
         return systemObj
 
     def streamFromNoteObjects(self, noteObjectsElement, streamObj=None):
+        # noinspection PyShadowingNames
         r'''
-
         Converts a <noteObjects> tag into a :class:`~music21.stream.Stream` object
         which is returned.
         A Stream can be given as an optional argument, in which case the objects of this
         Stream are appended to this object.
-
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> noteObjectsString = r"""
@@ -366,15 +365,15 @@ class CapellaImporter:
         ...            </noteObjects>
         ...            """
         >>> noteObjectsElement = ci.domElementFromText(noteObjectsString)
-        >>> s = ci.streamFromNoteObjects(noteObjectsElement)
-        >>> s.show('text')
+        >>> streamObj = ci.streamFromNoteObjects(noteObjectsElement)
+        >>> streamObj.show('text')
         {0.0} <music21.clef.Treble8vbClef>
         {0.0} <music21.key.KeySignature of 1 flat>
         {0.0} <music21.note.Note G>
         {2.0} <music21.note.Note A>
         {4.0} <music21.bar.Barline type=final>
 
-        >>> s.highestTime
+        >>> streamObj.highestTime
         4.0
         '''
         if streamObj is None:
@@ -392,11 +391,11 @@ class CapellaImporter:
 
         for d in noteObjectsElement:
             el = None
-            t = d.tag
-            if t not in mapping:
-                print(f'Unknown tag type: {t}')
+            dTag = d.tag
+            if dTag not in mapping:
+                print(f'Unknown tag type: {dTag}')
             else:
-                el = mapping[t](d)
+                el = mapping[dTag](d)
                 if isinstance(el, list):  # barlineList returns a list
                     for elSub in el:
                         s.coreAppend(elSub)
@@ -409,6 +408,7 @@ class CapellaImporter:
         return s
 
     def restFromRest(self, restElement):
+        # noinspection PyShadowingNames
         '''
         Returns a :class:`~music21.rest.Rest` object from a <rest> tag.
 
@@ -426,6 +426,7 @@ class CapellaImporter:
         return r
 
     def chordOrNoteFromChord(self, chordElement):
+        # noinspection PyShadowingNames
         '''
         returns a :class:`~music21.note.Note` or :class:`~music21.chord.Chord`
         from a chordElement -- a `Note`
@@ -481,9 +482,9 @@ class CapellaImporter:
         return noteOrChord
 
     def notesFromHeads(self, headsElement):
+        # noinspection PyShadowingNames
         '''
         returns a list of :class:`~music21.note.Note` elements for each <head> in <heads>
-
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> headsElement = ci.domElementFromText(
@@ -498,11 +499,11 @@ class CapellaImporter:
         return notes
 
     def noteFromHead(self, headElement):
+        # noinspection PyShadowingNames
         '''
         return a :class:`~music21.note.Note` object from a <head> element.  This will become
         part of Chord._notes if there are multiple, but in any case, it needs to be a Note
         not a Pitch for now, because it could have Tie information
-
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> headElement = ci.domElementFromText(
@@ -545,7 +546,6 @@ class CapellaImporter:
         '''
         return a :class:`~music21.pitch.Accidental` object from an <alter> tag.
 
-
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> alter = ci.domElementFromText('<alter step="-1"/>')
         >>> ci.accidentalFromAlter(alter)
@@ -554,10 +554,10 @@ class CapellaImporter:
         The only known display type is "suppress"
 
         >>> alter = ci.domElementFromText('<alter step="2" display="suppress"/>')
-        >>> acc = ci.accidentalFromAlter(alter)
-        >>> acc
+        >>> accidentalObject = ci.accidentalFromAlter(alter)
+        >>> accidentalObject
         <music21.pitch.Accidental double-sharp>
-        >>> acc.displayType
+        >>> accidentalObject.displayType
         'never'
         '''
         if 'step' in alterElement.attrib:
@@ -638,9 +638,9 @@ class CapellaImporter:
         return lyricList
 
     def lyricFromVerse(self, verse):
+        # noinspection PyShadowingNames
         '''
         returns a :class:`~music21.note.Lyric` object from a <verse> tag
-
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> verse = ci.domElementFromText('<verse i="0" hyphen="true">di&quot;</verse>')
@@ -676,9 +676,9 @@ class CapellaImporter:
                    }
 
     def clefFromClefSign(self, clefSign):
+        # noinspection PyShadowingNames
         '''
         returns a :class:`~music21.clef.Clef` object or subclass from a <clefSign> tag.
-
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> clefSign = ci.domElementFromText('<clefSign clef="treble"/>')
@@ -720,9 +720,9 @@ class CapellaImporter:
         return None
 
     def keySignatureFromKeySign(self, keySign):
+        # noinspection PyShadowingNames
         '''
         Returns a :class:`~music21.key.KeySignature` object from a keySign tag.
-
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> keySign = ci.domElementFromText('<keySign fifths="-1"/>')
@@ -734,9 +734,9 @@ class CapellaImporter:
             return key.KeySignature(keyFifths)
 
     def timeSignatureFromTimeSign(self, timeSign):
+        # noinspection PyShadowingNames
         '''
         Returns a :class:`~music21.meter.TimeSignature` object from a timeSign tag.
-
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> timeSign = ci.domElementFromText('<timeSign time="4/4"/>')
@@ -758,16 +758,20 @@ class CapellaImporter:
 
     def durationFromDuration(self, durationElement):
         '''
+        Return a music21.duration.Duration element from an XML Element representing
+        a duration.
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> durationTag = ci.domElementFromText('<duration base="1/32" dots="1"/>')
-        >>> d = ci.durationFromDuration(durationTag)
-        >>> d
+        >>> durationObj = ci.durationFromDuration(durationTag)
+        >>> durationObj
         <music21.duration.Duration 0.1875>
-        >>> d.type
+        >>> durationObj.type
         '32nd'
-        >>> d.dots
+        >>> durationObj.dots
         1
+
+        Here with Tuplets
 
         >>> durationTag2 = ci.domElementFromText(
         ...      '<duration base="1/4"><tuplet count="3"/></duration>')

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -19,8 +19,8 @@ __all__ = ['tables', 'Chord', 'ChordException', 'fromIntervalVector', 'fromForte
 
 import copy
 import unittest
-from typing import (Union, List, Optional, TypeVar, Set, Tuple, Dict,
-                    Sequence, overload)
+import typing as t
+from typing import overload
 
 from music21 import beam
 from music21 import common
@@ -39,7 +39,7 @@ from music21.common.decorators import cacheMethod
 
 environLocal = environment.Environment('chord')
 
-_ChordType = TypeVar('_ChordType', bound='music21.chord.Chord')
+_ChordType = t.TypeVar('_ChordType', bound='music21.chord.Chord')
 
 
 # ------------------------------------------------------------------------------
@@ -59,7 +59,7 @@ class ChordBase(note.NotRest):
     isNote = False
     isRest = False
 
-    _DOC_ATTR: Dict[str, str] = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'isNote': '''
             Boolean read-only value describing if this
             GeneralNote object is a Note. Is False''',
@@ -79,11 +79,12 @@ class ChordBase(note.NotRest):
     _DOC_ATTR.update(note.NotRest._DOC_ATTR)
 
     def __init__(self,
-                 notes: Union[None,
-                              str,
-                              Sequence[str],
-                              Sequence[note.NotRest],
-                              Sequence[int]] = None,
+                 notes: t.Union[None,
+                                str,
+                                t.Sequence[str],
+                                t.Sequence[pitch.Pitch],
+                                t.Sequence[note.NotRest],
+                                t.Sequence[int]] = None,
                  **keywords):
 
         if notes is None:
@@ -100,7 +101,7 @@ class ChordBase(note.NotRest):
 
         self._overrides = {}
 
-        self._notes: List[note.NotRest] = []
+        self._notes: t.List[note.NotRest] = []
         # here, pitch and duration data is extracted from notes
         # if provided
 
@@ -672,18 +673,19 @@ class Chord(ChordBase):
 
     # INITIALIZER #
     def __init__(self,
-                 notes: Union[None,
-                              Sequence[note.Note],
-                              Sequence[str],
-                              str,
-                              Sequence[int]] = None,
+                 notes: t.Union[None,
+                                t.Sequence[pitch.Pitch],
+                                t.Sequence[note.Note],
+                                t.Sequence[str],
+                                str,
+                                t.Sequence[int]] = None,
                  **keywords):
         if notes is not None and any(isinstance(n, note.GeneralNote)
                                      and not isinstance(n, (note.Note, Chord))
                                      for n in notes):
             raise TypeError(f'Use a PercussionChord to contain Unpitched objects; got {notes}')
         super().__init__(notes=notes, **keywords)
-        self._notes: List[note.Note]
+        self._notes: t.List[note.Note]
 
         if notes is not None and all(isinstance(n, int) for n in notes):
             self.simplifyEnharmonics(inPlace=True)
@@ -721,7 +723,7 @@ class Chord(ChordBase):
             return False
         return True
 
-    def __getitem__(self, key: Union[int, str, note.Note, pitch.Pitch]):
+    def __getitem__(self, key: t.Union[int, str, note.Note, pitch.Pitch]):
         '''
         Get item makes accessing pitch components for the Chord easier
 
@@ -939,7 +941,7 @@ class Chord(ChordBase):
         return ''.join(msg)
 
     # PRIVATE METHODS #
-    def _findBass(self) -> Optional[pitch.Pitch]:
+    def _findBass(self) -> t.Optional[pitch.Pitch]:
         '''
         Returns the lowest Pitch in the chord.
 
@@ -965,7 +967,7 @@ class Chord(ChordBase):
         attribute: str,
         *,
         inPlace=False
-    ) -> Union[_ChordType, List[pitch.Pitch]]:
+    ) -> t.Union[_ChordType, t.List[pitch.Pitch]]:
         '''
         Common method for stripping pitches based on redundancy of one pitch
         attribute. The `attribute` is provided by a string.
@@ -1195,26 +1197,26 @@ class Chord(ChordBase):
     def bass(self,
              newbass: None = None,
              *,
-             find: Union[bool, None] = None,
+             find: t.Union[bool, None] = None,
              allow_add: bool = False,
              ) -> pitch.Pitch:
         return self.pitches[0]  # dummy until Astroid 1015 is fixed.
 
     @overload
     def bass(self,
-             newbass: Union[str, pitch.Pitch, note.Note],
+             newbass: t.Union[str, pitch.Pitch, note.Note],
              *,
-             find: Union[bool, None] = None,
+             find: t.Union[bool, None] = None,
              allow_add: bool = False,
              ) -> None:
         return None
 
     def bass(self,
-             newbass: Union[None, str, pitch.Pitch, note.Note] = None,
+             newbass: t.Union[None, str, pitch.Pitch, note.Note] = None,
              *,
-             find: Union[bool, None] = None,
+             find: t.Union[bool, None] = None,
              allow_add: bool = False,
-             ) -> Optional[pitch.Pitch]:
+             ) -> t.Optional[pitch.Pitch]:
         '''
         Generally used to find and return the bass Pitch:
 
@@ -1653,7 +1655,7 @@ class Chord(ChordBase):
         elif lenPitches == 7:  # 13th chord
             return self.bass()
 
-        stepNumsToPitches: Dict[int, pitch.Pitch] = {pitch.STEP_TO_DNN_OFFSET[p.step]: p
+        stepNumsToPitches: t.Dict[int, pitch.Pitch] = {pitch.STEP_TO_DNN_OFFSET[p.step]: p
                                                      for p in nonDuplicatingPitches}
         stepNums = sorted(stepNumsToPitches)
         for startIndex in range(lenPitches):
@@ -1693,7 +1695,7 @@ class Chord(ChordBase):
         mostRootyIndex = rootnessFunctionScores.index(max(rootnessFunctionScores))
         return nonDuplicatingPitches[mostRootyIndex]
 
-    def geometricNormalForm(self) -> List[int]:
+    def geometricNormalForm(self) -> t.List[int]:
         '''
         Geometric Normal Form, as first defined by Dmitri Tymoczko, orders pitch classes
         such that the spacing is prioritized with the smallest spacing between the first and
@@ -1763,8 +1765,8 @@ class Chord(ChordBase):
         self,
         chordStep: int,
         *,
-        testRoot: Optional[Union[note.Note, pitch.Pitch]] = None
-    ) -> Optional[pitch.Pitch]:
+        testRoot: t.Optional[t.Union[note.Note, pitch.Pitch]] = None
+    ) -> t.Optional[pitch.Pitch]:
         '''
         Returns the (first) pitch at the provided scaleDegree (Thus, it's
         exactly like semitonesFromChordStep, except it instead of the number of
@@ -2024,7 +2026,7 @@ class Chord(ChordBase):
         except KeyError:
             raise ChordException(f'the given pitch is not in the Chord: {p}')
 
-    def getZRelation(self) -> Optional[Chord]:
+    def getZRelation(self) -> t.Optional[Chord]:
         '''
         Return a Z relation if it exists, otherwise return None.
 
@@ -2215,7 +2217,7 @@ class Chord(ChordBase):
         newInversion: int,
         *,
         find: bool = True,
-        testRoot: Optional[pitch.Pitch] = None,
+        testRoot: t.Optional[pitch.Pitch] = None,
         transposeOnSet: bool = True
     ) -> None:
         return None  # dummy until Astroid 1015 is fixed
@@ -2226,19 +2228,19 @@ class Chord(ChordBase):
         newInversion: None = None,
         *,
         find: bool = True,
-        testRoot: Optional[pitch.Pitch] = None,
+        testRoot: t.Optional[pitch.Pitch] = None,
         transposeOnSet: bool = True
     ) -> int:
         return -1  # dummy until Astroid 1015 is fixed
 
     def inversion(
         self,
-        newInversion: Optional[int] = None,
+        newInversion: t.Optional[int] = None,
         *,
         find: bool = True,
-        testRoot: Optional[pitch.Pitch] = None,
+        testRoot: t.Optional[pitch.Pitch] = None,
         transposeOnSet: bool = True
-    ) -> Union[int, None]:
+    ) -> t.Union[int, None]:
         '''
         Find the chord's inversion or (if called with a number) set the chord to
         the new inversion.
@@ -3159,10 +3161,10 @@ class Chord(ChordBase):
 
     def _isAugmentedSixthHelper(
         self,
-        chordTableAddress: Tuple[int, int, int],
+        chordTableAddress: t.Tuple[int, int, int],
         requiredInversion: int,
         permitAnyInversion: bool,
-        intervalsCheck: List[Tuple[str, str]],
+        intervalsCheck: t.List[t.Tuple[str, str]],
     ) -> bool:
         '''
         Helper method for simplifying checking Italian, German, etc. Augmented
@@ -3714,23 +3716,23 @@ class Chord(ChordBase):
     def root(self,
              newroot: None = None,
              *,
-             find: Union[bool, None] = None
+             find: t.Union[bool, None] = None
              ) -> pitch.Pitch:
         return self.pitches[0]  # dummy until Astroid 1015 is fixed.
 
     @overload
     def root(self,
-             newroot: Union[str, pitch.Pitch, note.Note],
+             newroot: t.Union[str, pitch.Pitch, note.Note],
              *,
-             find: Union[bool, None] = None
+             find: t.Union[bool, None] = None
              ) -> None:
         return None  # dummy until Astroid 1015 is fixed.
 
     def root(self,
-             newroot: Union[None, str, pitch.Pitch, note.Note] = None,
+             newroot: t.Union[None, str, pitch.Pitch, note.Note] = None,
              *,
-             find: Union[bool, None] = None
-             ) -> Optional[pitch.Pitch]:
+             find: t.Union[bool, None] = None
+             ) -> t.Optional[pitch.Pitch]:
         # noinspection PyShadowingNames
         '''
         Returns the root of the chord.  Or if given a Pitch as the
@@ -4347,7 +4349,7 @@ class Chord(ChordBase):
             raise ChordException(
                 f'the given pitch is not in the Chord: {pitchTarget}')
 
-    def setTie(self, t, pitchTarget):
+    def setTie(self, tieObjOrStr: t.Union[tie.Tie, str], pitchTarget):
         '''
         Given a tie object (or a tie type string) and a pitch or Note in this Chord,
         set the pitch's tie attribute in this chord to that tie type.
@@ -4397,19 +4399,22 @@ class Chord(ChordBase):
         elif isinstance(pitchTarget, str):
             pitchTarget = pitch.Pitch(pitchTarget)
 
-        if isinstance(t, str):
-            t = tie.Tie(t)
+        tieObj: tie.Tie
+        if isinstance(tieObjOrStr, str):
+            tieObj = tie.Tie(tieObjOrStr)
+        else:
+            tieObj = tieObjOrStr
 
         match = False
         for d in self._notes:
             if d.pitch is pitchTarget or d is pitchTarget:  # compare by obj id first
-                d.tie = t
+                d.tie = tieObj
                 match = True
                 break
         if not match:  # more loose comparison: by ==
             for d in self._notes:
                 if pitchTarget in (d, d.pitch):
-                    d.tie = t
+                    d.tie = tieObj
                     match = True
                     break
         if not match:
@@ -4890,7 +4895,7 @@ class Chord(ChordBase):
 
     @property  # type: ignore
     @cacheMethod
-    def fifth(self) -> Optional[pitch.Pitch]:
+    def fifth(self) -> t.Optional[pitch.Pitch]:
         '''
         Shortcut for getChordStep(5), but caches it and does not raise exceptions
 
@@ -5289,7 +5294,7 @@ class Chord(ChordBase):
         '''
         return Chord.formatVectorString(self.normalOrder)
 
-    def _unorderedPitchClasses(self) -> Set[int]:
+    def _unorderedPitchClasses(self) -> t.Set[int]:
         '''
         helper function for orderedPitchClasses but also routines
         like pitchClassCardinality which do not need sorting.
@@ -5302,7 +5307,7 @@ class Chord(ChordBase):
         return pcGroup
 
     @property
-    def orderedPitchClasses(self) -> List[int]:
+    def orderedPitchClasses(self) -> t.List[int]:
         '''
         Return a list of pitch class integers, ordered form lowest to highest.
 
@@ -5342,7 +5347,7 @@ class Chord(ChordBase):
         return len(self._unorderedPitchClasses())
 
     @property
-    def pitchClasses(self) -> List[int]:
+    def pitchClasses(self) -> t.List[int]:
         '''
         Return a list of all pitch classes in the chord as integers. Not sorted
 
@@ -5356,7 +5361,7 @@ class Chord(ChordBase):
         return pcGroup
 
     @property
-    def pitchNames(self) -> List[str]:
+    def pitchNames(self) -> t.List[str]:
         '''
         Return a list of Pitch names from each
         :class:`~music21.pitch.Pitch` object's
@@ -5504,7 +5509,7 @@ class Chord(ChordBase):
             return f'{rootName}-{nameStr}'
 
     @property
-    def pitches(self) -> Tuple[pitch.Pitch, ...]:
+    def pitches(self) -> t.Tuple[pitch.Pitch, ...]:
         '''
         Get or set a list or tuple of all Pitch objects in this Chord.
 
@@ -5543,7 +5548,7 @@ class Chord(ChordBase):
         <music21.pitch.Pitch A#4>
         '''
         # noinspection PyTypeChecker
-        pitches: Tuple[pitch.Pitch] = tuple(component.pitch for component in self._notes)
+        pitches: t.Tuple[pitch.Pitch] = tuple(component.pitch for component in self._notes)
         return pitches
 
     @pitches.setter
@@ -5556,7 +5561,7 @@ class Chord(ChordBase):
             self._notes.append(note.Note(p))
 
     @property
-    def primeForm(self) -> List[int]:
+    def primeForm(self) -> t.List[int]:
         '''
         Return a representation of the Chord as a prime-form list of pitch
         class integers:
@@ -5810,7 +5815,7 @@ class Chord(ChordBase):
 
     @property  # type: ignore
     @cacheMethod
-    def third(self) -> Optional[pitch.Pitch]:
+    def third(self) -> t.Optional[pitch.Pitch]:
         '''
         Shortcut for getChordStep(3), but caches the value, and returns
         None on errors.
@@ -5835,7 +5840,7 @@ class Chord(ChordBase):
 
 
 
-def fromForteClass(notation: Union[str, Sequence[int]]) -> Chord:
+def fromForteClass(notation: t.Union[str, t.Sequence[int]]) -> Chord:
     '''
     Return a Chord given a Forte-class notation. The Forte class can be
     specified as string (e.g., 3-11) or as a list of cardinality and number

--- a/music21/chord/tables.py
+++ b/music21/chord/tables.py
@@ -17,7 +17,7 @@ chord representations. All features of this module are made available through
 :class:`~music21.chord.Chord` objects. Use of this module directly is thus not necessary.
 '''
 from collections import namedtuple
-from typing import Tuple
+import typing as t
 import unittest
 
 from music21 import environment
@@ -52,10 +52,10 @@ class ChordTablesException(exceptions21.Music21Exception):
 # For index 2 (python [1]), a value of 1 or higher
 # is symmetrical under inversion.
 
-TNIStructure = Tuple[
-    Tuple[int, ...],
-    Tuple[int, int, int, int, int, int],
-    Tuple[int, int, int, int, int, int, int, int],
+TNIStructure = t.Tuple[
+    t.Tuple[int, ...],
+    t.Tuple[int, int, int, int, int, int],
+    t.Tuple[int, int, int, int, int, int, int, int],
     int,
 ]
 

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -19,8 +19,7 @@ commonly used clefs. Clef objects are often found
 within :class:`~music21.stream.Measure` objects.
 '''
 import unittest
-from typing import (Mapping, Optional, Iterable, Sequence, Union, Dict,
-                    Type, List, TYPE_CHECKING)
+import typing as t
 
 from music21 import base
 from music21 import exceptions21
@@ -60,7 +59,7 @@ class Clef(base.Music21Object):
     >>> tc.lowestLine
     31
     '''
-    _DOC_ATTR: Mapping[str, str] = {
+    _DOC_ATTR: t.Mapping[str, str] = {
         'sign': '''
             The sign of the clef, generally, 'C', 'G', 'F', 'percussion', 'none' or None.
 
@@ -99,9 +98,9 @@ class Clef(base.Music21Object):
 
     def __init__(self):
         super().__init__()
-        self.sign: Optional[str] = None
+        self.sign: t.Optional[str] = None
         # line counts start from the bottom up, the reverse of musedata
-        self.line: Optional[int] = None
+        self.line: t.Optional[int] = None
         self._octaveChange: int = 0  # set to zero as default
         # musicxml has an attribute for clefOctaveChange,
         # an integer to show transposing clef
@@ -185,7 +184,7 @@ class Clef(base.Music21Object):
 
     def getStemDirectionForPitches(
         self,
-        pitches: Union[pitch.Pitch, Sequence[pitch.Pitch]],
+        pitches: t.Union[pitch.Pitch, t.Sequence[pitch.Pitch]],
         *,
         firstLastOnly: bool = True,
         extremePitchOnly: bool = False,
@@ -228,12 +227,12 @@ class Clef(base.Music21Object):
         >>> bc.getStemDirectionForPitches(pitchList, extremePitchOnly=True)
         'up'
         '''
-        pitchList: Sequence[pitch.Pitch]
+        pitchList: t.Sequence[pitch.Pitch]
         if isinstance(pitches, pitch.Pitch):
             pitchList = [pitches]
         else:
             pitchList = pitches
-        relevantPitches: Sequence[pitch.Pitch]
+        relevantPitches: t.Sequence[pitch.Pitch]
 
         if not pitchList:
             raise ValueError('getStemDirectionForPitches cannot operate on an empty list')
@@ -272,7 +271,7 @@ class PitchClef(Clef):
     '''
     superclass for all other clef subclasses that use pitches...
     '''
-    _DOC_ATTR: Mapping[str, str] = {
+    _DOC_ATTR: t.Mapping[str, str] = {
         'lowestLine': '''
             The diatonicNoteNumber of the lowest line of the clef.
             (Can be none...)
@@ -284,7 +283,7 @@ class PitchClef(Clef):
 
     def __init__(self):
         super().__init__()
-        self.lowestLine: Optional[int] = None
+        self.lowestLine: t.Optional[int] = None
 
     @property
     def octaveChange(self) -> int:
@@ -338,7 +337,7 @@ class PercussionClef(Clef):
 
     Changed in v7.3 -- setting octaveChange no longer affects lowestLine
     '''
-    _DOC_ATTR: Mapping[str, str] = {}
+    _DOC_ATTR: t.Mapping[str, str] = {}
 
     def __init__(self):
         super().__init__()
@@ -359,7 +358,7 @@ class NoClef(Clef):
     >>> nc.sign is None
     False
     '''
-    _DOC_ATTR: Mapping[str, str] = {}
+    _DOC_ATTR: t.Mapping[str, str] = {}
 
     def __init__(self):
         super().__init__()
@@ -397,7 +396,7 @@ class TabClef(PitchClef):
 
     def getStemDirectionForPitches(
         self,
-        pitchList: Union[pitch.Pitch, Iterable[pitch.Pitch]],
+        pitchList: t.Union[pitch.Pitch, t.Iterable[pitch.Pitch]],
         *,
         firstLastOnly: bool = True,
         extremePitchOnly: bool = False,
@@ -725,7 +724,7 @@ class SubBassClef(FClef):
 
 
 # ------------------------------------------------------------------------------
-CLASS_FROM_TYPE: Dict[str, List[Optional[Type[Clef]]]] = {
+CLASS_FROM_TYPE: t.Dict[str, t.List[t.Optional[t.Type[Clef]]]] = {
     'G': [None, FrenchViolinClef, TrebleClef, GSopranoClef, None, None],
     'C': [None, SopranoClef, MezzoSopranoClef, AltoClef, TenorClef, CBaritoneClef],
     'F': [None, None, None, FBaritoneClef, BassClef, SubBassClef],
@@ -874,7 +873,7 @@ def clefFromString(clefString, octaveShift=0) -> Clef:
             clefObj.line = lineNum
         else:
             ClefType = line_list[lineNum]
-            if TYPE_CHECKING:
+            if t.TYPE_CHECKING:
                 assert ClefType is not None
                 assert issubclass(ClefType, PitchClef)
             clefObj = ClefType()

--- a/music21/common/classTools.py
+++ b/music21/common/classTools.py
@@ -10,7 +10,7 @@
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 import contextlib
-from typing import Any, Type, Dict
+import typing as t
 
 # from music21 import exceptions21
 __all__ = [
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-def isNum(usrData: Any) -> bool:
+def isNum(usrData: t.Any) -> bool:
     '''
     check if usrData is a number (float, int, long, Decimal),
     return boolean
@@ -63,7 +63,7 @@ def isNum(usrData: Any) -> bool:
         return False
 
 
-def isListLike(usrData: Any) -> bool:
+def isListLike(usrData: t.Any) -> bool:
     '''
     Returns True if is a List or Tuple
 
@@ -88,7 +88,7 @@ def isListLike(usrData: Any) -> bool:
     return isinstance(usrData, (list, tuple))
 
 
-def isIterable(usrData: Any) -> bool:
+def isIterable(usrData: t.Any) -> bool:
     '''
     Returns True if is the object can be iter'd over
     and is NOT a string
@@ -123,7 +123,7 @@ def isIterable(usrData: Any) -> bool:
     return False
 
 
-def classToClassStr(classObj: Type) -> str:
+def classToClassStr(classObj: t.Type) -> str:
     '''Convert a class object to a class string.
 
     >>> common.classToClassStr(note.Note)
@@ -230,7 +230,7 @@ def saveAttributes(obj, *attributeList):
 
     New in v7.
     '''
-    tempStorage: Dict[str, Any] = {}
+    tempStorage: t.Dict[str, t.Any] = {}
     for attribute in attributeList:
         tempStorage[attribute] = getattr(obj, attribute)
     try:

--- a/music21/common/fileTools.py
+++ b/music21/common/fileTools.py
@@ -20,7 +20,7 @@ import io
 import pathlib
 import pickle
 import os
-from typing import Union, Any
+import typing as t
 
 from music21.exceptions21 import Music21Exception
 
@@ -52,7 +52,7 @@ def cd(targetDir):
         os.chdir(cwd)
 
 
-def readPickleGzip(filePath: Union[str, pathlib.Path]) -> Any:
+def readPickleGzip(filePath: t.Union[str, pathlib.Path]) -> t.Any:
     '''
     Read a gzip-compressed pickle file, uncompress it, unpickle it, and
     return the contents.

--- a/music21/common/misc.py
+++ b/music21/common/misc.py
@@ -12,7 +12,7 @@
 '''
 If it doesn't fit anywhere else in the common directory, you'll find it here...
 '''
-from typing import Any, Tuple, List, Iterable, Optional, Callable
+import typing as t
 import platform
 import re
 
@@ -38,7 +38,7 @@ import time
 # -----------------------------------------------------------------------------
 
 
-def flattenList(originalList: List) -> List:
+def flattenList(originalList: t.List) -> t.List:
     '''
     Flatten a list of lists into a flat list
 
@@ -51,7 +51,7 @@ def flattenList(originalList: List) -> List:
     return [item for sublist in originalList for item in sublist]
 
 
-def unique(originalList: Iterable, *, key: Optional[Callable] = None) -> List:
+def unique(originalList: t.Iterable, *, key: t.Optional[t.Callable] = None) -> t.List:
     '''
     Return a List of unique items from an iterable, preserving order.
     (unlike casting to a set and back)
@@ -145,7 +145,7 @@ def getPlatform() -> str:
     else:
         return os.name
 
-def macOSVersion() -> Tuple[int, int, int]:  # pragma: no cover
+def macOSVersion() -> t.Tuple[int, int, int]:  # pragma: no cover
     '''
     On a Mac returns the current version as a tuple of (currently 3) ints,
     such as: (10, 5, 6) for 10.5.6.
@@ -165,7 +165,7 @@ def macOSVersion() -> Tuple[int, int, int]:  # pragma: no cover
     return (major, minor, maintenance)
 
 
-def sortModules(moduleList: Iterable[Any]) -> List[object]:
+def sortModules(moduleList: t.Iterable[t.Any]) -> t.List[object]:
     '''
     Sort a list of imported module names such that most recently modified is
     first.  In ties, last access time is used then module name

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -14,7 +14,7 @@ import math
 import numbers
 import random
 import unittest
-from typing import List, no_type_check, Tuple, Union, Sequence, Iterable
+import typing as t
 
 from fractions import Fraction
 from math import isclose
@@ -95,7 +95,7 @@ def cleanupFloat(floatNum, maxDenominator=defaults.limitOffsetDenominator):  # p
 # Number methods...
 
 
-def numToIntOrFloat(value: Union[int, float]) -> Union[int, float]:
+def numToIntOrFloat(value: t.Union[int, float]) -> t.Union[int, float]:
     '''
     Given a number, return an integer if it is very close to an integer,
     otherwise, return a float.
@@ -147,7 +147,7 @@ def numToIntOrFloat(value: Union[int, float]) -> Union[int, float]:
 DENOM_LIMIT = defaults.limitOffsetDenominator
 
 @lru_cache(1024)
-def _preFracLimitDenominator(n: int, d: int) -> Tuple[int, int]:
+def _preFracLimitDenominator(n: int, d: int) -> t.Tuple[int, int]:
     # noinspection PyShadowingNames
     '''
     Used in opFrac
@@ -227,8 +227,8 @@ def _preFracLimitDenominator(n: int, d: int) -> Tuple[int, int]:
 
 
 # no type checking due to accessing protected attributes (for speed)
-@no_type_check
-def opFrac(num: Union[OffsetQLIn, None]) -> Union[OffsetQL, None]:
+@t.no_type_check
+def opFrac(num: t.Union[OffsetQLIn, None]) -> t.Union[OffsetQL, None]:
     '''
     opFrac -> optionally convert a number to a fraction or back.
 
@@ -272,8 +272,8 @@ def opFrac(num: Union[OffsetQLIn, None]) -> Union[OffsetQL, None]:
     # hence redundancy -- first we check for type (no inheritance) and then we
     # repeat exact same test with inheritance.
     # Note that the later examples are more verbose
-    t = type(num)
-    if t is float:
+    numType = type(num)
+    if numType is float:
         # quick test of power of whether denominator is a power
         # of two, and thus representable exactly as a float: can it be
         # represented w/ a denominator less than DENOM_LIMIT?
@@ -288,9 +288,9 @@ def opFrac(num: Union[OffsetQLIn, None]) -> Union[OffsetQL, None]:
             # internally in Fraction constructor, but is twice as fast...
         else:
             return num
-    elif t is int:  # if vs. elif is negligible time difference.
+    elif numType is int:  # if vs. elif is negligible time difference.
         return num + 0.0  # 8x faster than float(num)
-    elif t is Fraction:
+    elif numType is Fraction:
         d = num._denominator  # private access instead of property: 6x faster; may break later...
         if (d & (d - 1)) == 0:  # power of two...
             return num._numerator / (d + 0.0)  # 50% faster than float(num)
@@ -385,7 +385,7 @@ def mixedNumeral(expr: numbers.Real,
     return str(0)
 
 
-def roundToHalfInteger(num: Union[float, int]) -> Union[float, int]:
+def roundToHalfInteger(num: t.Union[float, int]) -> t.Union[float, int]:
     '''
     Given a floating-point number, round to the nearest half-integer. Returns int or float
 
@@ -433,7 +433,7 @@ def roundToHalfInteger(num: Union[float, int]) -> Union[float, int]:
     return intVal + floatVal
 
 
-def addFloatPrecision(x, grain=1e-2) -> Union[float, Fraction]:
+def addFloatPrecision(x, grain=1e-2) -> t.Union[float, Fraction]:
     '''
     Given a value that suggests a floating point fraction, like 0.33,
     return a Fraction or float that provides greater specification, such as Fraction(1, 3)
@@ -493,7 +493,7 @@ def strTrimFloat(floatNum: float, maxNum: int = 4) -> str:
     return off
 
 
-def nearestMultiple(n: float, unit: float) -> Tuple[float, float, float]:
+def nearestMultiple(n: float, unit: float) -> t.Tuple[float, float, float]:
     '''
     Given a positive value `n`, return the nearest multiple of the supplied `unit` as well as
     the absolute difference (error) to seven significant digits and the signed difference.
@@ -591,7 +591,7 @@ def dotMultiplier(dots: int) -> float:
     return ((2 ** (dots + 1.0)) - 1.0) / (2 ** dots)
 
 
-def decimalToTuplet(decNum: float) -> Tuple[int, int]:
+def decimalToTuplet(decNum: float) -> t.Tuple[int, int]:
     '''
     For simple decimals (usually > 1), a quick way to figure out the
     fraction in lowest terms that gives a valid tuplet.
@@ -651,7 +651,7 @@ def decimalToTuplet(decNum: float) -> Tuple[int, int]:
         return (int(iy), int(jy))
 
 
-def unitNormalizeProportion(values: Sequence[int]) -> List[float]:
+def unitNormalizeProportion(values: t.Sequence[int]) -> t.List[float]:
     '''
     Normalize values within the unit interval, where max is determined by the sum of the series.
 
@@ -685,7 +685,7 @@ def unitNormalizeProportion(values: Sequence[int]) -> List[float]:
     return unit
 
 
-def unitBoundaryProportion(series: Sequence[int]) -> List[Tuple[Union[int, float], float]]:
+def unitBoundaryProportion(series: t.Sequence[int]) -> t.List[t.Tuple[t.Union[int, float], float]]:
     '''
     Take a series of parts with an implied sum, and create
     unit-interval boundaries proportional to the series components.
@@ -707,7 +707,7 @@ def unitBoundaryProportion(series: Sequence[int]) -> List[Tuple[Union[int, float
     return bounds
 
 
-def weightedSelection(values: List[int], weights: List[int], randomGenerator=None) -> int:
+def weightedSelection(values: t.List[int], weights: t.List[int], randomGenerator=None) -> int:
     '''
     Given a list of values and an equal-sized list of weights,
     return a randomly selected value using the weight.
@@ -751,7 +751,7 @@ def euclidGCD(a: int, b: int) -> int:
         return euclidGCD(b, a % b)
 
 
-def approximateGCD(values: List[Union[int, float]], grain: float = 1e-4) -> float:
+def approximateGCD(values: t.List[t.Union[int, float]], grain: float = 1e-4) -> float:
     '''Given a list of values, find the lowest common divisor of floating point values.
 
     >>> common.approximateGCD([2.5, 10, 0.25])
@@ -818,7 +818,7 @@ def approximateGCD(values: List[Union[int, float]], grain: float = 1e-4) -> floa
     return max(commonUniqueDivisions)
 
 
-def lcm(filterList: Iterable[int]) -> int:
+def lcm(filterList: t.Iterable[int]) -> int:
     '''
     Find the least common multiple of a list of values
 
@@ -882,7 +882,7 @@ def contiguousList(inputListOrTuple) -> bool:
     return True
 
 
-def groupContiguousIntegers(src: List[int]) -> List[List[int]]:
+def groupContiguousIntegers(src: t.List[int]) -> t.List[t.List[int]]:
     '''
     Given a list of integers, group contiguous values into sub lists
 

--- a/music21/common/objects.py
+++ b/music21/common/objects.py
@@ -20,7 +20,7 @@ __all__ = [
 
 import collections
 import time
-from typing import Tuple
+import typing as t
 import weakref
 
 
@@ -163,9 +163,9 @@ class SlottedObjectMixin:
     >>> s.time = 0.125
     >>> s.frequency = 440.0
     >>> #_DOCS_SHOW out = pickle.dumps(s)
-    >>> #_DOCS_SHOW t = pickle.loads(out)
-    >>> t = s #_DOCS_HIDE -- cannot define classes for pickling in doctests
-    >>> t.time, t.frequency
+    >>> #_DOCS_SHOW pickleLoad = pickle.loads(out)
+    >>> pickleLoad = s #_DOCS_HIDE -- cannot define classes for pickling in doctests
+    >>> pickleLoad.time, pickleLoad.frequency
     (0.125, 440.0)
 
     OMIT_FROM_DOCS
@@ -176,15 +176,15 @@ class SlottedObjectMixin:
     >>> bsc = BadSubclass()
     >>> bsc.amplitude = 2
     >>> #_DOCS_SHOW out = pickle.dumps(bsc)
-    >>> #_DOCS_SHOW t = pickle.loads(out)
-    >>> t = bsc #_DOCS_HIDE -- cannot define classes for pickling in doctests
-    >>> t.amplitude
+    >>> #_DOCS_SHOW outLoad = pickle.loads(out)
+    >>> outLoad = bsc #_DOCS_HIDE -- cannot define classes for pickling in doctests
+    >>> outLoad.amplitude
     2
     '''
 
     # CLASS VARIABLES #
 
-    __slots__: Tuple[str, ...] = ()
+    __slots__: t.Tuple[str, ...] = ()
 
     # SPECIAL METHODS #
 
@@ -270,19 +270,19 @@ class Timer:
     '''
     An object for timing. Call it to get the current time since starting.
 
-    >>> t = common.Timer()
-    >>> now = t()
+    >>> timer = common.Timer()
+    >>> now = timer()
     >>> import time  #_DOCS_HIDE
     >>> time.sleep(0.01)  #_DOCS_HIDE  -- some systems are extremely fast or have wide deltas
-    >>> nowNow = t()
+    >>> nowNow = timer()
     >>> nowNow > now
     True
 
     Call `stop` to stop it. Calling `start` again will reset the number
 
-    >>> t.stop()
-    >>> stopTime = t()
-    >>> stopNow = t()
+    >>> timer.stop()
+    >>> stopTime = timer()
+    >>> stopNow = timer()
     >>> stopTime == stopNow
     True
 
@@ -322,17 +322,17 @@ class Timer:
         '''
         # if stopped, gets _tDif; if not stopped, gets current time
         if self._tStop is None:  # if not stopped yet
-            t = time.time() - self._tStart
+            timeDifference = time.time() - self._tStart
         else:
-            t = self._tDif
-        return t
+            timeDifference = self._tDif
+        return timeDifference
 
     def __str__(self):
         if self._tStop is None:  # if not stopped yet
-            t = time.time() - self._tStart
+            timeDifference = time.time() - self._tStart
         else:
-            t = self._tDif
-        return str(round(t, 3))
+            timeDifference = self._tDif
+        return str(round(timeDifference, 3))
 
 
 if __name__ == '__main__':

--- a/music21/common/pathTools.py
+++ b/music21/common/pathTools.py
@@ -20,6 +20,7 @@ __all__ = [
 ]
 
 import typing as t
+from typing import overload
 import inspect
 import os
 import pathlib
@@ -144,22 +145,22 @@ def relativepath(path: str, start: t.Optional[str] = None) -> str:
     return os.path.relpath(path, start)
 
 
-@t.overload
+@overload
 def cleanpath(path: pathlib.Path, *,
               returnPathlib: t.Literal[None] = None) -> pathlib.Path:
     return pathlib.Path('/')  # dummy until Astroid #1015 is fixed.
 
-@t.overload
+@overload
 def cleanpath(path: str, *,
               returnPathlib: t.Literal[None] = None) -> str:
     return '/'  # dummy until Astroid #1015 is fixed.
 
-@t.overload
+@overload
 def cleanpath(path: t.Union[str, pathlib.Path], *,
               returnPathlib: t.Literal[True]) -> pathlib.Path:
     return pathlib.Path('/')  # dummy until Astroid #1015 is fixed.
 
-@t.overload
+@overload
 def cleanpath(path: t.Union[str, pathlib.Path], *,
               returnPathlib: t.Literal[False]) -> str:
     return '/'  # dummy until Astroid #1015 is fixed.

--- a/music21/common/pathTools.py
+++ b/music21/common/pathTools.py
@@ -19,7 +19,7 @@ __all__ = [
     'cleanpath',
 ]
 
-from typing import List, Union, Optional, overload, Literal
+import typing as t
 import inspect
 import os
 import pathlib
@@ -69,7 +69,7 @@ def getCorpusFilePath() -> pathlib.Path:
     return pathlib.Path(coreCorpus.manualCoreCorpusPath)
 
 
-def getCorpusContentDirs() -> List[str]:
+def getCorpusContentDirs() -> t.List[str]:
     '''
     Get all dirs that are found in the CoreCorpus that contain content;
     that is, exclude dirs that have code or other resources.
@@ -130,7 +130,7 @@ def getRootFilePath() -> pathlib.Path:
     return fpParent
 
 
-def relativepath(path: str, start: Optional[str] = None) -> str:
+def relativepath(path: str, start: t.Optional[str] = None) -> str:
     '''
     A cross-platform wrapper for `os.path.relpath()`, which returns `path` if
     under Windows, otherwise returns the relative path of `path`.
@@ -144,28 +144,28 @@ def relativepath(path: str, start: Optional[str] = None) -> str:
     return os.path.relpath(path, start)
 
 
-@overload
+@t.overload
 def cleanpath(path: pathlib.Path, *,
-              returnPathlib: Literal[None] = None) -> pathlib.Path:
+              returnPathlib: t.Literal[None] = None) -> pathlib.Path:
     return pathlib.Path('/')  # dummy until Astroid #1015 is fixed.
 
-@overload
+@t.overload
 def cleanpath(path: str, *,
-              returnPathlib: Literal[None] = None) -> str:
+              returnPathlib: t.Literal[None] = None) -> str:
     return '/'  # dummy until Astroid #1015 is fixed.
 
-@overload
-def cleanpath(path: Union[str, pathlib.Path], *,
-              returnPathlib: Literal[True]) -> pathlib.Path:
+@t.overload
+def cleanpath(path: t.Union[str, pathlib.Path], *,
+              returnPathlib: t.Literal[True]) -> pathlib.Path:
     return pathlib.Path('/')  # dummy until Astroid #1015 is fixed.
 
-@overload
-def cleanpath(path: Union[str, pathlib.Path], *,
-              returnPathlib: Literal[False]) -> str:
+@t.overload
+def cleanpath(path: t.Union[str, pathlib.Path], *,
+              returnPathlib: t.Literal[False]) -> str:
     return '/'  # dummy until Astroid #1015 is fixed.
 
-def cleanpath(path: Union[str, pathlib.Path], *,
-              returnPathlib: Union[bool, None] = None) -> Union[str, pathlib.Path]:
+def cleanpath(path: t.Union[str, pathlib.Path], *,
+              returnPathlib: t.Union[bool, None] = None) -> t.Union[str, pathlib.Path]:
     '''
     Normalizes the path by expanding ~user on Unix, ${var} environmental vars
     (is this a good idea?), expanding %name% on Windows, normalizing path names

--- a/music21/common/stringTools.py
+++ b/music21/common/stringTools.py
@@ -32,7 +32,7 @@ import time
 import string
 import unicodedata
 
-from typing import List, Tuple
+import typing as t
 
 # ------------------------------------------------------------------------------
 WHITESPACE = re.compile(r'\s+')
@@ -62,7 +62,7 @@ def whitespaceEqual(a: str, b: str) -> bool:
         return False
 
 
-def getNumFromStr(usrStr: str, numbers: str = '0123456789') -> Tuple[str, str]:
+def getNumFromStr(usrStr: str, numbers: str = '0123456789') -> t.Tuple[str, str]:
     '''
     Given a string, extract any numbers.
     Return two strings, the numbers (as strings) and the remaining characters.
@@ -195,7 +195,7 @@ def spaceCamelCase(usrStr: str, replaceUnderscore=True, fixMeList=None) -> str:
     firstChar = False
     isNumber = False
     lastIsNum = False
-    post: List[str] = []
+    post: t.List[str] = []
 
     # do not split these...
     if fixMeList is None:

--- a/music21/common/types.py
+++ b/music21/common/types.py
@@ -9,23 +9,22 @@
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 from fractions import Fraction
-from typing import (Union, TypeVar, TYPE_CHECKING, Iterable, Type, Literal, Callable,
-                    List)
+import typing as t
 
 from music21.common.enums import OffsetSpecial
 
-if TYPE_CHECKING:
-    import music21
+if t.TYPE_CHECKING:
+    import music21  # pylint: disable=unused-import
 
-DocOrder = List[Union[str, Callable]]
-OffsetQL = Union[float, Fraction]
-OffsetQLSpecial = Union[float, Fraction, OffsetSpecial]
-OffsetQLIn = Union[int, float, Fraction]
+DocOrder = t.List[t.Union[str, t.Callable]]
+OffsetQL = t.Union[float, Fraction]
+OffsetQLSpecial = t.Union[float, Fraction, OffsetSpecial]
+OffsetQLIn = t.Union[int, float, Fraction]
 
-StreamType = TypeVar('StreamType', bound='music21.stream.Stream')
-StreamType2 = TypeVar('StreamType2', bound='music21.stream.Stream')
-M21ObjType = TypeVar('M21ObjType', bound='music21.base.Music21Object')
-M21ObjType2 = TypeVar('M21ObjType2', bound='music21.base.Music21Object')  # when you need another
+StreamType = t.TypeVar('StreamType', bound='music21.stream.Stream')
+StreamType2 = t.TypeVar('StreamType2', bound='music21.stream.Stream')
+M21ObjType = t.TypeVar('M21ObjType', bound='music21.base.Music21Object')
+M21ObjType2 = t.TypeVar('M21ObjType2', bound='music21.base.Music21Object')  # when you need another
 
-ClassListType = Union[str, Iterable[str], Type[M21ObjType], Iterable[Type[M21ObjType]]]
-StepName = Literal['C', 'D', 'E', 'F', 'G', 'A', 'B']
+ClassListType = t.Union[str, t.Iterable[str], t.Type[M21ObjType], t.Iterable[t.Type[M21ObjType]]]
+StepName = t.Literal['C', 'D', 'E', 'F', 'G', 'A', 'B']

--- a/music21/configure.py
+++ b/music21/configure.py
@@ -1762,7 +1762,7 @@ if __name__ == '__main__':
 
     else:
         # only if running tests
-        t = Test()
+        testInstance = Test()
         te = TestUserInput()
 
         if len(sys.argv) < 2 or sys.argv[1] in ['all', 'test']:
@@ -1774,5 +1774,5 @@ if __name__ == '__main__':
             # run test user input
             getattr(te, sys.argv[2])()
         # just run named Test
-        elif hasattr(t, sys.argv[1]):
-            getattr(t, sys.argv[1])()
+        elif hasattr(testInstance, sys.argv[1]):
+            getattr(testInstance, sys.argv[1])()

--- a/music21/configure.py
+++ b/music21/configure.py
@@ -18,7 +18,7 @@ import unittest
 import textwrap
 import webbrowser
 
-from typing import List
+import typing as t
 
 from importlib import reload  # Python 3.4
 
@@ -1194,7 +1194,7 @@ class SelectFilePath(SelectFromList):
     def __init__(self, default=None, tryAgain=True, promptHeader=None):
         super().__init__(default=default, tryAgain=tryAgain, promptHeader=promptHeader)
 
-    def _getAppOSIndependent(self, comparisonFunction, path0: str, post: List[str],
+    def _getAppOSIndependent(self, comparisonFunction, path0: str, post: t.List[str],
                              *,
                              glob: str = '**/*'):
         '''
@@ -1212,23 +1212,23 @@ class SelectFilePath(SelectFromList):
             if comparisonFunction(str(path1)):
                 post.append(str(path1))
 
-    def _getDarwinApp(self, comparisonFunction) -> List[str]:
+    def _getDarwinApp(self, comparisonFunction) -> t.List[str]:
         '''
         Provide a comparison function that returns True or False based on the file name.
         This looks at everything in Applications, as well as every directory in Applications
         '''
-        post: List[str] = []
+        post: t.List[str] = []
         for path0 in ('/Applications', common.cleanpath('~/Applications', returnPathlib=False)):
             assert isinstance(path0, str)
             self._getAppOSIndependent(comparisonFunction, path0, post, glob='*')
         return post
 
-    def _getWinApp(self, comparisonFunction) -> List[str]:
+    def _getWinApp(self, comparisonFunction) -> t.List[str]:
         '''
         Provide a comparison function that returns True or False based on the file name.
         '''
         # provide a similar method to _getDarwinApp
-        post: List[str] = []
+        post: t.List[str] = []
         environKeys = ('ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432')
         for possibleEnvironKey in environKeys:
             if possibleEnvironKey not in os.environ:
@@ -1594,7 +1594,7 @@ class ConfigurationAssistant:
 #         print('got: %s' % post)
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 
 class TestUserInput(unittest.TestCase):  # pragma: no cover

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -48,7 +48,7 @@ import urllib
 import zipfile
 
 from math import isclose
-from typing import Union, Tuple, List, Optional, Literal, Type
+import typing as t
 
 __all__ = [
     'subConverters', 'ArchiveManagerException', 'PickleFilterException',
@@ -144,7 +144,7 @@ class ArchiveManager:
             raise ArchiveManagerException(f'no support for archiveType: {self.archiveType}')
         return False
 
-    def getNames(self) -> List[str]:
+    def getNames(self) -> t.List[str]:
         '''
         Return a list of all names contained in this archive.
         '''
@@ -308,7 +308,7 @@ class PickleFilter:
         if pickleFp.exists():
             os.remove(pickleFp)
 
-    def status(self) -> Tuple[pathlib.Path, bool, pathlib.Path]:
+    def status(self) -> t.Tuple[pathlib.Path, bool, pathlib.Path]:
         '''
         Given a file path specified with __init__, look for an up to date pickled
         version of this file path. If it exists, return its fp, otherwise return the
@@ -463,7 +463,7 @@ class Converter:
     def __init__(self):
         self.subConverter = None
         # a stream object unthawed
-        self._thawedStream: Union[stream.Score, stream.Part, stream.Opus, None] = None
+        self._thawedStream: t.Union[stream.Score, stream.Part, stream.Opus, None] = None
 
     def _getDownloadFp(self, directory, ext, url):
         if directory is None:
@@ -712,8 +712,8 @@ class Converter:
     # Subconverters
     def subconvertersList(
         self,
-        converterType: Literal['any', 'input', 'output'] = 'any'
-    ) -> List[Type[subConverters.SubConverter]]:
+        converterType: t.Literal['any', 'input', 'output'] = 'any'
+    ) -> t.List[t.Type[subConverters.SubConverter]]:
         '''
         Gives a list of all the subconverter classes that are registered.
 
@@ -796,7 +796,7 @@ class Converter:
 
         return filteredSubConvertersList
 
-    def defaultSubconverters(self) -> List[Type[subConverters.SubConverter]]:
+    def defaultSubconverters(self) -> t.List[t.Type[subConverters.SubConverter]]:
         '''
         return an alphabetical list of the default subconverters: those in converter.subConverters
         with the class Subconverter.
@@ -828,7 +828,7 @@ class Converter:
         <class 'music21.converter.subConverters.ConverterVolpiano'>
         <class 'music21.converter.subConverters.SubConverter'>
         '''
-        defaultSubconverters: List[Type[subConverters.SubConverter]] = []
+        defaultSubconverters: t.List[t.Type[subConverters.SubConverter]] = []
         for i in sorted(subConverters.__dict__):
             possibleSubConverter = getattr(subConverters, i)
             # noinspection PyTypeChecker
@@ -901,7 +901,7 @@ class Converter:
         subConverterClass = scf[converterFormat]
         self.subConverter = subConverterClass()
 
-    def formatFromHeader(self, dataStr: str) -> Tuple[str, str]:
+    def formatFromHeader(self, dataStr: str) -> t.Tuple[str, str]:
         '''
         if dataStr begins with a text header such as  "tinyNotation:" then
         return that format plus the dataStr with the head removed.
@@ -945,7 +945,7 @@ class Converter:
                     break
         return (foundFormat, dataStr)
 
-    def regularizeFormat(self, fmt: str) -> Optional[str]:
+    def regularizeFormat(self, fmt: str) -> t.Optional[str]:
         '''
         Take in a string representing a format, a file extension (w/ or without leading dot)
         etc. and find the format string that best represents the format that should be used.
@@ -1017,7 +1017,7 @@ class Converter:
     # --------------------------------------------------------------------------
     # properties
     @property
-    def stream(self) -> Union[stream.Score, stream.Part, stream.Opus, None]:
+    def stream(self) -> t.Union[stream.Score, stream.Part, stream.Opus, None]:
         '''
         Returns the .subConverter.stream object.
         '''
@@ -1040,7 +1040,7 @@ def parseFile(fp,
               number=None,
               format=None,
               forceSource=False,
-              **keywords) -> Union[stream.Score, stream.Part, stream.Opus]:
+              **keywords) -> t.Union[stream.Score, stream.Part, stream.Opus]:
     '''
     Given a file path, attempt to parse the file into a Stream.
     '''
@@ -1054,7 +1054,7 @@ def parseFile(fp,
 def parseData(dataStr,
               number=None,
               format=None,
-              **keywords) -> Union[stream.Score, stream.Part, stream.Opus]:
+              **keywords) -> t.Union[stream.Score, stream.Part, stream.Opus]:
     '''
     Given musical data represented within a Python string, attempt to parse the
     data into a Stream.
@@ -1070,7 +1070,7 @@ def parseURL(url,
              format=None,
              number=None,
              forceSource=False,
-             **keywords) -> Union[stream.Score, stream.Part, stream.Opus]:
+             **keywords) -> t.Union[stream.Score, stream.Part, stream.Opus]:
     '''
     Given a URL, attempt to download and parse the file into a Stream. Note:
     URL downloading will not happen automatically unless the user has set their
@@ -1083,9 +1083,9 @@ def parseURL(url,
     return v.stream
 
 
-def parse(value: Union[bundles.MetadataEntry, bytes, str, pathlib.Path],
+def parse(value: t.Union[bundles.MetadataEntry, bytes, str, pathlib.Path],
           *args,
-          **keywords) -> Union[stream.Score, stream.Part, stream.Opus]:
+          **keywords) -> t.Union[stream.Score, stream.Part, stream.Opus]:
     r'''
     Given a file path, encoded data in a Python string, or a URL, attempt to
     parse the item into a Stream.  Note: URL downloading will not happen

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -26,7 +26,7 @@ import pathlib
 import subprocess
 import unittest
 
-from typing import Union, Optional, Tuple, Dict
+import typing as t
 
 from music21 import common
 from music21 import defaults
@@ -72,18 +72,18 @@ class SubConverter:
     '''
     readBinary = False
     canBePickled = True
-    registerFormats: Tuple[str, ...] = ()
-    registerShowFormats: Tuple[str, ...] = ()
-    registerInputExtensions: Tuple[str, ...] = ()  # if converter supports input
-    registerOutputExtensions: Tuple[str, ...] = ()  # if converter supports output
-    registerOutputSubformatExtensions: Dict[str, str] = {}
+    registerFormats: t.Tuple[str, ...] = ()
+    registerShowFormats: t.Tuple[str, ...] = ()
+    registerInputExtensions: t.Tuple[str, ...] = ()  # if converter supports input
+    registerOutputExtensions: t.Tuple[str, ...] = ()  # if converter supports output
+    registerOutputSubformatExtensions: t.Dict[str, str] = {}
     launchKey = None
 
     codecWrite = False
     stringEncoding = 'utf-8'
 
     def __init__(self, **keywords):
-        self._stream: Union[stream.Score, stream.Part, stream.Opus] = stream.Score()
+        self._stream: t.Union[stream.Score, stream.Part, stream.Opus] = stream.Score()
         self.keywords = keywords
 
     def parseData(self, dataString, number=None):
@@ -856,7 +856,7 @@ class ConverterMusicXML(SubConverter):
                                          }
 
     @staticmethod
-    def findNumberedPNGPath(inputFp: Union[str, pathlib.Path]) -> pathlib.Path:
+    def findNumberedPNGPath(inputFp: t.Union[str, pathlib.Path]) -> pathlib.Path:
         '''
         Find the first numbered file path corresponding to the provided unnumbered file path
         ending in ".png". Raises an exception if no file can be found.
@@ -890,7 +890,7 @@ class ConverterMusicXML(SubConverter):
         c.parseXMLText()
         self.stream = c.stream
 
-    def parseFile(self, fp: Union[str, pathlib.Path], number=None):
+    def parseFile(self, fp: t.Union[str, pathlib.Path], number=None):
         '''
         Open from a file path; check to see if there is a pickled
         version available and up to date; if so, open that, otherwise
@@ -1038,7 +1038,7 @@ class ConverterMusicXML(SubConverter):
               fp=None,
               subformats=None,
               makeNotation=True,
-              compress: Optional[bool] = None,
+              compress: t.Optional[bool] = None,
               **keywords):
         '''
         Write to a .musicxml file.
@@ -1419,7 +1419,7 @@ class ConverterMEI(SubConverter):
 
     def parseFile(
         self,
-        filePath: Union[str, pathlib.Path],
+        filePath: t.Union[str, pathlib.Path],
         number=None
     ) -> 'music21.stream.Stream':
         '''

--- a/music21/corpus/corpora.py
+++ b/music21/corpus/corpora.py
@@ -12,7 +12,7 @@
 
 import abc
 import pathlib
-from typing import Dict, List, Sequence, Tuple, Union, cast
+import typing as t
 
 from music21 import common
 # from music21.corpus import virtual
@@ -43,9 +43,9 @@ class Corpus(prebase.ProtoM21Object):
     _allExtensions = tuple(common.flattenList([common.findInputExtension(x)
                                                for x in _acceptableExtensions]))
 
-    _pathsCache: Dict[Tuple[str, Tuple[str]], pathlib.Path] = {}
+    _pathsCache: t.Dict[t.Tuple[str, t.Tuple[str]], pathlib.Path] = {}
 
-    _directoryInformation: Union[Tuple[()], Sequence[Tuple[str, str, bool]]] = ()
+    _directoryInformation: t.Union[t.Tuple[()], t.Sequence[t.Tuple[str, str, bool]]] = ()
 
     parseUsingCorpus = True
 
@@ -67,7 +67,7 @@ class Corpus(prebase.ProtoM21Object):
     def _findPaths(
         self,
         rootDirectoryPath: pathlib.Path,
-        fileExtensions: List[str]
+        fileExtensions: t.List[str]
     ):
         '''
         Given a root filePath file path, recursively search all contained paths
@@ -81,7 +81,7 @@ class Corpus(prebase.ProtoM21Object):
 
         Generally cached.
         '''
-        rdp = cast(pathlib.Path, common.cleanpath(rootDirectoryPath, returnPathlib=True))
+        rdp = t.cast(pathlib.Path, common.cleanpath(rootDirectoryPath, returnPathlib=True))
         matched = []
 
         for filename in sorted(rdp.rglob('*')):
@@ -688,7 +688,7 @@ class LocalCorpus(Corpus):
 
     # CLASS VARIABLES #
 
-    _temporaryLocalPaths: Dict[str, set] = {}
+    _temporaryLocalPaths: t.Dict[str, set] = {}
 
     parseUsingCorpus = False
     # INITIALIZER #

--- a/music21/corpus/virtual.py
+++ b/music21/corpus/virtual.py
@@ -20,7 +20,7 @@ TURNED OFF in 2017 -- to be recreated with a bigger test set.
 TODO: Demonstrate with JRP.
 '''
 
-from typing import List
+import typing as t
 import unittest
 
 from music21 import common
@@ -208,7 +208,7 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 if __name__ == '__main__':
     import music21

--- a/music21/defaults.py
+++ b/music21/defaults.py
@@ -13,11 +13,11 @@
 Simple storage for data defaults used throughout music21.
 '''
 import unittest
-from typing import Literal
+import typing as t
 from music21 import _version
 
 # note: this module should not import any higher level modules
-StepName = Literal['C', 'D', 'E', 'F', 'G', 'A', 'B']  # restating so as not to import.
+StepName = t.Literal['C', 'D', 'E', 'F', 'G', 'A', 'B']  # restating so as not to import.
 
 _MOD = 'defaults'
 

--- a/music21/derivation.py
+++ b/music21/derivation.py
@@ -17,7 +17,7 @@ This module defines objects for tracking the derivation of one
 :class:`~music21.stream.Stream` from another.
 '''
 import functools
-from typing import Generator, Optional
+import typing as t
 import unittest
 
 from music21 import common
@@ -145,11 +145,11 @@ class Derivation(SlottedObjectMixin):
     def __init__(self, client=None):
         # store a reference to the Music21Object that has this Derivation object as a property
         self._client = None
-        self._clientId: Optional[int] = None  # store python-id to optimize w/o unwrapping
-        self._method: Optional[str] = None
+        self._clientId: t.Optional[int] = None  # store python-id to optimize w/o unwrapping
+        self._method: t.Optional[str] = None
         # origin should be stored as a weak ref -- the place where the client was derived from.
         self._origin = None
-        self._originId: Optional[int] = None  # store id to optimize w/o unwrapping
+        self._originId: t.Optional[int] = None  # store id to optimize w/o unwrapping
 
         # set client; can handle None
         self.client = client
@@ -188,7 +188,7 @@ class Derivation(SlottedObjectMixin):
     # PUBLIC PROPERTIES #
 
     @property
-    def client(self) -> Optional['music21.base.Music21Object']:
+    def client(self) -> t.Optional['music21.base.Music21Object']:
         c = common.unwrapWeakref(self._client)
         if c is None and self._clientId is not None:
             self._clientId = None
@@ -198,7 +198,7 @@ class Derivation(SlottedObjectMixin):
         return c
 
     @client.setter
-    def client(self, client: Optional['music21.base.Music21Object']):
+    def client(self, client: t.Optional['music21.base.Music21Object']):
         # client is the Stream that this derivation lives on
         if client is None:
             self._clientId = None
@@ -207,7 +207,7 @@ class Derivation(SlottedObjectMixin):
             self._clientId = id(client)
             self._client = common.wrapWeakref(client)
 
-    def chain(self) -> Generator['music21.base.Music21Object', None, None]:
+    def chain(self) -> t.Generator['music21.base.Music21Object', None, None]:
         '''
         Iterator/Generator
 
@@ -239,7 +239,7 @@ class Derivation(SlottedObjectMixin):
             origin = origin.derivation.origin
 
     @property
-    def method(self) -> Optional[str]:
+    def method(self) -> t.Optional[str]:
         '''
         Returns or sets the string of the method that was used to generate this
         Stream.
@@ -279,15 +279,15 @@ class Derivation(SlottedObjectMixin):
         return self._method
 
     @method.setter
-    def method(self, method: Optional[str]):
+    def method(self, method: t.Optional[str]):
         self._method = method
 
     @property
-    def origin(self) -> Optional['music21.base.Music21Object']:
+    def origin(self) -> t.Optional['music21.base.Music21Object']:
         return self._origin
 
     @origin.setter
-    def origin(self, origin: Optional['music21.base.Music21Object']):
+    def origin(self, origin: t.Optional['music21.base.Music21Object']):
         # for now, origin is not a weak ref
         if origin is None:
             self._originId = None
@@ -298,7 +298,7 @@ class Derivation(SlottedObjectMixin):
             # self._origin = common.wrapWeakref(origin)
 
     @property
-    def rootDerivation(self) -> Optional['music21.base.Music21Object']:
+    def rootDerivation(self) -> t.Optional['music21.base.Music21Object']:
         r'''
         Return a reference to the oldest source of this Stream; that is, chain
         calls to :attr:`~music21.stream.Stream.derivesFrom` until we get to a

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -53,8 +53,7 @@ import fractions
 from functools import lru_cache
 import io
 from math import inf, isnan
-from typing import (Union, Tuple, Dict, List, Optional,
-                    Iterable, Literal, Type, Callable)
+import typing as t
 import unittest
 
 
@@ -88,7 +87,7 @@ class TupletException(exceptions21.Music21Exception):
 
 
 # N.B.: MusicXML uses long instead of longa
-typeToDuration: Dict[str, float] = {
+typeToDuration: t.Dict[str, float] = {
     'duplex-maxima': 64.0,
     'maxima': 32.0,
     'longa': 16.0,
@@ -108,7 +107,7 @@ typeToDuration: Dict[str, float] = {
     'zero': 0.0,
 }
 
-typeFromNumDict: Dict[float, str] = {
+typeFromNumDict: t.Dict[float, str] = {
     1.0: 'whole',
     2.0: 'half',
     4.0: 'quarter',
@@ -127,9 +126,9 @@ typeFromNumDict: Dict[float, str] = {
     0.125: 'maxima',
     0.0625: 'duplex-maxima',
 }
-typeFromNumDictKeys: List[float] = sorted(list(typeFromNumDict.keys()))
+typeFromNumDictKeys: t.List[float] = sorted(list(typeFromNumDict.keys()))
 
-ordinalTypeFromNum: List[str] = [
+ordinalTypeFromNum: t.List[str] = [
     'duplex-maxima',
     'maxima',
     'longa',
@@ -149,9 +148,9 @@ ordinalTypeFromNum: List[str] = [
 ]
 
 
-defaultTupletNumerators: Tuple[int, ...] = (3, 5, 7, 11, 13)
+defaultTupletNumerators: t.Tuple[int, ...] = (3, 5, 7, 11, 13)
 
-extendedTupletNumerators: Tuple[int, ...] = (
+extendedTupletNumerators: t.Tuple[int, ...] = (
     3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67,
     71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139,
     149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199,
@@ -339,7 +338,7 @@ def convertQuarterLengthToType(qLen: OffsetQLIn) -> str:
 
 def dottedMatch(qLen: OffsetQLIn,
                 maxDots=4
-                ) -> Union[Tuple[int, str], Tuple[Literal[False], Literal[False]]]:
+                ) -> t.Union[t.Tuple[int, str], t.Tuple[t.Literal[False], t.Literal[False]]]:
     '''
     Given a quarterLength, determine if there is a dotted
     (or non-dotted) type that exactly matches. Returns a pair of
@@ -382,7 +381,7 @@ def dottedMatch(qLen: OffsetQLIn,
 
 def quarterLengthToNonPowerOf2Tuplet(
     qLen: OffsetQLIn
-) -> Tuple['music21.duration.Tuplet', 'music21.duration.DurationTuple']:
+) -> t.Tuple['music21.duration.Tuplet', 'music21.duration.DurationTuple']:
     '''
     Slow, last chance function that returns a tuple of a single tuplet, probably with a non
     power of 2 denominator (such as 7:6) that represents the quarterLength and the
@@ -432,7 +431,7 @@ def quarterLengthToTuplet(
     qLen: OffsetQLIn,
     maxToReturn=4,
     tupletNumerators=defaultTupletNumerators
-) -> List['music21.duration.Tuplet']:
+) -> t.List['music21.duration.Tuplet']:
     '''
     Returns a list of possible Tuplet objects for a
     given `qLen` (quarterLength). As there may be more than one
@@ -547,10 +546,10 @@ def quarterConversion(qLen: OffsetQLIn) -> QuarterLengthConversion:
     >>> duration.quarterConversion(2/3)
     QuarterLengthConversion(components=(DurationTuple(type='quarter', dots=0, quarterLength=1.0),),
         tuplet=<music21.duration.Tuplet 3/2/quarter>)
-    >>> t = duration.quarterConversion(2/3).tuplet
-    >>> t
+    >>> tup = duration.quarterConversion(2/3).tuplet
+    >>> tup
     <music21.duration.Tuplet 3/2/quarter>
-    >>> t.durationActual
+    >>> tup.durationActual
     DurationTuple(type='quarter', dots=0, quarterLength=1.0)
 
 
@@ -718,7 +717,7 @@ def quarterConversion(qLen: OffsetQLIn) -> QuarterLengthConversion:
 def convertTypeToQuarterLength(
     dType: str,
     dots=0,
-    tuplets: Optional[List['music21.duration.Tuplet']] = None,
+    tuplets: t.Optional[t.List['music21.duration.Tuplet']] = None,
     dotGroups=None
 ) -> OffsetQL:
     # noinspection PyShadowingNames
@@ -848,8 +847,8 @@ class DurationTuple(namedtuple('DurationTuple', ['type', 'dots', 'quarterLength'
         return ordinalFound
 
 
-_durationTupleCacheTypeDots: Dict[Tuple[str, int], DurationTuple] = {}
-_durationTupleCacheQuarterLength: Dict[OffsetQL, DurationTuple] = {}
+_durationTupleCacheTypeDots: t.Dict[t.Tuple[str, int], DurationTuple] = {}
+_durationTupleCacheQuarterLength: t.Dict[OffsetQL, DurationTuple] = {}
 
 
 def durationTupleFromQuarterLength(ql=1.0) -> DurationTuple:
@@ -1161,7 +1160,7 @@ class Tuplet(prebase.ProtoM21Object):
                 'A frozen tuplet (or one attached to a duration) has immutable length.')
 
     # PUBLIC METHODS #
-    def augmentOrDiminish(self, amountToScale: Union[int, float]):
+    def augmentOrDiminish(self, amountToScale: t.Union[int, float]):
         '''
         Given a number greater than zero,
         multiplies the current quarterLength of the
@@ -1219,7 +1218,7 @@ class Tuplet(prebase.ProtoM21Object):
 
     def setDurationType(
         self,
-        durType: Union[str, int, float, fractions.Fraction],
+        durType: t.Union[str, int, float, fractions.Fraction],
         dots=0
     ):
         '''
@@ -1385,7 +1384,7 @@ class Tuplet(prebase.ProtoM21Object):
         return self._durationActual
 
     @durationActual.setter
-    def durationActual(self, dA: Union[DurationTuple, 'Duration']):
+    def durationActual(self, dA: t.Union[DurationTuple, 'Duration']):
         self._checkFrozen()
 
         if isinstance(dA, DurationTuple):
@@ -1439,18 +1438,17 @@ class Tuplet(prebase.ProtoM21Object):
         Return the most complete representation of this tuplet in a readable
         form.
 
-        >>> t = duration.Tuplet(numberNotesActual=5, numberNotesNormal=2)
-        >>> t.fullName
+        >>> tup = duration.Tuplet(numberNotesActual=5, numberNotesNormal=2)
+        >>> tup.fullName
         'Quintuplet'
 
-        >>> t = duration.Tuplet(numberNotesActual=3, numberNotesNormal=2)
-        >>> t.fullName
+        >>> tup = duration.Tuplet(numberNotesActual=3, numberNotesNormal=2)
+        >>> tup.fullName
         'Triplet'
 
-        >>> t = duration.Tuplet(numberNotesActual=17, numberNotesNormal=14)
-        >>> t.fullName
+        >>> tup = duration.Tuplet(numberNotesActual=17, numberNotesNormal=14)
+        >>> tup.fullName
         'Tuplet of 17/14ths'
-
         '''
         # actual is what is presented to viewer
         numActual = self.numberNotesActual
@@ -1589,13 +1587,13 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         self._quarterLengthNeedsUpdating = False
         self._typeNeedsUpdating = False
 
-        self._unlinkedType: Optional[str] = None
-        self._dotGroups: Tuple[int, ...] = (0,)
-        self._tuplets: Union[Tuple['Tuplet', ...], Tuple] = ()  # an empty tuple
+        self._unlinkedType: t.Optional[str] = None
+        self._dotGroups: t.Tuple[int, ...] = (0,)
+        self._tuplets: t.Union[t.Tuple['Tuplet', ...], t.Tuple] = ()  # an empty tuple
         self._qtrLength: OffsetQL = 0.0
 
         # DurationTuples go here
-        self._components: List[DurationTuple] = []
+        self._components: t.List[DurationTuple] = []
 
         # defer updating until necessary
         self._quarterLengthNeedsUpdating = False
@@ -1799,7 +1797,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
     linked = property(_getLinked, _setLinked)
 
-    def addDurationTuple(self, dur: Union[DurationTuple, 'Duration']):
+    def addDurationTuple(self, dur: t.Union[DurationTuple, 'Duration']):
         '''
         Add a DurationTuple or a Duration's components to this Duration.
         Does not simplify the Duration.  For instance, adding two
@@ -1838,16 +1836,16 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         Adds a new Tuplet to a Duration, sets the Tuplet's .frozen state to True,
         and then informs the client (Note) that the duration has changed.
 
-        >>> t = duration.Tuplet(3, 2)
+        >>> tup = duration.Tuplet(3, 2)
         >>> d = duration.Duration(1.0)
-        >>> d.appendTuplet(t)
+        >>> d.appendTuplet(tup)
         >>> d.quarterLength
         Fraction(2, 3)
         >>> t2 = duration.Tuplet(5, 4)
         >>> d.appendTuplet(t2)
         >>> d.quarterLength
         Fraction(8, 15)
-        >>> t.frozen
+        >>> tup.frozen
         True
         '''
         newTuplet.frozen = True
@@ -2178,7 +2176,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
     def getGraceDuration(
         self,
         appoggiatura=False
-    ) -> Union['GraceDuration', 'AppoggiaturaDuration']:
+    ) -> t.Union['GraceDuration', 'AppoggiaturaDuration']:
         # noinspection PyShadowingNames
         '''
         Return a deepcopy of this Duration as a GraceDuration instance with the same types.
@@ -2385,7 +2383,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
         Does NOT handle tuplets etc.
         '''
-        t = self.type
+        tupleType = self.type
         dg = self.dotGroups
         if not inPlace:
             d = copy.deepcopy(self)
@@ -2394,7 +2392,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
         d.clear()
 
-        d.addDurationTuple(durationTupleFromTypeDots(t, dg[0]))
+        d.addDurationTuple(durationTupleFromTypeDots(tupleType, dg[0]))
         for i in range(1, len(dg)):
             for existingComponent in list(d.components):
                 d.addDurationTuple(
@@ -2427,7 +2425,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
     # PUBLIC PROPERTIES #
     @property
-    def components(self) -> Tuple[DurationTuple, ...]:
+    def components(self) -> t.Tuple[DurationTuple, ...]:
         '''
         Returns or sets a tuple of the component DurationTuples of this
         Duration object
@@ -2475,7 +2473,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         return tuple(self._components)
 
     @components.setter
-    def components(self, value: Iterable[DurationTuple]):
+    def components(self, value: t.Iterable[DurationTuple]):
         # previously, self._componentsNeedUpdating was not set here
         # this needs to be set because if _componentsNeedUpdating is True
         # new components will be derived from quarterLength
@@ -2489,7 +2487,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             # must be cleared
 
     @property
-    def dotGroups(self) -> Tuple[int, ...]:
+    def dotGroups(self) -> t.Tuple[int, ...]:
         '''
         Dot groups are medieval dotted-dotted notes (written one above another).
         For instance a half note with dotGroups = (1, 1) represents a dotted half note that
@@ -2516,7 +2514,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             return self._dotGroups
 
     @dotGroups.setter
-    def dotGroups(self, value: Tuple[int, ...]):
+    def dotGroups(self, value: t.Tuple[int, ...]):
         if not isinstance(value, tuple):
             raise TypeError('only tuple dotGroups values can be used with this method.')
         # removes dots from all components...
@@ -2757,7 +2755,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             return False
 
     @property
-    def ordinal(self) -> Union[int, str, None]:
+    def ordinal(self) -> t.Union[int, str, None]:
         '''
         Get the ordinal value of the Duration, where whole is 4,
         half is 5, etc.
@@ -2879,7 +2877,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         ''')
 
     @property
-    def tuplets(self) -> Tuple[Tuplet, ...]:
+    def tuplets(self) -> t.Tuple[Tuplet, ...]:
         '''
         Return a tuple of Tuplet objects.
         Setting tuplets will inform the client (Note) that the duration has changed.
@@ -2889,7 +2887,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         return self._tuplets
 
     @tuplets.setter
-    def tuplets(self, tupletTuple: Iterable[Tuplet]):
+    def tuplets(self, tupletTuple: t.Iterable[Tuplet]):
         # environLocal.printDebug(['assigning tuplets in Duration', tupletTuple])
         self._tuplets = tuple(tupletTuple)
         self._quarterLengthNeedsUpdating = True
@@ -3057,8 +3055,8 @@ class GraceDuration(Duration):
         self._slash = None
         self.slash = True  # can be True, False, or None; make None go to True?
         # values are unit interval percentages
-        self.stealTimePrevious: Union[float, None] = None
-        self.stealTimeFollowing: Union[float, None] = None
+        self.stealTimePrevious: t.Union[float, None] = None
+        self.stealTimeFollowing: t.Union[float, None] = None
 
 
     # PUBLIC PROPERTIES #
@@ -3073,7 +3071,7 @@ class GraceDuration(Duration):
         return self._makeTime
 
     @makeTime.setter
-    def makeTime(self, expr: Literal[True, False, None]):
+    def makeTime(self, expr: t.Literal[True, False, None]):
         if expr not in (True, False, None):
             raise ValueError('expr must be True, False, or None')
         self._makeTime = bool(expr)
@@ -3824,7 +3822,7 @@ class Test(unittest.TestCase):
 
 # -------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[Union[Type, Callable]] = [
+_DOC_ORDER: t.List[t.Union[t.Type, t.Callable]] = [
     Duration, Tuplet, GraceDuration, convertQuarterLengthToType, TupletFixer,
 ]
 

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -29,8 +29,7 @@ import sys
 import tempfile
 import unittest
 
-from typing import Union
-from typing import Optional
+import typing as t
 
 import xml.etree.ElementTree as ET
 from xml.sax import saxutils
@@ -434,7 +433,7 @@ class _EnvironmentCore:
             ]:
                 self.__setitem__(name, value)  # use for key checking
 
-    def _checkAccessibility(self, path: Optional[Union[str, pathlib.Path]]) -> bool:
+    def _checkAccessibility(self, path: t.Optional[t.Union[str, pathlib.Path]]) -> bool:
         '''
         Return True if the path exists, is readable and writable.
         '''
@@ -647,7 +646,7 @@ class _EnvironmentCore:
         # darwin specific option
         # os.path.join(os.environ['HOME'], 'Library',)
 
-    def getTempFile(self, suffix='', returnPathlib=True) -> Union[str, pathlib.Path]:
+    def getTempFile(self, suffix='', returnPathlib=True) -> t.Union[str, pathlib.Path]:
         '''
         Gets a temporary file with a suffix that will work for a bit.
 
@@ -999,7 +998,7 @@ class Environment:
         '''
         return envSingleton().getSettingsPath()
 
-    def getTempFile(self, suffix='', returnPathlib=True) -> Union[str, pathlib.Path]:
+    def getTempFile(self, suffix='', returnPathlib=True) -> t.Union[str, pathlib.Path]:
         '''
         Return a file path to a temporary file with the specified suffix (file
         extension).

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -26,7 +26,7 @@ For instance, TextExpressions.
 import copy
 import string
 import unittest
-from typing import List, Optional, Tuple
+import typing as t
 
 from music21 import base
 from music21 import common
@@ -169,7 +169,7 @@ class RehearsalMark(Expression):
         return repr(self.content)
 
     @staticmethod
-    def _getNumberingFromContent(c) -> Optional[str]:
+    def _getNumberingFromContent(c) -> t.Optional[str]:
         '''
         if numbering was not set, get it from the content
 
@@ -364,7 +364,7 @@ class TextExpression(Expression):
             return ''
 
     @property
-    def enclosure(self) -> Optional[style.Enclosure]:
+    def enclosure(self) -> t.Optional[style.Enclosure]:
         '''
         Returns or sets the enclosure on the Style object
         stored on .style.
@@ -390,7 +390,7 @@ class TextExpression(Expression):
         return self.style.enclosure
 
     @enclosure.setter
-    def enclosure(self, value: Optional[style.Enclosure]):
+    def enclosure(self, value: t.Optional[style.Enclosure]):
         if not self.hasStyleInformation and value is None:
             return
         self.style.enclosure = value
@@ -462,7 +462,7 @@ class Ornament(Expression):
     def fillListOfRealizedNotes(
         self,
         srcObj: 'music21.note.Note',
-        fillObjects: List['music21.note.Note'],
+        fillObjects: t.List['music21.note.Note'],
         transposeInterval
     ):
         '''
@@ -540,7 +540,7 @@ class GeneralMordent(Ornament):
             transposeInterval = self.size.reverse()
         else:
             transposeInterval = self.size
-        mordNotes: List['music21.note.Note'] = []
+        mordNotes: t.List['music21.note.Note'] = []
         self.fillListOfRealizedNotes(srcObj, mordNotes, transposeInterval)
 
         currentKeySig = srcObj.getContextByClass(key.KeySignature)
@@ -738,7 +738,7 @@ class Trill(Ornament):
     def realize(
         self,
         srcObj: 'music21.note.Note'
-    ) -> Tuple[List['music21.note.Note'], None, List['music21.note.Note']]:
+    ) -> t.Tuple[t.List['music21.note.Note'], None, t.List['music21.note.Note']]:
         '''
         realize a trill.
 
@@ -853,7 +853,7 @@ class Trill(Ornament):
         if self.nachschlag:
             numberOfTrillNotes -= 2
 
-        trillNotes: List['music21.note.Note'] = []
+        trillNotes: t.List['music21.note.Note'] = []
         for unused_counter in range(int(numberOfTrillNotes / 2)):
             self.fillListOfRealizedNotes(srcObj, trillNotes, transposeInterval)
 

--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -12,7 +12,7 @@
 Original music21 feature extractors.
 '''
 import unittest
-from typing import Optional
+import typing as t
 
 from music21.features import base as featuresModule
 from music21 import text
@@ -109,7 +109,7 @@ class QualityFeature(featuresModule.FeatureExtractor):
         Do processing necessary, storing result in feature.
         '''
         allKeys = self.data['flat.getElementsByClass(Key)']
-        keyFeature: Optional[int] = None
+        keyFeature: t.Optional[int] = None
         if len(allKeys) == 1:
             k0 = allKeys[0]
             if k0.mode == 'major':

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -10,7 +10,7 @@
 
 import collections
 import copy
-from typing import Dict, Tuple
+import typing as t
 import unittest
 
 from music21 import pitch
@@ -397,7 +397,10 @@ def voiceCrossing(possibA):
 # Consecutive Possibility Rule-Checking Methods
 
 
-PITCH_QUARTET_TO_BOOL_TYPE = Dict[Tuple[pitch.Pitch, pitch.Pitch, pitch.Pitch, pitch.Pitch], bool]
+PITCH_QUARTET_TO_BOOL_TYPE = t.Dict[
+    t.Tuple[pitch.Pitch, pitch.Pitch, pitch.Pitch, pitch.Pitch],
+    bool
+]
 parallelFifthsTable: PITCH_QUARTET_TO_BOOL_TYPE = {}
 parallelOctavesTable: PITCH_QUARTET_TO_BOOL_TYPE = {}
 hiddenFifthsTable: PITCH_QUARTET_TO_BOOL_TYPE = {}

--- a/music21/figuredBass/possibility.py
+++ b/music21/figuredBass/possibility.py
@@ -9,7 +9,8 @@
 # ------------------------------------------------------------------------------
 '''
 A possibility is a tuple with pitches, and is intended to encapsulate a possible
-solution to a :class:`~music21.figuredBass.segment.Segment`. Unlike a :class:`~music21.chord.Chord`,
+solution to a :class:`~music21.figuredBass.segment.Segment`.
+Unlike a :class:`~music21.chord.Chord`,
 the ordering of a possibility does matter. The assumption throughout fbRealizer
 is that a possibility is always in order from the highest part to the lowest part, and
 the last element of each possibility is the bass.
@@ -67,7 +68,7 @@ The application of these methods is controlled by corresponding instance variabl
 .. note:: The number of parts and maxPitch are universal for a
     :class:`~music21.figuredBass.realizer.FiguredBassLine`.
 '''
-from typing import Dict, Tuple
+import typing as t
 import unittest
 
 from music21 import chord
@@ -275,7 +276,10 @@ def limitPartToPitch(possibA, partPitchLimits=None):
 # CONSECUTIVE POSSIBILITY RULE-CHECKING METHODS
 # ---------------------------------------------
 # Speedup tables
-PITCH_QUARTET_TO_BOOL_TYPE = Dict[Tuple[pitch.Pitch, pitch.Pitch, pitch.Pitch, pitch.Pitch], bool]
+PITCH_QUARTET_TO_BOOL_TYPE = t.Dict[
+    t.Tuple[pitch.Pitch, pitch.Pitch, pitch.Pitch, pitch.Pitch],
+    bool
+]
 parallelFifthsTable: PITCH_QUARTET_TO_BOOL_TYPE = {}
 parallelOctavesTable: PITCH_QUARTET_TO_BOOL_TYPE = {}
 hiddenFifthsTable: PITCH_QUARTET_TO_BOOL_TYPE = {}

--- a/music21/figuredBass/resolution.py
+++ b/music21/figuredBass/resolution.py
@@ -25,7 +25,7 @@ arguments, the methods only :meth:`~music21.pitch.Pitch.transpose` each
 :class:`~music21.pitch.Pitch` in a possibility by the appropriate interval.
 '''
 import unittest
-from typing import List, Optional
+import typing as t
 
 from music21 import exceptions21
 from music21 import chord
@@ -757,7 +757,7 @@ def _resolvePitches(possibToResolve, howToResolve):
 
 def _unpackSeventhChord(
     seventhChord: 'music21.chord.Chord'
-) -> List[Optional['music21.pitch.Pitch']]:
+) -> t.List[t.Optional['music21.pitch.Pitch']]:
     '''
     Takes in a Chord and returns a list of Pitches (or Nones) corresponding
     to the bass, root, fifth, seventh.

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -12,7 +12,7 @@ import copy
 import itertools
 import unittest
 
-from typing import Dict, Optional, Union
+import typing as t
 
 from music21 import chord
 from music21 import environment
@@ -27,7 +27,7 @@ from music21.figuredBass import rules
 
 _MOD = 'figuredBass.segment'
 
-_defaultRealizerScale: Dict[str, Optional[realizerScale.FiguredBassScale]] = {
+_defaultRealizerScale: t.Dict[str, t.Optional[realizerScale.FiguredBassScale]] = {
     'scale': None,  # singleton
 }
 
@@ -64,12 +64,12 @@ class Segment:
     }
 
     def __init__(self,
-                 bassNote: Union[str, note.Note] = 'C3',
-                 notationString: Optional[str] = None,
-                 fbScale: Optional[realizerScale.FiguredBassScale] = None,
-                 fbRules: Optional[rules.Rules] = None,
+                 bassNote: t.Union[str, note.Note] = 'C3',
+                 notationString: t.Optional[str] = None,
+                 fbScale: t.Optional[realizerScale.FiguredBassScale] = None,
+                 fbRules: t.Optional[rules.Rules] = None,
                  numParts=4,
-                 maxPitch: Union[str, pitch.Pitch] = 'B5',
+                 maxPitch: t.Union[str, pitch.Pitch] = 'B5',
                  listOfPitches=None):
         '''
         A Segment corresponds to a 1:1 realization of a bassNote and notationString
@@ -864,8 +864,8 @@ class OverlaidSegment(Segment):
 # HELPER METHODS
 # --------------
 def getPitches(pitchNames=('C', 'E', 'G'),
-               bassPitch: Union[str, pitch.Pitch] = 'C3',
-               maxPitch: Union[str, pitch.Pitch] = 'C8'):
+               bassPitch: t.Union[str, pitch.Pitch] = 'C3',
+               maxPitch: t.Union[str, pitch.Pitch] = 'C8'):
     '''
     Given a list of pitchNames, a bassPitch, and a maxPitch, returns a sorted list of
     pitches between the two limits (inclusive) which correspond to items in pitchNames.

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -75,7 +75,7 @@ import time
 import unittest
 import zlib
 
-from typing import Union, List
+import typing as t
 
 from music21 import base
 from music21 import common
@@ -106,7 +106,7 @@ class StreamFreezeThawBase:
     def __init__(self):
         self.stream = None
 
-    def getPickleFp(self, directory: Union[str, pathlib.Path]) -> pathlib.Path:
+    def getPickleFp(self, directory: t.Union[str, pathlib.Path]) -> pathlib.Path:
         if not isinstance(directory, pathlib.Path):
             directory = pathlib.Path(directory)
 
@@ -114,7 +114,7 @@ class StreamFreezeThawBase:
         streamStr = str(time.time())
         return directory / ('m21-' + common.getMd5(streamStr) + '.p')
 
-    def getJsonFp(self, directory: Union[str, pathlib.Path]) -> pathlib.Path:
+    def getJsonFp(self, directory: t.Union[str, pathlib.Path]) -> pathlib.Path:
         return self.getPickleFp(directory).with_suffix('.p.json')
 
 
@@ -489,7 +489,7 @@ class StreamFreezer(StreamFreezeThawBase):
         hierarchyObject=None,
         getSpanners=True,
         getVariants=True
-    ) -> List[int]:
+    ) -> t.List[int]:
         '''
         Return a list of all Stream ids anywhere in the hierarchy.  By id,
         we mean `id(s)` not `s.id` -- so they are memory locations and unique.

--- a/music21/graph/findPlot.py
+++ b/music21/graph/findPlot.py
@@ -16,7 +16,7 @@ Functions that find appropriate plots for graph.plot.
 import collections
 import types
 import unittest
-from typing import List, Tuple
+import typing as t
 
 from music21.graph import axis
 from music21.graph import plot
@@ -33,7 +33,7 @@ PLOTCLASS_SHORTCUTS = {
 
 
 # all formats need to be here, and first for each row must match a graphType.
-FORMAT_SYNONYMS: List[Tuple[str, ...]] = [
+FORMAT_SYNONYMS: t.List[t.Tuple[str, ...]] = [
     ('horizontalbar', 'bar', 'horizontal', 'pianoroll', 'piano'),
     ('histogram', 'histo', 'count'),
     ('scatter', 'point'),

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -24,7 +24,7 @@ import os
 import pathlib
 import unittest
 import numbers
-from typing import Dict, List, Any
+import typing as t
 
 from music21 import base
 # from music21 import common
@@ -261,8 +261,8 @@ class PlotStreamMixin(prebase.ProtoM21Object):
 
     def postProcessElement(self,
                            el: base.Music21Object,
-                           formatDict: Dict[Any, Any],
-                           *values: List[numbers.Real]) -> None:
+                           formatDict: t.Dict[t.Any, t.Any],
+                           *values: t.List[numbers.Real]) -> None:
         '''
         Any processing that needs to take place for each element, independent
         of what the axis is finding can go here.  For chords, a single
@@ -1006,7 +1006,7 @@ class HorizontalBar(primitives.GraphHorizontalBar, PlotStreamMixin):
 
     def __init__(self, streamObj=None, *args, colorByPart=False, **keywords):
         self.colorByPart = colorByPart
-        self._partsToColor: Dict[stream.Part, str] = {}
+        self._partsToColor: t.Dict[stream.Part, str] = {}
 
         primitives.GraphHorizontalBar.__init__(self, *args, **keywords)
         PlotStreamMixin.__init__(self, streamObj, **keywords)
@@ -1021,7 +1021,7 @@ class HorizontalBar(primitives.GraphHorizontalBar, PlotStreamMixin):
             self.assignColorsToParts()
         super().run()
 
-    def assignColorsToParts(self) -> Dict[stream.Part, str]:
+    def assignColorsToParts(self) -> t.Dict[stream.Part, str]:
         '''
         Give a different color for each part, if self.colorByPart is True.
 
@@ -1046,8 +1046,8 @@ class HorizontalBar(primitives.GraphHorizontalBar, PlotStreamMixin):
 
     def postProcessElement(self,
                            el: base.Music21Object,
-                           formatDict: Dict[Any, Any],
-                           *values: List[numbers.Real]):
+                           formatDict: t.Dict[t.Any, t.Any],
+                           *values: t.List[numbers.Real]):
         '''
         Assign colors to each element if colorByPart is True.
         '''

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -27,7 +27,7 @@ From highest level to lowest level usage, ways of graphing are as follows:
 import math
 import random
 import unittest
-from typing import Union, List
+import typing as t
 
 from music21 import common
 from music21.graph.utilities import (getExtendedModules,
@@ -1005,7 +1005,7 @@ class GraphHorizontalBar(Graph):
 
             if points:
                 uniformFormatPerRow = (len(points[0]) == 2)
-                rowFaceColors: Union[str, List[str]]
+                rowFaceColors: t.Union[str, t.List[str]]
                 if uniformFormatPerRow:
                     rowFaceColors = faceColor
                     positionPoints = points

--- a/music21/graph/utilities.py
+++ b/music21/graph/utilities.py
@@ -15,7 +15,7 @@ Functions for finding external modules, converting colors to Matplotlib colors, 
 '''
 import unittest
 from collections import namedtuple
-from typing import Tuple, cast
+import typing as t
 
 import webcolors
 
@@ -180,7 +180,7 @@ def getColor(color):
             if len(color) == 1:
                 color = [color[0], color[0], color[0]]
             # convert to 0 100% values as strings with % symbol
-            colorStrList = cast(Tuple[str, str, str], tuple(str(x * 100) + '%' for x in color))
+            colorStrList = t.cast(t.Tuple[str, str, str], tuple(str(x * 100) + '%' for x in color))
             return webcolors.rgb_percent_to_hex(colorStrList)
         else:  # assume integers
             return webcolors.rgb_to_hex(tuple(color))

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -20,7 +20,7 @@ import copy
 import re
 import unittest
 
-from typing import Dict, List, Optional, Tuple, TypeVar, Union
+import typing as t
 
 from music21 import base
 from music21 import chord
@@ -38,8 +38,8 @@ from music21.figuredBass import realizerScale
 from music21 import environment
 environLocal = environment.Environment('harmony')
 
-T = TypeVar('T', bound='ChordSymbol')
-NCT = TypeVar('NCT', bound='NoChord')
+T = t.TypeVar('T', bound='ChordSymbol')
+NCT = t.TypeVar('NCT', bound='NoChord')
 
 # --------------------------------------------------------------------------
 
@@ -207,10 +207,10 @@ class Harmony(chord.Chord):
     # INITIALIZER #
 
     def __init__(self,
-                 figure: Optional[str] = None,
-                 root: Union[str, pitch.Pitch, None] = None,
-                 bass: Union[str, pitch.Pitch, None] = None,
-                 inversion: Optional[int] = None,
+                 figure: t.Optional[str] = None,
+                 root: t.Union[str, pitch.Pitch, None] = None,
+                 bass: t.Union[str, pitch.Pitch, None] = None,
+                 inversion: t.Optional[int] = None,
                  updatePitches: bool = True,
                  **keywords
                  ):
@@ -226,8 +226,8 @@ class Harmony(chord.Chord):
         # called <function> which might conflict with the Harmony...
         self._roman = None
         # specify an array of degree alteration objects
-        self.chordStepModifications: List[ChordStepModification] = []
-        self._degreesList: List[str] = []
+        self.chordStepModifications: t.List[ChordStepModification] = []
+        self._degreesList: t.List[str] = []
         self._key = None
         # senseless to parse inversion until chord members are populated
         self._updateFromParameters(root=root, bass=bass)
@@ -279,7 +279,7 @@ class Harmony(chord.Chord):
         '''
         return
 
-    def _updateFromParameters(self, root, bass, inversion: Optional[int] = None):
+    def _updateFromParameters(self, root, bass, inversion: t.Optional[int] = None):
         '''
         This method must be called twice, once before the pitches
         are rendered, and once after. This is because after the pitches
@@ -1391,7 +1391,7 @@ def removeChordSymbols(chordType):
 
 
 # --------------------------------------------------------------------------
-realizerScaleCache: Dict[Tuple[str, str], realizerScale.FiguredBassScale] = {}
+realizerScaleCache: t.Dict[t.Tuple[str, str], realizerScale.FiguredBassScale] = {}
 
 # --------------------------------------------------------------------------
 
@@ -1583,9 +1583,9 @@ class ChordSymbol(Harmony):
 
     def __init__(self,
                  figure=None,
-                 root: Union[pitch.Pitch, str, None] = None,
-                 bass: Union[pitch.Pitch, str, None] = None,
-                 inversion: Optional[int] = None,
+                 root: t.Union[pitch.Pitch, str, None] = None,
+                 bass: t.Union[pitch.Pitch, str, None] = None,
+                 inversion: t.Optional[int] = None,
                  kind='',
                  kindStr='',
                  **keywords
@@ -2341,7 +2341,7 @@ class ChordSymbol(Harmony):
         else:
             return False
 
-    def transpose(self: T, value, *, inPlace=False) -> Optional[T]:
+    def transpose(self: T, value, *, inPlace=False) -> t.Optional[T]:
         '''
         Overrides :meth:`~music21.chord.Chord.transpose` so that this ChordSymbol's
         `figure` is appropriately cleared afterward.
@@ -2448,7 +2448,7 @@ class NoChord(ChordSymbol):
         # do nothing, everything is already set.
         return
 
-    def transpose(self: NCT, _value, *, inPlace=False) -> Optional[NCT]:
+    def transpose(self: NCT, _value, *, inPlace=False) -> t.Optional[NCT]:
         '''
         Overrides :meth:`~music21.chord.Chord.transpose` to do nothing.
 

--- a/music21/humdrum/harmparser.py
+++ b/music21/humdrum/harmparser.py
@@ -15,7 +15,7 @@ The `**harm` representation is described here: https://www.humdrum.org/rep/harm/
 '''
 import re
 import unittest
-from typing import Dict, Any
+import typing as t
 
 def convertHarmToRoman(harmStr):
     # noinspection PyShadowingNames
@@ -201,9 +201,9 @@ class HarmParser:
         self.harmRegExp = re.compile(HarmParser.defs.harmExpression, re.VERBOSE)
         self.impliedRegExp = re.compile(HarmParser.defs.implied, re.VERBOSE)
 
-    def parse(self, harmExpression) -> Dict[str, Any]:
+    def parse(self, harmExpression) -> t.Dict[str, t.Any]:
         # Check for implied harmony
-        m: Dict[str, Any]
+        m: t.Dict[str, t.Any]
         impliedMatch = self.impliedRegExp.match(harmExpression)
         if impliedMatch:
             # This is implied harmony

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -48,7 +48,7 @@ import math
 import re
 import unittest
 
-from typing import List, Optional, Type
+import typing as t
 
 from music21 import articulations
 from music21 import bar
@@ -1631,7 +1631,7 @@ class SpineCollection(prebase.ProtoM21Object):
         self.iterIndex -= 1
         return thisSpine
 
-    def addSpine(self, streamClass: Type[stream.Stream] = stream.Part):
+    def addSpine(self, streamClass: t.Type[stream.Stream] = stream.Part):
         '''
         creates a new spine in the collection and returns it.
 
@@ -2004,7 +2004,7 @@ class SpineCollection(prebase.ProtoM21Object):
                 if not hasVoices:
                     continue
 
-                voices: List[Optional[stream.Voice]] = [None for i in range(10)]
+                voices: t.List[t.Optional[stream.Voice]] = [None for i in range(10)]
                 measureElements = el.elements
                 for mEl in measureElements:
                     mElGroups = mEl.groups

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -26,7 +26,7 @@ import importlib
 import unittest
 import sys
 from collections import OrderedDict
-from typing import Iterable, Optional
+import typing as t
 
 from music21 import base
 from music21 import common
@@ -43,7 +43,7 @@ environLocal = environment.Environment('instrument')
 
 def unbundleInstruments(streamIn: 'music21.stream.Stream',
                         *,
-                        inPlace=False) -> Optional['music21.stream.Stream']:
+                        inPlace=False) -> t.Optional['music21.stream.Stream']:
     # noinspection PyShadowingNames
     '''
     takes a :class:`~music21.stream.Stream` that has :class:`~music21.note.NotRest` objects
@@ -82,7 +82,7 @@ def unbundleInstruments(streamIn: 'music21.stream.Stream',
 
 def bundleInstruments(streamIn: 'music21.stream.Stream',
                       *,
-                      inPlace=False) -> Optional['music21.stream.Stream']:
+                      inPlace=False) -> t.Optional['music21.stream.Stream']:
     # noinspection PyShadowingNames
     '''
     >>> up1 = note.Unpitched()
@@ -159,7 +159,7 @@ class Instrument(base.Music21Object):
         self.printPartName = None  # True = yes, False = no, None = let others decide
         self.printPartAbbreviation = None
 
-        self.instrumentId: Optional[str] = None  # apply to midi and instrument
+        self.instrumentId: t.Optional[str] = None  # apply to midi and instrument
         self._instrumentIdIsRandom = False
 
         self.instrumentName = instrumentName
@@ -172,7 +172,7 @@ class Instrument(base.Music21Object):
         self.highestNote = None
 
         # define interval to go from written to sounding
-        self.transposition: Optional[interval.Interval] = None
+        self.transposition: t.Optional[interval.Interval] = None
 
         self.inGMPercMap = False
         self.soundfontFn = None  # if defined...
@@ -1870,7 +1870,7 @@ def deduplicate(s: 'music21.stream.Stream', inPlace: bool = False) -> 'music21.s
         returnObj = s.coreCopyAsDerivation('instrument.deduplicate')
 
     if not returnObj.hasPartLikeStreams():
-        substreams: Iterable[stream.Stream] = [returnObj]
+        substreams: t.Iterable[stream.Stream] = [returnObj]
     else:
         substreams = returnObj.getElementsByClass(stream.Stream)
 

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -25,7 +25,7 @@ import enum
 import math
 import re
 import unittest
-from typing import Dict, Union, Tuple, Optional
+import typing as t
 
 from music21 import base
 from music21 import common
@@ -304,7 +304,7 @@ class IntervalException(exceptions21.Music21Exception):
 # some utility functions
 
 
-def _extractPitch(nOrP: Union['music21.note.Note', 'music21.pitch.Pitch']):
+def _extractPitch(nOrP: t.Union['music21.note.Note', 'music21.pitch.Pitch']):
     '''
     utility function to return either the object itself
     or the `.pitch` if it's a Note.
@@ -400,7 +400,7 @@ def convertDiatonicNumberToStep(dn):
         stepNumber = (dn - 1) - (octave * 7)
         return STEPNAMES[stepNumber], (octave - 1)
 
-def parseSpecifier(value: Union[str, int, Specifier]) -> Specifier:
+def parseSpecifier(value: t.Union[str, int, Specifier]) -> Specifier:
     '''
     Given an integer or a string representing a "specifier" (major, minor,
     perfect, diminished, etc.), return the Specifier.
@@ -588,7 +588,7 @@ def convertSemitoneToSpecifierGenericMicrotone(count):
     return (spec, (generic + (octave * 7)) * dirScale, cents)
 
 
-def convertSemitoneToSpecifierGeneric(count: int) -> Tuple[Specifier, int]:
+def convertSemitoneToSpecifierGeneric(count: int) -> t.Tuple[Specifier, int]:
     '''
     Given a number of semitones, return a default diatonic specifier, and
     a number that can be used as a GenericInterval
@@ -621,7 +621,7 @@ def convertSemitoneToSpecifierGeneric(count: int) -> Tuple[Specifier, int]:
     return convertSemitoneToSpecifierGenericMicrotone(count)[:2]
 
 
-_pythagorean_cache: Dict[str, Fraction] = {}
+_pythagorean_cache: t.Dict[str, Fraction] = {}
 
 
 def intervalToPythagoreanRatio(intervalObj):
@@ -857,7 +857,7 @@ class GenericInterval(IntervalBase):
     Changed in v.6 -- large intervals get abbreviations
     '''
     def __init__(self,
-                 value: Union[int, str] = 'Unison'):
+                 value: t.Union[int, str] = 'Unison'):
         super().__init__()
         self._value: int = 1
         self.value = convertGeneric(value)
@@ -1630,8 +1630,8 @@ class DiatonicInterval(IntervalBase):
     }
 
     def __init__(self,
-                 specifier: Union[str, int] = 'P',
-                 generic: Union[int, GenericInterval, str] = 1):
+                 specifier: t.Union[str, int] = 'P',
+                 generic: t.Union[int, GenericInterval, str] = 1):
         super().__init__()
 
         self.generic: GenericInterval
@@ -2885,8 +2885,8 @@ class Interval(IntervalBase):
 
         # both self.diatonic and self.chromatic can still both be None if an
         # empty Interval class is being created, such as in deepcopy
-        self.diatonic: Optional[DiatonicInterval] = None
-        self.chromatic: Optional[ChromaticInterval] = None
+        self.diatonic: t.Optional[DiatonicInterval] = None
+        self.chromatic: t.Optional[ChromaticInterval] = None
 
         # these can be accessed through noteStart and noteEnd properties
         self._noteStart = None
@@ -3002,7 +3002,7 @@ class Interval(IntervalBase):
     # properties
 
     @property
-    def generic(self) -> Optional[GenericInterval]:
+    def generic(self) -> t.Optional[GenericInterval]:
         '''
         Returns the :class:`~music21.interval.GenericInterval` object
         associated with this Interval
@@ -3090,13 +3090,13 @@ class Interval(IntervalBase):
         return ''
 
     @property
-    def semitones(self) -> Union[int, float]:
+    def semitones(self) -> t.Union[int, float]:
         if self.chromatic is not None:
             return self.chromatic.semitones
         return 0
 
     @property
-    def direction(self) -> Optional[Direction]:
+    def direction(self) -> t.Optional[Direction]:
         if self.chromatic is not None:
             return self.chromatic.direction
         elif self.diatonic is not None:
@@ -3105,7 +3105,7 @@ class Interval(IntervalBase):
             return None
 
     @property
-    def specifier(self) -> Optional[Specifier]:
+    def specifier(self) -> t.Optional[Specifier]:
         if self.diatonic is not None:
             return self.diatonic.specifier
         return None
@@ -3708,7 +3708,7 @@ def getAbsoluteLowerNote(note1, note2):
 
 def transposePitch(
     pitch1: 'music21.pitch.Pitch',
-    interval1: Union[str, Interval],
+    interval1: t.Union[str, Interval],
     *,
     inPlace=False
 ) -> 'music21.pitch.Pitch':
@@ -3759,7 +3759,7 @@ def transposePitch(
 
 def transposeNote(
         note1: 'music21.note.Note',
-        intervalString: Union[str, Interval]) -> 'music21.note.Note':
+        intervalString: t.Union[str, Interval]) -> 'music21.note.Note':
     '''
     Given a :class:`~music21.note.Note` and
     a interval string (such as 'P5') or an Interval object,

--- a/music21/key.py
+++ b/music21/key.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 import copy
 import re
 import unittest
-from typing import Union, Optional, Dict, List, TypeVar, overload, Literal, cast
+import typing as t
+from typing import overload
 import warnings
 
 from music21 import base
@@ -38,14 +39,14 @@ from music21.common.types import StepName
 from music21 import environment
 environLocal = environment.Environment('key')
 
-KeySignatureType = TypeVar('KeySignatureType', bound='KeySignature')
-KeyType = TypeVar('KeyType', bound='Key')
-TransposeTypes = Union[int, str, interval.Interval, interval.GenericInterval]
+KeySignatureType = t.TypeVar('KeySignatureType', bound='KeySignature')
+KeyType = t.TypeVar('KeyType', bound='Key')
+TransposeTypes = t.Union[int, str, interval.Interval, interval.GenericInterval]
 
 
 # ------------------------------------------------------------------------------
 # store a cache of already-found values
-_sharpsToPitchCache: Dict[int, pitch.Pitch] = {}
+_sharpsToPitchCache: t.Dict[int, pitch.Pitch] = {}
 
 
 def convertKeyStringToMusic21KeyString(textString):
@@ -156,7 +157,7 @@ modeSharpsAlter = {'major': 0,
                    }
 
 
-def pitchToSharps(value: Union[str, pitch.Pitch, note.Note],
+def pitchToSharps(value: t.Union[str, pitch.Pitch, note.Note],
                   mode: str = None) -> int:
     '''
     Given a pitch string or :class:`music21.pitch.Pitch` or
@@ -331,7 +332,7 @@ class KeySignature(base.Music21Object):
 
     classSortOrder = 2
 
-    def __init__(self, sharps: Optional[int] = 0):
+    def __init__(self, sharps: t.Optional[int] = 0):
         super().__init__()
         # position on the circle of fifths, where 1 is one sharp, -1 is one flat
 
@@ -349,7 +350,7 @@ class KeySignature(base.Music21Object):
         self._sharps = sharps
         # need to store a list of pitch objects, used for creating a
         # non-traditional key
-        self._alteredPitches: Optional[List[pitch.Pitch]] = None
+        self._alteredPitches: t.Optional[t.List[pitch.Pitch]] = None
         self.accidentalsApplyOnlyToOctave = False
 
     def __hash__(self):
@@ -390,7 +391,7 @@ class KeySignature(base.Music21Object):
     def _reprInternal(self):
         return 'of ' + self._strDescription()
 
-    def asKey(self, mode: Optional[str] = None, tonic: Optional[str] = None):
+    def asKey(self, mode: t.Optional[str] = None, tonic: t.Optional[str] = None):
         '''
         Return a `key.Key` object representing this KeySignature object as a key in the
         given mode or in the given tonic. If `mode` is None, and `tonic` is not provided,
@@ -436,7 +437,7 @@ class KeySignature(base.Music21Object):
             except KeyError as ke:
                 raise KeyException(
                     f'Could not solve for mode from sharps={self.sharps}, tonic={tonic}') from ke
-        mode = cast(str, mode)
+        mode = t.cast(str, mode)
         mode = mode.lower()
         if mode not in modeSharpsAlter:
             raise KeyException(f'Mode {mode} is unknown')
@@ -448,7 +449,7 @@ class KeySignature(base.Music21Object):
 
     @property  # type: ignore
     @cacheMethod
-    def alteredPitches(self) -> List[pitch.Pitch]:
+    def alteredPitches(self) -> t.List[pitch.Pitch]:
         # unfortunately, mypy cannot deal with @property on decorated methods.
         # noinspection PyShadowingNames
         '''
@@ -506,7 +507,7 @@ class KeySignature(base.Music21Object):
         if self._alteredPitches is not None:
             return self._alteredPitches
 
-        post: List[pitch.Pitch] = []
+        post: t.List[pitch.Pitch] = []
         if self.sharps is None:
             return post
 
@@ -531,9 +532,10 @@ class KeySignature(base.Music21Object):
         return post
 
     @alteredPitches.setter
-    def alteredPitches(self, newAlteredPitches: List[Union[str, pitch.Pitch, note.Note]]) -> None:
+    def alteredPitches(self, newAlteredPitches: t.List[t.Union[str, pitch.Pitch, note.Note]]
+                       ) -> None:
         self.clearCache()
-        newList: List[pitch.Pitch] = []
+        newList: t.List[pitch.Pitch] = []
         for p in newAlteredPitches:
             if isinstance(p, str):
                 newList.append(pitch.Pitch(p))
@@ -568,7 +570,7 @@ class KeySignature(base.Music21Object):
         else:
             return False
 
-    def accidentalByStep(self, step: StepName) -> Optional[pitch.Accidental]:
+    def accidentalByStep(self, step: StepName) -> t.Optional[pitch.Accidental]:
         '''
         Given a step (C, D, E, F, etc.) return the accidental
         for that note in this key (using the natural minor for minor)
@@ -654,20 +656,20 @@ class KeySignature(base.Music21Object):
     def transpose(self: KeySignatureType,
                   value: TransposeTypes,
                   *,
-                  inPlace: Literal[False] = False) -> KeySignatureType:
+                  inPlace: t.Literal[False] = False) -> KeySignatureType:
         return self  # astroid 1015
 
     @overload
     def transpose(self: KeySignatureType,
                   value: TransposeTypes,
                   *,
-                  inPlace: Literal[True]) -> None:
+                  inPlace: t.Literal[True]) -> None:
         return None  # astroid 1015
 
     def transpose(self: KeySignatureType,
                   value: TransposeTypes,
                   *,
-                  inPlace: bool = False) -> Optional[KeySignatureType]:
+                  inPlace: bool = False) -> t.Optional[KeySignatureType]:
         '''
         Transpose the KeySignature by the user-provided value.
         If the value is an integer, the transposition is treated
@@ -714,7 +716,7 @@ class KeySignature(base.Music21Object):
         >>> eFlat
         <music21.key.KeySignature of 3 flats>
         '''
-        intervalObj: Union[interval.Interval, interval.GenericInterval]
+        intervalObj: t.Union[interval.Interval, interval.GenericInterval]
         if isinstance(value, interval.Interval):  # it is an Interval class
             intervalObj = value
         elif isinstance(value, interval.GenericInterval):
@@ -742,7 +744,7 @@ class KeySignature(base.Music21Object):
         else:
             return None
 
-    def transposePitchFromC(self, p: pitch.Pitch, *, inPlace=False) -> Optional[pitch.Pitch]:
+    def transposePitchFromC(self, p: pitch.Pitch, *, inPlace=False) -> t.Optional[pitch.Pitch]:
         '''
         Takes a pitch in C major and transposes it so that it has
         the same step position in the current key signature.
@@ -838,10 +840,10 @@ class KeySignature(base.Music21Object):
     # --------------------------------------------------------------------------
     # properties
 
-    def _getSharps(self) -> Optional[int]:
+    def _getSharps(self) -> t.Optional[int]:
         return self._sharps
 
-    def _setSharps(self, value: Optional[int]):
+    def _setSharps(self, value: t.Optional[int]):
         if value != self._sharps:
             self._sharps = value
             self.clearCache()
@@ -930,7 +932,7 @@ class Key(KeySignature, scale.DiatonicScale):
     tonic: pitch.Pitch
 
     def __init__(self,
-                 tonic: Union[str, pitch.Pitch, note.Note] = 'C',
+                 tonic: t.Union[str, pitch.Pitch, note.Note] = 'C',
                  mode=None):
         if isinstance(tonic, (note.Note, pitch.Pitch)):
             tonicStr = tonic.name
@@ -978,7 +980,7 @@ class Key(KeySignature, scale.DiatonicScale):
         self.correlationCoefficient = None
 
         # store an ordered list of alternative Key objects
-        self.alternateInterpretations: List[Key] = []
+        self.alternateInterpretations: t.List[Key] = []
 
     def __hash__(self):
         hashTuple = (self.tonic, self.mode)
@@ -1220,7 +1222,7 @@ class Key(KeySignature, scale.DiatonicScale):
     def transpose(self: KeyType,
                   value: TransposeTypes,
                   *,
-                  inPlace: Literal[False] = False
+                  inPlace: t.Literal[False] = False
                   ) -> KeyType:
         return self  # astroid 1015
 
@@ -1228,7 +1230,7 @@ class Key(KeySignature, scale.DiatonicScale):
     def transpose(self: KeyType,
                   value: TransposeTypes,
                   *,
-                  inPlace: Literal[True]
+                  inPlace: t.Literal[True]
                   ) -> None:
         return None
 
@@ -1236,7 +1238,7 @@ class Key(KeySignature, scale.DiatonicScale):
                   value: TransposeTypes,
                   *,
                   inPlace: bool = False
-                  ) -> Optional[KeyType]:
+                  ) -> t.Optional[KeyType]:
         '''
         Transpose the Key by the user-provided value.
         If the value is an integer, the transposition is treated

--- a/music21/languageExcerpts/naturalLanguageObjects.py
+++ b/music21/languageExcerpts/naturalLanguageObjects.py
@@ -12,7 +12,7 @@
 Multi-lingual conversion of pitch, etc. objects
 '''
 
-from typing import List
+import typing as t
 import unittest
 from music21 import pitch
 
@@ -268,7 +268,7 @@ class Test(unittest.TestCase):
 # define presented order in documentation
 
 
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 
 if __name__ == '__main__':

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -91,7 +91,7 @@ import copy
 import unittest
 
 from collections import namedtuple
-from typing import Tuple, Optional, List
+import typing as t
 
 from music21 import base
 from music21 import exceptions21
@@ -705,7 +705,7 @@ def divideByPages(scoreIn, printUpdates=False, fastMeasures=False):
 
                 staffObject.elements = p
                 thisSystem.replace(p, staffObject)
-                allStaffLayouts: List[StaffLayout] = list(p[StaffLayout])
+                allStaffLayouts: t.List[StaffLayout] = list(p[StaffLayout])
                 if not allStaffLayouts:
                     continue
                 # else:
@@ -1325,7 +1325,7 @@ class LayoutScore(stream.Opus):
         self,
         pageId: int,
         systemId: int
-    ) -> Tuple[Optional[int], int]:
+    ) -> t.Tuple[t.Optional[int], int]:
         # noinspection PyShadowingNames
         '''
         given a pageId and systemId, get the (pageId, systemId) for the previous system.

--- a/music21/lily/lilyObjects.py
+++ b/music21/lily/lilyObjects.py
@@ -20,7 +20,7 @@ this replaces (April 2012) the old LilyString() conversion methods.
 The Grammar for Lilypond comes from
 http://lilypond.org/doc/v2.14/Documentation/notation/lilypond-grammar
 '''
-from typing import Any, Dict, List
+import typing as t
 import unittest
 from music21 import common
 from music21 import exceptions21
@@ -40,9 +40,9 @@ class LyObject(prebase.ProtoM21Object):
     ''
 
     '''
-    supportedClasses: List[object] = []  # ordered list of classes to support
-    m21toLy: Dict[str, dict] = {}
-    defaultAttributes: Dict[str, Any] = {}
+    supportedClasses: t.List[object] = []  # ordered list of classes to support
+    m21toLy: t.Dict[str, dict] = {}
+    defaultAttributes: t.Dict[str, t.Any] = {}
     backslash = '\\'
 
     def __init__(self):
@@ -100,8 +100,8 @@ class LyObject(prebase.ProtoM21Object):
     def newlineIndent(self):
         # totalIndents = self.thisIndent
         ancestors = self.ancestorList()
-        # for a in ancestors:
-        #    totalIndents += a.thisIndent
+        # for ancestor in ancestors:
+        #    totalIndents += ancestor.thisIndent
         totalIndents = len(ancestors)
         indentSpaces = ' ' * totalIndents
         return '\n' + indentSpaces
@@ -376,7 +376,7 @@ class LyEmbeddedScm(LyObject):
     r'''
     represents Scheme embedded in Lilypond code.
 
-    Can be either a SCM_TOKEN (Scheme Token) or SCM_IDENTIFIER String stored in self.content
+    Can be either an SCM_TOKEN (Scheme Token) or SCM_IDENTIFIER String stored in self.content
 
     Note that if any LyEmbeddedScm is found in an output then the output SHOULD be marked as unsafe.
     But a lot of standard lilypond functions are actually embedded scheme.
@@ -792,7 +792,7 @@ class LyLayout(LyObject):
 
 class LyOutputDef(LyObject):
     r'''
-    ugly grammar since it doesnt close curly bracket...
+    This is an ugly grammar, since it does not close the curly bracket...
     '''
 
     def __init__(self, outputDefBody=None):
@@ -1307,35 +1307,35 @@ class LyPrefixCompositeMusic(LyObject):
         self.reRhythmedMusic = reRhythmedMusic
 
     def stringOutput(self):
-        t = self.type
-        if t == 'scheme':
+        myType = self.type
+        if myType == 'scheme':
             return str(self.genericPrefixMusicScm)
-        elif t in ('context', 'new'):
-            c = self.backslash + t + ' ' + str(self.simpleString) + ' '
+        elif myType in ('context', 'new'):
+            c = self.backslash + myType + ' ' + str(self.simpleString) + ' '
             if self.optionalId is not None:
                 c += str(self.optionalId) + ' '
             if self.optionalContextMod is not None:
                 c += str(self.optionalContextMod) + ' '
             c += str(self.music) + ' '
             return c
-        elif t == 'times':
+        elif myType == 'times':
             return self.backslash + 'times ' + str(self.fraction) + ' ' + str(self.music) + ' '
-        elif t == 'repeated':
+        elif myType == 'repeated':
             return str(self.repeatedMusic)
-        elif t == 'transpose':
+        elif myType == 'transpose':
             return ''.join([self.backslash, 'transpose ', str(self.pitchAlsoInChords1), ' ',
                             str(self.pitchAlsoInChords2), ' ', str(self.music), ' '])
-        elif t == 'modeChanging':
+        elif myType == 'modeChanging':
             return str(self.modeChangingHead) + ' ' + str(self.groupedMusicList)
-        elif t == 'modeChangingWith':
+        elif myType == 'modeChangingWith':
             c = str(self.modeChangingHeadWithContext) + ' '
             if self.optionalContextMod is not None:
                 c += str(self.optionalContextMod) + ' '
             c += str(self.groupedMusicList) + ' '
             return c
-        elif t == 'relative':
+        elif myType == 'relative':
             return str(self.relativeMusic)
-        elif t == 'rhythmed':
+        elif myType == 'rhythmed':
             return str(self.reRhythmedMusic)
         else:  # pragma: no cover
             raise LilyObjectsException(f'unknown self.type or None: {self.type}')

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -18,7 +18,7 @@ import pathlib
 import re
 import subprocess
 import sys
-from typing import Dict, Union
+import typing as t
 import unittest
 
 from collections import OrderedDict
@@ -52,7 +52,7 @@ del find_spec
 # TODO: speed up tests everywhere! move these to music21 base...
 
 class _sharedCorpusTestObject:
-    sharedCache: Dict[str, stream.Stream] = {}
+    sharedCache: t.Dict[str, stream.Stream] = {}
 
 
 sharedCacheObject = _sharedCorpusTestObject()
@@ -1526,7 +1526,7 @@ class LilypondConverter:
 
     def lyMultipliedDurationFromDuration(
         self,
-        durationObj: Union[duration.Duration, duration.DurationTuple],
+        durationObj: t.Union[duration.Duration, duration.DurationTuple],
     ):
         r'''
         take a simple Duration (that is, one with one DurationTuple)
@@ -1566,7 +1566,7 @@ class LilypondConverter:
         >>> [str(lpc.lyMultipliedDurationFromDuration(c)) for c in components]
         ['1 ', '4 ']
         '''
-        number_type: Union[float, int, str]
+        number_type: t.Union[float, int, str]
         try:
             number_type = duration.convertTypeToNumber(durationObj.type)  # module call
         except duration.DurationException as de:

--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -173,7 +173,7 @@ tool.
 * <sb>: a system break
 
 '''
-from typing import Optional, Union, List, Tuple
+import typing as t
 from xml.etree.ElementTree import Element, ParseError, fromstring, ElementTree
 
 from collections import defaultdict
@@ -341,8 +341,8 @@ class MeiToM21Converter:
 # -----------------------------------------------------------------------------
 def safePitch(
     name: str,
-    accidental: Optional[str] = None,
-    octave: Union[str, int] = ''
+    accidental: t.Optional[str] = None,
+    octave: t.Union[str, int] = ''
 ) -> pitch.Pitch:
     '''
     Safely build a :class:`~music21.pitch.Pitch` from a string.
@@ -380,7 +380,7 @@ def safePitch(
 
 
 def makeDuration(
-    base: Union[float, int, Fraction] = 0.0,
+    base: t.Union[float, int, Fraction] = 0.0,
     dots: int = 0
 ) -> 'music21.duration.Duration':
     '''
@@ -412,7 +412,7 @@ def makeDuration(
     return returnDuration
 
 
-def allPartsPresent(scoreElem) -> Tuple[str, ...]:
+def allPartsPresent(scoreElem) -> t.Tuple[str, ...]:
     # noinspection PyShadowingNames
     '''
     Find the @n values for all <staffDef> elements in a <score> element. This assumes that every
@@ -952,7 +952,7 @@ def _ppConclude(theConverter):
 # Helper Functions
 # -----------------------------------------------------------------------------
 def _processEmbeddedElements(
-    elements: List[Element],
+    elements: t.List[Element],
     mapping,
     callerTag=None,
     slurBundle=None
@@ -1032,7 +1032,7 @@ def _timeSigFromAttrs(elem):
     return meter.TimeSignature(f"{elem.get('meter.count')!s}/{elem.get('meter.unit')!s}")
 
 
-def _keySigFromAttrs(elem: Element) -> Union[key.Key, key.KeySignature]:
+def _keySigFromAttrs(elem: Element) -> t.Union[key.Key, key.KeySignature]:
     '''
     From any tag with (at minimum) either @key.pname or @key.sig attributes, make a
     :class:`KeySignature` or :class:`Key`, as possible.

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -45,7 +45,7 @@ import os
 import pathlib
 import re
 import unittest
-from typing import Optional, List
+import typing as t
 
 from music21 import base
 from music21 import common
@@ -675,7 +675,7 @@ class Metadata(base.Music21Object):
     def alternativeTitle(self, value):
         self._workIds['alternativeTitle'] = Text(value)
 
-    def _contributor_role_getter(self, role: str) -> Optional[str]:
+    def _contributor_role_getter(self, role: str) -> t.Optional[str]:
         '''
         get the name of the first contributor with this role, or None
 
@@ -706,7 +706,7 @@ class Metadata(base.Music21Object):
 
         c.name = name
 
-    def _contributor_multiple_role_getter(self, role: str) -> List[str]:
+    def _contributor_multiple_role_getter(self, role: str) -> t.List[str]:
         '''
         get a list of the names of contributors with a certain role.
 
@@ -719,7 +719,7 @@ class Metadata(base.Music21Object):
         else:
             return []
 
-    def _contributor_multiple_role_setter(self, role: str, value: List[str]) -> None:
+    def _contributor_multiple_role_setter(self, role: str, value: t.List[str]) -> None:
         '''
         set multiple names for a particular role, replacing the people
         already in those roles.
@@ -764,7 +764,7 @@ class Metadata(base.Music21Object):
         self._contributor_role_setter('composer', value)
 
     @property
-    def composers(self) -> List[str]:
+    def composers(self) -> t.List[str]:
         r'''
         Get or set a list of strings of all composer roles.
 
@@ -794,7 +794,7 @@ class Metadata(base.Music21Object):
         return self._contributor_multiple_role_getter('composer')
 
     @composers.setter
-    def composers(self, value: List[str]) -> None:
+    def composers(self, value: t.List[str]) -> None:
         self._contributor_multiple_role_setter('composer', value)
 
 
@@ -869,7 +869,7 @@ class Metadata(base.Music21Object):
         self._contributor_role_setter('librettist', value)
 
     @property
-    def librettists(self) -> List[str]:
+    def librettists(self) -> t.List[str]:
         r'''
         Gets or sets a list of librettists for this work:
 
@@ -883,7 +883,7 @@ class Metadata(base.Music21Object):
         return self._contributor_multiple_role_getter('librettist')
 
     @librettists.setter
-    def librettists(self, value: List[str]) -> None:
+    def librettists(self, value: t.List[str]) -> None:
         self._contributor_multiple_role_setter('librettist', value)
 
 
@@ -910,7 +910,7 @@ class Metadata(base.Music21Object):
         self._contributor_role_setter('lyricist', value)
 
     @property
-    def lyricists(self) -> List[str]:
+    def lyricists(self) -> t.List[str]:
         r'''
         Gets or sets a list of lyricists for this work:
 
@@ -924,7 +924,7 @@ class Metadata(base.Music21Object):
         return self._contributor_multiple_role_getter('lyricist')
 
     @lyricists.setter
-    def lyricists(self, value: List[str]) -> None:
+    def lyricists(self, value: t.List[str]) -> None:
         self._contributor_multiple_role_setter('lyricist', value)
 
 
@@ -946,7 +946,7 @@ class Metadata(base.Music21Object):
         self._workIds['movementName'] = Text(value)
 
     @property
-    def movementNumber(self) -> Optional[str]:
+    def movementNumber(self) -> t.Optional[str]:
         r'''
         Get or set the movement number.
 
@@ -1287,7 +1287,7 @@ class Test(unittest.TestCase):
 
 
 # -----------------------------------------------------------------------------
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 
 if __name__ == '__main__':

--- a/music21/metadata/caching.py
+++ b/music21/metadata/caching.py
@@ -15,7 +15,7 @@ import os
 import pathlib
 import pickle
 import traceback
-from typing import List
+import typing as t
 import unittest
 
 from music21 import common
@@ -424,7 +424,7 @@ class Test(unittest.TestCase):
 
 
 # -----------------------------------------------------------------------------
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 if __name__ == '__main__':
     import music21

--- a/music21/metadata/primitives.py
+++ b/music21/metadata/primitives.py
@@ -12,7 +12,7 @@
 import datetime
 import os
 import unittest
-from typing import List, Optional, Iterable, Any
+import typing as t
 
 from music21 import common
 from music21 import exceptions21
@@ -427,14 +427,14 @@ class DateSingle(prebase.ProtoM21Object):
 
     # INITIALIZER #
 
-    def __init__(self, data: Any = '', relevance='certain'):
-        self._data: List[Date] = []
+    def __init__(self, data: t.Any = '', relevance='certain'):
+        self._data: t.List[Date] = []
         self._relevance = None  # managed by property
         # not yet implemented
         # store an array of values marking if date data itself
         # is certain, approximate, or uncertain
         # here, dataError is relevance
-        self._dataError: List[str] = []
+        self._dataError: t.List[str] = []
         self._prepareData(data)
         self.relevance = relevance  # will use property
 
@@ -587,7 +587,7 @@ class DateBetween(DateSingle):
 
     # INITIALIZER #
 
-    def __init__(self, data: Optional[Iterable[str]] = None, relevance='between'):
+    def __init__(self, data: t.Optional[t.Iterable[str]] = None, relevance='between'):
         if data is None:
             data = []
         super().__init__(data, relevance)
@@ -664,7 +664,7 @@ class DateSelection(DateSingle):
     # INITIALIZER #
 
     def __init__(self,
-                 data: Optional[Iterable[str]] = None,
+                 data: t.Optional[t.Iterable[str]] = None,
                  relevance='or'):  # pylint: disable=useless-super-delegation
         super().__init__(data, relevance)
 
@@ -906,7 +906,7 @@ class Contributor(prebase.ProtoM21Object):
 
     # PUBLIC METHODS #
 
-    def age(self) -> Optional[DateSingle]:
+    def age(self) -> t.Optional[DateSingle]:
         r'''
         Calculate the age at death of the Contributor, returning a
         datetime.timedelta object.

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -17,7 +17,7 @@ as well as component objects for defining nested metrical structures,
 '''
 import copy
 import fractions
-from typing import Optional, Sequence, List, Dict, Tuple, Any
+import typing as t
 
 from music21 import base
 from music21 import beam
@@ -43,7 +43,7 @@ MIN_DENOMINATOR_TYPE = '128th'
 
 # store a module-level dictionary of partitioned meter sequences used
 # for setting default accent weights; store as needed
-_meterSequenceAccentArchetypes: Dict[Tuple[str, Any, int], MeterSequence] = {}
+_meterSequenceAccentArchetypes: t.Dict[t.Tuple[str, t.Any, int], MeterSequence] = {}
 _meterSequenceAccentArchetypesNoneCache = ('', -1, -1)  # a cache key representing None
 
 def bestTimeSignature(meas: 'music21.stream.Stream') -> 'music21.meter.TimeSignature':
@@ -462,10 +462,10 @@ class TimeSignature(base.Music21Object):
 
         self._overriddenBarDuration = None
         self.symbol = ''
-        self.displaySequence: Optional[MeterSequence] = None
-        self.beatSequence: Optional[MeterSequence] = None
-        self.accentSequence: Optional[MeterSequence] = None
-        self.beamSequence: Optional[MeterSequence] = None
+        self.displaySequence: t.Optional[MeterSequence] = None
+        self.beatSequence: t.Optional[MeterSequence] = None
+        self.accentSequence: t.Optional[MeterSequence] = None
+        self.beamSequence: t.Optional[MeterSequence] = None
         self.symbolizeDenominator = False
 
         self.resetValues(value, divisions)
@@ -963,7 +963,7 @@ class TimeSignature(base.Music21Object):
             return 'Other'
 
     @property
-    def beatDivisionDurations(self) -> List[duration.Duration]:
+    def beatDivisionDurations(self) -> t.List[duration.Duration]:
         '''
         Return the beat division, or the durations that make up one beat,
         as a list of :class:`~music21.duration.Duration` objects, if and only if
@@ -999,7 +999,7 @@ class TimeSignature(base.Music21Object):
             raise TimeSignatureException(f'non uniform beat division: {post}')
 
     @property
-    def beatSubDivisionDurations(self) -> List[duration.Duration]:
+    def beatSubDivisionDurations(self) -> t.List[duration.Duration]:
         '''
         Return a subdivision of the beat division, or a list
         of :class:`~music21.duration.Duration` objects representing each beat division
@@ -1233,7 +1233,7 @@ class TimeSignature(base.Music21Object):
 
     # --------------------------------------------------------------------------
     # access data for other processing
-    def getBeams(self, srcList, measureStartOffset=0.0) -> List[Optional[beam.Beams]]:
+    def getBeams(self, srcList, measureStartOffset=0.0) -> t.List[t.Optional[beam.Beams]]:
         '''
         Given a qLen position and an iterable of Music21Objects, return a list of Beams objects.
 
@@ -1548,7 +1548,7 @@ class TimeSignature(base.Music21Object):
             pos += self.accentSequence[i].duration.quarterLength
         return False
 
-    def setAccentWeight(self, weightList: Sequence[float], level: int = 0) -> None:
+    def setAccentWeight(self, weightList: t.Sequence[float], level: int = 0) -> None:
         '''
         Set accent weight, or floating point scalars, for the accent MeterSequence.
         Provide a list of float values; if this list is shorter than the length

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -15,7 +15,7 @@ This module defines two component objects for defining nested metrical structure
 :class:`~music21.meter.core.MeterTerminal` and :class:`~music21.meter.core.MeterSequence`.
 '''
 import copy
-from typing import Optional
+import typing as t
 
 from music21 import prebase
 from music21.common.numberTools import opFrac
@@ -56,7 +56,7 @@ class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
     )
 
     # INITIALIZER #
-    def __init__(self, slashNotation: Optional[str] = None, weight=1):
+    def __init__(self, slashNotation: t.Optional[str] = None, weight=1):
         self._duration = None
         self._numerator = 0
         self._denominator = 1
@@ -1161,7 +1161,7 @@ class MeterSequence(MeterTerminal):
             #    'created MeterSequence from MeterTerminal; old weight, new weight',
             #    value.weight, self.weight])
 
-        elif common.isIterable(value):  # a list of Terminals or Sequence es
+        elif common.isIterable(value):  # a list of Terminals or t.Sequence es
             for obj in value:
                 # environLocal.printDebug('creating MeterSequence with %s' % obj)
                 self._addTerminal(obj)
@@ -1768,7 +1768,7 @@ class MeterSequence(MeterTerminal):
         iMatch = self.offsetToIndex(qLenPos)
         return opFrac(self[iMatch].weight)
 
-    def offsetToDepth(self, qLenPos, align='quantize', index: Optional[int] = None):
+    def offsetToDepth(self, qLenPos, align='quantize', index: t.Optional[int] = None):
         '''
         Given a qLenPos, return the maximum available depth at this position.
 

--- a/music21/meter/tools.py
+++ b/music21/meter/tools.py
@@ -14,7 +14,7 @@ import collections
 import fractions
 from functools import lru_cache
 import re
-from typing import Tuple, List, TYPE_CHECKING, Union
+import typing as t
 
 from music21 import common
 from music21 import environment
@@ -25,9 +25,9 @@ environLocal = environment.Environment('meter.tools')
 
 MeterTerminalTuple = collections.namedtuple('MeterTerminalTuple',
                                             ['numerator', 'denominator', 'division'])
-NumDenom = Tuple[int, int]
-NumDenomTuple = Tuple[NumDenom, ...]
-MeterOptions = Tuple[Tuple[str, ...], ...]
+NumDenom = t.Tuple[int, int]
+NumDenomTuple = t.Tuple[NumDenom, ...]
+MeterOptions = t.Tuple[t.Tuple[str, ...], ...]
 
 validDenominators = [1, 2, 4, 8, 16, 32, 64, 128]  # in order
 validDenominatorsSet = set(validDenominators)
@@ -81,7 +81,7 @@ def slashCompoundToFraction(value: str) -> NumDenomTuple:
 
     Changed in v7 -- new location and returns a tuple.
     '''
-    post: List[NumDenom] = []
+    post: t.List[NumDenom] = []
     value = value.strip()  # rem whitespace
     valueList = value.split('+')
     for part in valueList:
@@ -94,7 +94,7 @@ def slashCompoundToFraction(value: str) -> NumDenomTuple:
 
 
 @lru_cache(512)
-def slashMixedToFraction(valueSrc: str) -> Tuple[NumDenomTuple, bool]:
+def slashMixedToFraction(valueSrc: str) -> t.Tuple[NumDenomTuple, bool]:
     '''
     Given a mixture if possible meter fraction representations, return a list
     of pairs. If originally given as a summed numerator; break into separate
@@ -128,8 +128,8 @@ def slashMixedToFraction(valueSrc: str) -> Tuple[NumDenomTuple, bool]:
 
     Changed in v7 -- new location and returns a tuple as first value.
     '''
-    pre: List[Union[NumDenom, Tuple[int, None]]] = []
-    post: List[NumDenom] = []
+    pre: t.List[t.Union[NumDenom, t.Tuple[int, None]]] = []
+    post: t.List[NumDenom] = []
     summedNumerator = False
     value = valueSrc.strip()  # rem whitespace
     value = value.split('+')
@@ -156,7 +156,7 @@ def slashMixedToFraction(valueSrc: str) -> Tuple[NumDenomTuple, bool]:
     # and apply to all previous
     for i in range(len(pre)):
         if pre[i][1] is not None:  # there is a denominator
-            if TYPE_CHECKING:
+            if t.TYPE_CHECKING:
                 assert isinstance(pre[i][0], int) and isinstance(pre[i][1], int)
             post.append(tuple(pre[i]))
         else:  # search ahead for next defined denominator
@@ -176,7 +176,7 @@ def slashMixedToFraction(valueSrc: str) -> Tuple[NumDenomTuple, bool]:
 
 
 @lru_cache(512)
-def fractionToSlashMixed(fList: NumDenomTuple) -> Tuple[Tuple[str, int], ...]:
+def fractionToSlashMixed(fList: NumDenomTuple) -> t.Tuple[t.Tuple[str, int], ...]:
     '''
     Given a tuple of fraction values, compact numerators by sum if denominators
     are the same
@@ -302,7 +302,7 @@ def proportionToFraction(value: float) -> NumDenom:
 # load common meter templates into this sequence
 # no need to cache these -- getPartitionOptions is cached
 
-def divisionOptionsFractionsUpward(n, d) -> Tuple[str, ...]:
+def divisionOptionsFractionsUpward(n, d) -> t.Tuple[str, ...]:
     '''
     This simply gets restatements of the same fraction in smaller units,
     up to the largest valid denominator.
@@ -328,7 +328,7 @@ def divisionOptionsFractionsUpward(n, d) -> Tuple[str, ...]:
     return tuple(opts)
 
 
-def divisionOptionsFractionsDownward(n, d) -> Tuple[str, ...]:
+def divisionOptionsFractionsDownward(n, d) -> t.Tuple[str, ...]:
     '''
     Get restatements of the same fraction in larger units
 

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -37,7 +37,7 @@ import struct
 import sys
 import unicodedata
 import unittest
-from typing import List, Optional, Union, Tuple
+import typing as t
 
 from enum import IntEnum
 
@@ -463,23 +463,23 @@ class MidiEvent(prebase.ProtoM21Object):
     '''
     # pylint: disable=redefined-builtin
     def __init__(self,
-                 track: Optional['music21.midi.MidiTrack'] = None,
+                 track: t.Optional['music21.midi.MidiTrack'] = None,
                  type=None,
                  time: int = 0,
-                 channel: Optional[int] = None):
-        self.track: Optional['music21.midi.MidiTrack'] = track  # a MidiTrack object
+                 channel: t.Optional[int] = None):
+        self.track: t.Optional['music21.midi.MidiTrack'] = track  # a MidiTrack object
         self.type = type
         self.time: int = time
-        self.channel: Optional[int] = channel
+        self.channel: t.Optional[int] = channel
 
-        self.parameter1: Union[int, bytes, None] = None  # pitch or first data value
-        self.parameter2: Union[int, bytes, None] = None  # velocity or second data value
+        self.parameter1: t.Union[int, bytes, None] = None  # pitch or first data value
+        self.parameter2: t.Union[int, bytes, None] = None  # velocity or second data value
 
         # data is a property...
 
         # if this is a Note on/off, need to store original
-        # pitch space value in order to determine if this is has a microtone
-        self.centShift: Optional[int] = None
+        # pitch space value in order to determine if this has a microtone
+        self.centShift: t.Optional[int] = None
 
         # store a reference to a corresponding event
         # if a noteOn, store the note off, and vice versa
@@ -487,7 +487,7 @@ class MidiEvent(prebase.ProtoM21Object):
         self.correspondingEvent = None
 
         # store and pass on a running status if found
-        self.lastStatusByte: Optional[int] = None
+        self.lastStatusByte: t.Optional[int] = None
 
     @property
     def sortOrder(self) -> int:
@@ -615,7 +615,7 @@ class MidiEvent(prebase.ProtoM21Object):
         (0, 64)
 
 
-        Parameter 2 is most significant digit, not
+        Parameter 2 is the most significant digit, not
         parameter 1.
 
         >>> me1.setPitchBend(101)
@@ -711,7 +711,7 @@ class MidiEvent(prebase.ProtoM21Object):
         # 'd1', d1, 'd2', d2,])
 
         self.parameter1 = d2
-        self.parameter2 = d1  # d1 is most significant byte here
+        self.parameter2 = d1  # d1 is the most significant byte here
 
     def parseChannelVoiceMessage(self, midiBytes: bytes) -> bytes:
         r'''
@@ -760,7 +760,7 @@ class MidiEvent(prebase.ProtoM21Object):
         1
 
 
-        Here we send the message for a note on on another channel (0x91 = channel 2):
+        Here we send the message for a note on another channel (0x91 = channel 2):
 
         >>> rem = me1.parseChannelVoiceMessage(to_bytes([0x91, 60, 120]))
         >>> me1
@@ -875,7 +875,7 @@ class MidiEvent(prebase.ProtoM21Object):
         # contains the midi channel number on which the command will be executed.
         byte0: int = midiBytes[0]  # extracting a single val from a byte makes it an int
 
-        # detect running status: if the status byte is less than 0x80, its
+        # detect running status: if the status byte is less than 0x80, it is
         # not a status byte, but a data byte
         if byte0 < 0x80:
             # environLocal.printDebug(['MidiEvent.read(): found running status even data',
@@ -963,7 +963,7 @@ class MidiEvent(prebase.ProtoM21Object):
                 data = param1data + param2data
             elif self.type == ChannelVoiceMessages.PROGRAM_CHANGE:
                 data = bytes([self.data])
-            else:  # all other messages
+            else:  # all the other messages
                 try:
                     if isinstance(self.data, int):
                         data = bytes([self.data])
@@ -1023,7 +1023,7 @@ class MidiEvent(prebase.ProtoM21Object):
 
     def isNoteOff(self):
         '''
-        Return a boolean if this is should be interpreted as a note-off message,
+        Return a boolean if this should be interpreted as a note-off message,
         either as a real note-off or as a note-on with zero velocity.
 
 
@@ -1147,7 +1147,7 @@ class DeltaTime(MidiEvent):
             rep = '(empty) ' + rep
         return rep
 
-    def read(self, oldBytes: bytes) -> Tuple[int, bytes]:
+    def read(self, oldBytes: bytes) -> t.Tuple[int, bytes]:
         r'''
         Read a byte-string until hitting a character below 0x80
         and return the converted number and the rest of the bytes
@@ -1799,11 +1799,11 @@ class Test(unittest.TestCase):
                 [1024, 50, 70],
                 [1024, 51, 120],
                 [1024, 62, 80]]
-        t = 0
+        timeNow = 0
         tLast = 0
         for d, p, v in data:
             dt = midi.DeltaTime(mt)
-            dt.time = t - tLast
+            dt.time = timeNow - tLast
             # add to track events
             mt.events.append(dt)
 
@@ -1827,8 +1827,8 @@ class Test(unittest.TestCase):
             me.velocity = 0
             mt.events.append(me)
 
-            tLast = t + d  # have delta to note off
-            t += d  # next time
+            tLast = timeNow + d  # have delta to note off
+            timeNow += d  # next time
 
         # add end of track
         dt = midi.DeltaTime(mt)
@@ -1873,13 +1873,13 @@ class Test(unittest.TestCase):
 
         # duration, pitch, velocity
         data = [[1024, 60, 90]] * 20
-        t = 0
+        timeNow = 0
         tLast = 0
         for i, e in enumerate(data):
             d, p, v = e
 
             dt = midi.DeltaTime(mt)
-            dt.time = t - tLast
+            dt.time = timeNow - tLast
             # add to track events
             mt.events.append(dt)
 
@@ -1889,7 +1889,7 @@ class Test(unittest.TestCase):
             mt.events.append(me)
 
             dt = midi.DeltaTime(mt)
-            dt.time = t - tLast
+            dt.time = timeNow - tLast
             # add to track events
             mt.events.append(dt)
 
@@ -1909,8 +1909,8 @@ class Test(unittest.TestCase):
             me.velocity = 0
             mt.events.append(me)
 
-            tLast = t + d  # have delta to note off
-            t += d  # next time
+            tLast = timeNow + d  # have delta to note off
+            timeNow += d  # next time
 
         # add end of track
         dt = midi.DeltaTime(mt)
@@ -1981,7 +1981,7 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 if __name__ == '__main__':
     import music21

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -16,7 +16,7 @@ notes takes place in the :meth:`~music21.stream.Stream.quantize` method not here
 import unittest
 import math
 import copy
-from typing import Optional, List, Tuple, Dict, Union, Any, TypeVar, Type
+import typing as t
 import warnings
 
 from music21 import chord
@@ -40,7 +40,7 @@ environLocal = environment.Environment('midi.translate')
 PERCUSSION_MAPPER = PercussionMapper()
 
 
-NotRestType = TypeVar('NotRestType', bound=note.NotRest)
+NotRestType = t.TypeVar('NotRestType', bound=note.NotRest)
 
 # ------------------------------------------------------------------------------
 class TranslateException(exceptions21.Music21Exception):
@@ -281,8 +281,8 @@ def _constructOrUpdateNotRestSubclass(
     tOff: int,
     ticksPerQuarter: int,
     *,
-    inputM21: Optional[NotRestType] = None,
-    preferredClass: Type[NotRestType] = note.Note,
+    inputM21: t.Optional[NotRestType] = None,
+    preferredClass: t.Type[NotRestType] = note.Note,
 ) -> NotRestType:
     '''
     Construct (or edit the duration of) a NotRest subclass, usually
@@ -323,8 +323,8 @@ def _constructOrUpdateNotRestSubclass(
 def midiEventsToNote(
     eventList,
     ticksPerQuarter=None,
-    inputM21: Optional[NotRestType] = None,
-) -> Optional[NotRestType]:
+    inputM21: t.Optional[NotRestType] = None,
+) -> t.Optional[NotRestType]:
     # noinspection PyShadowingNames
     '''
     Convert from a list of midi.DeltaTime and midi.MidiEvent objects to a music21 Note.
@@ -553,10 +553,10 @@ def noteToMidiEvents(inputM21, *, includeDeltaTime=True, channel=1):
 # Chords
 
 def midiEventsToChord(
-    eventList: List['music21.midi.MidiEvent'],
-    ticksPerQuarter: Optional[int] = None,
-    inputM21: Optional[chord.ChordBase] = None
-) -> Optional[chord.ChordBase]:
+    eventList: t.List['music21.midi.MidiEvent'],
+    ticksPerQuarter: t.Optional[int] = None,
+    inputM21: t.Optional[chord.ChordBase] = None
+) -> t.Optional[chord.ChordBase]:
     # noinspection PyShadowingNames
     '''
     Creates a Chord from a list of :class:`~music21.midi.DeltaTime`
@@ -624,10 +624,10 @@ def midiEventsToChord(
         ticksPerQuarter = defaults.ticksPerQuarter
 
     from music21 import volume
-    pitches: List[pitch.Pitch] = []
+    pitches: t.List[pitch.Pitch] = []
     volumes = []
 
-    firstOn: Optional['music21.midi.MidiEvent'] = None
+    firstOn: t.Optional['music21.midi.MidiEvent'] = None
     any_channel_10 = False
     # this is a format provided by the Stream conversion of
     # midi events; it pre-groups events for a chord together in nested pairs
@@ -1225,9 +1225,9 @@ def getPacketFromMidiEvent(
         trackId: int,
         offset: int,
         midiEvent: 'music21.midi.MidiEvent',
-        obj: Optional['music21.base.Music21Object'] = None,
-        lastInstrument: Optional['music21.instrument.Instrument'] = None
-) -> Dict[str, Any]:
+        obj: t.Optional['music21.base.Music21Object'] = None,
+        lastInstrument: t.Optional['music21.instrument.Instrument'] = None
+) -> t.Dict[str, t.Any]:
     '''
     Pack a dictionary of parameters for each event.
     Packets are used for sorting and configuring all note events.
@@ -1282,7 +1282,7 @@ def getPacketFromMidiEvent(
 
 def elementToMidiEventList(
     el: 'music21.base.Music21Object'
-) -> Optional[List['music21.midi.MidiEvent']]:
+) -> t.Optional[t.List['music21.midi.MidiEvent']]:
     '''
     Return a list of MidiEvents (or None) from a Music21Object,
     assuming that dynamics have already been applied, etc.
@@ -1337,7 +1337,7 @@ def streamToPackets(
     s: stream.Stream,
     trackId: int = 1,
     addStartDelay: bool = False,
-) -> List[Dict[str, Any]]:
+) -> t.List[t.Dict[str, t.Any]]:
     '''
     Convert a (flattened, sorted) Stream to packets.
 
@@ -1644,9 +1644,9 @@ def assignPacketsToChannels(
 
 
 def filterPacketsByTrackId(
-    packetsSrc: List[Dict[str, Any]],
-    trackIdFilter: Optional[int] = None,
-) -> List[Dict[str, Any]]:
+    packetsSrc: t.List[t.Dict[str, t.Any]],
+    trackIdFilter: t.Optional[int] = None,
+) -> t.List[t.Dict[str, t.Any]]:
     '''
     Given a list of Packet dictionaries, return a list of
     only those whose trackId matches the filter.
@@ -1678,9 +1678,9 @@ def filterPacketsByTrackId(
 
 
 def packetsToDeltaSeparatedEvents(
-        packets: List[Dict[str, Any]],
+        packets: t.List[t.Dict[str, t.Any]],
         midiTrack: 'music21.midi.MidiTrack'
-) -> List['music21.midi.MidiEvent']:
+) -> t.List['music21.midi.MidiEvent']:
     '''
     Given a list of packets (which already contain MidiEvent objects)
     return a list of those Events with proper delta times between them.
@@ -1697,11 +1697,11 @@ def packetsToDeltaSeparatedEvents(
     lastOffset = 0
     for packet in packets:
         midiEvent = packet['midiEvent']
-        t = packet['offset'] - lastOffset
-        if t < 0:
+        deltaTimeInt = packet['offset'] - lastOffset
+        if deltaTimeInt < 0:
             raise TranslateException('got a negative delta time')
         # set the channel from the midi event
-        dt = DeltaTime(midiTrack, time=t, channel=midiEvent.channel)
+        dt = DeltaTime(midiTrack, time=deltaTimeInt, channel=midiEvent.channel)
         # environLocal.printDebug(['packetsByOffset', packet])
         events.append(dt)
         events.append(midiEvent)
@@ -1744,7 +1744,7 @@ def packetsToMidiTrack(packets, trackId=1, channel=1, instrumentObj=None):
 
 def getTimeForEvents(
     mt: 'music21.midi.MidiTrack'
-) -> List[Tuple[int, 'music21.midi.MidiEvent']]:
+) -> t.List[t.Tuple[int, 'music21.midi.MidiEvent']]:
     '''
     Get a list of tuples of (tickTime, MidiEvent) from the events with time deltas.
     '''
@@ -1796,9 +1796,9 @@ def getTimeForEvents(
 
 
 def getNotesFromEvents(
-    events: List[Tuple[int, 'music21.midi.MidiEvent']]
-) -> List[Tuple[Tuple[int, 'music21.midi.MidiEvent'],
-                Tuple[int, 'music21.midi.MidiEvent']]]:
+    events: t.List[t.Tuple[int, 'music21.midi.MidiEvent']]
+) -> t.List[t.Tuple[t.Tuple[int, 'music21.midi.MidiEvent'],
+                t.Tuple[int, 'music21.midi.MidiEvent']]]:
     '''
     Returns a list of Tuples of MIDI events that are pairs of note-on and
     note-off events.
@@ -1841,7 +1841,7 @@ def getMetaEvents(events):
     metaEvents = []  # store pairs of abs time, m21 object
     last_program: int = -1
     for eventTuple in events:
-        t, e = eventTuple
+        timeEvent, e = eventTuple
         metaObj = None
         if e.type == MetaEvents.TIME_SIGNATURE:
             # time signature should be 4 bytes
@@ -1866,7 +1866,7 @@ def getMetaEvents(events):
         else:
             pass
         if metaObj:
-            pair = (t, metaObj)
+            pair = (timeEvent, metaObj)
             metaEvents.append(pair)
 
     return metaEvents
@@ -1897,7 +1897,7 @@ def midiTrackToStream(
     ticksPerQuarter=None,
     quantizePost=True,
     inputM21=None,
-    conductorPart: Optional[stream.Part] = None,
+    conductorPart: t.Optional[stream.Part] = None,
     isFirst: bool = False,
     **keywords
 ) -> stream.Part:
@@ -1978,9 +1978,9 @@ def midiTrackToStream(
     metaEvents = getMetaEvents(events)
 
     # first create meta events
-    for t, obj in metaEvents:
+    for tick, obj in metaEvents:
         # environLocal.printDebug(['insert midi meta event:', t, obj])
-        s.coreInsert(t / ticksPerQuarter, obj)
+        s.coreInsert(tick / ticksPerQuarter, obj)
     s.coreElementsChanged()
     deduplicate(s, inPlace=True)
     # environLocal.printDebug([
@@ -1989,7 +1989,7 @@ def midiTrackToStream(
     # collect notes with similar start times into chords
     # create a composite list of both notes and chords
     # composite = []
-    chordSub: Optional[List['music21.midi.MidiEvent']] = None
+    chordSub: t.Optional[t.List['music21.midi.MidiEvent']] = None
     i = 0
     iGathered = []  # store a list of indexes of gathered values put into chords
     voicesRequired = False
@@ -2007,7 +2007,7 @@ def midiTrackToStream(
                 continue
             # look at each note; get on time and event
             on, off = notes[i]
-            t, unused_e = on
+            timeNow, unused_e = on
             tOff, unused_eOff = off
             # environLocal.printDebug(['on, off', on, off, 'i', i, 'len(notes)', len(notes)])
 
@@ -2031,7 +2031,7 @@ def midiTrackToStream(
                     divisor = 16
                 chunkTolerance = ticksPerQuarter / divisor
                 # must be strictly less than the quantization unit
-                if abs(tSub - t) < chunkTolerance:
+                if abs(tSub - timeNow) < chunkTolerance:
                     # isolate case where end time is not w/n tolerance
                     if abs(tOffSub - tOff) > chunkTolerance:
                         # need to store this as requiring movement to a diff
@@ -2097,7 +2097,7 @@ def midiTrackToStream(
     if conductorPart is not None:
         insertConductorEvents(conductorPart, s, isFirst=isFirst)
 
-    meterStream: Optional[stream.Stream] = None
+    meterStream: t.Optional[stream.Stream] = None
     if conductorPart is not None:
         ts_iter = conductorPart['TimeSignature']
         if ts_iter:
@@ -2254,8 +2254,8 @@ def conductorStream(s: stream.Stream) -> stream.Part:
 
 def channelInstrumentData(
     s: stream.Stream,
-    acceptableChannelList: Optional[List[int]] = None,
-) -> Tuple[Dict[Union[int, None], int], List[int]]:
+    acceptableChannelList: t.Optional[t.List[int]] = None,
+) -> t.Tuple[t.Dict[t.Union[int, None], int], t.List[int]]:
     '''
     Read through Stream `s` and finding instruments in it, return a 2-tuple,
     the first a dictionary mapping MIDI program numbers to channel numbers,
@@ -2375,10 +2375,10 @@ def channelInstrumentData(
 
 
 def packetStorageFromSubstreamList(
-    substreamList: List[stream.Part],
+    substreamList: t.List[stream.Part],
     *,
     addStartDelay=False,
-) -> Dict[int, Dict[str, Any]]:
+) -> t.Dict[int, t.Dict[str, t.Any]]:
     # noinspection PyShadowingNames
     r'''
     Make a dictionary of raw packets and the initial instrument for each
@@ -2474,8 +2474,8 @@ def packetStorageFromSubstreamList(
 
 
 def updatePacketStorageWithChannelInfo(
-        packetStorage: Dict[int, Dict[str, Any]],
-        channelByInstrument: Dict[Union[int, None], Union[int, None]],
+        packetStorage: t.Dict[int, t.Dict[str, t.Any]],
+        channelByInstrument: t.Dict[t.Union[int, None], t.Union[int, None]],
 ) -> None:
     '''
     Take the packetStorage dictionary and using information
@@ -2592,10 +2592,10 @@ def streamHierarchyToMidiTracks(
 
 
 def midiTracksToStreams(
-    midiTracks: List['music21.midi.MidiTrack'],
+    midiTracks: t.List['music21.midi.MidiTrack'],
     ticksPerQuarter=None,
     quantizePost=True,
-    inputM21: Optional[stream.Score] = None,
+    inputM21: t.Optional[stream.Score] = None,
     **keywords
 ) -> stream.Score:
     '''
@@ -2640,7 +2640,7 @@ def streamToMidiFile(
     inputM21: stream.Stream,
     *,
     addStartDelay: bool = False,
-    acceptableChannelList: Optional[List[int]] = None,
+    acceptableChannelList: t.Optional[t.List[int]] = None,
 ) -> 'music21.midi.MidiFile':
     # noinspection PyShadowingNames
     '''
@@ -3476,8 +3476,8 @@ class Test(unittest.TestCase):
         s = corpus.parse('bwv66.6')
         p1 = s.parts[0]
         p2 = copy.deepcopy(p1)
-        t = interval.Interval(0.5)  # half sharp
-        p2.transpose(t, inPlace=True, classFilterList=('Note', 'Chord'))
+        halfSharp = interval.Interval(0.5)  # half sharp
+        p2.transpose(halfSharp, inPlace=True, classFilterList=('Note', 'Chord'))
         post = stream.Score()
         post.insert(0, p1)
         post.insert(0, p2)

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1798,7 +1798,7 @@ def getTimeForEvents(
 def getNotesFromEvents(
     events: t.List[t.Tuple[int, 'music21.midi.MidiEvent']]
 ) -> t.List[t.Tuple[t.Tuple[int, 'music21.midi.MidiEvent'],
-                t.Tuple[int, 'music21.midi.MidiEvent']]]:
+                    t.Tuple[int, 'music21.midi.MidiEvent']]]:
     '''
     Returns a list of Tuples of MIDI events that are pairs of note-on and
     note-off events.

--- a/music21/musicxml/archiveTools.py
+++ b/music21/musicxml/archiveTools.py
@@ -15,7 +15,7 @@ Tools for compressing and decompressing musicxml files.
 import os
 import pathlib
 import zipfile
-from typing import Union
+import typing as t
 
 from music21 import common
 from music21 import environment
@@ -45,7 +45,7 @@ def compressAllXMLFiles(*, deleteOriginal=False):
     )
 
 
-def compressXML(filename: Union[str, pathlib.Path],
+def compressXML(filename: t.Union[str, pathlib.Path],
                 *,
                 deleteOriginal=False,
                 silent=False,
@@ -97,7 +97,7 @@ def compressXML(filename: Union[str, pathlib.Path],
     return True
 
 
-def uncompressMXL(filename: Union[str, pathlib.Path],
+def uncompressMXL(filename: t.Union[str, pathlib.Path],
                   *,
                   deleteOriginal=False,
                   strictMxlCheck=True) -> bool:

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -13,7 +13,7 @@
 A mixin to ScoreExporter that includes the capabilities for producing a single
 MusicXML `<part>` from multiple music21 `PartStaff` objects.
 '''
-from typing import Dict, List, Optional, Union, Type
+import typing as t
 import unittest
 import warnings
 from xml.etree.ElementTree import Element, SubElement, Comment
@@ -27,7 +27,7 @@ from music21 import stream  # for typing
 from music21.musicxml import helpers
 from music21.musicxml.xmlObjects import MusicXMLExportException, MusicXMLWarning
 
-def addStaffTags(measure: Element, staffNumber: int, tagList: Optional[List[str]] = None):
+def addStaffTags(measure: Element, staffNumber: int, tagList: t.Optional[t.List[str]] = None):
     '''
     For a <measure> tag `measure`, add a <staff> grandchild to any instance of
     a child tag of a type in `tagList`.
@@ -145,7 +145,7 @@ class PartStaffExporterMixin:
             self.setEarliestAttributesAndClefsPartStaff(group)
             self.cleanUpSubsequentPartStaffs(group)
 
-    def joinableGroups(self) -> List[StaffGroup]:
+    def joinableGroups(self) -> t.List[StaffGroup]:
         '''
         Returns a list of :class:`~music21.layout.StaffGroup` objects that
         represent :class:`~music21.stream.base.PartStaff` objects that can be
@@ -226,7 +226,7 @@ class PartStaffExporterMixin:
          <music21.layout.StaffGroup <... p6a><... p6b>>]
         '''
         staffGroups = self.stream.getElementsByClass(StaffGroup)
-        joinableGroups: List[StaffGroup] = []
+        joinableGroups: t.List[StaffGroup] = []
         # Joinable groups must consist of only PartStaffs with Measures
         # and exist in self.stream
         for sg in staffGroups:
@@ -245,7 +245,7 @@ class PartStaffExporterMixin:
 
         # Deduplicate joinable groups (ex: bracket and brace enclose same PartStaffs)
         permutations = set()
-        deduplicatedGroups: List[StaffGroup] = []
+        deduplicatedGroups: t.List[StaffGroup] = []
         for jg in joinableGroups:
             containedParts = tuple(jg)
             if containedParts not in permutations:
@@ -312,7 +312,7 @@ class PartStaffExporterMixin:
           </note>
         </measure>
         '''
-        initialPartStaffRoot: Optional[Element] = None
+        initialPartStaffRoot: t.Optional[Element] = None
         for i, ps in enumerate(group):
             staffNumber: int = i + 1  # 1-indexed
             thisPartStaffRoot: Element = self.getRootForPartStaff(ps)
@@ -364,7 +364,7 @@ class PartStaffExporterMixin:
                                    target: Element,
                                    source: Element,
                                    staffNum: int
-                                   ) -> Dict[int, List[Element]]:
+                                   ) -> t.Dict[int, t.List[Element]]:
         '''
         Move elements from subsequent PartStaff's measures into `target`: the <part>
         element representing the initial PartStaff that will soon represent the merged whole.
@@ -377,12 +377,12 @@ class PartStaffExporterMixin:
         DIVIDER_COMMENT = '========================= Measure [NNN] =========================='
         PLACEHOLDER = '[NNN]'
 
-        def makeDivider(inner_sourceNumber: Union[int, str]) -> Element:
+        def makeDivider(inner_sourceNumber: t.Union[int, str]) -> Element:
             return Comment(DIVIDER_COMMENT.replace(PLACEHOLDER, str(inner_sourceNumber)))
 
         sourceMeasures = iter(source.findall('measure'))
         sourceMeasure = None  # Set back to None when disposed of
-        insertions: Dict[int, List[Element]] = {}
+        insertions: t.Dict[int, t.List[Element]] = {}
 
         # Walk through <measures> of the target <part>, compare measure numbers
         for i, targetMeasure in enumerate(target):
@@ -517,14 +517,14 @@ class PartStaffExporterMixin:
         </measure>
         '''
 
-        def isMultiAttribute(m21Class: Type[M21ObjType],
+        def isMultiAttribute(m21Class: t.Type[M21ObjType],
                              comparison: str = '__eq__') -> bool:
             '''
             Return True if any first instance of m21Class in any subsequent staff
             in this StaffGroup does not compare to the first instance of that class
             in the earliest staff where found (not necessarily the first) using `comparison`.
             '''
-            initialM21Instance: Optional[M21ObjType] = None
+            initialM21Instance: t.Optional[M21ObjType] = None
             # noinspection PyShadowingNames
             for ps in group:  # ps okay to reuse.
                 if initialM21Instance is None:
@@ -542,8 +542,8 @@ class PartStaffExporterMixin:
         multiKey: bool = isMultiAttribute(KeySignature)
         multiMeter: bool = isMultiAttribute(TimeSignature, comparison='ratioEqual')
 
-        initialPartStaffRoot: Optional[Element] = None
-        mxAttributes: Optional[Element] = None
+        initialPartStaffRoot: t.Optional[Element] = None
+        mxAttributes: t.Optional[Element] = None
         for i, ps in enumerate(group):
             staffNumber: int = i + 1  # 1-indexed
 
@@ -551,7 +551,7 @@ class PartStaffExporterMixin:
             if initialPartStaffRoot is None:
                 initialPartStaffRoot = self.getRootForPartStaff(ps)
                 mxAttributes = initialPartStaffRoot.find('measure/attributes')
-                clef1: Optional[Element] = mxAttributes.find('clef')
+                clef1: t.Optional[Element] = mxAttributes.find('clef')
                 if clef1 is not None:
                     clef1.set('number', '1')
 
@@ -576,7 +576,7 @@ class PartStaffExporterMixin:
             # Subsequent PartStaffs in group: set additional clefs on mxAttributes
             else:
                 thisPartStaffRoot: Element = self.getRootForPartStaff(ps)
-                oldClef: Optional[Element] = thisPartStaffRoot.find('measure/attributes/clef')
+                oldClef: t.Optional[Element] = thisPartStaffRoot.find('measure/attributes/clef')
                 if oldClef is not None and mxAttributes is not None:
                     clefsInMxAttributesAlready = mxAttributes.findall('clef')
                     if len(clefsInMxAttributesAlready) >= staffNumber:
@@ -598,7 +598,9 @@ class PartStaffExporterMixin:
                     )
 
                 if multiMeter:
-                    oldMeter: Optional[Element] = thisPartStaffRoot.find('measure/attributes/time')
+                    oldMeter: t.Optional[Element] = thisPartStaffRoot.find(
+                        'measure/attributes/time'
+                    )
                     if oldMeter:
                         oldMeter.set('number', str(staffNumber))
                         helpers.insertBeforeElements(
@@ -607,7 +609,7 @@ class PartStaffExporterMixin:
                             tagList=['staves']
                         )
                 if multiKey:
-                    oldKey: Optional[Element] = thisPartStaffRoot.find('measure/attributes/key')
+                    oldKey: t.Optional[Element] = thisPartStaffRoot.find('measure/attributes/key')
                     if oldKey:
                         oldKey.set('number', str(staffNumber))
                         helpers.insertBeforeElements(
@@ -639,7 +641,7 @@ class PartStaffExporterMixin:
             partStaffRoot: Element = self.getRootForPartStaff(ps)
             # Remove PartStaff from export list
             # noinspection PyAttributeOutsideInit
-            self.partExporterList: List[music21.musicxml.m21ToXml.PartExporter] = [
+            self.partExporterList: t.List[music21.musicxml.m21ToXml.PartExporter] = [
                 pex for pex in self.partExporterList if pex.xmlRoot != partStaffRoot
             ]
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4369,7 +4369,7 @@ class MeasureParser(XMLParserBase):
             # set to stop before removing
             self.activeTuplets[tupletIndexToRemove] = None
 
-        returnTuplets = [t for t in returnTuplets if t is not None]
+        returnTuplets = [tup for tup in returnTuplets if tup is not None]
 
         return returnTuplets
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -20,7 +20,7 @@ import re
 import warnings
 
 from math import isclose
-from typing import cast, List, Optional, Dict, Tuple, Set, Union
+import typing as t
 
 import xml.etree.ElementTree as ET
 
@@ -67,7 +67,7 @@ from music21 import environment
 environLocal = environment.Environment('musicxml.xmlToM21')
 
 # what goes in a `.staffReference`
-StaffReferenceType = Dict[int, List[base.Music21Object]]
+StaffReferenceType = t.Dict[int, t.List[base.Music21Object]]
 
 # const
 NO_STAFF_ASSIGNED = 0
@@ -75,7 +75,7 @@ NO_STAFF_ASSIGNED = 0
 
 # ------------------------------------------------------------------------------
 # Helpers...
-def _clean(badStr: Optional[str]) -> Optional[str]:
+def _clean(badStr: t.Optional[str]) -> t.Optional[str]:
     # need to remove badly-formed strings
     if badStr is None:
         return None
@@ -1282,7 +1282,7 @@ class MusicXMLImporter(XMLParserBase):
 
     def identificationToMetadata(self,
                                  identification: ET.Element,
-                                 inputM21: Optional[metadata.Metadata] = None):
+                                 inputM21: t.Optional[metadata.Metadata] = None):
         '''
         Convert an <identification> tag, containing <creator> tags, <rights> tags, and
         <miscellaneous> tag.
@@ -1362,7 +1362,7 @@ class MusicXMLImporter(XMLParserBase):
 
     def creatorToContributor(self,
                              creator: ET.Element,
-                             inputM21: Optional[metadata.primitives.Contributor] = None):
+                             inputM21: t.Optional[metadata.primitives.Contributor] = None):
         # noinspection PyShadowingNames
         '''
         Given a <creator> tag, fill the necessary parameters of a Contributor.
@@ -1467,15 +1467,15 @@ class PartParser(XMLParserBase):
 
         self.atSoundingPitch = True
 
-        self.staffReferenceList: List[StaffReferenceType] = []
+        self.staffReferenceList: t.List[StaffReferenceType] = []
 
         self.lastTimeSignature = None
         self.lastMeasureWasShort = False
         self.lastMeasureOffset = 0.0
 
         # a dict of clefs per staff number
-        self.lastClefs: Dict[int, Optional[clef.Clef]] = {NO_STAFF_ASSIGNED: clef.TrebleClef()}
-        self.activeTuplets: List[Optional[duration.Tuplet]] = [None] * 7
+        self.lastClefs: t.Dict[int, t.Optional[clef.Clef]] = {NO_STAFF_ASSIGNED: clef.TrebleClef()}
+        self.activeTuplets: t.List[t.Optional[duration.Tuplet]] = [None] * 7
 
         self.maxStaves = 1  # will be changed in measure parsing...
 
@@ -1640,7 +1640,7 @@ class PartParser(XMLParserBase):
         # TODO: elevation
         # TODO: store id attribute somewhere
         mxMIDIInstrument = mxScorePart.find('midi-instrument')
-        i: Optional[instrument.Instrument] = None
+        i: t.Optional[instrument.Instrument] = None
         if mxMIDIInstrument is not None:
             mxMidiProgram = mxMIDIInstrument.find('midi-program')
             mxMidiUnpitched = mxMIDIInstrument.find('midi-unpitched')
@@ -1759,9 +1759,9 @@ class PartParser(XMLParserBase):
             'TimeSignature',
         ]
 
-        uniqueStaffKeys: List[int] = self._getUniqueStaffKeys()
-        partStaffs: List[stream.PartStaff] = []
-        appendedElementIds: Set[int] = set()  # id is id(el) not el.id
+        uniqueStaffKeys: t.List[int] = self._getUniqueStaffKeys()
+        partStaffs: t.List[stream.PartStaff] = []
+        appendedElementIds: t.Set[int] = set()  # id is id(el) not el.id
 
         def copy_into_partStaff(source, target, omitTheseElementIds):
             for sourceElem in source.getElementsByClass(STAFF_SPECIFIC_CLASSES):
@@ -1792,7 +1792,7 @@ class PartParser(XMLParserBase):
             newPartStaff.groups.append(partStaffId)
             partStaffs.append(newPartStaff)
             self.parent.m21PartObjectsById[partStaffId] = newPartStaff
-            elementsIdsNotToGoInThisStaff: Set[int] = set()
+            elementsIdsNotToGoInThisStaff: t.Set[int] = set()
             for staffReference in self.staffReferenceList:
                 excludeOneMeasure = self._getStaffExclude(
                     staffReference,
@@ -1828,7 +1828,7 @@ class PartParser(XMLParserBase):
         self,
         staffReference: StaffReferenceType,
         targetKey: int
-    ) -> List[base.Music21Object]:
+    ) -> t.List[base.Music21Object]:
         '''
         Given a staff reference dictionary, remove and combine in a list all elements that
         are NOT part of the given key. Thus, return a list of all entries to remove.
@@ -1849,7 +1849,7 @@ class PartParser(XMLParserBase):
             post += staffReference[k]
         return post
 
-    def _getUniqueStaffKeys(self) -> List[int]:
+    def _getUniqueStaffKeys(self) -> t.List[int]:
         '''
         Given a list of staffReference dictionaries,
         collect and return a list of all unique keys except NO_STAFF_ASSIGNED (0)
@@ -2278,9 +2278,9 @@ class MeasureParser(XMLParserBase):
         self.staffReference: StaffReferenceType = {}
         if parent is not None:
             # list of current tuplets or Nones
-            self.activeTuplets: List[Optional[duration.Tuplet]] = parent.activeTuplets
+            self.activeTuplets: t.List[t.Optional[duration.Tuplet]] = parent.activeTuplets
         else:
-            self.activeTuplets: List[Optional[duration.Tuplet]] = [None] * 7
+            self.activeTuplets: t.List[t.Optional[duration.Tuplet]] = [None] * 7
 
         self.useVoices = False
         self.voicesById = {}
@@ -2301,7 +2301,7 @@ class MeasureParser(XMLParserBase):
         # key is a tuple of the
         #     staff number (or None) and offsetMeasureNote, and the value is a
         #     StaffLayout object.
-        self.staffLayoutObjects: Dict[Tuple[Optional[int], float], layout.StaffLayout] = {}
+        self.staffLayoutObjects: t.Dict[t.Tuple[t.Optional[int], float], layout.StaffLayout] = {}
         self.stream = stream.Measure()
 
         self.mxNoteList = []  # for accumulating notes in chords
@@ -2321,11 +2321,11 @@ class MeasureParser(XMLParserBase):
         self.restAndNoteCount = {'rest': 0, 'note': 0}
         if parent is not None:
             # share dict
-            self.lastClefs: Dict[int, Optional[clef.Clef]] = self.parent.lastClefs
+            self.lastClefs: t.Dict[int, t.Optional[clef.Clef]] = self.parent.lastClefs
 
         else:
             # a dict of clefs for staffIndexes:
-            self.lastClefs: Dict[int, Optional[clef.Clef]] = {NO_STAFF_ASSIGNED: None}
+            self.lastClefs: t.Dict[int, t.Optional[clef.Clef]] = {NO_STAFF_ASSIGNED: None}
         self.parseIndex = 0
 
         # what is the offset in the measure of the current note position?
@@ -2336,7 +2336,7 @@ class MeasureParser(XMLParserBase):
         # older versions of Finale put a forward tag at the end, but this
         # disguises the incomplete last measure.  The PartParser will
         # pick this up from the last measure.
-        self.endedWithForwardTag: Optional[note.Rest] = None
+        self.endedWithForwardTag: t.Optional[note.Rest] = None
 
     @staticmethod
     def getStaffNumber(mxObjectOrNumber) -> int:
@@ -2658,7 +2658,7 @@ class MeasureParser(XMLParserBase):
         isRest = False
         # TODO: Unpitched
 
-        offsetIncrement: Union[float, fractions.Fraction] = 0.0
+        offsetIncrement: t.Union[float, fractions.Fraction] = 0.0
 
         if mxNote.find('rest') is not None:  # it is a Rest
             isRest = True
@@ -2724,7 +2724,7 @@ class MeasureParser(XMLParserBase):
         self.offsetMeasureNote += offsetIncrement
         self.endedWithForwardTag = None
 
-    def xmlToChord(self, mxNoteList: List[ET.Element]) -> chord.ChordBase:
+    def xmlToChord(self, mxNoteList: t.List[ET.Element]) -> chord.ChordBase:
         # noinspection PyShadowingNames
         '''
         Given an a list of mxNotes, fill the necessary parameters
@@ -2811,7 +2811,7 @@ class MeasureParser(XMLParserBase):
         self.spannerBundle.freePendingSpannedElementAssignment(c)
         return c
 
-    def xmlToSimpleNote(self, mxNote, freeSpanners=True) -> Union[note.Note, note.Unpitched]:
+    def xmlToSimpleNote(self, mxNote, freeSpanners=True) -> t.Union[note.Note, note.Unpitched]:
         # noinspection PyShadowingNames
         '''
         Translate a MusicXML <note> (without <chord/>)
@@ -2859,7 +2859,7 @@ class MeasureParser(XMLParserBase):
         '''
         d = self.xmlToDuration(mxNote)
 
-        n: Union[note.Note, note.Unpitched]
+        n: t.Union[note.Note, note.Unpitched]
 
         mxUnpitched = mxNote.find('unpitched')
         if mxUnpitched is None:
@@ -2882,7 +2882,7 @@ class MeasureParser(XMLParserBase):
                 stemStyle = style.Style()
                 self.setColor(mxStem, stemStyle)
                 self.setPosition(mxStem, stemStyle)
-                this_note_style = cast(style.NoteStyle, n.style)
+                this_note_style = t.cast(style.NoteStyle, n.style)
                 this_note_style.stemStyle = stemStyle
 
         # gets the notehead object from the mxNote and sets value of the music21 note
@@ -4153,11 +4153,11 @@ class MeasureParser(XMLParserBase):
         ...            + '<notations>'
         ...            + '<tied line-type="dotted" orientation="over" type="start" />'
         ...            + '</notations></note>')
-        >>> t = MP.xmlToTie(mxNote)
-        >>> t.placement
+        >>> tieObj = MP.xmlToTie(mxNote)
+        >>> tieObj.placement
         'above'
         '''
-        t = tie.Tie()
+        tieObj = tie.Tie()
         allTies = mxNote.findall('tie')
         if not allTies:
             return None
@@ -4171,9 +4171,9 @@ class MeasureParser(XMLParserBase):
                 environLocal.printDebug('found tie element without required type')
 
         if len(typesFound) == 1:
-            t.type = typesFound[0]
+            tieObj.type = typesFound[0]
         elif 'stop' in typesFound and 'start' in typesFound:
-            t.type = 'continue'
+            tieObj.type = 'continue'
         else:
             environLocal.printDebug(
                 ['found unexpected arrangement of multiple tie types when '
@@ -4187,21 +4187,21 @@ class MeasureParser(XMLParserBase):
             mxTiedList = mxNotations.findall('tied')
             if mxTiedList:
                 firstTied = mxTiedList[0]
-                _synchronizeIds(firstTied, t)
+                _synchronizeIds(firstTied, tieObj)
 
                 tieStyle = firstTied.get('line-type')
                 if tieStyle is not None and tieStyle != 'wavy':  # do not support wavy...
-                    t.style = tieStyle
+                    tieObj.style = tieStyle
                 placement = firstTied.get('placement')
                 if placement is not None:
-                    t.placement = placement
+                    tieObj.placement = placement
                 else:
                     orientation = mxTiedList[0].get('orientation')
                     if orientation == 'over':
-                        t.placement = 'above'
+                        tieObj.placement = 'above'
                     elif orientation == 'under':
-                        t.placement = 'below'
-        return t
+                        tieObj.placement = 'below'
+        return tieObj
 
     def xmlToTuplets(self, mxNote):
         # noinspection PyShadowingNames
@@ -4224,21 +4224,21 @@ class MeasureParser(XMLParserBase):
         ...    '<normal-notes>3</normal-notes>' +
         ...    '<normal-type>16th</normal-type><normal-dot /><normal-dot />' +
         ...    '</time-modification></note>')
-        >>> t = MP.xmlToTuplets(mxNote)
-        >>> t
+        >>> tup = MP.xmlToTuplets(mxNote)
+        >>> tup
         [<music21.duration.Tuplet 5/3/16th>]
-        >>> t[0].durationNormal
+        >>> tup[0].durationNormal
         DurationTuple(type='16th', dots=2, quarterLength=0.4375)
         '''
-        t = duration.Tuplet()
+        tup = duration.Tuplet()
         mxTimeModification = mxNote.find('time-modification')
         # environLocal.printDebug(['got mxTimeModification', mxTimeModification])
 
         # This should only be a backup in case there are no tuplet definitions
         # in the tuplet tag.
         seta = _setAttributeFromTagText
-        seta(t, mxTimeModification, 'actual-notes', 'numberNotesActual', transform=int)
-        seta(t, mxTimeModification, 'normal-notes', 'numberNotesNormal', transform=int)
+        seta(tup, mxTimeModification, 'actual-notes', 'numberNotesActual', transform=int)
+        seta(tup, mxTimeModification, 'normal-notes', 'numberNotesNormal', transform=int)
 
         mxNormalType = mxTimeModification.find('normal-type')
         if textStripValid(mxNormalType):
@@ -4249,17 +4249,17 @@ class MeasureParser(XMLParserBase):
         durationNormalType = musicXMLTypeToType(musicXMLNormalType)
         numDots = len(mxTimeModification.findall('normal-dot'))
 
-        t.setDurationType(durationNormalType, numDots)
+        tup.setDurationType(durationNormalType, numDots)
 
         mxNotations = mxNote.find('notations')
         if mxNotations is None:
-            self.activeTuplets[0] = t
+            self.activeTuplets[0] = tup
         # environLocal.printDebug(['got mxNotations', mxNotations])
 
-        remainingTupletAmountToAccountFor = t.tupletMultiplier()
-        timeModTup = t
+        remainingTupletAmountToAccountFor = tup.tupletMultiplier()
+        timeModTup = tup
 
-        returnTuplets: List[Optional[duration.Tuplet]] = [None] * 8
+        returnTuplets: t.List[t.Optional[duration.Tuplet]] = [None] * 8
         removeFromActiveTuplets = set()
 
         # a set of tuplets to set to stop...
@@ -4280,7 +4280,6 @@ class MeasureParser(XMLParserBase):
                             activeT.type = 'startStop'
                         removeFromActiveTuplets.add(tupletIndex)
                         tupletsToStop.add(tupletIndex)
-
                     continue
 
                 mxTupletActual = mxTuplet.find('tuplet-actual')
@@ -4288,12 +4287,12 @@ class MeasureParser(XMLParserBase):
                 if mxTupletActual is None or mxTupletNormal is None:
                     # in theory either can be absent, but so far I have only seen both present
                     # or both absent
-                    t = copy.deepcopy(timeModTup)
+                    tup = copy.deepcopy(timeModTup)
                 else:
-                    t = duration.Tuplet()
-                    seta(t, mxTupletActual,
+                    tup = duration.Tuplet()
+                    seta(tup, mxTupletActual,
                          'tuplet-number', 'numberNotesActual', transform=int)
-                    seta(t, mxTupletNormal,
+                    seta(tup, mxTupletNormal,
                          'tuplet-number', 'numberNotesNormal', transform=int)
 
                     mxActualType = mxTupletActual.find('tuplet-type')
@@ -4301,45 +4300,45 @@ class MeasureParser(XMLParserBase):
                         xmlActualType = mxActualType.text.strip()
                         durType = musicXMLTypeToType(xmlActualType)
                         dots = len(mxActualType.findall('tuplet-dot'))
-                        t.durationActual = duration.durationTupleFromTypeDots(durType, dots)
+                        tup.durationActual = duration.durationTupleFromTypeDots(durType, dots)
 
                     mxNormalType = mxTupletNormal.find('tuplet-type')
                     if mxNormalType is not None:
                         xmlNormalType = mxNormalType.text.strip()
                         durType = musicXMLTypeToType(xmlNormalType)
                         dots = len(mxNormalType.findall('tuplet-dot'))
-                        t.durationNormal = duration.durationTupleFromTypeDots(durType, dots)
+                        tup.durationNormal = duration.durationTupleFromTypeDots(durType, dots)
 
                 # TODO: combine start + stop into startStop.
-                t.type = this_tuplet_type
+                tup.type = this_tuplet_type
 
                 bracketMaybe = mxTuplet.get('bracket')
                 if bracketMaybe is not None:
-                    t.bracket = xmlObjects.yesNoToBoolean(bracketMaybe)
+                    tup.bracket = xmlObjects.yesNoToBoolean(bracketMaybe)
                 # environLocal.printDebug(['got bracket', self.bracket])
                 showNumber = mxTuplet.get('show-number')
                 if showNumber is not None and showNumber == 'none':
-                    t.tupletActualShow = None
+                    tup.tupletActualShow = None
                     if bracketMaybe is None:
-                        t.bracket = False
+                        tup.bracket = False
                 elif showNumber is not None and showNumber == 'both':
-                    t.tupletNormalShow = 'number'
+                    tup.tupletNormalShow = 'number'
 
                 showType = mxTuplet.get('show-type')
                 if showType is not None and showType == 'actual':
-                    t.tupletActualShow = 'both' if t.tupletActualShow is not None else 'type'
+                    tup.tupletActualShow = 'both' if tup.tupletActualShow is not None else 'type'
                 elif showNumber is not None and showNumber == 'both':
-                    t.tupletActualShow = 'both' if t.tupletActualShow is not None else 'type'
-                    t.tupletNormalShow = 'both' if t.tupletNormalShow is not None else 'type'
+                    tup.tupletActualShow = 'both' if tup.tupletActualShow is not None else 'type'
+                    tup.tupletNormalShow = 'both' if tup.tupletNormalShow is not None else 'type'
 
                 lineShape = mxTuplet.get('line-shape')
                 if lineShape is not None and lineShape == 'curved':
-                    t.bracket = 'slur'
+                    tup.bracket = 'slur'
                 # TODO: default-x, default-y, relative-x, relative-y
-                t.placement = mxTuplet.get('placement')
-                returnTuplets[tupletIndex] = t
-                remainingTupletAmountToAccountFor /= t.tupletMultiplier()
-                self.activeTuplets[tupletIndex] = t
+                tup.placement = mxTuplet.get('placement')
+                returnTuplets[tupletIndex] = tup
+                remainingTupletAmountToAccountFor /= tup.tupletMultiplier()
+                self.activeTuplets[tupletIndex] = tup
 
         # find all activeTuplets that haven't been accounted for.
         for i in range(1, len(self.activeTuplets)):
@@ -4401,7 +4400,7 @@ class MeasureParser(XMLParserBase):
             n.lyrics.append(lyricObj)
             currentLyricNumber += 1
 
-    def xmlToLyric(self, mxLyric, inputM21=None) -> Optional[note.Lyric]:
+    def xmlToLyric(self, mxLyric, inputM21=None) -> t.Optional[note.Lyric]:
         # noinspection PyShadowingNames
         '''
         Translate a MusicXML <lyric> tag to a
@@ -4843,9 +4842,9 @@ class MeasureParser(XMLParserBase):
         # TODO: musicxml 4: attr: arrangement -- C/E or C over E etc.
         # TODO: offset
         # Element staff is covered by insertCoreAndReference in xmlHarmony()
-        b: Optional[pitch.Pitch] = None
-        r: Optional[pitch.Pitch] = None
-        inversion: Optional[int] = None
+        b: t.Optional[pitch.Pitch] = None
+        r: t.Optional[pitch.Pitch] = None
+        inversion: t.Optional[int] = None
         chordKind: str = ''
         chordKindStr: str = ''
 
@@ -5774,8 +5773,8 @@ class MeasureParser(XMLParserBase):
     def xmlStaffLayoutFromStaffDetails(
         self,
         mxDetails,
-        m21staffLayout: Optional[layout.StaffLayout] = None
-    ) -> Optional[layout.StaffLayout]:
+        m21staffLayout: t.Optional[layout.StaffLayout] = None
+    ) -> t.Optional[layout.StaffLayout]:
         # noinspection PyShadowingNames
         '''
         Returns a new StaffLayout object from staff-details or sets attributes on an existing one

--- a/music21/note.py
+++ b/music21/note.py
@@ -20,7 +20,7 @@ and used to configure, :class:`~music21.note.Note` objects.
 import copy
 import unittest
 
-from typing import Optional, List, Type, Union, Tuple, Iterable, Sequence, cast
+import typing as t
 
 from music21 import base
 from music21 import beam
@@ -79,8 +79,7 @@ stemDirectionNames = (
 
 def __dir__():
     out = [n for n in globals() if not n.startswith('__') and not n.startswith('Test')]
-    for n in ('Optional', 'List', 'Union', 'Tuple', 'Sequence', 'Iterable', 'Type', 'cast'):
-        out.remove(n)
+    out.remove('t')
     out.remove('unittest')
     out.remove('copy')
     out.remove('_DOC_ORDER')
@@ -100,7 +99,7 @@ class NotRestException(exceptions21.Music21Exception):
 
 
 # ------------------------------------------------------------------------------
-SYLLABIC_CHOICES: List[Optional[str]] = [
+SYLLABIC_CHOICES: t.List[t.Optional[str]] = [
     None, 'begin', 'single', 'end', 'middle', 'composite',
 ]
 
@@ -192,11 +191,11 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
 
     def __init__(self, text='', number=1, **kwargs):
         super().__init__()
-        self._identifier: Optional[str] = None
+        self._identifier: t.Optional[str] = None
         self._number: int = 1
         self._text: str = ''
         self._syllabic = None
-        self.components: Optional[List['music21.note.Lyric']] = None
+        self.components: t.Optional[t.List['music21.note.Lyric']] = None
         self.elisionBefore = ' '
 
         applyRaw = kwargs.get('applyRaw', False)
@@ -265,7 +264,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         if not self.isComposite:
             return self._text
         else:
-            assert isinstance(self.components, Sequence), \
+            assert isinstance(self.components, t.Sequence), \
                 'Programming error: isComposite implies that components exists'  # mypy
             text_out = self.components[0].text
             if text_out is None:
@@ -282,7 +281,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         self._text = newText
 
     @property
-    def syllabic(self) -> Optional[str]:
+    def syllabic(self) -> t.Optional[str]:
         '''
         Returns or sets the syllabic property of a lyric.
 
@@ -319,7 +318,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         self._syllabic = newSyllabic
 
     @property
-    def identifier(self) -> Union[str, int]:
+    def identifier(self) -> t.Union[str, int]:
         '''
         By default, this is the same as self.number. However, if there is a
         descriptive identifier like 'part2verse1', it is stored here and
@@ -393,7 +392,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
             else:
                 return text
         else:
-            assert isinstance(self.components, Sequence), \
+            assert isinstance(self.components, t.Sequence), \
                 'Programming error: isComposite should assert components exists'  # for mypy
             firstSyllabic = self.components[0].syllabic
             lastSyllabic = self.components[-1].syllabic
@@ -405,8 +404,8 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
 
 
     @rawText.setter
-    def rawText(self, t):
-        self.setTextAndSyllabic(t, applyRaw=True)
+    def rawText(self, rawTextIn: str):
+        self.setTextAndSyllabic(rawTextIn, applyRaw=True)
 
     @property
     def number(self) -> int:
@@ -536,7 +535,7 @@ class GeneralNote(base.Music21Object):
     isNote = False
     isRest = False
     isChord = False
-    _styleClass: Type[style.Style] = style.NoteStyle
+    _styleClass: t.Type[style.Style] = style.NoteStyle
 
     # define order for presenting names in documentation; use strings
     _DOC_ORDER = ['duration', 'quarterLength']
@@ -570,7 +569,7 @@ class GeneralNote(base.Music21Object):
         # this sets the stored duration defined in Music21Object
         super().__init__(duration=tempDuration)
 
-        self.lyrics: List[Lyric] = []  # a list of lyric objects
+        self.lyrics: t.List[Lyric] = []  # a list of lyric objects
         self.expressions = []
         self.articulations = []
 
@@ -609,14 +608,14 @@ class GeneralNote(base.Music21Object):
         return True
 
     # --------------------------------------------------------------------------
-    def _getLyric(self) -> Optional[str]:
+    def _getLyric(self) -> t.Optional[str]:
         if not self.lyrics:
             return None
 
         allText = [ly.text for ly in self.lyrics]
         return '\n'.join([t for t in allText if t is not None])
 
-    def _setLyric(self, value: Union[str, Lyric, None]) -> None:
+    def _setLyric(self, value: t.Union[str, Lyric, None]) -> None:
         self.lyrics = []
         if value is None:
             return
@@ -801,7 +800,7 @@ class GeneralNote(base.Music21Object):
         return self.classes[0]  # override in subclasses
 
     @property
-    def pitches(self) -> Tuple[pitch.Pitch, ...]:
+    def pitches(self) -> t.Tuple[pitch.Pitch, ...]:
         '''
         Returns an empty tuple.  (Useful for iterating over NotRests since they
         include Notes and Chords.)
@@ -809,7 +808,7 @@ class GeneralNote(base.Music21Object):
         return ()
 
     @pitches.setter
-    def pitches(self, _value: Iterable[pitch.Pitch]):
+    def pitches(self, _value: t.Iterable[pitch.Pitch]):
         pass
 
 
@@ -951,7 +950,7 @@ class NotRest(GeneralNote):
             self.beams = keywords['beams']
         else:
             self.beams = beam.Beams()
-        self._storedInstrument: Optional['music21.instrument.Instrument'] = None
+        self._storedInstrument: t.Optional['music21.instrument.Instrument'] = None
 
     # ==============================================================================================
     # Special functions
@@ -1177,7 +1176,7 @@ class NotRest(GeneralNote):
         else:
             return True
 
-    def _getVolume(self, forceClient: Optional[base.Music21Object] = None) -> volume.Volume:
+    def _getVolume(self, forceClient: t.Optional[base.Music21Object] = None) -> volume.Volume:
         # DO NOT CHANGE TO @property because of optional attributes
         # lazy volume creation
         if self._volume is None:
@@ -1250,7 +1249,7 @@ class NotRest(GeneralNote):
     def getInstrument(self,
                       *,
                       returnDefault: bool = True
-                      ) -> Optional['music21.instrument.Instrument']:
+                      ) -> t.Optional['music21.instrument.Instrument']:
         '''
         Retrieves the `.storedInstrument` on this `NotRest` instance, if any.
         If one is not found, executes a context search (without following
@@ -1308,7 +1307,7 @@ class NotRest(GeneralNote):
             return instrument.Instrument()
         elif instrument_or_none is None:
             return None
-        return cast(instrument.Instrument, instrument_or_none)
+        return t.cast(instrument.Instrument, instrument_or_none)
 
 
 # ------------------------------------------------------------------------------
@@ -1385,7 +1384,7 @@ class Note(NotRest):
     # Accepts an argument for pitch
     def __init__(self, pitchName=None, **keywords):
         super().__init__(**keywords)
-        self._chordAttached: Optional['music21.chord.Chord'] = None
+        self._chordAttached: t.Optional['music21.chord.Chord'] = None
 
         if 'pitch' in keywords and pitchName is None:
             pitchName = keywords['pitch']
@@ -1562,7 +1561,7 @@ class Note(NotRest):
         ''')
 
     @property
-    def pitches(self) -> Tuple[pitch.Pitch]:
+    def pitches(self) -> t.Tuple[pitch.Pitch]:
         '''
         Return the single :class:`~music21.pitch.Pitch` object in a tuple.
         This property is designed to provide an interface analogous to
@@ -1604,7 +1603,7 @@ class Note(NotRest):
         return (self.pitch,)
 
     @pitches.setter
-    def pitches(self, value: Sequence[pitch.Pitch]):
+    def pitches(self, value: t.Sequence[pitch.Pitch]):
         if common.isListLike(value) and value:
             self.pitch = value[0]
         else:

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -22,7 +22,7 @@ import copy
 import math
 import itertools
 from collections import OrderedDict
-from typing import List, Optional, Union, TypeVar, Tuple, Dict, Literal, Set, overload
+import typing as t
 
 from music21 import base
 from music21 import common
@@ -36,13 +36,13 @@ from music21.common.objects import SlottedObjectMixin
 from music21.common.types import StepName
 from music21 import environment
 
-PitchType = TypeVar('PitchType', bound='Pitch')
+PitchType = t.TypeVar('PitchType', bound='Pitch')
 
 environLocal = environment.Environment('pitch')
 
-PitchClassString = Literal['a', 'A', 't', 'T', 'b', 'B', 'e', 'E']
+PitchClassString = t.Literal['a', 'A', 't', 'T', 'b', 'B', 'e', 'E']
 
-STEPREF: Dict[StepName, int] = {
+STEPREF: t.Dict[StepName, int] = {
     'C': 0,
     'D': 2,
     'E': 4,
@@ -52,7 +52,7 @@ STEPREF: Dict[StepName, int] = {
     'B': 11,
 }
 NATURAL_PCS = (0, 2, 4, 5, 7, 9, 11)
-STEPREF_REVERSED: Dict[int, StepName] = {
+STEPREF_REVERSED: t.Dict[int, StepName] = {
     0: 'C',
     2: 'D',
     4: 'E',
@@ -61,8 +61,8 @@ STEPREF_REVERSED: Dict[int, StepName] = {
     9: 'A',
     11: 'B',
 }
-STEPNAMES: Set[StepName] = {'C', 'D', 'E', 'F', 'G', 'A', 'B'}  # set
-STEP_TO_DNN_OFFSET: Dict[StepName, int] = {'C': 0,
+STEPNAMES: t.Set[StepName] = {'C', 'D', 'E', 'F', 'G', 'A', 'B'}  # set
+STEP_TO_DNN_OFFSET: t.Dict[StepName, int] = {'C': 0,
                                            'D': 1,
                                            'E': 2,
                                            'F': 3,
@@ -133,8 +133,8 @@ accidentalModifiersSorted = _sortModifiers()
 # utility functions
 
 def _convertPitchClassToNumber(
-    ps: Union[int, float, PitchClassString]
-) -> Union[int, float]:
+    ps: t.Union[int, float, PitchClassString]
+) -> t.Union[int, float]:
     '''
     Given a pitch class string
     return the pitch class representation.
@@ -176,7 +176,7 @@ def convertPitchClassToStr(pc: int) -> str:
     return f'{pc:X}'  # using hex conversion, good up to 15
 
 
-def _convertPsToOct(ps: Union[int, float]) -> int:
+def _convertPsToOct(ps: t.Union[int, float]) -> int:
     '''
     Utility conversion; does not process internals.
     Converts a midiNote number to an octave number.
@@ -205,8 +205,8 @@ def _convertPsToOct(ps: Union[int, float]) -> int:
 
 
 def _convertPsToStep(
-    ps: Union[int, float]
-) -> Tuple[StepName,
+    ps: t.Union[int, float]
+) -> t.Tuple[StepName,
            Accidental,
            Microtone,
            int]:
@@ -359,7 +359,7 @@ def _convertPsToStep(
     return name, acc, microObj, octShift
 
 
-def _convertCentsToAlterAndCents(shift) -> Tuple[float, float]:
+def _convertCentsToAlterAndCents(shift) -> t.Tuple[float, float]:
     '''
     Given any floating point value, split into accidental and microtone components.
 
@@ -405,7 +405,7 @@ def _convertCentsToAlterAndCents(shift) -> Tuple[float, float]:
     return alterShift + alterAdd, float(cents)
 
 
-def _convertHarmonicToCents(value: Union[int, float]) -> int:
+def _convertHarmonicToCents(value: t.Union[int, float]) -> int:
     r'''
     Given a harmonic number, return the total number shift in cents
     assuming 12 tone equal temperament.
@@ -678,9 +678,9 @@ class Microtone(prebase.ProtoM21Object, SlottedObjectMixin):
     # INITIALIZER #
 
     def __init__(self,
-                 centsOrString: Union[str, int, float] = 0,
+                 centsOrString: t.Union[str, int, float] = 0,
                  harmonicShift=1):
-        self._centShift: Union[int, float] = 0
+        self._centShift: t.Union[int, float] = 0
         self._harmonicShift: int = harmonicShift  # the first harmonic is the start
 
         if isinstance(centsOrString, (int, float)):
@@ -878,7 +878,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
 
     # INITIALIZER #
 
-    def __init__(self, specifier: Union[int, str, float] = 'natural'):
+    def __init__(self, specifier: t.Union[int, str, float] = 'natural'):
         super().__init__()
         # managed by properties
         self._displayType = 'normal'
@@ -894,7 +894,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         self.displayLocation = 'normal'
 
         # store a reference to the object that has this duration object as a property
-        self._client: Optional['Pitch'] = None
+        self._client: t.Optional['Pitch'] = None
         self._name = ''
         self._modifier = ''
         self._alter = 0.0     # semitones to alter step
@@ -1793,10 +1793,10 @@ class Pitch(prebase.ProtoM21Object):
     }
 
     def __init__(self,
-                 name: Optional[Union[str, int, float]] = None,
+                 name: t.Optional[t.Union[str, int, float]] = None,
                  **keywords):
         # No need for super().__init__() on protoM21Object
-        self._groups: Optional[base.Groups] = None
+        self._groups: t.Optional[base.Groups] = None
 
         if isinstance(name, type(self)):
             name = name.nameWithOctave
@@ -1804,31 +1804,31 @@ class Pitch(prebase.ProtoM21Object):
         # this should not be set, as will be updated when needed
         self._step: StepName = defaults.pitchStep  # this is only the pitch step
 
-        self._overridden_freq440: Optional[float] = None
+        self._overridden_freq440: t.Optional[float] = None
 
         # store an Accidental and Microtone objects
         # note that creating an Accidental object is much more time-consuming
         # than a microtone
-        self._accidental: Optional[Accidental] = None
+        self._accidental: t.Optional[Accidental] = None
         # 5% of pitch creation time; it'll be created in a sec anyhow
-        self._microtone: Optional[Microtone] = None
+        self._microtone: t.Optional[Microtone] = None
 
         # CA, Q: should this remain an attribute or only refer to value in defaults?
         # MSC A: no, it's a useful attribute for cases such as scales where if there are
         #        no octaves we give a defaultOctave higher than the previous
         #        (MSC 12 years later: maybe Chris was right...)
         self.defaultOctave: int = defaults.pitchOctave
-        self._octave: Optional[int] = None
+        self._octave: t.Optional[int] = None
 
         # if True, accidental is not known; is determined algorithmically
         # likely due to pitch data from midi or pitch space/class numbers
         self.spellingIsInferred = False
         # the fundamental attribute stores an optional pitch
         # that defines the fundamental used to create this Pitch
-        self.fundamental: Optional['Pitch'] = None
+        self.fundamental: t.Optional['Pitch'] = None
 
         # so that we can tell clients about changes in pitches.
-        self._client: Optional['music21.note.Note'] = None
+        self._client: t.Optional['music21.note.Note'] = None
 
         # name combines step, octave, and accidental
         if name is not None:
@@ -2055,7 +2055,7 @@ class Pitch(prebase.ProtoM21Object):
         self._groups = new
 
     @property
-    def accidental(self) -> Optional[Accidental]:
+    def accidental(self) -> t.Optional[Accidental]:
         '''
         Stores an optional accidental object contained within the
         Pitch object.  This might return None, which is different
@@ -2079,7 +2079,7 @@ class Pitch(prebase.ProtoM21Object):
         return self._accidental
 
     @accidental.setter
-    def accidental(self, value: Union[str, Accidental, None, int, float]):
+    def accidental(self, value: t.Union[str, Accidental, None, int, float]):
         if isinstance(value, Accidental):
             self._accidental = value
         elif value is None:
@@ -2132,7 +2132,7 @@ class Pitch(prebase.ProtoM21Object):
             return self._microtone
 
     @microtone.setter
-    def microtone(self, value: Union[float, int, str, None, Microtone]):
+    def microtone(self, value: t.Union[float, int, str, None, Microtone]):
         if isinstance(value, (str, float, int)):
             self._microtone = Microtone(value)
         elif value is None:  # set to zero
@@ -2643,8 +2643,8 @@ class Pitch(prebase.ProtoM21Object):
         '''
         usrStr = usrStr.strip()
         # extract any numbers that may be octave designations
-        octFound: List[str] = []
-        octNot: List[str] = []
+        octFound: t.List[str] = []
+        octNot: t.List[str] = []
 
         for char in usrStr:
             if char in '0123456789':
@@ -2964,9 +2964,9 @@ class Pitch(prebase.ProtoM21Object):
         return round(self.ps) % 12
 
     @pitchClass.setter
-    def pitchClass(self, value: Union[int, PitchClassString]):
+    def pitchClass(self, value: t.Union[int, PitchClassString]):
         # permit the submission of strings, like "A" and "B"
-        valueOut: Union[int, float] = _convertPitchClassToNumber(value)
+        valueOut: t.Union[int, float] = _convertPitchClassToNumber(value)
         # get step and accidental w/o octave
         self.step, self._accidental = _convertPsToStep(valueOut)[0:2]
 
@@ -3002,7 +3002,7 @@ class Pitch(prebase.ProtoM21Object):
 
 
     @property
-    def octave(self) -> Optional[int]:
+    def octave(self) -> t.Optional[int]:
         '''
         Returns or sets the octave of the note.
         Setting the octave updates the pitchSpace attribute.
@@ -3030,7 +3030,7 @@ class Pitch(prebase.ProtoM21Object):
         return self._octave
 
     @octave.setter
-    def octave(self, value: Optional[Union[int, float]]):
+    def octave(self, value: t.Optional[t.Union[int, float]]):
         if value is not None:
             self._octave = int(value)
         else:
@@ -3194,7 +3194,7 @@ class Pitch(prebase.ProtoM21Object):
                 return ' cuádruple'
             return ''
 
-    _SPANISH_DICT: Dict[StepName, str] = {
+    _SPANISH_DICT: t.Dict[StepName, str] = {
         'A': 'la',
         'B': 'si',
         'C': 'do',
@@ -3250,7 +3250,7 @@ class Pitch(prebase.ProtoM21Object):
         else:
             raise PitchException('Unsupported accidental type.')
 
-    _FRENCH_DICT: Dict[StepName, str] = {
+    _FRENCH_DICT: t.Dict[StepName, str] = {
         'A': 'la',
         'B': 'si',
         'C': 'do',
@@ -3357,7 +3357,7 @@ class Pitch(prebase.ProtoM21Object):
         return self.freq440
 
     @frequency.setter
-    def frequency(self, value: Union[int, float]):
+    def frequency(self, value: t.Union[int, float]):
         self.freq440 = value
 
     # these methods may belong in a temperament object
@@ -3385,7 +3385,7 @@ class Pitch(prebase.ProtoM21Object):
             return 440.0 * (self._twelfth_root_of_two ** A4offset)
 
     @freq440.setter
-    def freq440(self, value: Union[int, float]):
+    def freq440(self, value: t.Union[int, float]):
         post = 12 * (math.log(value / 440.0) / math.log(2)) + 69
         # environLocal.printDebug(['convertFqToPs():', 'input', fq, 'output', repr(post)])
         # rounding here is essential
@@ -3494,8 +3494,8 @@ class Pitch(prebase.ProtoM21Object):
         return final
 
     def harmonicFromFundamental(self,
-                                fundamental: Union[str, 'Pitch']
-                                ) -> Tuple[int, float]:
+                                fundamental: t.Union[str, 'Pitch']
+                                ) -> t.Tuple[int, float]:
         # noinspection PyShadowingNames
         '''
         Given another Pitch as a fundamental, find the harmonic
@@ -3612,7 +3612,7 @@ class Pitch(prebase.ProtoM21Object):
         # return harmonicMatch, fundamental
 
     def harmonicString(self,
-                       fundamental: Union[str, 'music21.pitch.Pitch', None] = None
+                       fundamental: t.Union[str, 'music21.pitch.Pitch', None] = None
                        ) -> str:
         '''
         Return a string representation of a harmonic equivalence.
@@ -3674,8 +3674,8 @@ class Pitch(prebase.ProtoM21Object):
 
     def harmonicAndFundamentalFromPitch(
             self,
-            target: Union[str, 'Pitch']
-    ) -> Tuple[int, 'Pitch']:
+            target: t.Union[str, 'Pitch']
+    ) -> t.Tuple[int, 'Pitch']:
         '''
         Given a Pitch that is a plausible target for a fundamental,
         return the harmonic number and a potentially shifted fundamental
@@ -3707,7 +3707,7 @@ class Pitch(prebase.ProtoM21Object):
 
     def harmonicAndFundamentalStringFromPitch(
             self,
-            fundamental: Union[str, 'Pitch']
+            fundamental: t.Union[str, 'Pitch']
     ) -> str:
         '''
         Given a Pitch that is a plausible target for a fundamental,
@@ -3832,27 +3832,27 @@ class Pitch(prebase.ProtoM21Object):
             return False
 
     # a cache so that interval objects can be reused...
-    _transpositionIntervals: Dict[Literal['d2', '-d2'], interval.Interval] = {}
+    _transpositionIntervals: t.Dict[t.Literal['d2', '-d2'], interval.Interval] = {}
 
-    @overload
+    @t.overload
     def _getEnharmonicHelper(self: PitchType,
-                             inPlace: Literal[True],
+                             inPlace: t.Literal[True],
                              up: bool) -> None:
         return None  # astroid 1015
 
-    @overload
+    @t.overload
     def _getEnharmonicHelper(self: PitchType,
-                             inPlace: Literal[False],
+                             inPlace: t.Literal[False],
                              up: bool) -> PitchType:
         return self  # astroid 1015
 
     def _getEnharmonicHelper(self: PitchType,
                              inPlace: bool,
-                             up: bool) -> Optional[PitchType]:
+                             up: bool) -> t.Optional[PitchType]:
         '''
         abstracts the code from `getHigherEnharmonic` and `getLowerEnharmonic`
         '''
-        intervalString: Literal['d2', '-d2'] = 'd2'
+        intervalString: t.Literal['d2', '-d2'] = 'd2'
         if not up:
             intervalString = '-d2'
 
@@ -3876,15 +3876,15 @@ class Pitch(prebase.ProtoM21Object):
                 self.octave = p.octave
             return None
 
-    @overload
-    def getHigherEnharmonic(self: PitchType, *, inPlace: Literal[False]) -> PitchType:
+    @t.overload
+    def getHigherEnharmonic(self: PitchType, *, inPlace: t.Literal[False]) -> PitchType:
         return self
 
-    @overload
-    def getHigherEnharmonic(self: PitchType, *, inPlace: Literal[True]) -> None:
+    @t.overload
+    def getHigherEnharmonic(self: PitchType, *, inPlace: t.Literal[True]) -> None:
         return None
 
-    def getHigherEnharmonic(self: PitchType, *, inPlace: bool = False) -> Optional[PitchType]:
+    def getHigherEnharmonic(self: PitchType, *, inPlace: bool = False) -> t.Optional[PitchType]:
         '''
         Returns an enharmonic `Pitch` object that is a higher
         enharmonic.  That is, the `Pitch` a diminished-second above
@@ -3940,15 +3940,15 @@ class Pitch(prebase.ProtoM21Object):
             return self._getEnharmonicHelper(inPlace=False, up=True)
 
 
-    @overload
-    def getLowerEnharmonic(self: PitchType, *, inPlace: Literal[False]) -> PitchType:
+    @t.overload
+    def getLowerEnharmonic(self: PitchType, *, inPlace: t.Literal[False]) -> PitchType:
         return self
 
-    @overload
-    def getLowerEnharmonic(self: PitchType, *, inPlace: Literal[True]) -> None:
+    @t.overload
+    def getLowerEnharmonic(self: PitchType, *, inPlace: t.Literal[True]) -> None:
         return None
 
-    def getLowerEnharmonic(self: PitchType, *, inPlace: bool = False) -> Optional[PitchType]:
+    def getLowerEnharmonic(self: PitchType, *, inPlace: bool = False) -> t.Optional[PitchType]:
         '''
         returns a Pitch enharmonic that is a diminished second
         below the current note
@@ -3986,7 +3986,7 @@ class Pitch(prebase.ProtoM21Object):
         *,
         inPlace=False,
         mostCommon=False
-    ) -> Optional[PitchType]:
+    ) -> t.Optional[PitchType]:
         '''
         Returns a new Pitch (or sets the current one if inPlace is True)
         that is either the same as the current pitch or has fewer
@@ -4075,7 +4075,7 @@ class Pitch(prebase.ProtoM21Object):
         else:
             return returnObj
 
-    def getEnharmonic(self: PitchType, *, inPlace=False) -> Optional[PitchType]:
+    def getEnharmonic(self: PitchType, *, inPlace=False) -> t.Optional[PitchType]:
         '''
         Returns a new Pitch that is the(/an) enharmonic equivalent of this Pitch.
         Can be thought of as flipEnharmonic or something like that.
@@ -4172,7 +4172,7 @@ class Pitch(prebase.ProtoM21Object):
             self._client.pitchChanged()
 
 
-    def getAllCommonEnharmonics(self: PitchType, alterLimit: int = 2) -> List[PitchType]:
+    def getAllCommonEnharmonics(self: PitchType, alterLimit: int = 2) -> t.List[PitchType]:
         '''
         Return all common unique enharmonics for a pitch,
         or those that do not involve more than two accidentals.
@@ -4205,7 +4205,7 @@ class Pitch(prebase.ProtoM21Object):
         Music21 does not support accidentals beyond quadruple sharp/flat, so
         `alterLimit` = 4 is the most you can use. (Thank goodness!)
         '''
-        post: List[PitchType] = []
+        post: t.List[PitchType] = []
         c = self.simplifyEnharmonic(inPlace=False)
         if c is None:  # pragma: no follow
             return post  # not going to happen...
@@ -4325,35 +4325,35 @@ class Pitch(prebase.ProtoM21Object):
     def diatonicNoteNum(self, newNum: int):
         octave = int((newNum - 1) / 7)
         noteNameNum = newNum - 1 - (7 * octave)
-        pitchList: Tuple[StepName, ...] = ('C', 'D', 'E', 'F', 'G', 'A', 'B')
+        pitchList: t.Tuple[StepName, ...] = ('C', 'D', 'E', 'F', 'G', 'A', 'B')
         noteName: StepName = pitchList[noteNameNum]
         self.octave = octave
         self.step = noteName
 
-    @overload
+    @t.overload
     def transpose(
         self: PitchType,
-        value: Union['music21.interval.IntervalBase', str, int],
+        value: t.Union['music21.interval.IntervalBase', str, int],
         *,
-        inPlace: Literal[True]
+        inPlace: t.Literal[True]
     ) -> None:
         return None  # dummy until Astroid 1015
 
-    @overload
+    @t.overload
     def transpose(
         self: PitchType,
-        value: Union['music21.interval.IntervalBase', str, int],
+        value: t.Union['music21.interval.IntervalBase', str, int],
         *,
-        inPlace: Literal[False] = False
+        inPlace: t.Literal[False] = False
     ) -> PitchType:
         return self  # dummy until Astroid 1015
 
     def transpose(
         self: PitchType,
-        value: Union['music21.interval.IntervalBase', str, int],
+        value: t.Union['music21.interval.IntervalBase', str, int],
         *,
         inPlace: bool = False
-    ) -> Optional[PitchType]:
+    ) -> t.Optional[PitchType]:
         '''
         Transpose the pitch by the user-provided value.  If the value is an
         integer, the transposition is treated in half steps. If the value is a
@@ -4479,7 +4479,7 @@ class Pitch(prebase.ProtoM21Object):
         *,
         minimize=False,
         inPlace=False
-    ) -> Optional[PitchType]:
+    ) -> t.Optional[PitchType]:
         # noinspection PyShadowingNames
         '''
         Given a source Pitch, shift it down some number of octaves until it is below the
@@ -4577,7 +4577,7 @@ class Pitch(prebase.ProtoM21Object):
                              target,
                              *,
                              minimize=False,
-                             inPlace=False) -> Optional[PitchType]:
+                             inPlace=False) -> t.Optional[PitchType]:
         '''
         Given a source Pitch, shift it up octaves until it is above the target.
 
@@ -4730,9 +4730,9 @@ class Pitch(prebase.ProtoM21Object):
 
     def updateAccidentalDisplay(
         self,
-        pitchPast: Optional[List['Pitch']] = None,
-        pitchPastMeasure: Optional[List['Pitch']] = None,
-        alteredPitches: Optional[List['Pitch']] = None,
+        pitchPast: t.Optional[t.List['Pitch']] = None,
+        pitchPastMeasure: t.Optional[t.List['Pitch']] = None,
+        alteredPitches: t.Optional[t.List['Pitch']] = None,
         cautionaryPitchClass: bool = True,
         cautionaryAll: bool = False,
         overrideStatus: bool = False,

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -23,6 +23,7 @@ import math
 import itertools
 from collections import OrderedDict
 import typing as t
+from typing import overload
 
 from music21 import base
 from music21 import common
@@ -62,13 +63,15 @@ STEPREF_REVERSED: t.Dict[int, StepName] = {
     11: 'B',
 }
 STEPNAMES: t.Set[StepName] = {'C', 'D', 'E', 'F', 'G', 'A', 'B'}  # set
-STEP_TO_DNN_OFFSET: t.Dict[StepName, int] = {'C': 0,
-                                           'D': 1,
-                                           'E': 2,
-                                           'F': 3,
-                                           'G': 4,
-                                           'A': 5,
-                                           'B': 6}
+STEP_TO_DNN_OFFSET: t.Dict[StepName, int] = {
+    'C': 0,
+    'D': 1,
+    'E': 2,
+    'F': 3,
+    'G': 4,
+    'A': 5,
+    'B': 6,
+}
 
 
 TWELFTH_ROOT_OF_TWO = 2.0 ** (1 / 12)
@@ -207,9 +210,9 @@ def _convertPsToOct(ps: t.Union[int, float]) -> int:
 def _convertPsToStep(
     ps: t.Union[int, float]
 ) -> t.Tuple[StepName,
-           Accidental,
-           Microtone,
-           int]:
+             Accidental,
+             Microtone,
+             int]:
     '''
     Utility conversion; does not process internal representations.
 
@@ -218,7 +221,7 @@ def _convertPsToStep(
 
     Returns a tuple of Step, an Accidental object, a Microtone object or
     None, and an int representing octave shift (which is nearly always zero, but can be 1
-    for a B with very high microtones.
+    for a B with very high microtones).
 
     >>> pitch._convertPsToStep(60)
     ('C', <music21.pitch.Accidental natural>, <music21.pitch.Microtone (+0c)>, 0)
@@ -3834,13 +3837,13 @@ class Pitch(prebase.ProtoM21Object):
     # a cache so that interval objects can be reused...
     _transpositionIntervals: t.Dict[t.Literal['d2', '-d2'], interval.Interval] = {}
 
-    @t.overload
+    @overload
     def _getEnharmonicHelper(self: PitchType,
                              inPlace: t.Literal[True],
                              up: bool) -> None:
         return None  # astroid 1015
 
-    @t.overload
+    @overload
     def _getEnharmonicHelper(self: PitchType,
                              inPlace: t.Literal[False],
                              up: bool) -> PitchType:
@@ -3876,11 +3879,11 @@ class Pitch(prebase.ProtoM21Object):
                 self.octave = p.octave
             return None
 
-    @t.overload
+    @overload
     def getHigherEnharmonic(self: PitchType, *, inPlace: t.Literal[False]) -> PitchType:
         return self
 
-    @t.overload
+    @overload
     def getHigherEnharmonic(self: PitchType, *, inPlace: t.Literal[True]) -> None:
         return None
 
@@ -3940,11 +3943,11 @@ class Pitch(prebase.ProtoM21Object):
             return self._getEnharmonicHelper(inPlace=False, up=True)
 
 
-    @t.overload
+    @overload
     def getLowerEnharmonic(self: PitchType, *, inPlace: t.Literal[False]) -> PitchType:
         return self
 
-    @t.overload
+    @overload
     def getLowerEnharmonic(self: PitchType, *, inPlace: t.Literal[True]) -> None:
         return None
 
@@ -4330,7 +4333,7 @@ class Pitch(prebase.ProtoM21Object):
         self.octave = octave
         self.step = noteName
 
-    @t.overload
+    @overload
     def transpose(
         self: PitchType,
         value: t.Union['music21.interval.IntervalBase', str, int],
@@ -4339,7 +4342,7 @@ class Pitch(prebase.ProtoM21Object):
     ) -> None:
         return None  # dummy until Astroid 1015
 
-    @t.overload
+    @overload
     def transpose(
         self: PitchType,
         value: t.Union['music21.interval.IntervalBase', str, int],

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -17,15 +17,7 @@ Concept borrowed from m21j.
 '''
 import unittest
 
-from typing import (
-    Dict,
-    FrozenSet,
-    List,
-    Mapping,
-    Sequence,
-    Union,
-    Tuple,
-)
+import typing as t
 
 from music21.common import deprecated
 
@@ -78,19 +70,19 @@ class ProtoM21Object:
     ]
 
     # documentation for all attributes (not properties or methods)
-    _DOC_ATTR: Mapping[str, str] = {}
+    _DOC_ATTR: t.Mapping[str, str] = {}
 
     # this dictionary stores as a tuple of strings for each Class so that
     # it only needs to be made once (11 microseconds per call, can be
     # a big part of iteration; from cache just 1 microsecond)
-    _classTupleCacheDict: Dict[type, Tuple[str, ...]] = {}
-    _classSetCacheDict: Dict[type, FrozenSet[Union[str, type]]] = {}
+    _classTupleCacheDict: t.Dict[type, t.Tuple[str, ...]] = {}
+    _classSetCacheDict: t.Dict[type, t.FrozenSet[t.Union[str, type]]] = {}
 
-    __slots__: Tuple[str, ...] = ()
+    __slots__: t.Tuple[str, ...] = ()
 
     @deprecated('v7', 'v8', 'use `someClass in .classSet`'
         'or for intersection: `not classSet.isdisjoint(classList)`')
-    def isClassOrSubclass(self, classFilterList: Sequence) -> bool:
+    def isClassOrSubclass(self, classFilterList: t.Sequence) -> bool:
         '''
         Given a class filter list (a list or tuple must be submitted),
         which may have strings or class objects, determine
@@ -119,7 +111,7 @@ class ProtoM21Object:
         return not self.classSet.isdisjoint(classFilterList)
 
     @property
-    def classes(self) -> Tuple[str, ...]:
+    def classes(self) -> t.Tuple[str, ...]:
         '''
         Returns a tuple containing the names (strings, not objects) of classes that this
         object belongs to -- starting with the object's class name and going up the mro()
@@ -149,9 +141,9 @@ class ProtoM21Object:
         >>> s.insert(40, clef.Treble8vbClef())
         >>> s.insert(50, clef.BassClef())
         >>> s2 = stream.Stream()
-        >>> for t in s:
-        ...    if isinstance(t, clef.GClef) and not isinstance(t, clef.TrebleClef):
-        ...        s2.insert(t)
+        >>> for thing in s:
+        ...    if isinstance(thing, clef.GClef) and not isinstance(thing, clef.TrebleClef):
+        ...        s2.insert(thing)
         >>> s2.show('text')
         {10.0} <music21.clef.GClef>
         {30.0} <music21.clef.FrenchViolinClef>
@@ -166,7 +158,7 @@ class ProtoM21Object:
             return classTuple
 
     @property
-    def classSet(self) -> FrozenSet[Union[str, type]]:
+    def classSet(self) -> t.FrozenSet[t.Union[str, type]]:
         '''
         Returns a set (that is, unordered, but indexed) of all classes that
         this class belongs to, including
@@ -229,7 +221,7 @@ class ProtoM21Object:
         try:
             return self._classSetCacheDict[self.__class__]
         except KeyError:
-            classList: List[Union[str, type]] = list(self.classes)
+            classList: t.List[t.Union[str, type]] = list(self.classes)
             classList.extend(self.__class__.mro())
             fullyQualifiedStrings = [x.__module__ + '.' + x.__name__ for x in self.__class__.mro()]
             classList.extend(fullyQualifiedStrings)
@@ -285,13 +277,7 @@ class ProtoM21Object:
         return f'object at {hex(id(self))}'
 
 
-del (
-    Dict,
-    FrozenSet,
-    Sequence,
-    Union,
-    Tuple,
-)
+del t
 
 
 class Test(unittest.TestCase):

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -18,7 +18,7 @@ the :class:`~music21.bar.Repeat` which represents a normal barline repeat.
 '''
 import copy
 import string
-from typing import Union
+import typing as t
 
 from music21 import exceptions21
 from music21 import expressions
@@ -1730,7 +1730,7 @@ class Expander:
             return post
         return None
 
-    def isExpandable(self) -> Union[bool, None]:
+    def isExpandable(self) -> t.Union[bool, None]:
         '''
         Return True or False if this Stream is expandable, that is,
         if it has balanced repeats or sensible Da Capo or Dal Segno

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -19,7 +19,7 @@ import enum
 import unittest
 import copy
 import re
-from typing import Dict, Union, Optional, List, Tuple, Literal
+import typing as t
 
 from collections import namedtuple
 
@@ -50,8 +50,8 @@ ENDWITHFLAT_RE = re.compile(r'[b\-]$')
 
 # cache all Key/Scale objects created or passed in; re-use
 # permits using internally scored pitch segments
-_scaleCache: Dict[str, scale.Scale] = {}
-_keyCache: Dict[str, key.Key] = {}
+_scaleCache: t.Dict[str, scale.Scale] = {}
+_keyCache: t.Dict[str, key.Key] = {}
 
 # create a single notation object for RN initialization, for type-checking,
 # but it will always be replaced.
@@ -59,7 +59,7 @@ _NOTATION_SINGLETON = fbNotation.Notation()
 
 
 # only some figures imply bass (e.g. "54" does not)
-FIGURES_IMPLYING_BASS: Tuple[Tuple[int, ...], ...] = (
+FIGURES_IMPLYING_BASS: t.Tuple[t.Tuple[int, ...], ...] = (
     # triads
     (6,), (6, 3), (6, 4),
     # seventh chords
@@ -113,7 +113,7 @@ figureShorthands = {
     'b7b53': 'ø7',
 }
 
-figureShorthandsMode: Dict[str, Dict] = {
+figureShorthandsMode: t.Dict[str, t.Dict] = {
     'major': {
     },
     'minor': {
@@ -122,7 +122,7 @@ figureShorthandsMode: Dict[str, Dict] = {
 
 
 # this is sort of a crock...  :-)  but it's very helpful.
-functionalityScores = {
+functionalityScores: t.Dict[str, int] = {
     'I': 100,
     'i': 90,
     'V7': 80,
@@ -529,9 +529,9 @@ def figureTupleSolo(
 
 
 def identifyAsTonicOrDominant(
-    inChord: Union[list, tuple, chord.Chord],
+    inChord: t.Union[list, tuple, chord.Chord],
     inKey: key.Key
-) -> Union[str, Literal[False]]:
+) -> t.Union[str, t.Literal[False]]:
     '''
     Returns the roman numeral string expression (either tonic or dominant) that
     best matches the inChord. Useful when you know inChord is either tonic or
@@ -718,7 +718,7 @@ def correctRNAlterationForMinor(figureTuple, keyObj):
 
 def romanNumeralFromChord(
     chordObj,
-    keyObj: Union[key.Key, str] = None,
+    keyObj: t.Union[key.Key, str] = None,
     preferSecondaryDominants=False
 ):
     # noinspection PyShadowingNames
@@ -2099,8 +2099,8 @@ class RomanNumeral(harmony.Harmony):
 
     def __init__(
         self,
-        figure: Union[str, int] = '',
-        keyOrScale: Optional[Union[key.Key, scale.Scale, str]] = None,
+        figure: t.Union[str, int] = '',
+        keyOrScale: t.Optional[t.Union[key.Key, scale.Scale, str]] = None,
         *,
         caseMatters=True,
         updatePitches=True,
@@ -2108,10 +2108,10 @@ class RomanNumeral(harmony.Harmony):
         seventhMinor=Minor67Default.QUALITY,
     ):
         self.primaryFigure: str = ''
-        self.secondaryRomanNumeral: Optional[RomanNumeral] = None
-        self.secondaryRomanNumeralKey: Optional['key.Key'] = None
+        self.secondaryRomanNumeral: t.Optional[RomanNumeral] = None
+        self.secondaryRomanNumeralKey: t.Optional['key.Key'] = None
 
-        self.pivotChord: Optional[RomanNumeral] = None
+        self.pivotChord: t.Optional[RomanNumeral] = None
         self.caseMatters: bool = caseMatters
         self.scaleCardinality: int = 7
 
@@ -2136,8 +2136,8 @@ class RomanNumeral(harmony.Harmony):
         self._scale = None
         self.scaleDegree: int = 0
         self.frontAlterationString: str = ''
-        self.frontAlterationTransposeInterval: Optional[interval.Interval] = None
-        self.frontAlterationAccidental: Optional[pitch.Accidental] = None
+        self.frontAlterationTransposeInterval: t.Optional[interval.Interval] = None
+        self.frontAlterationAccidental: t.Optional[pitch.Accidental] = None
         self.romanNumeralAlone: str = ''
         self.figuresWritten: str = ''
         self.figuresNotationObj: fbNotation.Notation = _NOTATION_SINGLETON
@@ -2146,11 +2146,11 @@ class RomanNumeral(harmony.Harmony):
 
         self.impliedQuality: str = ''
 
-        self.impliedScale: Optional[scale.Scale] = None
+        self.impliedScale: t.Optional[scale.Scale] = None
         self.useImpliedScale: bool = False
-        self.bracketedAlterations: List[Tuple[str, int]] = []
-        self.omittedSteps: List[int] = []
-        self.addedSteps: List[Tuple[str, int]] = []
+        self.bracketedAlterations: t.List[t.Tuple[str, int]] = []
+        self.omittedSteps: t.List[int] = []
+        self.addedSteps: t.List[t.Tuple[str, int]] = []
         # do not update pitches.
         self._parsingComplete = False
         self.key = keyOrScale
@@ -2690,7 +2690,7 @@ class RomanNumeral(harmony.Harmony):
                     secondary_tonic = self.secondaryRomanNumeralKey.tonic
                     self.secondaryRomanNumeralKey = key.Key(secondary_tonic, 'minor')
 
-            aug6type: Literal['It', 'Ger', 'Fr', 'Sw'] = aug6Match.group(1)
+            aug6type: t.Literal['It', 'Ger', 'Fr', 'Sw'] = aug6Match.group(1)
 
             if aug6type in ('It', 'Ger'):
                 self.scaleDegree = 4

--- a/music21/romanText/testFiles.py
+++ b/music21/romanText/testFiles.py
@@ -12,7 +12,7 @@
 Objects for processing roman numeral analysis text files,
 as defined and demonstrated by Dmitri Tymoczko.
 '''
-from typing import List
+import typing as t
 import unittest
 
 _DOC_IGNORE_MODULE_OR_PACKAGE = True
@@ -700,7 +700,7 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 
 if __name__ == '__main__':

--- a/music21/romanText/writeRoman.py
+++ b/music21/romanText/writeRoman.py
@@ -15,7 +15,7 @@ Writer for the 'RomanText' format (Tymoczko, Gotham, Cuthbert, & Ariza ISMIR 201
 import fractions
 import unittest
 
-from typing import List, Optional, Union
+import typing as t
 
 from music21 import base
 from music21 import metadata
@@ -123,8 +123,8 @@ class RnWriter(prebase.ProtoM21Object):
 
         self.composer = 'Composer unknown'
         self.title = 'Title unknown'
-        self.combinedList: List[str] = []
-        self.container: Union[stream.Part, stream.Score]
+        self.combinedList: t.List[str] = []
+        self.container: t.Union[stream.Part, stream.Score]
 
         if isinstance(obj, stream.Stream):
             if isinstance(obj, stream.Opus):
@@ -174,7 +174,7 @@ class RnWriter(prebase.ProtoM21Object):
         self.prepSequentialListOfLines()
 
     def _makeContainer(self,
-                       obj: Union[stream.Stream, List]):
+                       obj: t.Union[stream.Stream, t.List]):
         '''
         Makes a placeholder container for the unusual cases where this class is called on
         generic- or non-stream object as opposed to
@@ -299,9 +299,9 @@ class RnWriter(prebase.ProtoM21Object):
 # ------------------------------------------------------------------------------
 
 def rnString(measureNumber: int,
-             beat: Union[str, int, float, fractions.Fraction],
+             beat: t.Union[str, int, float, fractions.Fraction],
              chordString: str,
-             inString: Optional[str] = ''):
+             inString: t.Optional[str] = ''):
     '''
     Creates or extends a string of RomanText such that the output corresponds to a single
     measure line.
@@ -345,7 +345,7 @@ def rnString(measureNumber: int,
     return newString
 
 
-def intBeat(beat: Union[str, int, float, fractions.Fraction],
+def intBeat(beat: t.Union[str, int, float, fractions.Fraction],
             roundValue: int = 2):
     '''
     Converts beats to integers if possible, and otherwise to rounded decimals.

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -66,7 +66,7 @@ __all__ = [
 import abc
 import copy
 import unittest
-from typing import Optional, Union, List
+import typing as t
 
 from music21.scale import intervalNetwork
 from music21.scale import scala
@@ -561,7 +561,7 @@ class AbstractScale(Scale):
                   pitchOrigin,
                   direction=DIRECTION_ASCENDING,
                   stepSize=1,
-                  getNeighbor: Union[str, bool] = True):
+                  getNeighbor: t.Union[str, bool] = True):
         '''
         Expose functionality from :class:`~music21.intervalNetwork.IntervalNetwork`,
         passing on the stored alteredDegrees dictionary.
@@ -660,7 +660,7 @@ class AbstractDiatonicScale(AbstractScale):
     True
 
     '''
-    def __init__(self, mode: Optional[str] = None):
+    def __init__(self, mode: t.Optional[str] = None):
         super().__init__()
         self.mode = mode
         self.type = 'Abstract diatonic'
@@ -1270,14 +1270,14 @@ class ConcreteScale(Scale):
     usePitchDegreeCache = False
 
     def __init__(self,
-                 tonic: Optional[Union[str, pitch.Pitch, note.Note]] = None,
-                 pitches: Optional[List[Union[pitch.Pitch, str]]] = None):
+                 tonic: t.Optional[t.Union[str, pitch.Pitch, note.Note]] = None,
+                 pitches: t.Optional[t.List[t.Union[pitch.Pitch, str]]] = None):
         super().__init__()
 
         self.type = 'Concrete'
         # store an instance of an abstract scale
         # subclasses might use multiple abstract scales?
-        self._abstract: Optional[AbstractScale] = None
+        self._abstract: t.Optional[AbstractScale] = None
 
         # determine whether this is a limited range
         self.boundRange = False
@@ -1576,7 +1576,7 @@ class ConcreteScale(Scale):
         minPitch=None,
         maxPitch=None,
         direction=None
-    ) -> List[pitch.Pitch]:
+    ) -> t.List[pitch.Pitch]:
         '''
         Return a list of Pitch objects, using a
         deepcopy of a cached version if available.
@@ -2029,9 +2029,9 @@ class ConcreteScale(Scale):
 
     def next(self,
              pitchOrigin=None,
-             direction: Union[str, int, bool] = 'ascending',
+             direction: t.Union[str, int, bool] = 'ascending',
              stepSize=1,
-             getNeighbor: Union[str, bool] = True):
+             getNeighbor: t.Union[str, bool] = True):
         '''
         Get the next pitch above (or if direction is 'descending', below)
         a `pitchOrigin` or None. If the `pitchOrigin` is None, the tonic pitch is
@@ -2116,7 +2116,7 @@ class ConcreteScale(Scale):
                pitchOrigin,
                direction='ascending',
                stepSize=1,
-               getNeighbor: Union[str, bool] = True,
+               getNeighbor: t.Union[str, bool] = True,
                comparisonAttribute='name'):
         '''
         Given another pitch, as well as an origin and a direction,
@@ -2964,7 +2964,7 @@ class OctaveRepeatingScale(ConcreteScale):
     [<music21.pitch.Pitch C4>, <music21.pitch.Pitch D-4>, <music21.pitch.Pitch C5>]
     '''
 
-    def __init__(self, tonic=None, intervalList: Optional[List] = None):
+    def __init__(self, tonic=None, intervalList: t.Optional[t.List] = None):
         super().__init__(tonic=tonic)
         mode = intervalList if intervalList else ['m2']
         self._abstract = AbstractOctaveRepeatingScale(mode=mode)
@@ -2992,7 +2992,7 @@ class CyclicalScale(ConcreteScale):
     [<music21.pitch.Pitch C4>, <music21.pitch.Pitch D-4>]
     '''
 
-    def __init__(self, tonic=None, intervalList: Optional[List] = None):
+    def __init__(self, tonic=None, intervalList: t.Optional[t.List] = None):
         super().__init__(tonic=tonic)
         mode = intervalList if intervalList else ['m2']
         self._abstract = AbstractCyclicalScale(mode=mode)
@@ -3096,7 +3096,7 @@ class SieveScale(ConcreteScale):
     def __init__(self,
                  tonic=None,
                  sieveString='2@0',
-                 eld: Union[int, float] = 1):
+                 eld: t.Union[int, float] = 1):
         super().__init__(tonic=tonic)
 
         # self.tonic is a Pitch

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -31,7 +31,7 @@ finals, or other attributes of the network.
 '''
 import copy
 import unittest
-from typing import Tuple, Union
+import typing as t
 
 from collections import OrderedDict
 
@@ -1661,7 +1661,7 @@ class IntervalNetwork:
         return pre, preNodeId
 
     def realize(self,
-                pitchReference: Union[str, pitch.Pitch],
+                pitchReference: t.Union[str, pitch.Pitch],
                 nodeId=None,
                 minPitch=None,
                 maxPitch=None,
@@ -2809,7 +2809,7 @@ class IntervalNetwork:
         return post
 
 
-    _SCALE_STARTS: Tuple[str, ...] = (
+    _SCALE_STARTS: t.Tuple[str, ...] = (
         'C', 'C#', 'D-',
         'D', 'D#', 'E-',
         'E', 'F',

--- a/music21/scale/scala/__init__.py
+++ b/music21/scale/scala/__init__.py
@@ -42,7 +42,7 @@ For most people you'll want to do something like this:
 ['A4', 'B4(-15c)', 'C#5(-11c)', 'E-5(-7c)', 'E~5(+6c)', 'F#5(+14c)', 'G~5(+1c)', 'B-5(+2c)']
 
 '''
-from typing import Dict, Optional, List, Callable
+import typing as t
 
 import io
 import math
@@ -62,7 +62,7 @@ environLocal = environment.Environment('scale.scala')
 
 # ------------------------------------------------------------------------------
 # global variable to cache the paths returned from getPaths()
-SCALA_PATHS: Dict[str, Optional[Dict[str, List[str]]]] = {'allPaths': None}
+SCALA_PATHS: t.Dict[str, t.Optional[t.Dict[str, t.List[str]]]] = {'allPaths': None}
 
 def getPaths():
     '''
@@ -721,7 +721,7 @@ Aristoxenos' Chromatic/Enharmonic, 3 + 9 + 18 parts
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[Callable] = []
+_DOC_ORDER: t.List[t.Callable] = []
 
 
 if __name__ == '__main__':

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -13,7 +13,7 @@ Classes for searching for Lyric objects.
 '''
 import re
 from collections import namedtuple, OrderedDict
-from typing import Optional, List
+import typing as t
 import unittest
 
 from music21.exceptions21 import Music21Exception
@@ -125,8 +125,8 @@ class LyricSearcher:
         self.includeIntermediateElements = False  # currently does nothing
         self.includeTrailingMelisma = False  # currently does nothing
 
-        self._indexText: Optional[str] = None
-        self._indexTuples: List[IndexedLyric] = []
+        self._indexText: t.Optional[str] = None
+        self._indexTuples: t.List[IndexedLyric] = []
 
     @property
     def indexText(self) -> str:
@@ -143,12 +143,12 @@ class LyricSearcher:
         return self._indexText or ''
 
     @property
-    def indexTuples(self) -> List[IndexedLyric]:
+    def indexTuples(self) -> t.List[IndexedLyric]:
         if self._indexText is None:  # correct -- check text to see if has run.
             self.index()
         return self._indexTuples
 
-    def index(self, s=None) -> List[IndexedLyric]:
+    def index(self, s=None) -> t.List[IndexedLyric]:
         # noinspection PyShadowingNames
         '''
         A method that indexes the Stream's lyrics and returns the list
@@ -190,7 +190,7 @@ class LyricSearcher:
         lastSyllabicByIdentifier = OrderedDict()
 
         for n in s.recurse().notes:
-            ls: List[note.Lyric] = n.lyrics
+            ls: t.List[note.Lyric] = n.lyrics
             if not ls:
                 continue
             mNum = n.measureNumber
@@ -250,7 +250,7 @@ class LyricSearcher:
         self._indexText = iText
         return index
 
-    def search(self, textOrRe, s=None) -> List[SearchMatch]:
+    def search(self, textOrRe, s=None) -> t.List[SearchMatch]:
         # noinspection SpellCheckingInspection
         r'''
         Return a list of SearchMatch objects matching a string or regular expression.
@@ -325,7 +325,7 @@ class LyricSearcher:
 
         raise LyricSearcherException(f'Could not find position {pos} in text')
 
-    def _findObjsInIndexByPos(self, posStart, posEnd=999999) -> List[IndexedLyric]:
+    def _findObjsInIndexByPos(self, posStart, posEnd=999999) -> t.List[IndexedLyric]:
         '''
         Finds a list of objects in ._indexTuples by search position (inclusive)
         '''
@@ -357,7 +357,7 @@ class LyricSearcher:
     #     lineBreakStart += len(LINEBREAK_TOKEN)
     #     return lineBreakStart
 
-    def _reSearch(self, r: re.Pattern) -> List[SearchMatch]:
+    def _reSearch(self, r: re.Pattern) -> t.List[SearchMatch]:
         locations = []
         for m in r.finditer(self._indexText):
             absoluteFoundPos, absoluteEndPos = m.span()

--- a/music21/search/segment.py
+++ b/music21/search/segment.py
@@ -33,7 +33,7 @@ import random
 
 from collections import OrderedDict
 from functools import partial
-from typing import List
+import typing as t
 
 from music21 import common
 from music21 import converter
@@ -403,7 +403,7 @@ def scoreSimilarity(
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 
 if __name__ == '__main__':

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -19,7 +19,7 @@ Serial searching methods that were previously here have been moved to `alpha.sea
 
 import unittest
 import copy
-from typing import Union, List, Any
+import typing as t
 import warnings
 
 from music21 import exceptions21
@@ -556,7 +556,7 @@ class ToneRow(stream.Stream):
 
         return self.zeroCenteredTransformation(transformationType, newIndex)
 
-    def findZeroCenteredTransformations(self, otherRow) -> Union[bool, List[Any]]:
+    def findZeroCenteredTransformations(self, otherRow) -> t.Union[bool, t.List[t.Any]]:
         '''
         Gives the list of zero-centered serial transformations
         taking one :class:`~music21.serial.ToneRow`
@@ -1309,7 +1309,7 @@ def pcToToneRow(pcSet):
     return a
 
 
-def rowToMatrix(p: List[int]) -> str:
+def rowToMatrix(p: t.List[int]) -> str:
     # noinspection PyShadowingNames
     '''
     Takes a list of numbers of converts it to a string representation of a

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -60,7 +60,7 @@ import copy
 import random
 import string
 import unittest
-from typing import List, Union
+import typing as t
 
 from music21 import exceptions21
 from music21 import pitch
@@ -1893,7 +1893,7 @@ class PitchSieve:
                  pitchLower=None,
                  pitchUpper=None,
                  pitchOrigin=None,
-                 eld: Union[int, float] = 1):
+                 eld: t.Union[int, float] = 1):
         self.pitchLower = None  # 'c3'
         self.pitchUpper = None  # 'c5' -- default ps Range
         self.pitchOrigin = None  # pitchLower -- default
@@ -2194,7 +2194,7 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 if __name__ == '__main__':
     import music21

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -15,7 +15,7 @@ sites.py -- Objects for keeping track of relationships among Music21Objects
 import collections
 import unittest
 import weakref
-from typing import Any, MutableMapping, Optional, Union
+import typing as t
 
 from music21 import common
 from music21 import exceptions21
@@ -34,7 +34,7 @@ WEAKREF_ACTIVE = True
 # that still exists, then restore it from the dictionary; otherwise, do not
 # sweat it.  Should make pickle deepcopies of music21 objects in Streams still
 # possible without needing to recreate the whole stream.
-GLOBAL_SITE_STATE_DICT: MutableMapping[str, Optional[Any]] = weakref.WeakValueDictionary()
+GLOBAL_SITE_STATE_DICT: t.MutableMapping[str, t.Optional[t.Any]] = weakref.WeakValueDictionary()
 
 
 class SitesException(exceptions21.Music21Exception):
@@ -380,7 +380,7 @@ class Sites(common.SlottedObjectMixin):
         self._lastID = -1  # cannot be None
 
     def yieldSites(self,
-                   sortByCreationTime: Union[str, bool] = False,
+                   sortByCreationTime: t.Union[str, bool] = False,
                    priorityTarget=None,
                    excludeNone=False):
         # noinspection PyDunderSlots

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -20,7 +20,7 @@ can be found in modules such as :ref:`moduleDynamics` (for things such as cresce
 '''
 import unittest
 import copy
-from typing import Any, Dict, Sequence, Union, List, Optional, TypedDict
+import typing as t
 
 from music21 import exceptions21
 from music21 import base
@@ -407,7 +407,7 @@ class Spanner(base.Music21Object):
 
     def addSpannedElements(
         self,
-        spannedElements: Union[Sequence[base.Music21Object],
+        spannedElements: t.Union[t.Sequence[base.Music21Object],
                                base.Music21Object],
         *arguments,
         **keywords
@@ -606,7 +606,7 @@ class Spanner(base.Music21Object):
 
 
 # ------------------------------------------------------------------------------
-class _SpannerRef(TypedDict):
+class _SpannerRef(t.TypedDict):
     # noinspection PyTypedDict
     spanner: 'Spanner'
     className: str
@@ -632,10 +632,10 @@ class SpannerBundle(prebase.ProtoM21Object):
     Changed in v7: only argument must be a List of spanners.
     Creators of SpannerBundles are required to check that this constraint is True
     '''
-    def __init__(self, spanners: Optional[List[Spanner]] = None):
-        self._cache: Dict[str, Any] = {}  # cache is defined on Music21Object not ProtoM21Object
+    def __init__(self, spanners: t.Optional[t.List[Spanner]] = None):
+        self._cache: t.Dict[str, t.Any] = {}  # cache is defined on Music21Object not ProtoM21Object
 
-        self._storage: List[Spanner]
+        self._storage: t.List[Spanner]
         if spanners:
             self._storage = spanners[:]  # a simple List, not a Stream
         else:
@@ -645,7 +645,7 @@ class SpannerBundle(prebase.ProtoM21Object):
         # SpannerBundle as missing a spannedElement; the next obj that meets
         # the class expectation will then be assigned and the spannedElement
         # cleared
-        self._pendingSpannedElementAssignment: List[_SpannerRef] = []
+        self._pendingSpannedElementAssignment: t.List[_SpannerRef] = []
 
     def append(self, other):
         '''
@@ -805,7 +805,7 @@ class SpannerBundle(prebase.ProtoM21Object):
         self,
         old: base.Music21Object,
         new: base.Music21Object
-    ) -> List[Spanner]:
+    ) -> t.List[Spanner]:
         # noinspection PyShadowingNames
         '''
         Given a spanner spannedElement (an object), replace all old spannedElements
@@ -872,7 +872,7 @@ class SpannerBundle(prebase.ProtoM21Object):
 
         return replacedSpanners
 
-    def getByClass(self, className: Union[str, type]) -> 'SpannerBundle':
+    def getByClass(self, className: t.Union[str, type]) -> 'SpannerBundle':
         '''
         Given a spanner class, return a new SpannerBundle of all Spanners of the desired class.
 
@@ -2722,7 +2722,7 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[type] = [Spanner]
+_DOC_ORDER: t.List[type] = [Spanner]
 
 
 if __name__ == '__main__':

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -408,7 +408,7 @@ class Spanner(base.Music21Object):
     def addSpannedElements(
         self,
         spannedElements: t.Union[t.Sequence[base.Music21Object],
-                               base.Music21Object],
+                                 base.Music21Object],
         *arguments,
         **keywords
     ):

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -34,6 +34,7 @@ from collections import namedtuple
 from fractions import Fraction
 from math import isclose
 import typing as t
+from typing import overload
 
 from music21 import base
 
@@ -390,7 +391,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         adds necessary Stream-specific features.
         '''
         return t.cast(iterator.StreamIterator[M21ObjType],
-                    iterator.StreamIterator(self))
+                      iterator.StreamIterator(self))
 
     def iter(self) -> iterator.StreamIterator[M21ObjType]:
         '''
@@ -404,21 +405,21 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         '''
         return self.__iter__()
 
-    @t.overload
+    @overload
     def __getitem__(self, k: str) -> iterator.RecursiveIterator[M21ObjType]:
         # Remove this code and replace with ... once Astroid #1015 is fixed.
         x: iterator.RecursiveIterator[M21ObjType] = self.recurse()
         return x
 
-    @t.overload
+    @overload
     def __getitem__(self, k: int) -> M21ObjType:
         return self[k]  # dummy code
 
-    @t.overload
+    @overload
     def __getitem__(self, k: slice) -> t.List[M21ObjType]:
         return list(self.elements)  # dummy code
 
-    @t.overload
+    @overload
     def __getitem__(
         self,
         k: t.Type[ChangedM21ObjType]
@@ -429,9 +430,9 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     def __getitem__(self,
                     k: t.Union[str, int, slice, t.Type[ChangedM21ObjType]]
                     ) -> t.Union[iterator.RecursiveIterator[M21ObjType],
-                               iterator.RecursiveIterator[ChangedM21ObjType],
-                               M21ObjType,
-                               t.List[M21ObjType]]:
+                                 iterator.RecursiveIterator[ChangedM21ObjType],
+                                 M21ObjType,
+                                 t.List[M21ObjType]]:
         '''
         Get a Music21Object from the Stream using a variety of keys or indices.
 
@@ -3371,7 +3372,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     # getElementsByX(self): anything that returns a collection of Elements
     #  formerly always returned a Stream; turning to Iterators in September 2015
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Union[str, t.Iterable[str]]
                            ) -> iterator.StreamIterator[M21ObjType]:
@@ -3379,7 +3380,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         x: iterator.StreamIterator[M21ObjType] = self.iter()
         return x  # dummy code
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Type[ChangedM21ObjType]
                            ) -> iterator.StreamIterator[ChangedM21ObjType]:
@@ -3388,7 +3389,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         )
         return x  # dummy code
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Iterable[t.Type[ChangedM21ObjType]]
                            ) -> iterator.StreamIterator[M21ObjType]:
@@ -7578,7 +7579,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         '''
         return self.flatten(retainContainers=True)
 
-    @t.overload
+    @overload
     def recurse(self,
                 *,
                 streamsOnly: t.Literal[True],
@@ -7587,7 +7588,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                 includeSelf=None) -> iterator.RecursiveIterator[Stream]:
         return iterator.RecursiveIterator(self).getElementsByClass(Stream)
 
-    @t.overload
+    @overload
     def recurse(self,
                 *,
                 streamsOnly: t.Literal[False] = False,
@@ -7602,7 +7603,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                 restoreActiveSites=True,
                 classFilter=(),
                 includeSelf=None) -> t.Union[iterator.RecursiveIterator[M21ObjType],
-                                           iterator.RecursiveIterator[Stream]]:
+                                             iterator.RecursiveIterator[Stream]]:
         '''
         `.recurse()` is a fundamental method of music21 for getting into
         elements contained in a Score, Part, or Measure, where elements such as

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -33,9 +33,7 @@ import sys
 from collections import namedtuple
 from fractions import Fraction
 from math import isclose
-from typing import (Dict, Iterable, List, Optional, Set, Tuple, cast,
-                    TypeVar, Type, Union, Generic, Literal, overload,
-                    Sequence, TYPE_CHECKING, Any)
+import typing as t
 
 from music21 import base
 
@@ -77,9 +75,9 @@ environLocal = environment.Environment('stream')
 StreamException = exceptions21.StreamException
 ImmutableStreamException = exceptions21.ImmutableStreamException
 
-T = TypeVar('T')
+T = t.TypeVar('T')
 # we sometimes need to return a different type.
-ChangedM21ObjType = TypeVar('ChangedM21ObjType', bound=base.Music21Object)
+ChangedM21ObjType = t.TypeVar('ChangedM21ObjType', bound=base.Music21Object)
 
 BestQuantizationMatch = namedtuple(
     'BestQuantizationMatch',
@@ -98,7 +96,7 @@ OffsetMap = collections.namedtuple('OffsetMap', ['element', 'offset', 'endTime',
 
 
 # -----------------------------------------------------------------------------
-class Stream(core.StreamCore, Generic[M21ObjType]):
+class Stream(core.StreamCore, t.Generic[M21ObjType]):
     '''
     This is the fundamental container for Music21Objects;
     objects may be ordered and/or placed in time based on
@@ -221,7 +219,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
     # forms of checking class
     isStream = True
     isMeasure = False
-    classSortOrder: Union[int, float] = -20
+    classSortOrder: t.Union[int, float] = -20
     recursionType = 'elementsFirst'
 
     _styleClass = style.StreamStyle
@@ -277,7 +275,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
     def __init__(self,
                  givenElements=None,
                  *args,
-                 # restrictClass: Type[M21ObjType] = base.Music21Object,
+                 # restrictClass: t.Type[M21ObjType] = base.Music21Object,
                  **keywords):
         super().__init__(self, *args, **keywords)
 
@@ -294,7 +292,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         self.definesExplicitPageBreaks = False
 
         # property for transposition status;
-        self._atSoundingPitch: Union[bool, Literal['unknown']] = 'unknown'
+        self._atSoundingPitch: t.Union[bool, t.Literal['unknown']] = 'unknown'
 
         # experimental
         self._mutable = True
@@ -391,7 +389,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         specialized :class:`music21.stream.StreamIterator` class, which
         adds necessary Stream-specific features.
         '''
-        return cast(iterator.StreamIterator[M21ObjType],
+        return t.cast(iterator.StreamIterator[M21ObjType],
                     iterator.StreamIterator(self))
 
     def iter(self) -> iterator.StreamIterator[M21ObjType]:
@@ -406,34 +404,34 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         '''
         return self.__iter__()
 
-    @overload
+    @t.overload
     def __getitem__(self, k: str) -> iterator.RecursiveIterator[M21ObjType]:
         # Remove this code and replace with ... once Astroid #1015 is fixed.
         x: iterator.RecursiveIterator[M21ObjType] = self.recurse()
         return x
 
-    @overload
+    @t.overload
     def __getitem__(self, k: int) -> M21ObjType:
         return self[k]  # dummy code
 
-    @overload
-    def __getitem__(self, k: slice) -> List[M21ObjType]:
+    @t.overload
+    def __getitem__(self, k: slice) -> t.List[M21ObjType]:
         return list(self.elements)  # dummy code
 
-    @overload
+    @t.overload
     def __getitem__(
         self,
-        k: Type[ChangedM21ObjType]
+        k: t.Type[ChangedM21ObjType]
     ) -> iterator.RecursiveIterator[ChangedM21ObjType]:
-        x = cast(iterator.RecursiveIterator[ChangedM21ObjType], self.recurse())
+        x = t.cast(iterator.RecursiveIterator[ChangedM21ObjType], self.recurse())
         return x  # dummy code
 
     def __getitem__(self,
-                    k: Union[str, int, slice, Type[ChangedM21ObjType]]
-                    ) -> Union[iterator.RecursiveIterator[M21ObjType],
+                    k: t.Union[str, int, slice, t.Type[ChangedM21ObjType]]
+                    ) -> t.Union[iterator.RecursiveIterator[M21ObjType],
                                iterator.RecursiveIterator[ChangedM21ObjType],
                                M21ObjType,
-                               List[M21ObjType]]:
+                               t.List[M21ObjType]]:
         '''
         Get a Music21Object from the Stream using a variety of keys or indices.
 
@@ -584,17 +582,17 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
                     )
             # setting active site as cautionary measure
             self.coreSelfActiveSite(match)
-            return cast(M21ObjType, match)
+            return t.cast(M21ObjType, match)
 
         elif isinstance(k, slice):  # get a slice of index values
             # manually inserting elements is critical to setting the element
             # locations
-            searchElements: List[base.Music21Object] = self._elements
+            searchElements: t.List[base.Music21Object] = self._elements
             if (k.start is not None and k.start < 0) or (k.stop is not None and k.stop < 0):
                 # Must use .elements property to incorporate end elements
                 searchElements = list(self.elements)
 
-            return cast(M21ObjType, searchElements[k])
+            return t.cast(M21ObjType, searchElements[k])
 
         elif isinstance(k, type) and issubclass(k, base.Music21Object):
             return self.recurse().getElementsByClass(k)
@@ -611,7 +609,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
             f'Streams can get items by int, slice, class, or string query; got {type(k)}'
         )
 
-    def first(self) -> Optional[M21ObjType]:
+    def first(self) -> t.Optional[M21ObjType]:
         '''
         Return the first element of a Stream.  (Added for compatibility with StreamIterator)
         Or None if the Stream is empty.
@@ -637,7 +635,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         except IndexError:
             return None
 
-    def last(self) -> Optional[M21ObjType]:
+    def last(self) -> t.Optional[M21ObjType]:
         '''
         Return the last element of a Stream.  (Added for compatibility with StreamIterator)
         Or None if the Stream is empty.
@@ -696,7 +694,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         return False
 
     @property
-    def elements(self) -> Tuple[M21ObjType, ...]:
+    def elements(self) -> t.Tuple[M21ObjType, ...]:
         '''
         .elements is a Tuple representing the elements contained in the Stream.
 
@@ -745,11 +743,11 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
             # coreElementsChanged has been called
             if not self.isSorted and self.autoSort:
                 self.sort()  # will set isSorted to True
-            self._cache['elements'] = cast(List[M21ObjType], self._elements + self._endElements)
+            self._cache['elements'] = t.cast(t.List[M21ObjType], self._elements + self._endElements)
         return tuple(self._cache['elements'])
 
     @elements.setter
-    def elements(self, value: Union[Stream, Iterable[base.Music21Object]]):
+    def elements(self, value: t.Union[Stream, t.Iterable[base.Music21Object]]):
         '''
         Sets this stream's elements to the elements in another stream (just give
         the stream, not the stream's .elements), or to a list of elements.
@@ -769,15 +767,15 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         are we going to get the new stream's elements' offsets from? why
         from their active sites! So don't do this!
         '''
-        self._offsetDict: Dict[int, Tuple[OffsetQLSpecial, base.Music21Object]] = {}
+        self._offsetDict: t.Dict[int, t.Tuple[OffsetQLSpecial, base.Music21Object]] = {}
         if isinstance(value, Stream):
             # set from a Stream. Best way to do it
-            self._elements: List[base.Music21Object] = list(value._elements)  # copy list.
+            self._elements: t.List[base.Music21Object] = list(value._elements)  # copy list.
             for e in self._elements:
                 self.coreSetElementOffset(e, value.elementOffset(e), addElement=True)
                 e.sites.add(self)
                 self.coreSelfActiveSite(e)
-            self._endElements: List[base.Music21Object] = list(value._endElements)
+            self._endElements: t.List[base.Music21Object] = list(value._endElements)
             for e in self._endElements:
                 self.coreSetElementOffset(e,
                                       value.elementOffset(e, returnSpecial=True),
@@ -951,7 +949,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
 
     # ------------------------------
     @property
-    def clef(self) -> Optional['music21.clef.Clef']:
+    def clef(self) -> t.Optional['music21.clef.Clef']:
         '''
         Finds or sets a :class:`~music21.clef.Clef` at offset 0.0 in the Stream
         (generally a Measure):
@@ -992,7 +990,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         return clefList.first()
 
     @clef.setter
-    def clef(self, clefObj: Optional['music21.clef.Clef']):
+    def clef(self, clefObj: t.Optional['music21.clef.Clef']):
         # if clef is None; remove object?
         oldClef = self.clef
         if oldClef is not None:
@@ -1005,7 +1003,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         self.insert(0.0, clefObj)
 
     @property
-    def timeSignature(self) -> Optional['music21.meter.TimeSignature']:
+    def timeSignature(self) -> t.Optional['music21.meter.TimeSignature']:
         '''
         Gets or sets the timeSignature at offset 0.0 of the Stream (generally a Measure)
 
@@ -1057,7 +1055,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         return tsList.first()
 
     @timeSignature.setter
-    def timeSignature(self, tsObj: Optional['music21.meter.TimeSignature']):
+    def timeSignature(self, tsObj: t.Optional['music21.meter.TimeSignature']):
         oldTimeSignature = self.timeSignature
         if oldTimeSignature is not None:
             # environLocal.printDebug(['removing ts', oldTimeSignature])
@@ -1069,7 +1067,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         self.insert(0, tsObj)
 
     @property
-    def keySignature(self) -> Optional[key.KeySignature]:
+    def keySignature(self) -> t.Optional[key.KeySignature]:
         '''
         Find or set a Key or KeySignature at offset 0.0 of a stream.
 
@@ -1106,7 +1104,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
             return None
 
     @keySignature.setter
-    def keySignature(self, keyObj: Optional[key.KeySignature]):
+    def keySignature(self, keyObj: t.Optional[key.KeySignature]):
         '''
         >>> a = stream.Measure()
         >>> a.keySignature = key.KeySignature(6)
@@ -1213,7 +1211,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         '''
         self.elements = ()
 
-    def cloneEmpty(self: StreamType, derivationMethod: Optional[str] = None) -> StreamType:
+    def cloneEmpty(self: StreamType, derivationMethod: t.Optional[str] = None) -> StreamType:
         '''
         Create a Stream that is identical to this one except that the elements are empty
         and set derivation.
@@ -1446,7 +1444,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         raise StreamException(f'cannot find object ({el}) in Stream')
 
     def remove(self,
-               targetOrList: Union[base.Music21Object, Sequence[base.Music21Object]],
+               targetOrList: t.Union[base.Music21Object, t.Sequence[base.Music21Object]],
                *,
                shiftOffsets=False,
                recurse=False):
@@ -1588,13 +1586,13 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
             raise StreamException(
                 'Cannot do both shiftOffsets and recurse search at the same time...yet')
 
-        targetList: List[base.Music21Object]
+        targetList: t.List[base.Music21Object]
         if not common.isListLike(targetOrList):
-            if TYPE_CHECKING:
+            if t.TYPE_CHECKING:
                 assert isinstance(targetOrList, base.Music21Object)
             targetList = [targetOrList]
-        elif isinstance(targetOrList, Sequence) and len(targetOrList) > 1:
-            if TYPE_CHECKING:
+        elif isinstance(targetOrList, t.Sequence) and len(targetOrList) > 1:
+            if t.TYPE_CHECKING:
                 assert not isinstance(targetOrList, base.Music21Object)
             try:
                 targetList = list(sorted(targetOrList, key=self.elementOffset))
@@ -1602,7 +1600,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
                 # will not be found if recursing, it's not such a big deal...
                 targetList = list(targetOrList)
         else:
-            if TYPE_CHECKING:
+            if t.TYPE_CHECKING:
                 assert not isinstance(targetOrList, base.Music21Object)
             targetList = list(targetOrList)
 
@@ -1902,7 +1900,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
     def setElementOffset(
         self,
         element: base.Music21Object,
-        offset: Union[int, float, Fraction, OffsetSpecial],
+        offset: t.Union[int, float, Fraction, OffsetSpecial],
     ):
         '''
         Sets the Offset for an element that is already in a given stream.
@@ -3100,22 +3098,22 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         targetSplit = []
         targetMove = []
         # find all those that need to split v. those that need to be moved
-        for t in targets:
+        for target in targets:
             # if target starts before the boundary, it needs to be split
-            if sLeft.elementOffset(t) < quarterLength:
-                targetSplit.append(t)
+            if sLeft.elementOffset(target) < quarterLength:
+                targetSplit.append(target)
             else:
-                targetMove.append(t)
+                targetMove.append(target)
 
         # environLocal.printDebug(['split', targetSplit, 'move', targetMove])
 
-        for t in targetSplit:
+        for target in targetSplit:
             # must retain original, as a deepcopy, if necessary, has
             # already been made
 
             # the split point needs to be relative to this element's start
-            qlSplit = quarterLength - sLeft.elementOffset(t)
-            unused_eLeft, eRight = t.splitAtQuarterLength(
+            qlSplit = quarterLength - sLeft.elementOffset(target)
+            unused_eLeft, eRight = target.splitAtQuarterLength(
                 qlSplit,
                 retainOrigin=True,
                 addTies=addTies,
@@ -3125,9 +3123,9 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
             # it is assumed that anything cut will start at zero
             sRight.insert(0, eRight)
 
-        for t in targetMove:
-            sRight.insert(t.getOffsetBySite(sLeft) - quarterLength, t)
-            sLeft.remove(t)
+        for target in targetMove:
+            sRight.insert(target.getOffsetBySite(sLeft) - quarterLength, target)
+            sLeft.remove(target)
 
         return sLeft, sRight
 
@@ -3373,38 +3371,38 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
     # getElementsByX(self): anything that returns a collection of Elements
     #  formerly always returned a Stream; turning to Iterators in September 2015
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Union[str, Iterable[str]]
+                           classFilterList: t.Union[str, t.Iterable[str]]
                            ) -> iterator.StreamIterator[M21ObjType]:
         # Remove all dummy code once Astroid #1015 is fixed
         x: iterator.StreamIterator[M21ObjType] = self.iter()
         return x  # dummy code
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Type[ChangedM21ObjType]
+                           classFilterList: t.Type[ChangedM21ObjType]
                            ) -> iterator.StreamIterator[ChangedM21ObjType]:
         x: iterator.StreamIterator[ChangedM21ObjType] = (
             self.iter().getElementsByClass(classFilterList)
         )
         return x  # dummy code
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Iterable[Type[ChangedM21ObjType]]
+                           classFilterList: t.Iterable[t.Type[ChangedM21ObjType]]
                            ) -> iterator.StreamIterator[M21ObjType]:
         x: iterator.StreamIterator[M21ObjType] = self.iter()
         return x  # dummy code
 
     def getElementsByClass(self,
-                           classFilterList: Union[
+                           classFilterList: t.Union[
                                str,
-                               Type[ChangedM21ObjType],
-                               Iterable[str],
-                               Iterable[Type[ChangedM21ObjType]],
+                               t.Type[ChangedM21ObjType],
+                               t.Iterable[str],
+                               t.Iterable[t.Type[ChangedM21ObjType]],
                            ],
-                           ) -> Union[iterator.StreamIterator[M21ObjType],
+                           ) -> t.Union[iterator.StreamIterator[M21ObjType],
                                       iterator.StreamIterator[ChangedM21ObjType]]:
         '''
         Return a StreamIterator that will iterate over Elements that match one
@@ -3543,7 +3541,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         '''
         return self.iter().getElementsByGroup(groupFilterList, returnClone=False)
 
-    def getElementById(self, elementId) -> Optional[base.Music21Object]:
+    def getElementById(self, elementId) -> t.Optional[base.Music21Object]:
         '''
         Returns the first encountered element for a given id. Return None
         if no match. Note: this uses the id attribute stored on elements,
@@ -3829,7 +3827,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
             sIterator = sIterator.getElementsByClass(classList)
         return sIterator
 
-    def getElementAtOrBefore(self, offset, classList=None) -> Optional[base.Music21Object]:
+    def getElementAtOrBefore(self, offset, classList=None) -> t.Optional[base.Music21Object]:
         # noinspection PyShadowingNames
         '''
         Given an offset, find the element at this offset,
@@ -3949,7 +3947,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         else:
             return None
 
-    def getElementBeforeOffset(self, offset, classList=None) -> Optional[base.Music21Object]:
+    def getElementBeforeOffset(self, offset, classList=None) -> t.Optional[base.Music21Object]:
         '''
         Get element before (and not at) a provided offset.
 
@@ -4300,7 +4298,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         <music21.layout.StaffGroup <music21.stream.PartStaff P5-Staff1><... P5-Staff2>>
         <music21.layout.StaffGroup <music21.stream.Part Soprano I><...Alto II>>
         '''
-        startMeasure: Optional[Measure]
+        startMeasure: t.Optional[Measure]
 
         def hasMeasureNumberInformation(measureIterator):
             '''
@@ -4432,7 +4430,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
     def measure(self,
                 measureNumber,
                 collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature'),
-                indicesNotNumbers=False) -> Optional[Measure]:
+                indicesNotNumbers=False) -> t.Optional[Measure]:
         '''
         Given a measure number, return a single
         :class:`~music21.stream.Measure` object if the Measure number exists, otherwise return None.
@@ -4485,7 +4483,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
                               collect=collect,
                               indicesNotNumbers=indicesNotNumbers)
             measureIter = s.getElementsByClass(Measure)
-            m: Optional[Measure]
+            m: t.Optional[Measure]
             # noinspection PyTypeChecker
             m = measureIter.first()
             if m is None:  # not 'if not m' because m might be an empty measure.
@@ -4979,7 +4977,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
     # handling transposition values and status
 
     @property
-    def atSoundingPitch(self) -> Union[bool, Literal['unknown']]:
+    def atSoundingPitch(self) -> t.Union[bool, t.Literal['unknown']]:
         '''
         Get or set the atSoundingPitch status, that is whether the
         score is at concert pitch or may have transposing instruments
@@ -5003,7 +5001,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         return self._atSoundingPitch
 
     @atSoundingPitch.setter
-    def atSoundingPitch(self, value: Union[bool, Literal['unknown']]):
+    def atSoundingPitch(self, value: t.Union[bool, t.Literal['unknown']]):
         if value in [True, False, 'unknown']:
             self._atSoundingPitch = value
         else:
@@ -5029,7 +5027,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
             returnObj = self
 
         instrument_stream = returnObj.getInstruments(recurse=True)
-        instrument_map: Dict[instrument.Instrument, OffsetQL] = {}
+        instrument_map: t.Dict[instrument.Instrument, OffsetQL] = {}
         for inst in instrument_stream:
             # keep track of original durations of each instrument
             instrument_map[inst] = inst.duration.quarterLength
@@ -5070,7 +5068,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
 
         return returnObj
 
-    def _treatAtSoundingPitch(self) -> Union[bool, str]:
+    def _treatAtSoundingPitch(self) -> t.Union[bool, str]:
         '''
         `atSoundingPitch` might be True, False, or 'unknown'. Given that
         setting the property does not automatically synchronize the corresponding
@@ -5333,9 +5331,9 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         else:
             sIter = self.recurse()
 
-        post = cast(Stream[instrument.Instrument],
-                    sIter.getElementsByClass(instrument.Instrument).stream()
-                    )
+        post = t.cast(Stream[instrument.Instrument],
+                      sIter.getElementsByClass(instrument.Instrument).stream()
+                      )
 
         if post:
             # environLocal.printDebug(['found local instrument:', post[0]])
@@ -5370,7 +5368,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
                       *,
                       searchActiveSite=True,
                       returnDefault=True,
-                      recurse=False) -> Optional['music21.instrument.Instrument']:
+                      recurse=False) -> t.Optional['music21.instrument.Instrument']:
         '''
         Return the first Instrument found in this Stream, or None.
 
@@ -6308,17 +6306,17 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
     def makeAccidentals(
         self,
         *,
-        pitchPast: Optional[List[pitch.Pitch]] = None,
-        pitchPastMeasure: Optional[List[pitch.Pitch]] = None,
-        useKeySignature: Union[bool, key.KeySignature] = True,
-        alteredPitches: Optional[List[pitch.Pitch]] = None,
+        pitchPast: t.Optional[t.List[pitch.Pitch]] = None,
+        pitchPastMeasure: t.Optional[t.List[pitch.Pitch]] = None,
+        useKeySignature: t.Union[bool, key.KeySignature] = True,
+        alteredPitches: t.Optional[t.List[pitch.Pitch]] = None,
         searchKeySignatureByContext: bool = False,
         cautionaryPitchClass: bool = True,
         cautionaryAll: bool = False,
         inPlace: bool = False,
         overrideStatus: bool = False,
         cautionaryNotImmediateRepeat: bool = True,
-        tiePitchSet: Optional[Set[str]] = None
+        tiePitchSet: t.Optional[t.Set[str]] = None
     ):
         '''
         A method to set and provide accidentals given various conditions and contexts.
@@ -6384,12 +6382,12 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         # see if there is any key signatures to add to altered pitches
         if alteredPitches is None:
             alteredPitches = []
-        addAlteredPitches: List[pitch.Pitch] = []
+        addAlteredPitches: t.List[pitch.Pitch] = []
         if isinstance(useKeySignature, key.KeySignature):
             addAlteredPitches = useKeySignature.alteredPitches
         elif useKeySignature is True:  # get from defined contexts
             # will search local, then activeSite
-            ksIter: Union[List[key.KeySignature],
+            ksIter: t.Union[t.List[key.KeySignature],
                           iterator.StreamIterator[key.KeySignature],
                           None] = None
             if searchKeySignatureByContext:
@@ -6417,7 +6415,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         if tiePitchSet is None:
             tiePitchSet = set()
 
-        last_measure: Optional[Measure] = None
+        last_measure: t.Optional[Measure] = None
 
         for e in noteIterator:
             if e.activeSite is not None and e.activeSite.isMeasure:
@@ -6505,15 +6503,15 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
                      refStreamOrTimeRange=None,
                      inPlace=False,
                      bestClef=False,
-                     pitchPast: Optional[List[pitch.Pitch]] = None,
-                     pitchPastMeasure: Optional[List[pitch.Pitch]] = None,
-                     useKeySignature: Union[bool, key.KeySignature] = True,
-                     alteredPitches: Optional[List[pitch.Pitch]] = None,
+                     pitchPast: t.Optional[t.List[pitch.Pitch]] = None,
+                     pitchPastMeasure: t.Optional[t.List[pitch.Pitch]] = None,
+                     useKeySignature: t.Union[bool, key.KeySignature] = True,
+                     alteredPitches: t.Optional[t.List[pitch.Pitch]] = None,
                      cautionaryPitchClass: bool = True,
                      cautionaryAll: bool = False,
                      overrideStatus: bool = False,
                      cautionaryNotImmediateRepeat: bool = True,
-                     tiePitchSet: Optional[Set[str]] = None
+                     tiePitchSet: t.Optional[t.Set[str]] = None
                      ):
         '''
         This method calls a sequence of Stream methods on this Stream to prepare
@@ -6548,7 +6546,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         'final'
         '''
         # determine what is the object to work on first
-        returnStream: Union[StreamType, Stream[Any]]
+        returnStream: t.Union[StreamType, Stream[t.Any]]
         if inPlace:
             returnStream = self
         else:
@@ -7580,19 +7578,19 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         '''
         return self.flatten(retainContainers=True)
 
-    @overload
+    @t.overload
     def recurse(self,
                 *,
-                streamsOnly: Literal[True],
+                streamsOnly: t.Literal[True],
                 restoreActiveSites=True,
                 classFilter=(),
                 includeSelf=None) -> iterator.RecursiveIterator[Stream]:
         return iterator.RecursiveIterator(self).getElementsByClass(Stream)
 
-    @overload
+    @t.overload
     def recurse(self,
                 *,
-                streamsOnly: Literal[False] = False,
+                streamsOnly: t.Literal[False] = False,
                 restoreActiveSites=True,
                 classFilter=(),
                 includeSelf=None) -> iterator.RecursiveIterator[M21ObjType]:
@@ -7603,7 +7601,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
                 streamsOnly=False,
                 restoreActiveSites=True,
                 classFilter=(),
-                includeSelf=None) -> Union[iterator.RecursiveIterator[M21ObjType],
+                includeSelf=None) -> t.Union[iterator.RecursiveIterator[M21ObjType],
                                            iterator.RecursiveIterator[Stream]]:
         '''
         `.recurse()` is a fundamental method of music21 for getting into
@@ -7753,7 +7751,12 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
             ri = ri.getElementsByClass(classFilter)
         return ri
 
-    def containerInHierarchy(self, el, *, setActiveSite=True) -> Optional['music21.stream.Stream']:
+    def containerInHierarchy(
+        self,
+        el: base.Music21Object,
+        *,
+        setActiveSite=True
+    ) -> t.Optional[Stream]:
         '''
         Returns the container in a hierarchy that this element belongs to.
 
@@ -8969,7 +8972,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         if recurse is True:
             useStreams = returnStream.recurse(streamsOnly=True, includeSelf=True)
 
-        rests_lacking_durations: List[note.Rest] = []
+        rests_lacking_durations: t.List[note.Rest] = []
         for useStream in useStreams:
             for i, e in enumerate(useStream._elements):
                 if processOffsets:
@@ -9639,7 +9642,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         return noteIterator
 
     @property
-    def pitches(self) -> List[pitch.Pitch]:
+    def pitches(self) -> t.List[pitch.Pitch]:
         '''
         Returns all :class:`~music21.pitch.Pitch` objects found in any
         element in the Stream as a Python List. Elements such as
@@ -9717,7 +9720,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         getOverlaps=False,
         noNone=False,
         **keywords
-    ) -> List[Union[note.NotRest, None]]:
+    ) -> t.List[t.Union[note.NotRest, None]]:
         r'''
         Returns a list of consecutive *pitched* Notes in a Stream.
 
@@ -9773,7 +9776,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         '''
         if self.isSorted is False and self.autoSort:
             self.sort()
-        returnList: List[Union[note.NotRest, None]] = []
+        returnList: t.List[t.Union[note.NotRest, None]] = []
         lastStart: OffsetQL = 0.0
         lastEnd: OffsetQL = 0.0
         lastContainerEnd: OffsetQL = 0.0
@@ -9957,7 +9960,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         return returnStream
 
     # --------------------------------------------------------------------------
-    def _getDurSpan(self, flatStream) -> List[Tuple[OffsetQL, OffsetQL]]:
+    def _getDurSpan(self, flatStream) -> t.List[t.Tuple[OffsetQL, OffsetQL]]:
         '''
         Given a flat stream, create a list of the start and end
         times (as a tuple pair) of all elements in the Stream.
@@ -10032,8 +10035,8 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         durSpanSorted = self._getDurSpan(flatStream)
         # According to the above comment, the spans may not be sorted.
         # So we sort them to be sure, but keep track of their original indices
-        durSpanSortedIndex: List[Tuple[int, OffsetQL]] = cast(
-            List[Tuple[int, OffsetQL]],
+        durSpanSortedIndex: t.List[t.Tuple[int, OffsetQL]] = t.cast(
+            t.List[t.Tuple[int, OffsetQL]],
             list(enumerate(durSpanSorted))
         )
         durSpanSortedIndex.sort()
@@ -10684,7 +10687,7 @@ class Stream(core.StreamCore, Generic[M21ObjType]):
         if not inPlace:
             return returnObj
 
-    def _maxVoiceCount(self, *, countById=False) -> Union[int, Tuple[int, List[str]]]:
+    def _maxVoiceCount(self, *, countById=False) -> t.Union[int, t.Tuple[int, t.List[str]]]:
         '''
         Returns the maximum number of voices in a part.  Used by voicesToParts.
         Minimum returned is 1.  If `countById` is True, returns a tuple of
@@ -13601,7 +13604,7 @@ class Score(Stream):
             return returnObj
 
     def partsToVoices(self,
-                      voiceAllocation: Union[int, List[Union[List, int]]] = 2,
+                      voiceAllocation: t.Union[int, t.List[t.Union[t.List, int]]] = 2,
                       permitOneVoicePerPart=False,
                       setStems=True):
         # noinspection PyShadowingNames
@@ -13629,7 +13632,7 @@ class Score(Stream):
         165
 
         '''
-        sub: List[Part] = []
+        sub: t.List[Part] = []
         bundle = []
         if isinstance(voiceAllocation, int):
             voicesPerPart = voiceAllocation
@@ -13646,7 +13649,7 @@ class Score(Stream):
                 bundle.append(sub)
         # else, assume it is a list of groupings
         elif common.isIterable(voiceAllocation):
-            voiceAllocation = cast(List[Union[List, int]], voiceAllocation)
+            voiceAllocation = t.cast(t.List[t.Union[t.List, int]], voiceAllocation)
             for group in voiceAllocation:
                 sub = []
                 # if a single entry
@@ -13665,7 +13668,7 @@ class Score(Stream):
         s = self.cloneEmpty(derivationMethod='partsToVoices')
         s.metadata = self.metadata
 
-        pActive: Optional[Part]
+        pActive: t.Optional[Part]
         for sub in bundle:  # each sub contains parts
             if len(sub) == 1 and not permitOneVoicePerPart:
                 # probably need to create a new part and measure

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -24,7 +24,7 @@ All functions here will eventually begin with `.core`.
 from __future__ import annotations
 
 import copy
-from typing import List, Dict, Union, Tuple, Optional, TYPE_CHECKING
+import typing as t
 from fractions import Fraction
 import unittest
 
@@ -49,14 +49,14 @@ class StreamCore(Music21Object):
         # the _offsetDict is a dictionary where id(element) is the
         # index and the value is a tuple of offset and element.
         # offsets can be floats, Fractions, or a member of the enum OffsetSpecial
-        self._offsetDict: Dict[int, Tuple[OffsetQLSpecial, Music21Object]] = {}
+        self._offsetDict: t.Dict[int, t.Tuple[OffsetQLSpecial, Music21Object]] = {}
 
         # self._elements stores Music21Object objects.
-        self._elements: List[Music21Object] = []
+        self._elements: t.List[Music21Object] = []
 
         # self._endElements stores Music21Objects found at
         # the highestTime of this Stream.
-        self._endElements: List[Music21Object] = []
+        self._endElements: t.List[Music21Object] = []
 
         self.isSorted = True
         # should isFlat become readonly?
@@ -67,7 +67,7 @@ class StreamCore(Music21Object):
 
     def coreInsert(
         self,
-        offset: Union[float, Fraction],
+        offset: t.Union[float, Fraction],
         element: Music21Object,
         *,
         ignoreSort=False,
@@ -162,7 +162,7 @@ class StreamCore(Music21Object):
     def coreSetElementOffset(
         self,
         element: Music21Object,
-        offset: Union[int, float, Fraction, OffsetSpecial],
+        offset: t.Union[int, float, Fraction, OffsetSpecial],
         *,
         addElement=False,
         setActiveSite=True
@@ -542,7 +542,7 @@ class StreamCore(Music21Object):
         >>> scoreTree
         <ElementTree {20} (0.0 <0.-25...> to 8.0) <music21.stream.Score exampleScore>>
         '''
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             from music21 import stream
             assert isinstance(self, stream.Stream)
         hashedAttributes = hash((tuple(classList or ()),
@@ -565,8 +565,8 @@ class StreamCore(Music21Object):
         recurse=True,
         requireAllPresent=True,
         insert=True,
-        constrainingSpannerBundle: Optional[spanner.SpannerBundle] = None
-    ) -> Optional[List[spanner.Spanner]]:
+        constrainingSpannerBundle: t.Optional[spanner.SpannerBundle] = None
+    ) -> t.Optional[t.List[spanner.Spanner]]:
         '''
         find all spanners that are referenced by elements in the
         (recursed if recurse=True) stream and either inserts them in the Stream
@@ -711,7 +711,7 @@ class StreamCore(Music21Object):
         {1.0} <music21.note.Note D>
         '''
         sb = self.spannerBundle
-        sIter: Union[StreamIterator, RecursiveIterator]
+        sIter: t.Union[StreamIterator, RecursiveIterator]
         if recurse is True:
             sIter = self.recurse()  # type: ignore
         else:

--- a/music21/stream/filters.py
+++ b/music21/stream/filters.py
@@ -19,7 +19,7 @@ filtered.  Filters are used by methods on streams such as
 # import inspect
 import unittest
 from math import inf
-from typing import Optional, TypeVar
+import typing as t
 
 from music21 import common
 from music21.common.numberTools import opFrac
@@ -27,7 +27,7 @@ from music21.exceptions21 import Music21Exception
 from music21 import prebase
 
 
-StreamIteratorType = TypeVar('StreamIteratorType', bound='music21.stream.iterator.StreamIterator')
+StreamIteratorType = t.TypeVar('StreamIteratorType', bound='music21.stream.iterator.StreamIterator')
 
 class FilterException(Music21Exception):
     pass
@@ -73,7 +73,7 @@ class StreamFilter(prebase.ProtoM21Object):
     def reset(self):
         pass
 
-    def __call__(self, item, iterator: Optional[StreamIteratorType] = None):
+    def __call__(self, item, iterator: t.Optional[StreamIteratorType] = None):
         return True
 
 class IsFilter(StreamFilter):

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -18,10 +18,7 @@ StreamIterators are explicitly allowed to access private methods on streams.
 from __future__ import annotations
 
 import copy
-from typing import (TypeVar, List, Union, Callable, Optional, Literal,
-                    TypedDict, Generic, overload, Iterable, Type, cast,
-                    Sequence,
-                    Tuple, Any, TYPE_CHECKING)
+import typing as t
 import unittest
 import warnings
 
@@ -37,11 +34,11 @@ from music21 import base   # just for typing.
 
 from music21.sites import SitesException
 
-T = TypeVar('T')
-S = TypeVar('S')
-ChangedM21ObjType = TypeVar('ChangedM21ObjType', bound=base.Music21Object)
-_SIter = TypeVar('_SIter', bound='StreamIterator')
-FilterType = Union[Callable, filters.StreamFilter]
+T = t.TypeVar('T')
+S = t.TypeVar('S')
+ChangedM21ObjType = t.TypeVar('ChangedM21ObjType', bound=base.Music21Object)
+_SIter = t.TypeVar('_SIter', bound='StreamIterator')
+FilterType = t.Union[t.Callable, filters.StreamFilter]
 
 # -----------------------------------------------------------------------------
 
@@ -54,17 +51,17 @@ class StreamIteratorInefficientWarning(PendingDeprecationWarning):
     pass
 
 
-class ActiveInformation(TypedDict, total=False):
-    stream: Optional['music21.stream.Stream']
+class ActiveInformation(t.TypedDict, total=False):
+    stream: t.Optional['music21.stream.Stream']
     elementIndex: int
-    iterSection: Literal['_elements', '_endElements']
+    iterSection: t.Literal['_elements', '_endElements']
     sectionIndex: int
-    lastYielded: Optional[base.Music21Object]
+    lastYielded: t.Optional[base.Music21Object]
 
 
 
 # -----------------------------------------------------------------------------
-class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
+class StreamIterator(prebase.ProtoM21Object, t.Generic[M21ObjType], t.Sequence):
     '''
     An Iterator object used to handle getting items from Streams.
     The :meth:`~music21.stream.Stream.__iter__` method
@@ -114,7 +111,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
 
     Changed in v.5.2 -- all arguments except srcStream are keyword only.
     Changed in v.8 -- filterList must be a list or None, not a single filter.
-                      StreamIterator inherits from Sequence, hence index
+                      StreamIterator inherits from typing.Sequence, hence index
                       was moved to elementIndex
 
     OMIT_FROM_DOCS
@@ -132,10 +129,10 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
     def __init__(self,
                  srcStream: StreamType,
                  *,
-                 # restrictClass: Type[M21ObjType] = base.Music21Object,
-                 filterList: Optional[List[FilterType]] = None,
+                 # restrictClass: t.Type[M21ObjType] = base.Music21Object,
+                 filterList: t.Optional[t.List[FilterType]] = None,
                  restoreActiveSites: bool = True,
-                 activeInformation: Optional[ActiveInformation] = None,
+                 activeInformation: t.Optional[ActiveInformation] = None,
                  ignoreSorting: bool = False):
         if not ignoreSorting and srcStream.isSorted is False and srcStream.autoSort:
             srcStream.sort()
@@ -143,7 +140,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
         self.elementIndex: int = 0
 
         # use .elements instead of ._elements/etc. so that it is sorted...
-        self.srcStreamElements = cast(Tuple[M21ObjType, ...], srcStream.elements)
+        self.srcStreamElements = t.cast(t.Tuple[M21ObjType, ...], srcStream.elements)
         self.streamLength: int = len(self.srcStreamElements)
 
         # this information can help in speed later
@@ -151,12 +148,12 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
 
         # where we are within a given section (_elements or _endElements)
         self.sectionIndex: int = -1
-        self.iterSection: Literal['_elements', '_endElements'] = '_elements'
+        self.iterSection: t.Literal['_elements', '_endElements'] = '_elements'
 
         self.cleanupOnStop: bool = False
         self.restoreActiveSites: bool = restoreActiveSites
 
-        self.overrideDerivation: Optional[str] = None
+        self.overrideDerivation: t.Optional[str] = None
 
         if filterList is None:
             filterList = []
@@ -167,9 +164,9 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
         # self.filters is a list of expressions that
         # return True or False for an element for
         # whether it should be yielded.
-        self.filters: List[FilterType] = filterList
-        self._len: Optional[int] = None
-        self._matchingElements: Optional[List[M21ObjType]] = None
+        self.filters: t.List[FilterType] = filterList
+        self._len: t.Optional[int] = None
+        self._matchingElements: t.Optional[t.List[M21ObjType]] = None
         # keep track of where we are in the parse.
         # esp important for recursive streams...
         if activeInformation is not None:
@@ -323,20 +320,20 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
         sOut = self.stream()
         return getattr(sOut, attr)
 
-    @overload
+    @t.overload
     def __getitem__(self, k: int) -> M21ObjType:
         return self.matchingElements()[k]
 
-    @overload
-    def __getitem__(self, k: slice) -> List[M21ObjType]:
+    @t.overload
+    def __getitem__(self, k: slice) -> t.List[M21ObjType]:
         return self.matchingElements()
 
-    @overload
-    def __getitem__(self, k: str) -> Optional[M21ObjType]:
+    @t.overload
+    def __getitem__(self, k: str) -> t.Optional[M21ObjType]:
         return None
 
-    def __getitem__(self, k: Union[int, slice, str]) -> Union[M21ObjType,
-                                                              List[M21ObjType],
+    def __getitem__(self, k: t.Union[int, slice, str]) -> t.Union[M21ObjType,
+                                                              t.List[M21ObjType],
                                                               None]:
         '''
         Iterators can request other items by index or slice.
@@ -529,7 +526,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
         )
         return out
 
-    def first(self) -> Optional[M21ObjType]:
+    def first(self) -> t.Optional[M21ObjType]:
         '''
         Efficiently return the first matching element, or None if no
         elements match.
@@ -579,7 +576,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
         except StopIteration:
             return None
 
-    def last(self) -> Optional[M21ObjType]:
+    def last(self) -> t.Optional[M21ObjType]:
         '''
         Returns the last matching element, or None if no elements match.
 
@@ -664,7 +661,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
 
             # cleanupOnStop is rarely used, so we put in
             # a dummy stream so that srcStream does not need
-            # to be Optional[]
+            # to be t.Optional[]
             SrcStreamClass = self.srcStream.__class__
 
             del self.srcStream
@@ -675,7 +672,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
     # ---------------------------------------------------------------
     # getting items
 
-    def matchingElements(self, *, restoreActiveSites: bool = True) -> List[M21ObjType]:
+    def matchingElements(self, *, restoreActiveSites: bool = True) -> t.List[M21ObjType]:
         '''
         Returns a list of elements that match the filter.
 
@@ -746,14 +743,14 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
         '''
         returns False if any filter returns False, True otherwise.
         '''
-        f: Union[Callable[[Any, Optional[Any]], Any], filters.StreamFilter]
+        f: t.Union[t.Callable[[t.Any, t.Optional[t.Any]], t.Any], filters.StreamFilter]
         for f in self.filters:
             try:
                 try:
                     if f(e, self) is False:
                         return False
                 except TypeError:  # one element filters are acceptable.
-                    if TYPE_CHECKING:
+                    if t.TYPE_CHECKING:
                         assert isinstance(f, filters.StreamFilter)
                     if f(e) is False:
                         return False
@@ -779,18 +776,18 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
         from music21 import stream
         return stream.Stream()
 
-    @overload
-    def stream(self, returnStreamSubClass: Literal[False]) -> 'music21.stream.Stream':
+    @t.overload
+    def stream(self, returnStreamSubClass: t.Literal[False]) -> 'music21.stream.Stream':
         # ignore this code -- just here until Astroid bug #1015 is fixed
         x: 'music21.stream.Stream' = self.streamObj
         return x
 
-    @overload
-    def stream(self, returnStreamSubClass: Literal[True] = True) -> StreamType:
+    @t.overload
+    def stream(self, returnStreamSubClass: t.Literal[True] = True) -> StreamType:
         x: StreamType = self.streamObj
         return x
 
-    def stream(self, returnStreamSubClass=True) -> Union['music21.stream.Stream', StreamType]:
+    def stream(self, returnStreamSubClass=True) -> t.Union['music21.stream.Stream', StreamType]:
         '''
         return a new stream from this iterator.
 
@@ -859,7 +856,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
 
         # if this stream was sorted, the resultant stream is sorted
         clearIsSorted = False
-        found: Union['music21.stream.Stream', StreamType]
+        found: t.Union['music21.stream.Stream', StreamType]
         if returnStreamSubClass is True:
             try:
                 found = ss.__class__()
@@ -907,7 +904,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
         return found
 
     @property
-    def activeElementList(self) -> Literal['_elements', '_endElements']:
+    def activeElementList(self) -> t.Literal['_elements', '_endElements']:
         '''
         returns the element list ('_elements' or '_endElements')
         for the current activeInformation
@@ -954,7 +951,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
 
         return out
 
-    def getElementById(self, elementId) -> Optional[M21ObjType]:
+    def getElementById(self, elementId) -> t.Optional[M21ObjType]:
         '''
         Returns a single element (or None) that matches elementId.
 
@@ -979,7 +976,7 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
     # Replace all code in overload statements once
     # https://github.com/PyCQA/astroid/issues/1015
     # is fixed and deployed
-    @overload
+    @t.overload
     def getElementsByClass(self,
                            classFilterList: str,
                            *,
@@ -987,25 +984,25 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
         x: StreamIterator[M21ObjType] = self.__class__(self.streamObj)
         return x
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Iterable[str],
+                           classFilterList: t.Iterable[str],
                            *,
                            returnClone: bool = True) -> StreamIterator[M21ObjType]:
         x: StreamIterator[M21ObjType] = self.__class__(self.streamObj)
         return x
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Type[ChangedM21ObjType],
+                           classFilterList: t.Type[ChangedM21ObjType],
                            *,
                            returnClone: bool = True) -> StreamIterator[ChangedM21ObjType]:
-        x = cast(StreamIterator[ChangedM21ObjType], self.__class__(self.streamObj))
+        x = t.cast(StreamIterator[ChangedM21ObjType], self.__class__(self.streamObj))
         return x
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Iterable[Type[ChangedM21ObjType]],
+                           classFilterList: t.Iterable[t.Type[ChangedM21ObjType]],
                            *,
                            returnClone: bool = True) -> StreamIterator[M21ObjType]:
         x: StreamIterator[M21ObjType] = self.__class__(self.streamObj)
@@ -1014,15 +1011,15 @@ class StreamIterator(prebase.ProtoM21Object, Generic[M21ObjType], Sequence):
 
     def getElementsByClass(
         self,
-        classFilterList: Union[
+        classFilterList: t.Union[
             str,
-            Type[ChangedM21ObjType],
-            Iterable[str],
-            Iterable[Type[ChangedM21ObjType]],
+            t.Type[ChangedM21ObjType],
+            t.Iterable[str],
+            t.Iterable[t.Type[ChangedM21ObjType]],
         ],
         *,
         returnClone: bool = True
-    ) -> Union[StreamIterator[M21ObjType], StreamIterator[ChangedM21ObjType]]:
+    ) -> t.Union[StreamIterator[M21ObjType], StreamIterator[ChangedM21ObjType]]:
         '''
         Add a filter to the Iterator to remove all elements
         except those that match one
@@ -1549,7 +1546,7 @@ class OffsetIterator(StreamIterator[M21ObjType]):
     def __init__(self,
                  srcStream,
                  *,
-                 # restrictClass: Type[M21ObjType] = base.Music21Object,
+                 # restrictClass: t.Type[M21ObjType] = base.Music21Object,
                  filterList=None,
                  restoreActiveSites=True,
                  activeInformation=None,
@@ -1563,10 +1560,10 @@ class OffsetIterator(StreamIterator[M21ObjType]):
                          ignoreSorting=ignoreSorting,
                          )
         self.raiseStopIterationNext = False
-        self.nextToYield: List[M21ObjType] = []
+        self.nextToYield: t.List[M21ObjType] = []
         self.nextOffsetToYield = None
 
-    def __next__(self) -> List[M21ObjType]:  # type: ignore
+    def __next__(self) -> t.List[M21ObjType]:  # type: ignore
         if self.raiseStopIterationNext:
             raise StopIteration
 
@@ -1614,7 +1611,7 @@ class OffsetIterator(StreamIterator[M21ObjType]):
     # can be done with inheritance.
     # TODO: remove code and replace with ... when Astroid bug #1015 is fixed.
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
                            classFilterList: str,
                            *,
@@ -1622,25 +1619,25 @@ class OffsetIterator(StreamIterator[M21ObjType]):
         x: OffsetIterator[M21ObjType] = self.__class__(self.streamObj)
         return x
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Iterable[str],
+                           classFilterList: t.Iterable[str],
                            *,
                            returnClone: bool = True) -> OffsetIterator[M21ObjType]:
         x: OffsetIterator[M21ObjType] = self.__class__(self.streamObj)
         return x
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Type[ChangedM21ObjType],
+                           classFilterList: t.Type[ChangedM21ObjType],
                            *,
                            returnClone: bool = True) -> OffsetIterator[ChangedM21ObjType]:
-        x = cast(OffsetIterator[ChangedM21ObjType], self.__class__(self.streamObj))
+        x = t.cast(OffsetIterator[ChangedM21ObjType], self.__class__(self.streamObj))
         return x
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Iterable[Type[ChangedM21ObjType]],
+                           classFilterList: t.Iterable[t.Type[ChangedM21ObjType]],
                            *,
                            returnClone: bool = True) -> OffsetIterator[M21ObjType]:
         x: OffsetIterator[M21ObjType] = self.__class__(self.streamObj)
@@ -1648,15 +1645,15 @@ class OffsetIterator(StreamIterator[M21ObjType]):
 
 
     def getElementsByClass(self,
-                           classFilterList: Union[
+                           classFilterList: t.Union[
                                str,
-                               Type[ChangedM21ObjType],
-                               Iterable[str],
-                               Iterable[Type[ChangedM21ObjType]],
+                               t.Type[ChangedM21ObjType],
+                               t.Iterable[str],
+                               t.Iterable[t.Type[ChangedM21ObjType]],
                            ],
                            *,
                            returnClone: bool = True
-                           ) -> Union[OffsetIterator[M21ObjType],
+                           ) -> t.Union[OffsetIterator[M21ObjType],
                                       OffsetIterator[ChangedM21ObjType]]:
         '''
         Identical to the same method in StreamIterator, but needs to be duplicated
@@ -1733,7 +1730,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
     def __init__(self,
                  srcStream,
                  *,
-                 # restrictClass: Type[M21ObjType] = base.Music21Object,
+                 # restrictClass: t.Type[M21ObjType] = base.Music21Object,
                  filterList=None,
                  restoreActiveSites=True,
                  activeInformation=None,
@@ -1757,7 +1754,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
 
         if streamsOnly is True:
             self.filters.append(filters.ClassFilter('Stream'))
-        self.childRecursiveIterator: Optional[RecursiveIterator[Any]] = None
+        self.childRecursiveIterator: t.Optional[RecursiveIterator[t.Any]] = None
         # not yet used.
         # self.parentIterator = None
 
@@ -1785,7 +1782,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
                 self.activeInformation['elementIndex'] = -1
                 self.activeInformation['lastYielded'] = self.srcStream
                 self.returnSelf = False
-                return cast(M21ObjType, self.srcStream)
+                return t.cast(M21ObjType, self.srcStream)
 
             elif self.returnSelf is True:
                 self.returnSelf = False
@@ -1808,7 +1805,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
             # in a recursive filter, the stream does not need to match the filter,
             # only the internal elements.
             if e.isStream:
-                if TYPE_CHECKING:
+                if t.TYPE_CHECKING:
                     from music21 import stream
                     assert isinstance(e, stream.Stream)
 
@@ -1863,7 +1860,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
             fe = super().matchingElements(restoreActiveSites=restoreActiveSites)
         return fe
 
-    def iteratorStack(self) -> List[RecursiveIterator]:
+    def iteratorStack(self) -> t.List[RecursiveIterator]:
         '''
         Returns a stack of RecursiveIterators at this point in the iteration.  Last is most recent.
 
@@ -2017,7 +2014,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
             includeElementsThatEndAtStart=includeElementsThatEndAtStart)
         return self.addFilter(f)
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
                            classFilterList: str,
                            *,
@@ -2025,25 +2022,25 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
         x: RecursiveIterator[M21ObjType] = self.__class__(self.streamObj)
         return x  # dummy code  remove when Astroid #1015 is fixed.
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Iterable[str],
+                           classFilterList: t.Iterable[str],
                            *,
                            returnClone: bool = True) -> RecursiveIterator[M21ObjType]:
         x: RecursiveIterator[M21ObjType] = self.__class__(self.streamObj)
         return x  # dummy code
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Type[ChangedM21ObjType],
+                           classFilterList: t.Type[ChangedM21ObjType],
                            *,
                            returnClone: bool = True) -> RecursiveIterator[ChangedM21ObjType]:
-        x = cast(RecursiveIterator[ChangedM21ObjType], self.__class__(self.streamObj))
+        x = t.cast(RecursiveIterator[ChangedM21ObjType], self.__class__(self.streamObj))
         return x  # dummy code
 
-    @overload
+    @t.overload
     def getElementsByClass(self,
-                           classFilterList: Iterable[Type[ChangedM21ObjType]],
+                           classFilterList: t.Iterable[t.Type[ChangedM21ObjType]],
                            *,
                            returnClone: bool = True) -> RecursiveIterator[M21ObjType]:
         x: RecursiveIterator[M21ObjType] = self.__class__(self.streamObj)
@@ -2051,21 +2048,21 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
 
 
     def getElementsByClass(self,
-                           classFilterList: Union[
+                           classFilterList: t.Union[
                                str,
-                               Type[ChangedM21ObjType],
-                               Iterable[str],
-                               Iterable[Type[ChangedM21ObjType]],
+                               t.Type[ChangedM21ObjType],
+                               t.Iterable[str],
+                               t.Iterable[t.Type[ChangedM21ObjType]],
                            ],
                            *,
                            returnClone: bool = True
-                           ) -> Union[RecursiveIterator[M21ObjType],
+                           ) -> t.Union[RecursiveIterator[M21ObjType],
                                       RecursiveIterator[ChangedM21ObjType]]:
         out = super().getElementsByClass(classFilterList, returnClone=returnClone)
         if isinstance(classFilterList, type) and issubclass(classFilterList, base.Music21Object):
-            return cast(RecursiveIterator[ChangedM21ObjType], out)
+            return t.cast(RecursiveIterator[ChangedM21ObjType], out)
         else:
-            return cast(RecursiveIterator[M21ObjType], out)
+            return t.cast(RecursiveIterator[M21ObjType], out)
 
 
 class Test(unittest.TestCase):

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import copy
 import typing as t
+from typing import overload
 import unittest
 import warnings
 
@@ -320,21 +321,21 @@ class StreamIterator(prebase.ProtoM21Object, t.Generic[M21ObjType], t.Sequence):
         sOut = self.stream()
         return getattr(sOut, attr)
 
-    @t.overload
+    @overload
     def __getitem__(self, k: int) -> M21ObjType:
         return self.matchingElements()[k]
 
-    @t.overload
+    @overload
     def __getitem__(self, k: slice) -> t.List[M21ObjType]:
         return self.matchingElements()
 
-    @t.overload
+    @overload
     def __getitem__(self, k: str) -> t.Optional[M21ObjType]:
         return None
 
     def __getitem__(self, k: t.Union[int, slice, str]) -> t.Union[M21ObjType,
-                                                              t.List[M21ObjType],
-                                                              None]:
+                                                                  t.List[M21ObjType],
+                                                                  None]:
         '''
         Iterators can request other items by index or slice.
 
@@ -776,13 +777,13 @@ class StreamIterator(prebase.ProtoM21Object, t.Generic[M21ObjType], t.Sequence):
         from music21 import stream
         return stream.Stream()
 
-    @t.overload
+    @overload
     def stream(self, returnStreamSubClass: t.Literal[False]) -> 'music21.stream.Stream':
         # ignore this code -- just here until Astroid bug #1015 is fixed
         x: 'music21.stream.Stream' = self.streamObj
         return x
 
-    @t.overload
+    @overload
     def stream(self, returnStreamSubClass: t.Literal[True] = True) -> StreamType:
         x: StreamType = self.streamObj
         return x
@@ -976,7 +977,7 @@ class StreamIterator(prebase.ProtoM21Object, t.Generic[M21ObjType], t.Sequence):
     # Replace all code in overload statements once
     # https://github.com/PyCQA/astroid/issues/1015
     # is fixed and deployed
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: str,
                            *,
@@ -984,7 +985,7 @@ class StreamIterator(prebase.ProtoM21Object, t.Generic[M21ObjType], t.Sequence):
         x: StreamIterator[M21ObjType] = self.__class__(self.streamObj)
         return x
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Iterable[str],
                            *,
@@ -992,7 +993,7 @@ class StreamIterator(prebase.ProtoM21Object, t.Generic[M21ObjType], t.Sequence):
         x: StreamIterator[M21ObjType] = self.__class__(self.streamObj)
         return x
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Type[ChangedM21ObjType],
                            *,
@@ -1000,7 +1001,7 @@ class StreamIterator(prebase.ProtoM21Object, t.Generic[M21ObjType], t.Sequence):
         x = t.cast(StreamIterator[ChangedM21ObjType], self.__class__(self.streamObj))
         return x
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Iterable[t.Type[ChangedM21ObjType]],
                            *,
@@ -1611,7 +1612,7 @@ class OffsetIterator(StreamIterator[M21ObjType]):
     # can be done with inheritance.
     # TODO: remove code and replace with ... when Astroid bug #1015 is fixed.
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: str,
                            *,
@@ -1619,7 +1620,7 @@ class OffsetIterator(StreamIterator[M21ObjType]):
         x: OffsetIterator[M21ObjType] = self.__class__(self.streamObj)
         return x
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Iterable[str],
                            *,
@@ -1627,7 +1628,7 @@ class OffsetIterator(StreamIterator[M21ObjType]):
         x: OffsetIterator[M21ObjType] = self.__class__(self.streamObj)
         return x
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Type[ChangedM21ObjType],
                            *,
@@ -1635,7 +1636,7 @@ class OffsetIterator(StreamIterator[M21ObjType]):
         x = t.cast(OffsetIterator[ChangedM21ObjType], self.__class__(self.streamObj))
         return x
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Iterable[t.Type[ChangedM21ObjType]],
                            *,
@@ -2014,7 +2015,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
             includeElementsThatEndAtStart=includeElementsThatEndAtStart)
         return self.addFilter(f)
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: str,
                            *,
@@ -2022,7 +2023,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
         x: RecursiveIterator[M21ObjType] = self.__class__(self.streamObj)
         return x  # dummy code  remove when Astroid #1015 is fixed.
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Iterable[str],
                            *,
@@ -2030,7 +2031,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
         x: RecursiveIterator[M21ObjType] = self.__class__(self.streamObj)
         return x  # dummy code
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Type[ChangedM21ObjType],
                            *,
@@ -2038,7 +2039,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
         x = t.cast(RecursiveIterator[ChangedM21ObjType], self.__class__(self.streamObj))
         return x  # dummy code
 
-    @t.overload
+    @overload
     def getElementsByClass(self,
                            classFilterList: t.Iterable[t.Type[ChangedM21ObjType]],
                            *,
@@ -2057,7 +2058,7 @@ class RecursiveIterator(StreamIterator[M21ObjType]):
                            *,
                            returnClone: bool = True
                            ) -> t.Union[RecursiveIterator[M21ObjType],
-                                      RecursiveIterator[ChangedM21ObjType]]:
+                                        RecursiveIterator[ChangedM21ObjType]]:
         out = super().getElementsByClass(classFilterList, returnClone=returnClone)
         if isinstance(classFilterList, type) and issubclass(classFilterList, base.Music21Object):
             return t.cast(RecursiveIterator[ChangedM21ObjType], out)

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -15,7 +15,7 @@
 
 import copy
 import unittest
-from typing import List, Generator, Optional, Set, Union
+import typing as t
 from fractions import Fraction  # typing only
 
 from music21 import beam
@@ -47,7 +47,7 @@ def makeBeams(
     inPlace=False,
     setStemDirections=True,
     failOnNoTimeSignature=False,
-) -> Optional[StreamType]:
+) -> t.Optional[StreamType]:
     # noinspection PyShadowingNames
     '''
     Return a new Measure, or Stream of Measures, with beams applied to all
@@ -127,7 +127,7 @@ def makeBeams(
         returnObj = s
 
     # if s.isClass(Measure):
-    mColl: List[stream.Measure]
+    mColl: t.List[stream.Measure]
     if isinstance(returnObj, stream.Measure):
         mColl = [returnObj]  # store a list of measures for processing
     else:
@@ -231,7 +231,7 @@ def makeMeasures(
     finalBarline='final',
     bestClef=False,
     inPlace=False,
-) -> Optional[StreamType]:
+) -> t.Optional[StreamType]:
     '''
     Takes a stream and places all of its elements into
     measures (:class:`~music21.stream.Measure` objects)
@@ -710,7 +710,7 @@ def makeRests(
     timeRangeFromBarDuration=False,
     inPlace=False,
     hideRests=False,
-) -> Optional[StreamType]:
+) -> t.Optional[StreamType]:
     '''
     Given a Stream with an offset not equal to zero,
     fill with one Rest preceding this offset.
@@ -854,14 +854,14 @@ def makeRests(
             return returnObj
 
     def oHighTargetForMeasure(
-        m: Optional[stream.Measure] = None,
-        ts: Optional[meter.TimeSignature] = None
-    ) -> Union[float, Fraction]:
+        m: t.Optional[stream.Measure] = None,
+        ts: t.Optional[meter.TimeSignature] = None
+    ) -> t.Union[float, Fraction]:
         """
         Needed for timeRangeFromBarDuration.
         Returns 0.0 if no meter can be found.
         """
-        post: Union[float, Fraction] = 0.0
+        post: t.Union[float, Fraction] = 0.0
         if ts is not None:
             post = ts.barDuration.quarterLength
         elif m is not None:
@@ -881,7 +881,7 @@ def makeRests(
             if isinstance(refStreamOrTimeRange, stream.Measure):
                 oHighTarget = oHighTargetForMeasure(m=refStreamOrTimeRange)
             elif isinstance(refStreamOrTimeRange, meter.TimeSignature):
-                maybe_measure: Optional[stream.Measure] = None
+                maybe_measure: t.Optional[stream.Measure] = None
                 if isinstance(returnObj.activeSite, stream.Measure):
                     maybe_measure = returnObj.activeSite
                 oHighTarget = oHighTargetForMeasure(m=maybe_measure, ts=refStreamOrTimeRange)
@@ -904,7 +904,7 @@ def makeRests(
             oLowTarget = min(refStreamOrTimeRange)
             oHighTarget = max(refStreamOrTimeRange)
 
-    bundle: List[StreamType]
+    bundle: t.List[StreamType]
     if returnObj.hasVoices():
         bundle = list(returnObj.voices)
     elif returnObj.hasMeasures():
@@ -912,7 +912,7 @@ def makeRests(
     else:
         bundle = [returnObj]
 
-    lastTimeSignature: Optional[meter.TimeSignature] = None
+    lastTimeSignature: t.Optional[meter.TimeSignature] = None
     # bundle components may be voices, measures, or a flat Stream
     for component in bundle:
         oLow = component.lowestOffset
@@ -984,7 +984,7 @@ def makeTies(
     inPlace=False,
     displayTiedAccidentals=False,
     classFilterList=(note.GeneralNote,),
-) -> Optional[StreamType]:
+) -> t.Optional[StreamType]:
     # noinspection PyShadowingNames
     '''
     Given a stream containing measures, examine each element in the
@@ -1355,7 +1355,7 @@ def makeTies(
         return None
 
 
-def makeTupletBrackets(s: StreamType, *, inPlace=False) -> Optional[StreamType]:
+def makeTupletBrackets(s: StreamType, *, inPlace=False) -> t.Optional[StreamType]:
     # noinspection PyShadowingNames
     '''
     Given a flat Stream of mixed durations, designates the first and last tuplet of any group
@@ -1409,8 +1409,8 @@ def makeTupletBrackets(s: StreamType, *, inPlace=False) -> Optional[StreamType]:
             tupletMap.append([tupletList[0], dur])
 
     # have a list of tuplet, Duration pairs
-    completionCount: Union[float, int, Fraction] = 0  # qLen currently filled
-    completionTarget: Union[float, int, Fraction, None] = None  # qLen necessary to fill tuplet
+    completionCount: t.Union[float, int, Fraction] = 0  # qLen currently filled
+    completionTarget: t.Union[float, int, Fraction, None] = None  # qLen necessary to fill tuplet
     for i in range(len(tupletMap)):
         tupletObj, dur = tupletMap[i]
 
@@ -1573,7 +1573,7 @@ def moveNotesToVoices(source: StreamType,
     source.insert(0, dst)
 
 
-def getTiePitchSet(prior: 'music21.note.NotRest') -> Optional[Set[str]]:
+def getTiePitchSet(prior: 'music21.note.NotRest') -> t.Optional[t.Set[str]]:
     # noinspection PyShadowingNames
     '''
     helper method for makeAccidentals to get the tie pitch set (or None)
@@ -1631,17 +1631,17 @@ def getTiePitchSet(prior: 'music21.note.NotRest') -> Optional[Set[str]]:
     return tiePitchSet
 
 def makeAccidentalsInMeasureStream(
-    s: Union[StreamType, StreamIterator],
+    s: t.Union[StreamType, StreamIterator],
     *,
-    pitchPast: Optional[List[pitch.Pitch]] = None,
-    pitchPastMeasure: Optional[List[pitch.Pitch]] = None,
-    useKeySignature: Union[bool, key.KeySignature] = True,
-    alteredPitches: Optional[List[pitch.Pitch]] = None,
+    pitchPast: t.Optional[t.List[pitch.Pitch]] = None,
+    pitchPastMeasure: t.Optional[t.List[pitch.Pitch]] = None,
+    useKeySignature: t.Union[bool, key.KeySignature] = True,
+    alteredPitches: t.Optional[t.List[pitch.Pitch]] = None,
     cautionaryPitchClass: bool = True,
     cautionaryAll: bool = False,
     overrideStatus: bool = False,
     cautionaryNotImmediateRepeat: bool = True,
-    tiePitchSet: Optional[Set[str]] = None
+    tiePitchSet: t.Optional[t.Set[str]] = None
 ) -> None:
     '''
     Makes accidentals in place on a stream consisting of only Measures.
@@ -1722,7 +1722,7 @@ def iterateBeamGroups(
     s: StreamType,
     skipNoBeams=True,
     recurse=True
-) -> Generator[List[note.NotRest], None, None]:
+) -> t.Generator[t.List[note.NotRest], None, None]:
     '''
     Generator that yields a List of NotRest objects that fall within a beam group.
 
@@ -1767,10 +1767,10 @@ def iterateBeamGroups(
     New in v6.7.
     '''
     iterator: 'music21.stream.iterator.StreamIterator' = s.recurse() if recurse else s.iter()
-    current_beam_group: List[note.NotRest] = []
+    current_beam_group: t.List[note.NotRest] = []
     in_beam_group: bool = False
     for el in iterator.notes:
-        first_el_type: Optional[str] = None
+        first_el_type: t.Optional[str] = None
         if el.beams and el.beams.getByNumber(1):
             first_el_type = el.beams.getTypeByNumber(1)
 
@@ -1815,7 +1815,7 @@ def setStemDirectionForBeamGroups(
 
     New in v6.7.
     '''
-    beamGroup: List[note.NotRest]
+    beamGroup: t.List[note.NotRest]
     for beamGroup in iterateBeamGroups(s, skipNoBeams=True, recurse=True):
         setStemDirectionOneGroup(
             beamGroup,
@@ -1825,7 +1825,7 @@ def setStemDirectionForBeamGroups(
 
 
 def setStemDirectionOneGroup(
-    group: List[note.NotRest],
+    group: t.List[note.NotRest],
     *,
     setNewStems=True,
     overrideConsistentStemDirections=False,
@@ -1850,12 +1850,12 @@ def setStemDirectionOneGroup(
         has_consistent_stem_directions = False
 
     # noinspection PyTypeChecker
-    optional_clef_context: Optional[clef.Clef] = group[0].getContextByClass(clef.Clef)
+    optional_clef_context: t.Optional[clef.Clef] = group[0].getContextByClass(clef.Clef)
     if optional_clef_context is None:
         return
     clef_context: clef.Clef = optional_clef_context
 
-    pitchList: List[pitch.Pitch] = []
+    pitchList: t.List[pitch.Pitch] = []
     for n in group:
         pitchList.extend(n.pitches)
     if not pitchList:

--- a/music21/style.py
+++ b/music21/style.py
@@ -13,7 +13,7 @@
 The style module represents information about the style of a Note, Accidental,
 etc. such that precise positioning information, layout, size, etc. can be specified.
 '''
-from typing import Optional, Union
+import typing as t
 import unittest
 
 from music21 import common
@@ -75,28 +75,28 @@ class Style(ProtoM21Object):
     def __init__(self):
         self.size = None
 
-        self.relativeX: Optional[Union[float, int]] = None
-        self.relativeY: Optional[Union[float, int]] = None
-        self.absoluteX: Optional[Union[float, int]] = None
+        self.relativeX: t.Optional[t.Union[float, int]] = None
+        self.relativeY: t.Optional[t.Union[float, int]] = None
+        self.absoluteX: t.Optional[t.Union[float, int]] = None
 
         # managed by property below.
-        self._absoluteY: Optional[Union[float, int]] = None
+        self._absoluteY: t.Optional[t.Union[float, int]] = None
 
-        self._enclosure: Optional[Enclosure] = None
+        self._enclosure: t.Optional[Enclosure] = None
 
         # how should this symbol be represented in the font?
         # SMuFL characters are allowed.
         self.fontRepresentation = None
 
-        self.color: Optional[str] = None
+        self.color: t.Optional[str] = None
 
         self.units: str = 'tenths'
         self.hideObjectOnPrint: bool = False
 
-    def _getEnclosure(self) -> Optional[Enclosure]:
+    def _getEnclosure(self) -> t.Optional[Enclosure]:
         return self._enclosure
 
-    def _setEnclosure(self, value: Optional[Enclosure]):
+    def _setEnclosure(self, value: t.Optional[Enclosure]):
         if value is None:
             self._enclosure = value
         elif value == Enclosure.NONE:
@@ -263,9 +263,9 @@ class NoteStyle(Style):
 
     def __init__(self):
         super().__init__()
-        self.stemStyle: Optional[Style] = None
-        self.accidentalStyle: Optional[Style] = None
-        self.noteSize: Optional[str] = None  # can be 'cue' etc.
+        self.stemStyle: t.Optional[Style] = None
+        self.accidentalStyle: t.Optional[Style] = None
+        self.noteSize: t.Optional[str] = None  # can be 'cue' etc.
 
 
 class TextStyle(Style):
@@ -618,8 +618,8 @@ class StyleMixin(common.SlottedObjectMixin):
 
     def __init__(self):
         #  no need to call super().__init__() on SlottedObjectMixin
-        self._style: Optional[Style] = None
-        self._editorial: Optional['music21.editorial.Editorial'] = None
+        self._style: t.Optional[Style] = None
+        self._editorial: t.Optional['music21.editorial.Editorial'] = None
 
     @property
     def hasStyleInformation(self) -> bool:

--- a/music21/tablature.py
+++ b/music21/tablature.py
@@ -16,7 +16,7 @@ Chord from Figure
 Chord from FretBoard Object with tuning.
 '''
 import unittest
-from typing import List, Optional
+import typing as t
 
 from music21 import common
 from music21 import exceptions21
@@ -227,7 +227,7 @@ class FretBoard(prebase.ProtoM21Object):
                     self.numStrings
                 ))
 
-        pitchList: List[Optional['music21.pitch.Pitch']] = [None] * self.numStrings
+        pitchList: t.List[t.Optional['music21.pitch.Pitch']] = [None] * self.numStrings
 
         if not self.fretNotes:
             return pitchList

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -14,7 +14,7 @@ This module defines objects for describing tempo and changes in tempo.
 '''
 import copy
 import unittest
-from typing import Union, Optional
+import typing as t
 
 from music21 import base
 from music21 import common
@@ -1152,8 +1152,8 @@ class MetricModulation(TempoIndication):
 
     def setOtherByReferent(
         self,
-        side: Optional[str] = None,
-        referent: Union[str, int, float] = 1.0
+        side: t.Optional[str] = None,
+        referent: t.Union[str, int, float] = 1.0
     ):
         '''
         Set the other side of the metric modulation not based on equality,

--- a/music21/test/multiprocessTest.py
+++ b/music21/test/multiprocessTest.py
@@ -27,7 +27,7 @@ import os
 import sys
 import time
 import unittest
-from typing import Optional, Any
+import typing as t
 
 from music21 import environment
 from music21 import common
@@ -38,15 +38,15 @@ environLocal = environment.Environment('test.multiprocessTest')
 
 @dataclasses.dataclass
 class ModuleResponse:
-    returnCode: Optional[str] = None
-    fp: Any = None
-    moduleName: Optional[str] = None
-    success: Any = None
-    testRunner: Any = None
-    errors: Any = None
-    failures: Any = None
-    testsRun: Any = None
-    runTime: Any = None
+    returnCode: t.Optional[str] = None
+    fp: t.Any = None
+    moduleName: t.Optional[str] = None
+    success: t.Any = None
+    testRunner: t.Any = None
+    errors: t.Any = None
+    failures: t.Any = None
+    testsRun: t.Any = None
+    runTime: t.Any = None
 
 
 # ------------------------------------------------------------------------------

--- a/music21/test/testSingleCoreAll.py
+++ b/music21/test/testSingleCoreAll.py
@@ -17,7 +17,7 @@ Runs great, but slowly on multiprocessor systems.
 
 import doctest
 import sys
-from typing import Sequence
+import typing as t
 import unittest
 import warnings
 
@@ -36,7 +36,7 @@ environLocal = environment.Environment('test.testSingleCoreAll')
 cov = coverageM21.getCoverage()
 
 
-def main(testGroup: Sequence[str] = ('test',),
+def main(testGroup: t.Sequence[str] = ('test',),
          restoreEnvironmentDefaults=False,
          limit=None,
          verbosity=2,

--- a/music21/tree/core.py
+++ b/music21/tree/core.py
@@ -16,7 +16,7 @@ These are the lowest level tools for working with self-balancing AVL trees.
 There's an overhead to creating an AVL tree, but for a large score it is
 absolutely balanced by having O(log n) search times.
 '''
-from typing import Optional
+import typing as t
 
 from music21 import prebase
 from music21.exceptions21 import TreeException
@@ -572,7 +572,7 @@ class AVLTree(prebase.ProtoM21Object):
         <AVLNode: Start:1 Height:1 L:0 R:0> '1'
         <AVLNode: Start:0 Height:0 L:None R:None> '0'
         '''
-        def recurse(subListOfTuples) -> Optional[AVLNode]:
+        def recurse(subListOfTuples) -> t.Optional[AVLNode]:
             '''
             Divide and conquer.
             '''

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -14,7 +14,7 @@
 Tools for creating timespans (fast, manipulable objects) from Streams
 '''
 import unittest
-from typing import Optional, Sequence, List, Type, Union, Tuple, Literal, cast
+import typing as t
 
 from music21.base import Music21Object
 from music21.common.types import M21ObjType, StreamType
@@ -29,12 +29,12 @@ from music21.tree import trees
 def listOfTreesByClass(
     inputStream: StreamType,
     *,
-    classLists: Optional[List[Sequence[Type[M21ObjType]]]] = None,
-    currentParentage: Optional[Tuple['music21.stream.Stream', ...]] = None,
+    classLists: t.Optional[t.List[t.Sequence[t.Type[M21ObjType]]]] = None,
+    currentParentage: t.Optional[t.Tuple['music21.stream.Stream', ...]] = None,
     initialOffset: float = 0.0,
-    flatten: Union[bool, str] = False,
+    flatten: t.Union[bool, str] = False,
     useTimespans: bool = False
-) -> List[Union[trees.OffsetTree, timespanTree.TimespanTree]]:
+) -> t.List[t.Union[trees.OffsetTree, timespanTree.TimespanTree]]:
     # noinspection PyShadowingNames
     r'''
     To be DEPRECATED in v8: this is no faster than calling streamToTimespanTree
@@ -109,7 +109,7 @@ def listOfTreesByClass(
         wasStream = False
 
         if element.isStream:
-            element = cast('music21.stream.Stream', element)
+            element = t.cast('music21.stream.Stream', element)
             localParentage = currentParentage + (element,)
             containedTrees = listOfTreesByClass(element,
                                                 currentParentage=localParentage,
@@ -154,11 +154,11 @@ def listOfTreesByClass(
 def asTree(
     inputStream: StreamType,
     *,
-    flatten: Union[Literal['semiFlat'], bool] = False,
-    classList: Optional[Sequence[Type]] = None,
+    flatten: t.Union[t.Literal['semiFlat'], bool] = False,
+    classList: t.Optional[t.Sequence[t.Type]] = None,
     useTimespans: bool = False,
     groupOffsets: bool = False
-) -> Union[trees.OffsetTree, trees.ElementTree, timespanTree.TimespanTree]:
+) -> t.Union[trees.OffsetTree, trees.ElementTree, timespanTree.TimespanTree]:
     '''
     Converts a Stream and constructs an :class:`~music21.tree.trees.ElementTree` based on this.
 
@@ -274,7 +274,7 @@ def asTree(
     if (inputStream.isSorted
             and groupOffsets is False  # currently we can't populate for an OffsetTree*
             and (inputStream.isFlat or flatten is False)):
-        outputTree: Union[trees.OffsetTree, trees.ElementTree] = treeClass(source=inputStream)
+        outputTree: t.Union[trees.OffsetTree, trees.ElementTree] = treeClass(source=inputStream)
         return makeFastShallowTreeFromSortedStream(inputStream,
                                                    outputTree=outputTree,
                                                    classList=classList)
@@ -286,9 +286,9 @@ def asTree(
 def makeFastShallowTreeFromSortedStream(
     inputStream: 'music21.stream.Stream',
     *,
-    outputTree: Union[trees.OffsetTree, trees.ElementTree],
-    classList: Optional[Sequence[Type]] = None,
-) -> Union[trees.OffsetTree, trees.ElementTree]:
+    outputTree: t.Union[trees.OffsetTree, trees.ElementTree],
+    classList: t.Optional[t.Sequence[t.Type]] = None,
+) -> t.Union[trees.OffsetTree, trees.ElementTree]:
     '''
     Use populateFromSortedList to quickly make a tree from a stream.
 
@@ -313,8 +313,8 @@ def makeFastShallowTreeFromSortedStream(
 def asTimespans(
     inputStream,
     *,
-    flatten: Union[str, bool] = False,
-    classList: Optional[Sequence[Type]] = None
+    flatten: t.Union[str, bool] = False,
+    classList: t.Optional[t.Sequence[t.Type]] = None
 ) -> timespanTree.TimespanTree:
     r'''
     Recurses through a score and constructs a
@@ -394,9 +394,9 @@ class Test(unittest.TestCase):
         from music21.tree import makeExampleScore
         sc = makeExampleScore()
         sc.sort()
-        t = asTree(sc)
-        self.assertEqual(t.endTime, 8.0)
-        # print(repr(t))
+        scTree = asTree(sc)
+        self.assertEqual(scTree.endTime, 8.0)
+        # print(repr(scTree))
 
 
 # --------------------

--- a/music21/tree/trees.py
+++ b/music21/tree/trees.py
@@ -18,7 +18,7 @@ and other positions.
 import unittest
 import weakref
 from math import inf
-from typing import Optional
+import typing as t
 
 from music21 import common
 from music21 import exceptions21
@@ -96,7 +96,7 @@ class ElementTree(core.AVLTree):
     6.0
     '''
     # TYPING #
-    rootNode: Optional[nodeModule.ElementNode]
+    rootNode: t.Optional[nodeModule.ElementNode]
 
     # CLASS VARIABLES #
     nodeClass = nodeModule.ElementNode
@@ -550,7 +550,7 @@ class ElementTree(core.AVLTree):
         <ElementNode: Start:36.0 <0.-5...> Indices:(l:193 *194* r:195)
             Payload:<music21.bar.Barline type=final>>
         '''
-        def recurse(subListOfTuples, globalStartOffset) -> Optional[core.AVLNode]:
+        def recurse(subListOfTuples, globalStartOffset) -> t.Optional[core.AVLNode]:
             '''
             Divide and conquer.
             '''
@@ -895,7 +895,7 @@ class OffsetTree(ElementTree):
     __slots__ = ()
 
     # TYPING #
-    rootNode: Optional[nodeModule.OffsetNode]
+    rootNode: t.Optional[nodeModule.OffsetNode]
 
     nodeClass = nodeModule.OffsetNode
 

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -18,7 +18,7 @@ import collections.abc
 import copy
 import itertools
 import unittest
-from typing import Optional, Union
+import typing as t
 
 from music21 import chord
 from music21 import common
@@ -335,7 +335,7 @@ class Verticality(prebase.ProtoM21Object):
         return self.startTimespans[0].measureNumber
 
     @property
-    def nextStartOffset(self) -> Optional[float]:
+    def nextStartOffset(self) -> t.Optional[float]:
         r'''
         Gets the next start-offset in the verticality's offset-tree.
 
@@ -534,7 +534,7 @@ class Verticality(prebase.ProtoM21Object):
         return tuple(self.startTimespans[:] + self.overlapTimespans[:])
 
     @property
-    def timeToNextEvent(self) -> Optional[OffsetQL]:
+    def timeToNextEvent(self) -> t.Optional[OffsetQL]:
         '''
         Returns a float or Fraction of the quarterLength to the next
         event (usually the next Verticality, but also to the end of the piece).
@@ -553,7 +553,7 @@ class Verticality(prebase.ProtoM21Object):
 
     def makeElement(
         self,
-        quarterLength: Union[OffsetQLIn, None] = None,
+        quarterLength: t.Union[OffsetQLIn, None] = None,
         *,
         addTies=True,
         addPartIdAsGroup=False,
@@ -561,7 +561,7 @@ class Verticality(prebase.ProtoM21Object):
         gatherArticulations='single',
         gatherExpressions='single',
         copyPitches=True,
-    ) -> Union[note.Rest, chord.Chord]:
+    ) -> t.Union[note.Rest, chord.Chord]:
         # noinspection PyDunderSlots, PyShadowingNames
         r'''
         Makes a Chord or Rest from this verticality and quarterLength.

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -20,7 +20,7 @@ and showing different variant streams. These functions and the variant class sho
 used when variants of a score are the same length and contain the same measure structure at
 this time.
 '''
-from typing import Union
+import typing as t
 import unittest
 
 import copy
@@ -1379,8 +1379,8 @@ def mergePartAsOssia(mainPart, ossiaPart, ossiaName,
 
 def addVariant(
     s: stream.Stream,
-    startOffset: Union[int, float],
-    sVariant: Union[stream.Stream, Variant],
+    startOffset: t.Union[int, float],
+    sVariant: t.Union[stream.Stream, Variant],
     variantName=None,
     variantGroups=None,
     replacementDuration=None

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -36,7 +36,7 @@ The list of objects included here are:
 '''
 import enum
 import unittest
-from typing import List, no_type_check
+import typing as t
 
 from music21 import base
 from music21 import chord
@@ -57,7 +57,7 @@ from music21 import scale
 
 # create a module level shared cache for intervals of P1, P5, P8
 # to be populated the first time a VLQ object is created
-intervalCache: List[interval.Interval] = []
+intervalCache: t.List[interval.Interval] = []
 
 
 class MotionType(str, enum.Enum):
@@ -112,8 +112,8 @@ class VoiceLeadingQuartet(base.Music21Object):
         self.v2n1 = v2n1
         self.v2n2 = v2n2
 
-        self.vIntervals: List[interval.Interval] = []  # vertical intervals (harmonic)
-        self.hIntervals: List[interval.Interval] = []  # horizontal intervals (melodic)
+        self.vIntervals: t.List[interval.Interval] = []  # vertical intervals (harmonic)
+        self.hIntervals: t.List[interval.Interval] = []  # horizontal intervals (melodic)
 
         self._key = None
         if analyticKey is not None:
@@ -447,7 +447,7 @@ class VoiceLeadingQuartet(base.Music21Object):
             else:
                 return False
 
-    @no_type_check
+    @t.no_type_check
     def parallelMotion(
         self,
         requiredInterval=None,
@@ -990,7 +990,7 @@ class VoiceLeadingQuartet(base.Music21Object):
         else:
             return False
 
-    @no_type_check
+    @t.no_type_check
     def isProperResolution(self) -> bool:
         '''
         Checks whether the voice-leading quartet resolves correctly according to standard
@@ -1149,7 +1149,7 @@ class VoiceLeadingQuartet(base.Music21Object):
         else:
             return True
 
-    @no_type_check
+    @t.no_type_check
     def leapNotSetWithStep(self) -> bool:
         '''
         Returns True if there is a leap or skip in once voice then the other voice must
@@ -1240,7 +1240,7 @@ class VoiceLeadingQuartet(base.Music21Object):
                       and (r1[0].upper() in openings if r1 is not False else False
                            or r2[0].upper() in openings if r2 is not False else False))
 
-    @no_type_check
+    @t.no_type_check
     def closesIncorrectly(self) -> bool:
         '''
         TODO(msc): will be renamed to be less dogmatic

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -15,7 +15,7 @@
 This module defines the object model of Volume, covering all representation of
 amplitude, volume, velocity, and related parameters.
 '''
-from typing import Iterable, List, Union
+import typing as t
 import unittest
 
 
@@ -133,12 +133,12 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
             self.velocityIsRelative = other.velocityIsRelative
 
     def getRealizedStr(self,
-                       useDynamicContext: Union[dynamics.Dynamic, bool] = True,
+                       useDynamicContext: t.Union[dynamics.Dynamic, bool] = True,
                        useVelocity=True,
-                       useArticulations: Union[bool,
-                                               articulations.Articulation,
-                                               Iterable[articulations.Articulation]
-                                               ] = True,
+                       useArticulations: t.Union[bool,
+                                                 articulations.Articulation,
+                                                 t.Iterable[articulations.Articulation]
+                                                 ] = True,
                        baseLevel=0.5,
                        clip=True):
         '''Return the realized as rounded and formatted string value. Useful for testing.
@@ -157,10 +157,10 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
 
     def getRealized(
         self,
-        useDynamicContext: Union[bool, dynamics.Dynamic] = True,
+        useDynamicContext: t.Union[bool, dynamics.Dynamic] = True,
         useVelocity=True,
-        useArticulations: Union[
-            bool, articulations.Articulation, Iterable[articulations.Articulation]
+        useArticulations: t.Union[
+            bool, articulations.Articulation, t.Iterable[articulations.Articulation]
         ] = True,
         baseLevel=0.5,
         clip=True,
@@ -262,7 +262,7 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
             # useArticulations can be a list of 1 or more articulation objects
             # as well as True/False
             if useArticulations is not False:
-                am: Iterable[articulations.Articulation]
+                am: t.Iterable[articulations.Articulation]
                 if isinstance(useArticulations, articulations.Articulation):
                     am = [useArticulations]  # place in a list
                 elif common.isIterable(useArticulations):
@@ -752,7 +752,7 @@ class Test(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-_DOC_ORDER: List[type] = []
+_DOC_ORDER: t.List[type] = []
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Because we're importing so much from typing, it makes more sense to standardize importing the entire module as `t` and then using `t.Union` etc.  When 3.9 is the minimum version, this will be a lot less line noise.

Removing existing uses of `t` as a variable makes everything cleaner with better names.