### PR TITLE
typing on chord module

### DIFF
--- a/.github/workflows/pythonpylint.yml
+++ b/.github/workflows/pythonpylint.yml
@@ -66,4 +66,4 @@ jobs:
                   python -m pip install -r requirements.txt
             - name: Type-check certain modules with mypy
               run: |
-                  mypy --follow-imports=silent music21/*.py music21/abcFormat music21/alpha music21/analysis music21/audioSearch music21/braille music21/capella music21/common music21/corpus music21/features music21/figuredBass music21/humdrum music21/ipython21 music21/languageExcerpts music21/lily music21/mei music21/metadata music21/musedata music21/noteworthy music21/omr music21/romanText music21/stream music21/test music21/vexflow
+                  mypy --follow-imports=silent music21/*.py music21/abcFormat music21/alpha music21/analysis music21/audioSearch music21/braille music21/capella music21/chord music21/common music21/corpus music21/features music21/figuredBass music21/humdrum music21/ipython21 music21/languageExcerpts music21/lily music21/mei music21/metadata music21/musedata music21/noteworthy music21/omr music21/romanText music21/stream music21/test music21/vexflow

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ music21/monkeytype.sqlite3
 .pytest_cache/v/cache/nodeids
 .pytest_cache/v/cache/lastfailed
 .pytest_cache/v/cache/nodeids
+.dmypy.json

--- a/documentation/docbuild/documenters.py
+++ b/documentation/docbuild/documenters.py
@@ -82,7 +82,7 @@ class ObjectDocumenter(Documenter):
     Base class for object documenting sub-classes. such as ClassDocumenter
     '''
 
-    _DOC_ATTR = {'referent': 'the object being documented'}
+    _DOC_ATTR: t.Dict[str, str] = {'referent': 'the object being documented'}
     # INITIALIZER #
 
     sphinxCrossReferenceRole = ''
@@ -187,7 +187,7 @@ class MemberDocumenter(ObjectDocumenter):
     '''
     Abstract base class for documenting class members such as Methods and Attributes and Properties
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'memberName': 'the short name of the member, for instance "mode"',
         'referent': '''the attribute or method itself, such as (no quotes)
                        key.KeySignature.mode''',

--- a/music21/analysis/harmonicFunction.py
+++ b/music21/analysis/harmonicFunction.py
@@ -5,11 +5,10 @@
 #
 # Authors:      Mark Gotham
 #
-# Copyright:    Copyright © 2022 Michael Scott Cuthbert and the music21 Project
+# Copyright:    Copyright © 2022 Michael Scott Asato Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
-
-from typing import Optional, Union
+import typing as t
 import unittest
 
 from music21 import common
@@ -17,13 +16,8 @@ from music21 import key
 from music21 import roman
 from music21 import scale
 
-from music21 import environment
-_MOD = 'analysis.harmonicFunction'
-environLocal = environment.Environment(_MOD)
-
 
 class HarmonicFunction(common.enums.StrEnum):
-
     TONIC_MAJOR = 'T'
     TONIC_MAJOR_PARALLELKLANG_MINOR = 'Tp'
     TONIC_MAJOR_GEGENKLANG_MINOR = 'Tg'
@@ -50,7 +44,6 @@ class HarmonicFunction(common.enums.StrEnum):
 
 
 _functionFigureTuplesKeyNeutral = {
-
     HarmonicFunction.TONIC_MAJOR: 'I',  # 'T'
     HarmonicFunction.TONIC_MINOR: 'i',  # 't'
 
@@ -68,11 +61,9 @@ _functionFigureTuplesKeyNeutral = {
     HarmonicFunction.SUBDOMINANT_MAJOR_GEGENKLANG_MINOR: 'vi',  # 'Sg'
 
     HarmonicFunction.DOMINANT_MAJOR_GEGENKLANG_MINOR: 'bvii',  # 'Dg'
-
 }
 
 functionFigureTuplesMajor = {
-
     HarmonicFunction.TONIC_MINOR_PARALLELKLANG_MAJOR: 'bIII',  # 'tP', note first
     HarmonicFunction.DOMINANT_MINOR_GEGENKLANG_MAJOR: 'bIII',  # 'dG'
 
@@ -83,7 +74,6 @@ functionFigureTuplesMajor = {
     HarmonicFunction.TONIC_MINOR_GEGENKLANG_MAJOR: 'bVI',  # 'tG'
 
     HarmonicFunction.DOMINANT_MINOR_PARALLELKLANG_MAJOR: 'bVII',  # 'dP'
-
 }
 
 functionFigureTuplesMajor = {
@@ -92,7 +82,6 @@ functionFigureTuplesMajor = {
 }
 
 functionFigureTuplesMinor = {
-
     HarmonicFunction.TONIC_MINOR_PARALLELKLANG_MAJOR: 'III',  # 'tP', note first
     HarmonicFunction.DOMINANT_MINOR_GEGENKLANG_MAJOR: 'III',  # 'dG'
 
@@ -103,7 +92,6 @@ functionFigureTuplesMinor = {
     HarmonicFunction.TONIC_MINOR_GEGENKLANG_MAJOR: 'VI',  # 'tG'
 
     HarmonicFunction.DOMINANT_MINOR_PARALLELKLANG_MAJOR: 'VII',  # 'dP'
-
 }
 
 functionFigureTuplesMinor = {
@@ -113,8 +101,8 @@ functionFigureTuplesMinor = {
 
 
 def functionToRoman(thisHarmonicFunction: HarmonicFunction,
-                    keyOrScale: Union[key.Key, scale.Scale, str] = 'C'
-                    ) -> Optional[roman.RomanNumeral]:
+                    keyOrScale: t.Union[key.Key, scale.Scale, str] = 'C'
+                    ) -> t.Optional[roman.RomanNumeral]:
     '''
     Takes harmonic function labels (such as 'T' for major tonic)
     with a key (keyOrScale, default = 'C') and
@@ -196,7 +184,7 @@ def functionToRoman(thisHarmonicFunction: HarmonicFunction,
         keyOrScale = key.Key(keyOrScale)
 
     referenceTuples = functionFigureTuplesMajor
-    if keyOrScale.mode == 'minor':
+    if isinstance(keyOrScale, key.Key) and keyOrScale.mode == 'minor':
         referenceTuples = functionFigureTuplesMinor
 
     try:
@@ -208,7 +196,7 @@ def functionToRoman(thisHarmonicFunction: HarmonicFunction,
 
 def romanToFunction(rn: roman.RomanNumeral,
                     onlyHauptHarmonicFunction: bool = False
-                    ) -> Optional[HarmonicFunction]:
+                    ) -> t.Optional[HarmonicFunction]:
     '''
     Takes a Roman numeral and returns a corresponding harmonic function label.
 
@@ -266,9 +254,7 @@ def romanToFunction(rn: roman.RomanNumeral,
 
 
 # ------------------------------------------------------------------------------
-
 class Test(unittest.TestCase):
-
     def testAllFunctionLabelsInEnum(self):
         '''
         Test that all the entries in the functionFigureTuples
@@ -276,7 +262,6 @@ class Test(unittest.TestCase):
 
         Also tests one fake (invalid) function label.
         '''
-
         # All and only valid
         for thisHarmonicFunction in functionFigureTuplesMajor:
             HarmonicFunction(thisHarmonicFunction)
@@ -288,7 +273,7 @@ class Test(unittest.TestCase):
         self.assertRaises(ValueError, HarmonicFunction, fakeExample)
 
     def testFunctionToRoman(self):
-        self.assertEqual(functionToRoman('T').figure, 'I')
+        self.assertEqual(functionToRoman(HarmonicFunction.TONIC_MAJOR).figure, 'I')
 
     def testSimplified(self):
         rn = roman.RomanNumeral('III', 'f')
@@ -306,7 +291,6 @@ class Test(unittest.TestCase):
 
 
 # -----------------------------------------------------------------------------
-
 if __name__ == '__main__':
     import music21
     music21.mainTest(Test)

--- a/music21/articulations.py
+++ b/music21/articulations.py
@@ -78,6 +78,8 @@ A longer test showing the utility of the module:
     :width: 628
 
 '''
+from __future__ import annotations
+
 import typing as t
 import unittest
 
@@ -90,6 +92,8 @@ from music21 import style
 
 environLocal = environment.Environment('articulations')
 
+if t.TYPE_CHECKING:
+    from music21 import interval
 
 
 class ArticulationException(exceptions21.Music21Exception):
@@ -142,7 +146,7 @@ class Articulation(base.Music21Object):
     # def __eq__(self, other):
     #     '''
     #     Equality. Based only on the class name,
-    #     as other other attributes are independent of context and deployment.
+    #     as other attributes are independent of context and deployment.
     #
     #
     #     >>> at1 = articulations.StrongAccent()
@@ -589,10 +593,10 @@ class PullOff(FretIndication):
     pass
 
 class FretBend(FretIndication):
-    bendAlter = None  # music21.interval.Interval object
-    preBend = None
-    release = None
-    withBar = None
+    bendAlter: t.Optional[interval.IntervalBase] = None
+    preBend: t.Any = None
+    release: t.Any = None
+    withBar: t.Any = None
 
 class FretTap(FretIndication):
     pass

--- a/music21/base.py
+++ b/music21/base.py
@@ -2622,19 +2622,23 @@ class Music21Object(prebase.ProtoM21Object):
                           self.classSortOrder, isNotGrace, insertIndex)
 
     # -----------------------------------------------------------------
-    def _getDuration(self) -> t.Optional[duration.Duration]:
+    @property
+    def duration(self) -> 'music21.duration.Duration':
         '''
-        Gets the DurationObject of the object or None
+        Get and set the duration of this object as a Duration object.
         '''
         # lazy duration creation
         if self._duration is None:
             self._duration = duration.Duration(0)
-        return self._duration
 
-    def _setDuration(self, durationObj: duration.Duration):
-        '''
-        Set the duration as a quarterNote length
-        '''
+        d_out = self._duration
+        if t.TYPE_CHECKING:
+            assert d_out is not None
+
+        return d_out
+
+    @duration.setter
+    def duration(self, durationObj: 'music21.duration.Duration'):
         durationObjAlreadyExists = not (self._duration is None)
 
         try:
@@ -2649,11 +2653,6 @@ class Music21Object(prebase.ProtoM21Object):
             raise Exception(
                 f'this must be a Duration object, not {durationObj}'
             ) from ae
-
-    duration = property(_getDuration, _setDuration,
-                        doc='''
-        Get and set the duration of this object as a Duration object.
-        ''')
 
     def informSites(self, changedInformation=None):
         '''
@@ -3969,14 +3968,16 @@ class ElementWrapper(Music21Object):
     <music21.base.ElementWrapper id=1_wrapper offset=1.0 obj='<...Wave_read object...'>
     <music21.base.ElementWrapper offset=2.0 obj='<...Wave_read object...>'>
     '''
-    obj = None
+    obj: t.Any = None
 
     _DOC_ORDER = ['obj']
     _DOC_ATTR = {
-        'obj': 'The object this wrapper wraps. It should not be a Music21Object.',
+        'obj': '''
+        The object this wrapper wraps. It should not be a Music21Object, since
+        if so, you might as well put that directly into the Stream itself.''',
     }
 
-    def __init__(self, obj=None):
+    def __init__(self, obj: t.Any = None):
         super().__init__()
         self.obj = obj  # object stored here
 
@@ -3995,7 +3996,8 @@ class ElementWrapper(Music21Object):
             return f'offset={self.offset} obj={shortObj!r}'
 
     def __eq__(self, other) -> bool:
-        '''Test ElementWrapper equality
+        '''
+        Test ElementWrapper equality
 
         >>> import music21
         >>> n = note.Note('C#')

--- a/music21/base.py
+++ b/music21/base.py
@@ -61,6 +61,7 @@ from music21 import editorial
 from music21 import defaults
 from music21.derivation import Derivation
 from music21 import duration
+from music21.duration import Duration, DurationException
 from music21 import prebase
 from music21 import sites
 from music21 import style  # pylint: disable=unused-import
@@ -304,7 +305,7 @@ class Music21Object(prebase.ProtoM21Object):
     _DOC_ORDER: t.List[str] = []
 
     # documentation for all attributes (not properties or methods)
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'groups': '''An instance of a :class:`~music21.base.Group`
             object which describes
             arbitrary `Groups` that this object belongs to.''',
@@ -365,7 +366,7 @@ class Music21Object(prebase.ProtoM21Object):
         self._editorial: t.Optional[editorial.Editorial] = None
 
         # private duration storage; managed by property
-        self._duration: t.Optional[duration.Duration] = None
+        self._duration: t.Optional[Duration] = None
         self._priority = 0  # default is zero
 
         # store cached values here:
@@ -2623,13 +2624,13 @@ class Music21Object(prebase.ProtoM21Object):
 
     # -----------------------------------------------------------------
     @property
-    def duration(self) -> 'music21.duration.Duration':
+    def duration(self) -> Duration:
         '''
         Get and set the duration of this object as a Duration object.
         '''
         # lazy duration creation
         if self._duration is None:
-            self._duration = duration.Duration(0)
+            self._duration = Duration(0)
 
         d_out = self._duration
         if t.TYPE_CHECKING:
@@ -2638,7 +2639,7 @@ class Music21Object(prebase.ProtoM21Object):
         return d_out
 
     @duration.setter
-    def duration(self, durationObj: 'music21.duration.Duration'):
+    def duration(self, durationObj: Duration):
         durationObjAlreadyExists = not (self._duration is None)
 
         try:
@@ -3048,7 +3049,7 @@ class Music21Object(prebase.ProtoM21Object):
         quarterLength = opFrac(quarterLength)
 
         if quarterLength > self.duration.quarterLength:
-            raise duration.DurationException(
+            raise DurationException(
                 f'cannot split a duration ({self.duration.quarterLength}) '
                 + f'at this quarterLength ({quarterLength})'
             )
@@ -3100,10 +3101,10 @@ class Music21Object(prebase.ProtoM21Object):
         lenEnd = self.duration.quarterLength - quarterLength
         lenStart = self.duration.quarterLength - lenEnd
 
-        d1 = duration.Duration()
+        d1 = Duration()
         d1.quarterLength = lenStart
 
-        d2 = duration.Duration()
+        d2 = Duration()
         d2.quarterLength = lenEnd
 
         e.duration = d1
@@ -3639,7 +3640,7 @@ class Music21Object(prebase.ProtoM21Object):
             return 'nan'
 
     @property
-    def beatDuration(self) -> 'music21.duration.Duration':
+    def beatDuration(self) -> Duration:
         '''
         Return a :class:`~music21.duration.Duration` of the beat
         active for this object as found in the most recently
@@ -3679,7 +3680,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> [n.beatDuration.quarterLength for n in s.notes]
         [2.0, 2.0, 3.0, 3.0, 3.0, 2.0, 2.0, 3.0]
 
-
         If there is no TimeSignature object in sites then returns a duration object
         of Zero length.
 
@@ -3694,7 +3694,7 @@ class Music21Object(prebase.ProtoM21Object):
             ts = self._getTimeSignatureForBeat()
             return ts.getBeatDuration(ts.getMeasureOffsetOrMeterModulusOffset(self))
         except Music21ObjectException:
-            return duration.Duration(0)
+            return Duration(0)
 
     @property
     def beatStrength(self) -> float:
@@ -3971,7 +3971,7 @@ class ElementWrapper(Music21Object):
     obj: t.Any = None
 
     _DOC_ORDER = ['obj']
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'obj': '''
         The object this wrapper wraps. It should not be a Music21Object, since
         if so, you might as well put that directly into the Stream itself.''',

--- a/music21/base.py
+++ b/music21/base.py
@@ -60,7 +60,6 @@ from music21 import environment
 from music21 import editorial
 from music21 import defaults
 from music21.derivation import Derivation
-from music21 import duration
 from music21.duration import Duration, DurationException
 from music21 import prebase
 from music21 import sites

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -204,7 +204,7 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
         'id',
     )
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'feathered': '''
             Boolean determining if this is a feathered beam or not
             (does nothing for now).''',

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -153,7 +153,7 @@ SegmentKey.__new__.__defaults__ = (0, 0, None, None)
 # ------------------------------------------------------------------------------
 
 class BrailleElementGrouping(ProtoM21Object):
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'keySignature': 'The last :class:`~music21.key.KeySignature` preceding the grouping.',
         'timeSignature': 'The last :class:`~music21.meter.TimeSignature` preceding the grouping.',
         'descendingChords': '''True if a :class:`~music21.chord.Chord` should be spelled
@@ -270,7 +270,7 @@ class BrailleElementGrouping(ProtoM21Object):
 
 
 class BrailleSegment(text.BrailleText):
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'cancelOutgoingKeySig': '''If True, the previous key signature should be
                  cancelled immediately before a new key signature is encountered.''',
         'dummyRestLength': '''For a given positive integer n, adds n "dummy rests"

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -25,7 +25,6 @@ from typing import overload
 from music21 import beam
 from music21 import common
 from music21 import derivation
-from music21 import duration
 from music21.duration import Duration
 from music21 import exceptions21
 from music21 import interval

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -1404,7 +1404,6 @@ class Chord(ChordBase):
             self._cache['bass'] = self._findBass()
             return self._cache['bass']
 
-
     def canBeDominantV(self) -> bool:
         '''
         Returns True if the chord is a Major Triad or a Dominant Seventh:
@@ -1440,13 +1439,33 @@ class Chord(ChordBase):
         else:
             return False
 
+    @overload
+    def closedPosition(
+        self: _ChordType,
+        *,
+        forceOctave,
+        inPlace: t.Literal[True],
+        leaveRedundantPitches=False
+    ) -> None:
+        return None
+
+    @overload
+    def closedPosition(
+        self: _ChordType,
+        *,
+        forceOctave=None,
+        inPlace: t.Literal[False] = False,
+        leaveRedundantPitches=False
+    ) -> _ChordType:
+        return self
+
     def closedPosition(
         self: _ChordType,
         *,
         forceOctave=None,
         inPlace=False,
         leaveRedundantPitches=False
-    ) -> _ChordType:
+    ) -> t.Optional[_ChordType]:
         '''
         Returns a new Chord object with the same pitch classes,
         but now in closed position.
@@ -4901,7 +4920,7 @@ class Chord(ChordBase):
         >>> c.duration is d
         True
         '''
-        d = t.cast(t.Union[Duration, None], self._duration)
+        d = t.cast(t.Union[Duration, None], self._duration)  # type: ignore
         if d is None and self._notes:
             # pitchZeroDuration = self._notes[0]['pitch'].duration
             pitchZeroDuration = self._notes[0].duration
@@ -4909,7 +4928,7 @@ class Chord(ChordBase):
 
         d_out = self._duration
         if t.TYPE_CHECKING:
-            assert d_out is not None
+            assert isinstance(d_out, Duration)
         return d_out
 
     @duration.setter

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -26,6 +26,7 @@ from music21 import beam
 from music21 import common
 from music21 import derivation
 from music21 import duration
+from music21.duration import Duration
 from music21 import exceptions21
 from music21 import interval
 from music21 import note
@@ -74,7 +75,6 @@ class ChordBase(note.NotRest):
         'beams': 'A :class:`music21.beam.Beams` object.',
     }
 
-
     # update inherited _DOC_ATTR dictionary
     _DOC_ATTR.update(note.NotRest._DOC_ATTR)
 
@@ -120,7 +120,7 @@ class ChordBase(note.NotRest):
         if durationKeyword is not None:
             self.duration = durationKeyword
         elif 'type' in keywords or 'quarterLength' in keywords:  # dots dont cut it
-            self.duration = duration.Duration(**keywords)
+            self.duration = Duration(**keywords)
 
         # elif len(notes) > 0:
         #     for thisNote in notes:
@@ -440,7 +440,7 @@ class ChordBase(note.NotRest):
         >>> chord.Chord().volume
         <music21.volume.Volume realized=0.71>
         '''
-        if self._volume is not None:
+        if isinstance(self._volume, volume.Volume):
             # if we already have a Volume, use that
             return self._volume
 
@@ -704,7 +704,7 @@ class Chord(ChordBase):
     # define order of presenting names in documentation; use strings
     _DOC_ORDER = ['pitches']
     # documentation for all attributes (not properties or methods)
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'isChord': '''
             Boolean read-only value describing if this
             GeneralNote object is a Chord. Is True''',
@@ -4879,7 +4879,8 @@ class Chord(ChordBase):
 
 
     @property
-    def duration(self) -> 'music21.duration.Duration':
+    def duration(self) -> Duration:
+        # noinspection PyShadowingNames
         '''
         Get or set the duration of this Chord as a Duration object.
 
@@ -4901,7 +4902,8 @@ class Chord(ChordBase):
         >>> c.duration is d
         True
         '''
-        if self._duration is None and self._notes:
+        d = t.cast(t.Union[Duration, None], self._duration)
+        if d is None and self._notes:
             # pitchZeroDuration = self._notes[0]['pitch'].duration
             pitchZeroDuration = self._notes[0].duration
             self._duration = pitchZeroDuration
@@ -4912,11 +4914,11 @@ class Chord(ChordBase):
         return d_out
 
     @duration.setter
-    def duration(self, durationObj: 'music21.duration.Duration'):
+    def duration(self, durationObj: Duration):
         '''
         Set a Duration object.
         '''
-        if isinstance(durationObj, duration.Duration):
+        if isinstance(durationObj, Duration):
             self._duration = durationObj
         else:
             # need to permit Duration object assignment here

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -39,8 +39,8 @@ from music21.common.decorators import cacheMethod
 
 environLocal = environment.Environment('chord')
 
+_ChordBaseType = t.TypeVar('_ChordBaseType', bound='music21.chord.ChordBase')
 _ChordType = t.TypeVar('_ChordType', bound='music21.chord.Chord')
-
 
 # ------------------------------------------------------------------------------
 class ChordException(exceptions21.Music21Exception):
@@ -99,7 +99,7 @@ class ChordBase(note.NotRest):
         # the list of pitch objects is managed by a property; this permits
         # only updating the _chordTablesAddress when ".pitches" has changed
 
-        self._overrides = {}
+        self._overrides: t.Dict[str, t.Any] = {}
 
         self._notes: t.List[note.NotRest] = []
         # here, pitch and duration data is extracted from notes
@@ -165,7 +165,7 @@ class ChordBase(note.NotRest):
             return False
         return True
 
-    def __deepcopy__(self: _ChordType, memo=None) -> _ChordType:
+    def __deepcopy__(self: _ChordBaseType, memo=None) -> _ChordBaseType:
         '''As Chord objects have one or more Volume, objects, and Volume
         objects store weak refs to the client object, need to specialize
         deepcopy handling depending on if the chord has its own volume object.
@@ -362,9 +362,6 @@ class ChordBase(note.NotRest):
                     return
             raise ValueError('Chord.remove(x), x not in chord')
 
-        if not hasattr(removeItem, 'classes'):
-            raise ValueError('Cannot remove {} from a chord; try a Pitch or Note object'.format(
-                removeItem))
         if isinstance(removeItem, pitch.Pitch):
             for n in self._notes:
                 if hasattr(n, 'pitch') and n.pitch == removeItem:
@@ -373,6 +370,10 @@ class ChordBase(note.NotRest):
                     return
             raise ValueError('Chord.remove(x), x not in chord')
 
+        if not isinstance(removeItem, note.NotRest):
+            raise ValueError(
+                f'Cannot remove {removeItem} from a chord; try a Pitch or Note object'
+            )
         try:
             self._notes.remove(removeItem)
             self.clearCache()
@@ -412,7 +413,7 @@ class ChordBase(note.NotRest):
             # d['tie'] = value
 
     @property
-    def volume(self):
+    def volume(self) -> 'music21.volume.Volume':
         '''
         Get or set the :class:`~music21.volume.Volume` object for this
         Chord.
@@ -429,28 +430,8 @@ class ChordBase(note.NotRest):
         >>> c.volume
         <music21.volume.Volume realized=0.5>
 
-        >>> c.volume = [volume.Volume(velocity=96), volume.Volume(velocity=96)]
-        >>> c.hasComponentVolumes()
-        True
-
-        Note that this means that the chord itself does not have a volume at this moment!
-
-        >>> c.hasVolumeInformation()
-        False
-
-        >>> c.volume.velocity
-        96
-
-        But after called, now it does:
-
-        >>> c.hasVolumeInformation()
-        True
-
-        Return a new volume that is an average of the components
-
-        >>> c.volume.velocityIsRelative = False
-        >>> c.volume
-        <music21.volume.Volume realized=0.76>
+        Changed in v.8 -- setting volume to a list of volumes is no longer supported.
+            See :meth:`~music21.chord.ChordBase.setVolumes` instead
 
         OMIT_FROM_DOCS
 
@@ -477,11 +458,14 @@ class ChordBase(note.NotRest):
         self._volume = volume.Volume(client=self)
         if velocities:  # avoid division by zero error
             self._volume.velocity = int(round(sum(velocities) / len(velocities)))
+
+        if t.TYPE_CHECKING:
+            assert self._volume is not None
         return self._volume
 
 
     @volume.setter
-    def volume(self, expr):
+    def volume(self, expr: t.Union[None, 'music21.volume.Volume', int, float]):
         if isinstance(expr, volume.Volume):
             expr.client = self
             # remove any component volumes
@@ -490,60 +474,118 @@ class ChordBase(note.NotRest):
             note.NotRest._setVolume(self, expr, setClient=False)
         elif common.isNum(expr):
             vol = self._getVolume()
+            if t.TYPE_CHECKING:
+                assert isinstance(expr, (int, float))
+
             if expr < 1:  # assume a scalar
                 vol.velocityScalar = expr
             else:  # assume velocity
                 vol.velocity = expr
-        elif common.isListLike(expr):  # assume an array of vol objects
-            # if setting components, remove single velocity
-            self._volume = None
-            for i, c in enumerate(self._notes):
-                v = expr[i % len(expr)]
-                if common.isNum(v):  # create a new Volume
-                    if v < 1:  # assume a scalar
-                        v = volume.Volume(velocityScalar=v)
-                    else:  # assume velocity
-                        v = volume.Volume(velocity=v)
-                v.client = self
-                # noinspection PyArgumentList
-                c._setVolume(v, setClient=False)
         else:
             raise ChordException(f'unhandled setting expr: {expr}')
 
+    def hasComponentVolumes(self) -> bool:
+        '''
+        Utility method to determine if this object has component
+        :class:`~music21.volume.Volume` objects assigned to each
+        note-component.
+
+        >>> c1 = chord.Chord(['c4', 'd-1', 'g6'])
+        >>> c1.setVolumes([60, 20, 120])
+        >>> [n.volume.velocity for n in c1]
+        [60, 20, 120]
+
+        >>> c1.hasComponentVolumes()
+        True
+
+        >>> c2 = chord.Chord(['c4', 'd-1', 'g6'])
+        >>> c2.volume.velocity = 23
+        >>> c2.hasComponentVolumes()
+        False
+
+        >>> c3 = chord.Chord(['c4', 'd-1', 'g6'])
+        >>> c3.setVolumes([0.2, 0.5, 0.8])
+        >>> [n.volume.velocity for n in c3]
+        [25, 64, 102]
+
+        >>> c4 = chord.Chord(['c4', 'd-1', 'g6'])
+        >>> c4.volume = 89
+        >>> c4.volume.velocity
+        89
+
+        >>> c4.hasComponentVolumes()
+        False
+
+        '''
+        count = 0
+        for c in self._notes:
+            # access private attribute, as property will create otherwise
+            if c.hasVolumeInformation():
+                count += 1
+        if count == len(self._notes):
+            # environLocal.printDebug(['hasComponentVolumes:', True])
+            return True
+        else:
+            # environLocal.printDebug(['hasComponentVolumes:', False])
+            return False
 
     # --------------------------------------------------------------------------
     # volume per pitch ??
     # --------------------------------------------------------------------------
-    def setVolume(self, vol, pitchTarget=None):
+    def setVolumes(self, volumes: t.Sequence[t.Union['music21.volume.Volume', int, float]]):
+        # noinspection PyShadowingNames
         '''
-        Set the :class:`~music21.volume.Volume` object of a specific pitch
-        target. If no pitch target is given, the first pitch is used.
+        Set as many individual volumes as appear in volumes.  If there are not
+        enough volumes, then cycles through the list of volumes here:
+
+        >>> c = chord.Chord(['g#', 'd-'])
+        >>> c.setVolumes([volume.Volume(velocity=96), volume.Volume(velocity=96)])
+        >>> c.hasComponentVolumes()
+        True
+
+        Note that this means that the chord itself does not have a volume at this moment!
+
+        >>> c.hasVolumeInformation()
+        False
+
+        >>> c.volume.velocity
+        96
+
+        But after having called the volume, now it does:
+
+        >>> c.hasVolumeInformation()
+        True
+
+        >>> c.volume.velocityIsRelative = False
+        >>> c.volume
+        <music21.volume.Volume realized=0.76>
+
+        New in v.8 -- replaces setting .volume to a list
         '''
-        # assign to first pitch by default
-        if pitchTarget is None and self._notes:  # if no pitches
-            pitchTarget = self._notes[0].pitch
-        elif isinstance(pitchTarget, str):
-            pitchTarget = pitch.Pitch(pitchTarget)
-        match = False
-        for d in self._notes:
-            if d.pitch is pitchTarget or d.pitch == pitchTarget:
-                vol.client = self
-                # noinspection PyArgumentList
-                d._setVolume(vol, setClient=False)
-                match = True
-                break
-        if not match:
-            raise ChordException(f'the given pitch is not in the Chord: {pitchTarget}')
+        # if setting components, remove single velocity
+        self._volume = None
+        for i, c in enumerate(self._notes):
+            v_entry = volumes[i % len(volumes)]
+            v: volume.Volume
+            if isinstance(v_entry, volume.Volume):
+                v = v_entry
+            else:  # create a new Volume
+                if v_entry < 1:  # assume a scalar
+                    v = volume.Volume(velocityScalar=v_entry)
+                else:  # assume velocity
+                    v = volume.Volume(velocity=v_entry)
+            v.client = self
+            c._setVolume(v, setClient=False)
 
 
 # ------------------------------------------------------------------------------
 class Chord(ChordBase):
     '''
-    Class representing Chords
+    Class representing Chords.
 
     A Chord functions like a Note object but has multiple pitches.
 
-    Create chords by passing a list of strings of pitch names
+    Create chords by passing a list of strings of pitch names:
 
     >>> dMaj = chord.Chord(['D', 'F#', 'A'])
     >>> dMaj
@@ -576,7 +618,7 @@ class Chord(ChordBase):
 
     Or with pitches:
 
-    >>> cmaj2 = chord.Chord([cNote.pitch, eNote.pitch, gNote.pitch])
+    >>> cmaj2 = chord.Chord([pitch.Pitch('C'), pitch.Pitch('E'), pitch.Pitch('G')])
     >>> cmaj2
     <music21.chord.Chord C E G>
 
@@ -685,7 +727,9 @@ class Chord(ChordBase):
                                      for n in notes):
             raise TypeError(f'Use a PercussionChord to contain Unpitched objects; got {notes}')
         super().__init__(notes=notes, **keywords)
-        self._notes: t.List[note.Note]
+
+        # if there were a covariant list, we would use that instead.
+        self._notes: t.List[note.Note]  # type: ignore
 
         if notes is not None and all(isinstance(n, int) for n in notes):
             self.simplifyEnharmonics(inPlace=True)
@@ -736,7 +780,7 @@ class Chord(ChordBase):
         'C'
         >>> c['3.accidental']
         Traceback (most recent call last):
-        KeyError: 'Cannot access component with: 3.accidental'
+        KeyError: "Cannot access component with: '3.accidental'"
 
         >>> c[5]
         Traceback (most recent call last):
@@ -773,14 +817,17 @@ class Chord(ChordBase):
         Traceback (most recent call last):
         KeyError: 'Cannot access component with: None'
         '''
-        keyErrorStr = f'Cannot access component with: {key}'
+        foundNote: note.Note
+        attributes: t.Tuple[str, ...]
+
+        keyErrorStr = f'Cannot access component with: {key!r}'
         if isinstance(key, str):
             if key.count('.'):
                 key, attrStr = key.split('.', 1)
                 if not attrStr.count('.'):
                     attributes = (attrStr,)
                 else:
-                    attributes = attrStr.split('.')
+                    attributes = tuple(attrStr.split('.'))
             else:
                 attributes = ()
 
@@ -806,10 +853,6 @@ class Chord(ChordBase):
                     break
             else:
                 raise KeyError(keyErrorStr)
-
-        elif not hasattr(key, 'classes'):
-            raise KeyError(keyErrorStr)
-
         elif isinstance(key, note.Note):
             for n in self._notes:
                 if n is key:
@@ -822,7 +865,6 @@ class Chord(ChordBase):
                         break
                 else:
                     raise KeyError(keyErrorStr)
-
         elif isinstance(key, pitch.Pitch):
             for n in self._notes:
                 if n.pitch is key:
@@ -841,7 +883,7 @@ class Chord(ChordBase):
         if not attributes:
             return foundNote
 
-        currentValue = foundNote
+        currentValue: t.Any = foundNote
 
         for attr in attributes:
             if attr == 'volume':  # special handling
@@ -890,8 +932,6 @@ class Chord(ChordBase):
 
         if isinstance(value, str):
             value = note.Note(value)
-        elif not hasattr(value, 'classes'):
-            raise ValueError('Chord index must be set to a valid note object')
         elif isinstance(value, pitch.Pitch):
             value = note.Note(pitch=value)
         elif not isinstance(value, note.Note):
@@ -2108,50 +2148,6 @@ class Chord(ChordBase):
         if len(set(p.step for p in self.pitches)) != len(set(p.name for p in self.pitches)):
             return True
         else:
-            return False
-
-    def hasComponentVolumes(self) -> bool:
-        '''Utility method to determine if this object has component
-        :class:`~music21.volume.Volume` objects assigned to each
-        note-component.
-
-        >>> c1 = chord.Chord(['c4', 'd-1', 'g6'])
-        >>> c1.volume = [60, 20, 120]
-        >>> [n.volume.velocity for n in c1]
-        [60, 20, 120]
-
-        >>> c1.hasComponentVolumes()
-        True
-
-        >>> c2 = chord.Chord(['c4', 'd-1', 'g6'])
-        >>> c2.volume.velocity = 23
-        >>> c2.hasComponentVolumes()
-        False
-
-        >>> c3 = chord.Chord(['c4', 'd-1', 'g6'])
-        >>> c3.volume = [0.2, 0.5, 0.8]
-        >>> [n.volume.velocity for n in c3]
-        [25, 64, 102]
-
-        >>> c4 = chord.Chord(['c4', 'd-1', 'g6'])
-        >>> c4.volume = 89
-        >>> c4.volume.velocity
-        89
-
-        >>> c4.hasComponentVolumes()
-        False
-
-        '''
-        count = 0
-        for c in self._notes:
-            # access private attribute, as property will create otherwise
-            if c.hasVolumeInformation():
-                count += 1
-        if count == len(self._notes):
-            # environLocal.printDebug(['hasComponentVolumes:', True])
-            return True
-        else:
-            # environLocal.printDebug(['hasComponentVolumes:', False])
             return False
 
     def hasRepeatedChordStep(self, chordStep, *, testRoot=None):
@@ -4372,7 +4368,6 @@ class Chord(ChordBase):
         None
         <music21.tie.Tie start>
 
-
         >>> c3 = chord.Chord('C3 F4')
         >>> c3.setTie('start', None)
         >>> c3.getTie(c3.pitches[0])
@@ -4386,13 +4381,11 @@ class Chord(ChordBase):
         >>> c4.getTie('F#4')
         <music21.tie.Tie start>
 
-
-        Error:
+        Setting a tie on a note not in the chord is an error:
 
         >>> c3.setTie('stop', 'G4')
         Traceback (most recent call last):
         music21.chord.ChordException: the given pitch is not in the Chord: G4
-
         '''
         if pitchTarget is None and self._notes:  # if no pitch
             pitchTarget = self._notes[0].pitch
@@ -4420,6 +4413,38 @@ class Chord(ChordBase):
         if not match:
             raise ChordException(
                 f'the given pitch is not in the Chord: {pitchTarget}')
+
+    def setVolume(self,
+                  vol: 'music21.volume.Volume',
+                  target: t.Union[str, note.Note, pitch.Pitch]):
+        '''
+        Set the :class:`~music21.volume.Volume` object of a specific Pitch.
+
+        Changed in v.8 -- after appearing in ChordBase in v.7, it has been properly
+            moved back to Chord itself.  The ability to change just the first note's
+            volume has been removed.  Use `Chord().volume = vol` to change the
+            volume for a whole chord.
+        '''
+        # assign to first pitch by default
+        if isinstance(target, str):
+            pitchTarget = pitch.Pitch(target)
+        elif isinstance(target, note.Note):
+            pitchTarget = target.pitch
+        elif isinstance(target, pitch.Pitch):
+            pitchTarget = target
+        else:
+            raise ValueError(f'Cannot setVolume on target {target!r}')
+
+        match = False
+        for d in self._notes:
+            if d.pitch is pitchTarget or d.pitch == pitchTarget:
+                vol.client = self
+                # noinspection PyArgumentList
+                d._setVolume(vol, setClient=False)
+                match = True
+                break
+        if not match:
+            raise ChordException(f'the given pitch is not in the Chord: {pitchTarget}')
 
     def simplifyEnharmonics(self, *, inPlace=False, keyContext=None):
         '''
@@ -4854,7 +4879,7 @@ class Chord(ChordBase):
 
 
     @property
-    def duration(self):
+    def duration(self) -> 'music21.duration.Duration':
         '''
         Get or set the duration of this Chord as a Duration object.
 
@@ -4880,14 +4905,18 @@ class Chord(ChordBase):
             # pitchZeroDuration = self._notes[0]['pitch'].duration
             pitchZeroDuration = self._notes[0].duration
             self._duration = pitchZeroDuration
-        return self._duration
+
+        d_out = self._duration
+        if t.TYPE_CHECKING:
+            assert d_out is not None
+        return d_out
 
     @duration.setter
-    def duration(self, durationObj):
+    def duration(self, durationObj: 'music21.duration.Duration'):
         '''
         Set a Duration object.
         '''
-        if hasattr(durationObj, 'quarterLength'):
+        if isinstance(durationObj, duration.Duration):
             self._duration = durationObj
         else:
             # need to permit Duration object assignment here
@@ -5548,11 +5577,11 @@ class Chord(ChordBase):
         <music21.pitch.Pitch A#4>
         '''
         # noinspection PyTypeChecker
-        pitches: t.Tuple[pitch.Pitch] = tuple(component.pitch for component in self._notes)
+        pitches: t.Tuple[pitch.Pitch, ...] = tuple(component.pitch for component in self._notes)
         return pitches
 
     @pitches.setter
-    def pitches(self, value):
+    def pitches(self, value: t.Sequence[t.Union[str, pitch.Pitch, int]]):
         self._notes = []
         self.clearCache()
         # TODO: individual ties are not being retained here
@@ -6526,7 +6555,7 @@ class Test(unittest.TestCase):
 
     def testVolumeInformation(self):
         c = Chord(['g#', 'd-'])
-        c.volume = [volume.Volume(velocity=96), volume.Volume(velocity=96)]
+        c.setVolumes([volume.Volume(velocity=96), volume.Volume(velocity=96)])
         self.assertTrue(c.hasComponentVolumes())
 
         self.assertFalse(c.hasVolumeInformation())
@@ -6605,7 +6634,7 @@ class Test(unittest.TestCase):
                 self.assertFalse(cNew.hasComponentVolumes())
             else:
                 random.shuffle(amps)
-                cNew.volume = [volume.Volume(velocityScalar=x) for x in amps]
+                cNew.setVolumes([volume.Volume(velocityScalar=x) for x in amps])
                 self.assertTrue(cNew.hasComponentVolumes())
             s.append(cNew)
 
@@ -6616,7 +6645,7 @@ class Test(unittest.TestCase):
         self.assertEqual(c.volume.velocity, 121)
         self.assertFalse(c.hasComponentVolumes())
         # set individual velocities
-        c.volume = [volume.Volume(velocity=x) for x in (30, 60, 90)]
+        c.setVolumes([volume.Volume(velocity=x) for x in (30, 60, 90)])
         # components are set
         self.assertEqual([x.volume.velocity for x in c], [30, 60, 90])
         # hasComponentVolumes is True
@@ -6637,7 +6666,7 @@ class Test(unittest.TestCase):
         self.assertEqual(c.volume.velocity, 20)
         self.assertFalse(c.hasComponentVolumes())
         # if we can still set components
-        c.volume = [volume.Volume(velocity=x) for x in (10, 20, 30)]
+        c.setVolumes([volume.Volume(velocity=x) for x in (10, 20, 30)])
         self.assertEqual([x.volume.velocity for x in c], [10, 20, 30])
         self.assertTrue(c.hasComponentVolumes())
         self.assertEqual(c._volume, None)

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -59,7 +59,7 @@ class Clef(base.Music21Object):
     >>> tc.lowestLine
     31
     '''
-    _DOC_ATTR: t.Mapping[str, str] = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'sign': '''
             The sign of the clef, generally, 'C', 'G', 'F', 'percussion', 'none' or None.
 
@@ -327,8 +327,8 @@ class PercussionClef(Clef):
     >>> pc.line is None
     True
 
-    Percussion clefs should not, technically. have a
-    lowest line, but it is a common usage to assume that
+    Percussion clefs should not, technically have a
+    "lowestLine," but it is a common usage to assume that
     in pitch-centric contexts to use the pitch numbers
     from treble clef for percussion clefs.  Thus:
 
@@ -337,7 +337,7 @@ class PercussionClef(Clef):
 
     Changed in v7.3 -- setting octaveChange no longer affects lowestLine
     '''
-    _DOC_ATTR: t.Mapping[str, str] = {}
+    _DOC_ATTR: t.Dict[str, str] = {}
 
     def __init__(self):
         super().__init__()

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -271,7 +271,7 @@ class PitchClef(Clef):
     '''
     superclass for all other clef subclasses that use pitches...
     '''
-    _DOC_ATTR: t.Mapping[str, str] = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'lowestLine': '''
             The diatonicNoteNumber of the lowest line of the clef.
             (Can be none...)
@@ -358,7 +358,7 @@ class NoClef(Clef):
     >>> nc.sign is None
     False
     '''
-    _DOC_ATTR: t.Mapping[str, str] = {}
+    _DOC_ATTR: t.Dict[str, str] = {}
 
     def __init__(self):
         super().__init__()

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -458,7 +458,9 @@ class Converter:
 
     Not a subclass, but a wrapper for different converter objects based on format.
     '''
-    _DOC_ATTR = {'subConverter': 'a ConverterXXX object that will do the actual converting.', }
+    _DOC_ATTR: t.Dict[str, str] = {
+        'subConverter': 'a ConverterXXX object that will do the actual converting.',
+    }
 
     def __init__(self):
         self.subConverter = None

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -3017,7 +3017,7 @@ class GraceDuration(Duration):
     # CLASS VARIABLES #
 
     # TODO: What does 'amount of time' mean here?
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'stealTimePrevious': '''
                 Float number from 0.0 to 1.0, or None (default) for the proportion
                 of the previous duration to steal from the previous note.''',

--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -14,7 +14,7 @@
 Classes and functions for creating and manipulating dynamic symbols. Rather than
 subclasses, the :class:`~music21.dynamics.Dynamic` object is often specialized by parameters.
 '''
-
+import typing as t
 import unittest
 
 from music21 import base

--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -194,7 +194,7 @@ class Dynamic(base.Music21Object):
     _styleClass = style.TextStyle
 
     _DOC_ORDER = ['longName', 'englishName']
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'longName': r'''
             the name of this dynamic in Italian.
 

--- a/music21/editorial.py
+++ b/music21/editorial.py
@@ -14,8 +14,8 @@
 Editorial objects store comments and other metadata associated with specific
 :class:`~music21.base.Music21Object` elements such as Notes.
 
-Some of the aspects of :class:`~music21.editorial.Editorial` objects
-represent very early (pre-v0.1) versions of music21.  Thus some of the
+Some aspects of :class:`~music21.editorial.Editorial` objects
+represent very early (pre-v0.1) versions of music21.  Thus some
 pre-defined aspects might be removed from documentation in the future.
 
 Access an editorial object by calling `.editorial` on any music21 object:
@@ -37,6 +37,7 @@ False
 >>> n.hasEditorialInformation
 True
 '''
+import typing as t
 import unittest
 from music21 import exceptions21
 from music21 import prebase

--- a/music21/editorial.py
+++ b/music21/editorial.py
@@ -85,7 +85,7 @@ class Editorial(prebase.ProtoM21Object, dict):
         :width: 103
 
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'comments': '''
             a list of :class:`~music21.editorial.Comment` objects that represent any comments
             about the object.

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -832,7 +832,7 @@ class Environment:
     _DOC_ORDER = ['read', 'write', 'getSettingsPath']
 
     # documentation for all attributes (not properties or methods)
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'modNameParent': '''
             A string representation of the module that contains this
             Environment instance.

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -328,7 +328,7 @@ class TextExpression(Expression):
     classSortOrder = -30
     _styleClass = style.TextStyle
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'placement': '''
             Staff placement: 'above', 'below', or None.
 

--- a/music21/figuredBass/notation.py
+++ b/music21/figuredBass/notation.py
@@ -141,24 +141,42 @@ class Notation(prebase.ProtoM21Object):
     '''
     _DOC_ORDER = ['notationColumn', 'figureStrings', 'numbers', 'modifiers',
                   'figures', 'origNumbers', 'origModStrings', 'modifierStrings']
-    _DOC_ATTR: t.Dict[str, str] = {'modifiers': 'A list of :class:`~music21.figuredBass.notation.Modifier` '
-                    'objects associated with the expanded '
-                    ':attr:`~music21.figuredBass.notation.Notation.notationColumn`.',
-                 'notationColumn': 'A string of figures delimited by commas, '
-                    'each associated with a number and an optional modifier.',
-                 'modifierStrings': 'The modifiers associated with the expanded '
-                    ':attr:`~music21.figuredBass.notation.Notation.notationColumn`, as strings.',
-                 'figureStrings': 'A list of figures derived from the original '
-                    ':attr:`~music21.figuredBass.notation.Notation.notationColumn`.',
-                 'origNumbers': 'The numbers associated with the original '
-                    ':attr:`~music21.figuredBass.notation.Notation.notationColumn`.',
-                 'numbers': 'The numbers associated with the expanded '
-                    ':attr:`~music21.figuredBass.notation.Notation.notationColumn`.',
-                 'origModStrings': 'The modifiers associated with the original '
-                    ':attr:`~music21.figuredBass.notation.Notation.notationColumn`, as strings.',
-                 'figures': 'A list of :class:`~music21.figuredBass.notation.Figure` objects '
-                    'associated with figures in the expanded '
-                    ':attr:`~music21.figuredBass.notation.Notation.notationColumn`.'}
+    _DOC_ATTR: t.Dict[str, str] = {
+        'modifiers': '''
+            A list of :class:`~music21.figuredBass.notation.Modifier`
+            objects associated with the expanded
+            :attr:`~music21.figuredBass.notation.Notation.notationColumn`.
+            ''',
+        'notationColumn': '''
+            A string of figures delimited by commas,
+            each associated with a number and an optional modifier.
+            ''',
+        'modifierStrings': '''
+            The modifiers associated with the expanded
+            :attr:`~music21.figuredBass.notation.Notation.notationColumn`, as strings.
+            ''',
+        'figureStrings': '''
+            A list of figures derived from the original
+            :attr:`~music21.figuredBass.notation.Notation.notationColumn`.
+            ''',
+        'origNumbers': '''
+            The numbers associated with the original
+            :attr:`~music21.figuredBass.notation.Notation.notationColumn`.
+            ''',
+        'numbers': '''
+            The numbers associated with the expanded
+            :attr:`~music21.figuredBass.notation.Notation.notationColumn`.
+            ''',
+        'origModStrings': '''
+            The modifiers associated with the original
+            :attr:`~music21.figuredBass.notation.Notation.notationColumn`, as strings.
+            ''',
+        'figures': '''
+            A list of :class:`~music21.figuredBass.notation.Figure` objects
+            associated with figures in the expanded
+            :attr:`~music21.figuredBass.notation.Notation.notationColumn`.
+            ''',
+    }
 
     def __init__(self, notationColumn=None):
         # Parse notation string

--- a/music21/figuredBass/notation.py
+++ b/music21/figuredBass/notation.py
@@ -141,7 +141,7 @@ class Notation(prebase.ProtoM21Object):
     '''
     _DOC_ORDER = ['notationColumn', 'figureStrings', 'numbers', 'modifiers',
                   'figures', 'origNumbers', 'origModStrings', 'modifierStrings']
-    _DOC_ATTR = {'modifiers': 'A list of :class:`~music21.figuredBass.notation.Modifier` '
+    _DOC_ATTR: t.Dict[str, str] = {'modifiers': 'A list of :class:`~music21.figuredBass.notation.Modifier` '
                     'objects associated with the expanded '
                     ':attr:`~music21.figuredBass.notation.Notation.notationColumn`.',
                  'notationColumn': 'A string of figures delimited by commas, '
@@ -377,7 +377,7 @@ class Figure(prebase.ProtoM21Object):
     >>> f1.modifier
     <music21.figuredBass.notation.Modifier + sharp>
     '''
-    _DOC_ATTR = {'number': 'A number associated with an expanded '
+    _DOC_ATTR: t.Dict[str, str] = {'number': 'A number associated with an expanded '
                     ':attr:`~music21.figuredBass.notation.Notation.notationColumn`.',
                  'modifierString': 'A modifier string associated with an '
                     'expanded :attr:`~music21.figuredBass.notation.Notation.notationColumn`.',
@@ -457,7 +457,7 @@ class Modifier(prebase.ProtoM21Object):
     >>> m3b.accidental is None
     True
     '''
-    _DOC_ATTR = {'modifierString': 'A modifier string associated with an '
+    _DOC_ATTR: t.Dict[str, str] = {'modifierString': 'A modifier string associated with an '
                     'expanded :attr:`~music21.figuredBass.notation.Notation.notationColumn`.',
                  'accidental': ' A :class:`~music21.pitch.Accidental` corresponding to '
                     ':attr:`~music21.figuredBass.notation.Modifier.modifierString`.'}

--- a/music21/figuredBass/notation.py
+++ b/music21/figuredBass/notation.py
@@ -7,10 +7,10 @@
 # Copyright:    Copyright © 2011 Michael Scott Asato Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
-
-import unittest
 import copy
 import re
+import typing as t
+import unittest
 
 from music21 import exceptions21
 from music21 import pitch

--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -220,7 +220,7 @@ class FiguredBassLine:
     <music21.meter.TimeSignature 3/4>
     '''
     _DOC_ORDER = ['addElement', 'generateBassLine', 'realize']
-    _DOC_ATTR = {'inKey': 'A :class:`~music21.key.Key` which implies a scale value, '
+    _DOC_ATTR: t.Dict[str, str] = {'inKey': 'A :class:`~music21.key.Key` which implies a scale value, '
                     'scale mode, and key signature for a '
                     ':class:`~music21.figuredBass.realizerScale.FiguredBassScale`.',
                  'inTime': 'A :class:`~music21.meter.TimeSignature` which specifies the '
@@ -572,7 +572,7 @@ class Realization:
                   'generateRandomRealizations', 'generateAllRealizations',
                   'getAllPossibilityProgressions', 'getRandomPossibilityProgression',
                   'generateRealizationFromPossibilityProgression']
-    _DOC_ATTR = {'keyboardStyleOutput': '''True by default. If True, generated realizations
+    _DOC_ATTR: t.Dict[str, str] = {'keyboardStyleOutput': '''True by default. If True, generated realizations
                         are represented in keyboard style, with two staves. If False,
                         realizations are represented in chorale style with n staves,
                         where n is the number of parts. SATB if n = 4.'''}

--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -220,12 +220,18 @@ class FiguredBassLine:
     <music21.meter.TimeSignature 3/4>
     '''
     _DOC_ORDER = ['addElement', 'generateBassLine', 'realize']
-    _DOC_ATTR: t.Dict[str, str] = {'inKey': 'A :class:`~music21.key.Key` which implies a scale value, '
-                    'scale mode, and key signature for a '
-                    ':class:`~music21.figuredBass.realizerScale.FiguredBassScale`.',
-                 'inTime': 'A :class:`~music21.meter.TimeSignature` which specifies the '
-                    'time signature of realizations outputted to a '
-                    ':class:`~music21.stream.Score`.'}
+    _DOC_ATTR: t.Dict[str, str] = {
+        'inKey': '''
+            A :class:`~music21.key.Key` which implies a scale value,
+            scale mode, and key signature for a
+            :class:`~music21.figuredBass.realizerScale.FiguredBassScale`.
+            ''',
+        'inTime': '''
+            A :class:`~music21.meter.TimeSignature` which specifies the
+            time signature of realizations outputted to a
+            :class:`~music21.stream.Score`.
+            ''',
+    }
 
     def __init__(self, inKey=None, inTime=None):
         if inKey is None:
@@ -572,10 +578,13 @@ class Realization:
                   'generateRandomRealizations', 'generateAllRealizations',
                   'getAllPossibilityProgressions', 'getRandomPossibilityProgression',
                   'generateRealizationFromPossibilityProgression']
-    _DOC_ATTR: t.Dict[str, str] = {'keyboardStyleOutput': '''True by default. If True, generated realizations
-                        are represented in keyboard style, with two staves. If False,
-                        realizations are represented in chorale style with n staves,
-                        where n is the number of parts. SATB if n = 4.'''}
+    _DOC_ATTR: t.Dict[str, str] = {
+        'keyboardStyleOutput': '''
+            True by default. If True, generated realizations
+            are represented in keyboard style, with two staves. If False,
+            realizations are represented in chorale style with n staves,
+            where n is the number of parts. SATB if n = 4.''',
+    }
 
     def __init__(self, **fbLineOutputs):
         # fbLineOutputs always will have three elements, checks are for sphinx documentation only.

--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -41,10 +41,10 @@ See :meth:`~music21.figuredBass.realizer.figuredBassFromStream` for more details
 >>> allSols2.getNumSolutions()
 30
 '''
-
 import collections
 import copy
 import random
+import typing as t
 import unittest
 
 

--- a/music21/figuredBass/realizerScale.py
+++ b/music21/figuredBass/realizerScale.py
@@ -9,6 +9,7 @@
 # ------------------------------------------------------------------------------
 import copy
 import itertools
+import typing as t
 import unittest
 
 from music21 import exceptions21

--- a/music21/figuredBass/realizerScale.py
+++ b/music21/figuredBass/realizerScale.py
@@ -50,7 +50,7 @@ class FiguredBassScale:
     >>> fbScale.keySig
     <music21.key.KeySignature of 1 flat>
     '''
-    _DOC_ATTR = {'realizerScale': 'A :class:`~music21.scale.Scale` based on the '
+    _DOC_ATTR: t.Dict[str, str] = {'realizerScale': 'A :class:`~music21.scale.Scale` based on the '
                     'desired value and mode.',
                  'keySig': 'A :class:`~music21.key.KeySignature` corresponding to '
                     'the scale value and mode.'}

--- a/music21/figuredBass/rules.py
+++ b/music21/figuredBass/rules.py
@@ -143,7 +143,11 @@ class Rules(prebase.ProtoM21Object):
     _DOC_ORDER = ([_x[0] for _x in singlePossibilityDoc]
                   + [_y[0] for _y in consecutivePossibilityDoc]
                   + [_z[0] for _z in specialResDoc])
-    _DOC_ATTR: t.Dict[str, str] = dict(singlePossibilityDoc + consecutivePossibilityDoc + specialResDoc)
+    _DOC_ATTR: t.Dict[str, str] = dict(
+        singlePossibilityDoc
+        + consecutivePossibilityDoc
+        + specialResDoc
+    )
 
     def __init__(self):
         # Single Possibility rules

--- a/music21/figuredBass/rules.py
+++ b/music21/figuredBass/rules.py
@@ -143,7 +143,7 @@ class Rules(prebase.ProtoM21Object):
     _DOC_ORDER = ([_x[0] for _x in singlePossibilityDoc]
                   + [_y[0] for _y in consecutivePossibilityDoc]
                   + [_z[0] for _z in specialResDoc])
-    _DOC_ATTR = dict(singlePossibilityDoc + consecutivePossibilityDoc + specialResDoc)
+    _DOC_ATTR: t.Dict[str, str] = dict(singlePossibilityDoc + consecutivePossibilityDoc + specialResDoc)
 
     def __init__(self):
         # Single Possibility rules

--- a/music21/figuredBass/rules.py
+++ b/music21/figuredBass/rules.py
@@ -7,7 +7,7 @@
 # Copyright:    Copyright © 2010 Michael Scott Asato Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
-
+import typing as t
 import unittest
 from music21 import exceptions21
 from music21 import prebase

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -42,7 +42,7 @@ class Segment:
                   'resolveDominantSeventhSegment',
                   'resolveDiminishedSeventhSegment',
                   'resolveAugmentedSixthSegment']
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'bassNote': '''A :class:`~music21.note.Note` whose pitch
              forms the bass of each possibility.''',
         'numParts': '''The number of parts (including the bass) that possibilities

--- a/music21/graph/axis.py
+++ b/music21/graph/axis.py
@@ -17,8 +17,9 @@ Definitions for extracting data from a Stream to place on one axis of a
 '''
 import collections
 import math
-import unittest
 import re
+import typing as t
+import unittest
 
 from music21.graph.utilities import accidentalLabelToUnicode, GraphException
 

--- a/music21/graph/axis.py
+++ b/music21/graph/axis.py
@@ -44,7 +44,7 @@ class Axis(prebase.ProtoM21Object):
     Client should be a .plot.PlotStream or None.  Eventually a Stream may be allowed,
     but not yet.
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'axisName': 'the name of the axis.  One of "x" or "y" or for 3D Plots, "z"',
         'minValue': '''
             None or number representing the axis minimum.  Default None.
@@ -291,7 +291,7 @@ class PitchAxis(Axis):
     '''
     Axis subclass for dealing with Pitches
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'showEnharmonic': '''
             bool on whether to show both common enharmonics in labels, default True
             ''',
@@ -737,7 +737,7 @@ class PositionAxis(Axis):
     '''
     Axis subclass for dealing with Positions
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'graceNoteQL': '''
             length to substitute a grace note or other Zero-length element for.
             Default is the length of a 64th note (1/16 of a QL)
@@ -756,7 +756,7 @@ class OffsetAxis(PositionAxis):
     '''
     Axis subclass for dealing with Offsets
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'useMeasures': '''
             bool or None for whether offsets (False) or measure numbers (True) should be used
             in the case of an offset access.  Default, None, meaning to check whether
@@ -1106,7 +1106,7 @@ class QuarterLengthAxis(PositionAxis):
     '''
     Axis subclass for dealing with QuarterLengths
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'useLogScale': '''
             bool or int for whether to scale numbers logarithmically.  Adds (log2) to the
             axis label if used.  If True (default) then log2 is assumed.  If an int, then
@@ -1254,7 +1254,7 @@ class OffsetEndAxis(OffsetAxis):
     '''
     An Axis that gives beginning and ending values for each element
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'noteSpacing': '''
             amount in QL to leave blank between untied notes.
             (default = self.graceNoteQL)
@@ -1344,7 +1344,7 @@ class CountingAxis(Axis):
     >>> plotS.data
     [(42.0, 1, {}), (45.0, 1, {}), (46.0, 1, {}), (47.0, 5, {}), (49.0, 6, {}), ...]
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'countAxes': '''
             a string or tuple of strings representing an axis or axes to use in counting
             ''',

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -590,7 +590,7 @@ class GraphNetworkxGraph(Graph):
     #
     # .. image:: images/GraphNetworkxGraph.*
     #     :width: 600
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'networkxGraph': '''An instance of a networkx graph object.''',
         'hideLeftBottomSpines': 'bool to hide the left and bottom axis spines; default True',
     }
@@ -687,7 +687,7 @@ class GraphColorGrid(Graph):
     .. image:: images/GraphColorGrid.*
         :width: 600
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'hideLeftBottomSpines': 'bool to hide the left and bottom axis spines; default True',
     }
 
@@ -794,7 +794,7 @@ class GraphColorGridLegend(Graph):
         :width: 600
 
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'hideLeftBottomSpines': 'bool to hide the left and bottom axis spines; default True',
     }
 
@@ -954,7 +954,7 @@ class GraphHorizontalBar(Graph):
         `('', [], {})`
 
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'barSpace': 'Amount of vertical space each bar takes; default 8',
         'margin': '''
             Vertical space above and below the bars, default 2 (= total4 space between bars)
@@ -1064,7 +1064,7 @@ class GraphHorizontalBarWeighted(Graph):
     can have different heights and colors within their
     respective channel.
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'barSpace': 'Amount of vertical space each bar takes; default 8',
         'margin': 'Space around the bars, default 2',
     }
@@ -1210,7 +1210,7 @@ class GraphScatterWeighted(Graph):
         :width: 600
 
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'maxDiameter': 'the maximum diameter of any ellipse, default 1.25',
         'minDiameter': 'the minimum diameter of any ellipse, default 0.25',
     }
@@ -1411,7 +1411,7 @@ class GraphHistogram(Graph):
     .. image:: images/GraphHistogram.*
         :width: 600
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'binWidth': '''
             Size of each bin; if the bins are equally spaced at intervals of 1,
             then 0.8 is a good default to allow a little space. 1.0 will give no

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -43,6 +43,8 @@ SpineParsing consists of several steps.
 * Stream elements are moved into their measures within a Stream
 * Measures are searched for elements with voice groups and Voice objects are created
 '''
+from __future__ import annotations
+
 import copy
 import math
 import re
@@ -1040,8 +1042,8 @@ class HumdrumSpine(prebase.ProtoM21Object):
     <music21.stream.Part ...>
     '''
 
-    def __init__(self, spineId=0, eventList=None, streamClass=stream.Stream):
-        self.id = spineId
+    def __init__(self, spineId: int = 0, eventList=None, streamClass=stream.Stream):
+        self.id: int = spineId
         if eventList is None:
             eventList = []
         for event in eventList:
@@ -1054,8 +1056,8 @@ class HumdrumSpine(prebase.ProtoM21Object):
         self.parentSpine = None
         self.newSpine = None
         self.isLastSpine = False
-        self.childSpines = []
-        self.childSpineInsertPoints = {}
+        self.childSpines: t.List[HumdrumSpine] = []
+        self.childSpineInsertPoints: t.Dict[int, t.Tuple[HumdrumSpine, ...]] = {}
 
         self.parsed = False
         self.measuresMoved = False
@@ -1064,7 +1066,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
         self._spineCollection = None
         self._spineType = None
 
-        self.isFirstVoice = None
+        self.isFirstVoice: t.Union[bool, None] = None
         self.iterIndex = None
 
     def _reprInternal(self):
@@ -1291,7 +1293,7 @@ class KernSpine(HumdrumSpine):
     are kern notes
     '''
 
-    def __init__(self, spineId=0, eventList=None, streamClass=stream.Stream):
+    def __init__(self, spineId: int = 0, eventList=None, streamClass=stream.Stream):
         super().__init__(spineId, eventList, streamClass)
         self.lastContainer = None
         self.inTuplet = None
@@ -1565,12 +1567,11 @@ class SpineEvent(prebase.ProtoM21Object):
     >>> n
     <music21.note.Note E->
     '''
-    protoSpineId = 0
-    spineId = None
-
     def __init__(self, contents=None, position=0):
         self.contents = contents
         self.position = position
+        self.protoSpineId: int = 0
+        self.spineId: t.Optional[int] = None
 
     def _reprInternal(self):
         return str(self.contents)

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -1622,7 +1622,7 @@ class DiatonicInterval(IntervalBase):
     Traceback (most recent call last):
     music21.interval.IntervalException: There is no such thing as a descending Perfect Unison
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'specifier': 'A :class:`~music21.interval.Specifier` enum representing '
                      + 'the Quality of the interval.',
         'generic': 'A :class:`~music21.interval.GenericInterval` enum representing '

--- a/music21/key.py
+++ b/music21/key.py
@@ -928,7 +928,7 @@ class Key(KeySignature, scale.DiatonicScale):
     <music21.key.Key of f# minor>
     '''
     _sharps = 0
-    _mode = None
+    _mode: t.Optional[str] = None
     tonic: pitch.Pitch
 
     def __init__(self,

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -367,7 +367,7 @@ class StaffLayout(LayoutBase):
 
     Note: (TODO: .hidden None is not working; always gives False)
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'staffType': '''
             What kind of staff is this as a stream.enums.StaffType.
 

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -436,7 +436,7 @@ class TimeSignature(base.Music21Object):
     _styleClass = style.TextStyle
     classSortOrder = 4
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'beatSequence': 'A :class:`~music21.meter.MeterSequence` governing beat partitioning.',
         'beamSequence': 'A :class:`~music21.meter.MeterSequence` governing automatic beaming.',
         'accentSequence': 'A :class:`~music21.meter.MeterSequence` governing accent partitioning.',

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -998,7 +998,6 @@ def midiEventsToTimeSignature(eventList):
     # Time Signature Event should appear in the first track chunk (or all track
     # chunks in a Type 2 file) before any non-zero delta time events. If one
     # is not specified 4/4, 24, 8 should be assumed.
-    from music21 import meter
     from music21 import midi as midiModule
 
     if not common.isListLike(eventList):
@@ -2138,7 +2137,6 @@ def midiTrackToStream(
 
             # Supply any missing time signature at the start
             if not meterStream.getElementsByOffset(0):
-                from music21 import meter
                 meterStream.insert(0, meter.TimeSignature())
 
     # Only make measures once time signatures have been inserted
@@ -2255,7 +2253,6 @@ def conductorStream(s: stream.Stream) -> stream.Part:
         {0.0} <music21.stream.Stream measureLike>
             {0.0} <music21.note.Note C>
     '''
-    from music21 import meter
     partsList = list(s.getElementsByClass(stream.Stream).getElementsByOffset(0))
     minPriority = min(p.priority for p in partsList) if partsList else 0
     conductorPriority = minPriority - 1
@@ -3008,7 +3005,6 @@ class Test(unittest.TestCase):
             [ChannelVoiceMessages.NOTE_ON, ChannelVoiceMessages.NOTE_OFF] * 3)
 
     def testTimeSignature(self):
-        from music21 import meter
         n = note.Note()
         n.quarterLength = 0.5
         s = stream.Stream()
@@ -3046,8 +3042,6 @@ class Test(unittest.TestCase):
         self.assertTrue(common.whitespaceEqual(conductorEvents, match), conductorEvents)
 
     def testKeySignature(self):
-        from music21 import meter
-
         n = note.Note()
         n.quarterLength = 0.5
         s = stream.Stream()
@@ -3331,8 +3325,6 @@ class Test(unittest.TestCase):
         # s.show('midi')
 
     def testOverlappedEventsC(self):
-        from music21 import meter
-
         s = stream.Stream()
         s.insert(key.KeySignature(3))
         s.insert(meter.TimeSignature('2/4'))
@@ -3676,8 +3668,6 @@ class Test(unittest.TestCase):
 
     def testMidiExportConductorA(self):
         '''Export conductor data to MIDI conductor track.'''
-        from music21 import meter
-
         p1 = stream.Part()
         p1.repeatAppend(note.Note('c4'), 12)
         p1.insert(0, meter.TimeSignature('3/4'))
@@ -3814,13 +3804,13 @@ class Test(unittest.TestCase):
                 c = note.Rest()
             else:
                 c = chord.Chord(['c3', 'd-4', 'g5'])
-                vChord = []
+                vChord: t.List[volume.Volume] = []
                 for i, unused_cSub in enumerate(c):
                     v = volume.Volume()
                     v.velocityScalar = amps[(j + shift[i]) % len(amps)]
                     v.velocityIsRelative = False
                     vChord.append(v)
-                c.volume = vChord  # can set to list
+                c.setVolumes(vChord)
             c.duration.quarterLength = ql
             s1.append(c)
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -28,7 +28,7 @@ from xml.etree.ElementTree import (
 import typing as t
 
 # external dependencies
-import webcolors
+import webcolors  # type: ignore
 
 # modules that import this include converter.py.
 # thus, cannot import these here

--- a/music21/note.py
+++ b/music21/note.py
@@ -1104,7 +1104,7 @@ class NotRest(GeneralNote):
 
         >>> n.noteheadFill = 'jelly'
         Traceback (most recent call last):
-        music21.note.NotRestException: not a valid notehead fill value: jelly
+        music21.note.NotRestException: not a valid notehead fill value: 'jelly'
         '''
         return self._noteheadFill
 

--- a/music21/note.py
+++ b/music21/note.py
@@ -540,7 +540,7 @@ class GeneralNote(base.Music21Object):
     # define order for presenting names in documentation; use strings
     _DOC_ORDER = ['duration', 'quarterLength']
     # documentation for all attributes (not properties or methods)
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'isChord': 'Boolean read-only value describing if this object is a Chord.',
         'lyrics': 'A list of :class:`~music21.note.Lyric` objects.',
         'tie': 'either None or a :class:`~music21.note.Tie` object.',
@@ -931,7 +931,7 @@ class NotRest(GeneralNote):
     # unspecified means that there may be a stem, but its orientation
     # has not been declared.
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'beams': '''
             A :class:`~music21.beam.Beams` object that contains
             information about the beaming of this note.''',
@@ -939,11 +939,11 @@ class NotRest(GeneralNote):
 
     def __init__(self, *arguments, **keywords):
         super().__init__(**keywords)
-        self._notehead = 'normal'
+        self._notehead: str = 'normal'
         self._noteheadFill = None
-        self._noteheadParenthesis = False
-        self._stemDirection = 'unspecified'
-        self._volume = None  # created on demand
+        self._noteheadParenthesis: bool = False
+        self._stemDirection: str = 'unspecified'
+        self._volume: t.Optional[volume.Volume] = None  # created on demand
         # replace
         self.linkage = 'tie'
         if 'beams' in keywords:
@@ -1088,7 +1088,7 @@ class NotRest(GeneralNote):
         self._notehead = value
 
     @property
-    def noteheadFill(self) -> str:
+    def noteheadFill(self) -> bool:
         '''
         Get or set the note head fill status of this NotRest. Valid note head fill values are
         True, False, or None (meaning default).  "yes" and "no" are converted to True
@@ -1109,16 +1109,16 @@ class NotRest(GeneralNote):
         return self._noteheadFill
 
     @noteheadFill.setter
-    def noteheadFill(self, value):
+    def noteheadFill(self, value: t.Union[bool, None, str]):
         if value in ('none', None, 'default'):
-            value = None  # allow setting to none or None
-        if value in ('filled', 'yes'):
-            value = True
-        elif value in ('notfilled', 'no'):
-            value = False
-        if value not in (True, False, None):
-            raise NotRestException(f'not a valid notehead fill value: {value}')
-        self._noteheadFill = value
+            boolValue = None  # allow setting to none or None
+        elif value in (True, 'filled', 'yes'):
+            boolValue = True
+        elif value in (False, 'notfilled', 'no'):
+            boolValue = False
+        else:
+            raise NotRestException(f'not a valid notehead fill value: {value!r}')
+        self._noteheadFill = boolValue
 
     @property
     def noteheadParenthesis(self) -> bool:
@@ -1147,14 +1147,15 @@ class NotRest(GeneralNote):
         return self._noteheadParenthesis
 
     @noteheadParenthesis.setter
-    def noteheadParenthesis(self, value):
+    def noteheadParenthesis(self, value: t.Union[bool, str, int]):
+        boolValue: bool
         if value in (True, 'yes', 1):
-            value = True
+            boolValue = True
         elif value in (False, 'no', 0):
-            value = False
+            boolValue = False
         else:
             raise NotRestException(f'notehead parentheses must be True or False, not {value!r}')
-        self._noteheadParenthesis = value
+        self._noteheadParenthesis = boolValue
 
     # --------------------------------------------------------------------------
     def hasVolumeInformation(self) -> bool:
@@ -1384,7 +1385,7 @@ class Note(NotRest):
     # Defines the order of presenting names in the documentation; use strings
     _DOC_ORDER = ['duration', 'quarterLength', 'nameWithOctave']
     # documentation for all attributes (not properties or methods)
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'isNote': 'Boolean read-only value describing if this Note is a Note (True).',
         'isRest': 'Boolean read-only value describing if this Note is a Rest (False).',
         'pitch': '''A :class:`~music21.pitch.Pitch` object containing all the
@@ -1545,10 +1546,10 @@ class Note(NotRest):
         See `Pitch`'s attribute :attr:`~music21.pitch.Pitch.nameWithOctave`.
         ''')
 
-    def _getStep(self) -> str:
+    def _getStep(self) -> StepName:
         return self.pitch.step
 
-    def _setStep(self, value: str):
+    def _setStep(self, value: StepName):
         self.pitch.step = value
 
     step = property(_getStep,
@@ -1558,10 +1559,10 @@ class Note(NotRest):
         See :attr:`~music21.pitch.Pitch.step`.
         ''')
 
-    def _getOctave(self) -> int:
+    def _getOctave(self) -> t.Optional[int]:
         return self.pitch.octave
 
-    def _setOctave(self, value: int):
+    def _setOctave(self, value: t.Optional[int]):
         self.pitch.octave = value
 
     octave = property(_getOctave,
@@ -1845,7 +1846,7 @@ class Rest(GeneralNote):
     isRest = True
     name = 'rest'
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'isNote': 'Boolean read-only value describing if this Rest is a Note (False).',
         'isRest': 'Boolean read-only value describing if this Rest is a Rest (True, obviously).',
         'name': '''returns "rest" always.  It is here so that you can get

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -873,7 +873,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
     _DOC_ORDER = ['name', 'modifier', 'alter', 'set']
 
     # documentation for all attributes (not properties or methods)
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'displaySize': 'Size in display: "cue", "large", or a percentage.',
         'displayStyle': 'Style of display: "parentheses", "bracket", "both".',
         'displayLocation': 'Location of accidental: "normal", "above", "below".',
@@ -1737,13 +1737,13 @@ class Pitch(prebase.ProtoM21Object):
     _DOC_ORDER = ['name', 'nameWithOctave', 'step', 'pitchClass', 'octave', 'midi', 'german',
                   'french', 'spanish', 'italian', 'dutch']
     # documentation for all attributes (not properties or methods)
-    # _DOC_ATTR = {
+    # _DOC_ATTR: t.Dict[str, str] = {
     # }
 
     # constants shared by all classes
     _twelfth_root_of_two = TWELFTH_ROOT_OF_TWO
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'spellingIsInferred': '''
             Returns True or False about whether enharmonic spelling
             Has been inferred on pitch creation or whether it has

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -1949,7 +1949,7 @@ class RepeatFinder:
                   'getQuarterLengthOfPickupMeasure',
                   'hasPickup']
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'defaultHash': r'''A function that takes a stream of notes and rests and
                                 returns a string or an
                                 integer such that two measures are equal if their

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -1731,7 +1731,7 @@ class RomanNumeral(harmony.Harmony):
     _aug6defaultInversions = {'It': '6', 'Fr': '43', 'Ger': '65', 'Sw': '43'}
     _slashedAug6Inv = re.compile(r'(\d)/(\d)')
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'addedSteps': '''
             Returns a list of the added steps, each as a tuple of
             modifier as a string (which might be empty) and a chord factor as an int.

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -372,8 +372,8 @@ class CTSong(prebase.ProtoM21Object):
         Get the comments list of all CTRule objects.
 
         comments are stored as a list of comments, each comment on a line as a list. If the
-        comment is on a rule line, the list contains both the line's LHS (like In:) and the comment
-        if the comment is on a line of its own, only the comment is
+        comment is on a rule line, the list contains both the line's LHS (like "In:")
+        and the comment if the comment is on a line of its own, only the comment is
         appended as a list of length one.
 
         The title is not a comment. The title is stored under self.title
@@ -546,7 +546,10 @@ class CTRule(prebase.ProtoM21Object):
     which is the stream from the entire score that the rule corresponds to.
     '''
     _DOC_ORDER = ['LHS', 'sectionName', 'musicText', 'homeTimeSig', 'homeKeySig', 'comments']
-    _DOC_ATTR: t.Dict[str, str] = {'text': 'the full text of the CTRule, including the LHS, chords, and comments'}
+    _DOC_ATTR: t.Dict[str, str] = {
+        'text': '''
+            The full text of the CTRule, including the LHS, chords, and comments.''',
+    }
 
     SPLITMEASURES = re.compile(r'(\|\*?\d*)')
     REPETITION = re.compile(r'\*(\d+)')

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -286,7 +286,7 @@ class CTSong(prebase.ProtoM21Object):
 
     """
     _DOC_ORDER = ['text', 'toScore', 'title', 'homeTimeSig', 'homeKeySig', 'comments', 'rules']
-    _DOC_ATTR = {'year': 'the year of the CTSong; not formally defined '
+    _DOC_ATTR: t.Dict[str, str] = {'year': 'the year of the CTSong; not formally defined '
                          + 'by the Clercq-Temperley format'}
 
     def __init__(self, textFile, **keywords):
@@ -545,7 +545,7 @@ class CTRule(prebase.ProtoM21Object):
     which is the stream from the entire score that the rule corresponds to.
     '''
     _DOC_ORDER = ['LHS', 'sectionName', 'musicText', 'homeTimeSig', 'homeKeySig', 'comments']
-    _DOC_ATTR = {'text': 'the full text of the CTRule, including the LHS, chords, and comments'}
+    _DOC_ATTR: t.Dict[str, str] = {'text': 'the full text of the CTRule, including the LHS, chords, and comments'}
 
     SPLITMEASURES = re.compile(r'(\|\*?\d*)')
     REPETITION = re.compile(r'\*(\d+)')

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -18,6 +18,7 @@ information may be located at http://rockcorpus.midside.com
 import copy
 import io
 import re
+import typing as t
 import unittest
 
 from collections import OrderedDict

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -6,7 +6,7 @@
 # Authors:      Christopher Ariza
 #               Michael Scott Asato Cuthbert
 #
-# Copyright:    Copyright © 2010-2012, 2015-16 Michael Scott Asato Cuthbert and the music21 Project
+# Copyright:    Copyright © 2010-2022 Michael Scott Asato Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
@@ -2185,7 +2185,7 @@ class IntervalNetwork:
 
         '''
         # noinspection PyPackageRequirements
-        import networkx  # pylint: disable=import-error
+        import networkx  # type: ignore  # pylint: disable=import-error
         weight = 1
         style = 'solid'
 

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -16,6 +16,7 @@ See User's Guide, Chapter 43: Searching in and Among Scores for details.
 import copy
 import difflib
 import math
+import typing as t
 import unittest
 from collections import namedtuple
 

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -80,7 +80,7 @@ class SearchMatch(namedtuple('SearchMatch', ['elStart', 'els', 'index', 'iterato
     A lightweight object representing the match (if any) for a search.  Derived from namedtuple
     '''
     __slots__ = ()
-    _DOC_ATTR = {'elStart': '''The first element that matches the list.''',
+    _DOC_ATTR: t.Dict[str, str] = {'elStart': '''The first element that matches the list.''',
                  'els': '''A tuple of all the matching elements.''',
                  'index': '''The index in the iterator at which the first element can be found''',
                  'iterator': '''The iterator which produced these elements.''',

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -26,7 +26,7 @@ from music21 import base as m21Base
 from music21 import exceptions21
 from music21 import duration
 from music21 import note
-from music21.stream import Measure
+from music21.stream import Measure, Stream
 from music21.stream import filters
 
 __all__ = [
@@ -81,11 +81,12 @@ class SearchMatch(namedtuple('SearchMatch', ['elStart', 'els', 'index', 'iterato
     A lightweight object representing the match (if any) for a search.  Derived from namedtuple
     '''
     __slots__ = ()
-    _DOC_ATTR: t.Dict[str, str] = {'elStart': '''The first element that matches the list.''',
-                 'els': '''A tuple of all the matching elements.''',
-                 'index': '''The index in the iterator at which the first element can be found''',
-                 'iterator': '''The iterator which produced these elements.''',
-                 }
+    _DOC_ATTR: t.Dict[str, str] = {
+        'elStart': '''The first element that matches the list.''',
+        'els': '''A tuple of all the matching elements.''',
+        'index': '''The index in the iterator at which the first element can be found''',
+        'iterator': '''The iterator which produced these elements.''',
+    }
 
     def __repr__(self):
         return 'SearchMatch(elStart={0}, els=len({1}), index={2}, iterator=[...])'.format(
@@ -200,7 +201,12 @@ class StreamSearcher:
         self.filterNotes = False
         self.filterNotesAndRests = False
 
-        self.algorithms = [StreamSearcher.wildcardAlgorithm]
+        self.algorithms: t.List[
+                                t.Callable[
+                                           [Stream, m21Base.Music21Object],
+                                           t.Union[bool, None]
+                                ]
+        ] = [StreamSearcher.wildcardAlgorithm]
 
         self.activeIterator = None
 

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -202,10 +202,8 @@ class StreamSearcher:
         self.filterNotesAndRests = False
 
         self.algorithms: t.List[
-                                t.Callable[
-                                           [Stream, m21Base.Music21Object],
-                                           t.Union[bool, None]
-                                ]
+            t.Callable[[Stream, m21Base.Music21Object],
+                       t.Union[bool, None]]
         ] = [StreamSearcher.wildcardAlgorithm]
 
         self.activeIterator = None

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -70,20 +70,30 @@ class SearchMatch(namedtuple('SearchMatch',
     A lightweight object representing the match (if any) for a search.
     '''
     __slots__ = ()
-    _DOC_ATTR: t.Dict[str, str] = {'mStart': '''The measureNumber of the measure that the first
-                                matching lyric is in''',
-                 'mEnd': '''The measureNumber of the measure that the last
-                                matching lyric is in''',
-                 'matchText': '''The text of the lyric that matched the search.  For a
-                                 plaintext search, this will be the same as the search
-                                 term, but for a regular expression
-                                 search this will be the text that matched the regular
-                                 expression''',
-                 'els': '''A list of all lyric-containing elements that matched this text.''',
-                 'indices': '''A list of IndexedLyric objects that match''',
-                 'identifier': '''The identifier of (presumably all,
-                                  but at least the first) lyric to match''',
-                 }
+    _DOC_ATTR: t.Dict[str, str] = {
+        'mStart': '''
+            The measureNumber of the measure that the first matching lyric is in.
+            ''',
+        'mEnd': '''
+            The measureNumber of the measure that the last matching lyric is in.
+            ''',
+        'matchText': '''
+            The text of the lyric that matched the search.  For a
+            plaintext search, this will be the same as the search
+            term, but for a regular expression
+            search this will be the text that matched the regular
+            expression.
+            ''',
+        'els': '''
+            A list of all lyric-containing elements that matched this text.
+            ''',
+        'indices': '''
+            A list of IndexedLyric objects that match.
+            ''',
+        'identifier': '''
+            The identifier of (presumably all, but at least the first) lyric to match.
+            ''',
+    }
 
     def __repr__(self):
         return (f'SearchMatch(mStart={self.mStart!r}, mEnd={self.mEnd!r}, '
@@ -144,7 +154,7 @@ class LyricSearcher:
 
     @property
     def indexTuples(self) -> t.List[IndexedLyric]:
-        if self._indexText is None:  # correct -- check text to see if has run.
+        if self._indexText is None:  # correct -- check text to see if it has run.
             self.index()
         return self._indexTuples
 

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -34,7 +34,7 @@ class IndexedLyric(namedtuple(
 
     '''
     __slots__ = ()
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'el': 'the element that the lyric is attached to',
         'start': '''Suppose that the entire lyric for the stream were a single string:
                  this is the index of the position in the string that this
@@ -70,7 +70,7 @@ class SearchMatch(namedtuple('SearchMatch',
     A lightweight object representing the match (if any) for a search.
     '''
     __slots__ = ()
-    _DOC_ATTR = {'mStart': '''The measureNumber of the measure that the first
+    _DOC_ATTR: t.Dict[str, str] = {'mStart': '''The measureNumber of the measure that the first
                                 matching lyric is in''',
                  'mEnd': '''The measureNumber of the measure that the last
                                 matching lyric is in''',

--- a/music21/search/segment.py
+++ b/music21/search/segment.py
@@ -292,7 +292,7 @@ def getDifflibOrPyLev(
     else:
         try:
             # noinspection PyPackageRequirements
-            from Levenshtein import StringMatcher as pyLevenshtein
+            from Levenshtein import StringMatcher as pyLevenshtein  # type: ignore
             smObject = pyLevenshtein.StringMatcher(junk, '', seq2)
         except ImportError:
             smObject = difflib.SequenceMatcher(junk, '', seq2)

--- a/music21/search/serial.py
+++ b/music21/search/serial.py
@@ -47,7 +47,7 @@ class ContiguousSegmentOfNotes(base.Music21Object):
     <music21.search.serial.ContiguousSegmentOfNotes ['C4', 'D4']>
 
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'segment': 'The list of notes and chords in the contiguous segment.',
         'containerStream': '''
             The stream containing the contiguous segment -

--- a/music21/search/serial.py
+++ b/music21/search/serial.py
@@ -9,11 +9,11 @@
 # Copyright:    Copyright © 2009-2012, 2016 Michael Scott Asato Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # -------------------------------------------------
-import copy
-import unittest
-
 from collections import Counter
+import copy
 from operator import attrgetter
+import typing as t
+import unittest
 
 from music21 import base
 from music21 import common

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -282,7 +282,7 @@ class ToneRow(stream.Stream):
     >>> len(rcsRow)
     10
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'row': 'A list representing the pitch class values of the row.',
     }
 
@@ -669,7 +669,7 @@ class TwelveToneRow(ToneRow):
     '''
     # row = None
 
-    # _DOC_ATTR = {
+    # _DOC_ATTR: t.Dict[str, str] = {
     # 'row': 'A list representing the pitch class values of the row.',
     # }
 
@@ -1097,7 +1097,7 @@ class HistoricalTwelveToneRow(TwelveToneRow):
     Subclass of :class:`~music21.serial.TwelveToneRow` storing additional attributes of a
     twelve-tone row used in the historical literature.
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'composer': 'The name of the composer.',
         'opus': 'The opus of the work, or None.',
         'title': 'The title of the work.',

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -1145,7 +1145,7 @@ class MultiMeasureRest(Spanner):
     '''
     _styleClass = style.TextStyle
 
-    _DOC_ATTR = {'useSymbols': '''boolean to indicate whether rest symbols
+    _DOC_ATTR: t.Dict[str, str] = {'useSymbols': '''boolean to indicate whether rest symbols
                                     (breve, longa, etc.) should be used when
                                     displaying the rest. Your music21 inventor
                                     is a medievalist, so this defaults to True.

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -1145,23 +1145,26 @@ class MultiMeasureRest(Spanner):
     '''
     _styleClass = style.TextStyle
 
-    _DOC_ATTR: t.Dict[str, str] = {'useSymbols': '''boolean to indicate whether rest symbols
-                                    (breve, longa, etc.) should be used when
-                                    displaying the rest. Your music21 inventor
-                                    is a medievalist, so this defaults to True.
+    _DOC_ATTR: t.Dict[str, str] = {
+        'useSymbols': '''
+            Boolean to indicate whether rest symbols
+            (breve, longa, etc.) should be used when
+            displaying the rest. Your music21 inventor
+            is a medievalist, so this defaults to True.
 
-                                    Change defaults.multiMeasureRestUseSymbols to
-                                    change globally.
-                                    ''',
-                 'maxSymbols': '''int, specifying the maximum number of rests
-                                     to display as symbols.  Default is 11.
-                                     If useSymbols is False then this setting
-                                     does nothing.
+            Change defaults.multiMeasureRestUseSymbols to
+            change globally.
+            ''',
+        'maxSymbols': '''
+            An int, specifying the maximum number of rests
+            to display as symbols.  Default is 11.
+            If useSymbols is False then this setting
+            does nothing.
 
-                                     Change defaults.multiMeasureRestMaxSymbols to
-                                     change globally.
-                                     '''
-                 }
+            Change defaults.multiMeasureRestMaxSymbols to
+            change globally.
+            ''',
+    }
 
     def __init__(self, *arguments, **keywords):
         super().__init__(*arguments, **keywords)

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9819,10 +9819,10 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                         lastWasNone = True
                 if isinstance(e, note.Note):
                     if not(skipUnisons is False
-                            or not lastPitches
-                            or len(lastPitches) > 1
-                            or e.pitch.pitchClass != lastPitches[0].pitchClass
-                            or (skipOctaves is False
+                           or not lastPitches
+                           or len(lastPitches) > 1
+                           or e.pitch.pitchClass != lastPitches[0].pitchClass
+                           or (skipOctaves is False
                                 and e.pitch.ps != lastPitches[0].ps)):
                         continue
                     if getOverlaps is False and e.offset < lastEnd:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9809,7 +9809,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             if container.getElementsByClass(note.GeneralNote):
                 lastContainerEnd = container.highestTime
 
-            # Filter out all but notes and rests
+            # Filter out all but notes and rests and chords, etc.
             for e in container.getElementsByClass(note.GeneralNote):
                 if (lastWasNone is False
                         and skipGaps is False
@@ -9819,8 +9819,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                         lastWasNone = True
                 if isinstance(e, note.Note):
                     if not(skipUnisons is False
-                           or not lastPitches
-                           or len(lastPitches) > 1
+                           or len(lastPitches) != 1
                            or e.pitch.pitchClass != lastPitches[0].pitchClass
                            or (skipOctaves is False
                                 and e.pitch.ps != lastPitches[0].ps)):
@@ -9846,17 +9845,16 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                             lastPitches = ()
                     # if we have a chord
                     elif (not (skipUnisons is True
-                                and lastPitches
-                                and e.pitches[0].ps == lastPitches[0].ps
-                               ) and (getOverlaps is True or e.offset >= lastEnd)):
+                                and len(lastPitches) == len(e.pitches)
+                                and (p.ps for p in e.pitches) == (p.ps for p in lastPitches)
+                               )
+                          and (getOverlaps is True or e.offset >= lastEnd)):
                         returnList.append(e)
                         if e.offset < lastEnd:  # is an overlap...
                             continue
 
                         lastStart = e.offset
                         lastEnd = opFrac(lastStart + e.duration.quarterLength)
-                        # this is the case where the last pitch is
-                        # a list
                         lastPitches = e.pitches
                         lastWasNone = False
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -232,7 +232,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                   'transpose',
                   'augmentOrDiminish', 'scaleOffsets', 'scaleDurations']
     # documentation for all attributes (not properties or methods)
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'recursionType': '''
             Class variable:
 
@@ -8061,7 +8061,9 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         else:  # need to permit Duration object assignment here
             raise StreamException(f'this must be a Duration object, not {durationObj}')
 
-    duration = property(_getDuration, _setDuration, doc='''
+    @property
+    def duration(self) -> 'music21.duration.Duration':
+        '''
         Returns the total duration of the Stream, from the beginning of the
         stream until the end of the final element.
         May be set independently by supplying a Duration object.
@@ -8077,7 +8079,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         <music21.duration.Duration 4.0>
         >>> a.duration.quarterLength
         4.0
-
 
         Advanced usage: override the duration from what is set:
 
@@ -8100,7 +8101,12 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         >>> a.highestTime
         4.0
-        ''')
+        '''
+        return self._getDuration()
+
+    @duration.setter
+    def duration(self, value: 'music21.duration.Duration'):
+        self._setDuration(value)
 
     def _setSeconds(self, value):
         pass
@@ -9782,7 +9788,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         lastEnd: OffsetQL = 0.0
         lastContainerEnd: OffsetQL = 0.0
         lastWasNone = False
-        lastPitch = None
+        lastPitches: t.Tuple[pitch.Pitch, ...] = ()
         if skipOctaves is True:
             skipUnisons = True  # implied
 
@@ -9792,7 +9798,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                     and noNone is False):
                 returnList.append(None)
                 lastWasNone = True
-                lastPitch = None
+                lastPitches = ()
 
             lastStart = 0.0
             lastEnd = 0.0
@@ -9812,15 +9818,12 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                         returnList.append(None)
                         lastWasNone = True
                 if isinstance(e, note.Note):
-                    # if (skipUnisons is False or isinstance(lastPitch, list)
                     if not(skipUnisons is False
-                            or isinstance(lastPitch, tuple)
-                            or lastPitch is None
-                            or (hasattr(lastPitch, 'pitchClass')
-                                and e.pitch.pitchClass != lastPitch.pitchClass)
+                            or not lastPitches
+                            or len(lastPitches) > 1
+                            or e.pitch.pitchClass != lastPitches[0].pitchClass
                             or (skipOctaves is False
-                                and hasattr(lastPitch, 'pitchClass')
-                                and e.pitch.ps != lastPitch.ps)):
+                                and e.pitch.ps != lastPitches[0].ps)):
                         continue
                     if getOverlaps is False and e.offset < lastEnd:
                         continue
@@ -9830,12 +9833,9 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                         continue
 
                     lastStart = e.offset
-                    if hasattr(e, 'duration'):
-                        lastEnd = opFrac(lastStart + e.duration.quarterLength)
-                    else:
-                        lastEnd = lastStart
+                    lastEnd = opFrac(lastStart + e.duration.quarterLength)
                     lastWasNone = False
-                    lastPitch = e.pitch
+                    lastPitches = e.pitches
 
                 # if we have a chord
                 elif isinstance(e, chord.Chord) and len(e.pitches) > 1:
@@ -9843,24 +9843,21 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                         if lastWasNone is False and not noNone:
                             returnList.append(None)
                             lastWasNone = True
-                            lastPitch = None
+                            lastPitches = ()
                     # if we have a chord
                     elif (not (skipUnisons is True
-                                and isinstance(lastPitch, (list, tuple))
-                                and e.pitches[0].ps == lastPitch[0].ps
+                                and lastPitches
+                                and e.pitches[0].ps == lastPitches[0].ps
                                ) and (getOverlaps is True or e.offset >= lastEnd)):
                         returnList.append(e)
                         if e.offset < lastEnd:  # is an overlap...
                             continue
 
                         lastStart = e.offset
-                        if hasattr(e, 'duration'):
-                            lastEnd = opFrac(lastStart + e.duration.quarterLength)
-                        else:
-                            lastEnd = lastStart
+                        lastEnd = opFrac(lastStart + e.duration.quarterLength)
                         # this is the case where the last pitch is
                         # a list
-                        lastPitch = e.pitches
+                        lastPitches = e.pitches
                         lastWasNone = False
 
                 elif (skipRests is False
@@ -9869,7 +9866,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                     if noNone is False:
                         returnList.append(None)
                         lastWasNone = True
-                        lastPitch = None
+                        lastPitches = ()
                 elif skipRests is True and isinstance(e, note.Rest):
                     lastEnd = opFrac(e.offset + e.duration.quarterLength)
 
@@ -12449,7 +12446,7 @@ class Measure(Stream):
     # define order for presenting names in documentation; use strings
     _DOC_ORDER = ['']
     # documentation for all attributes (not properties or methods)
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'timeSignatureIsNew': '''
             Boolean describing if the TimeSignature
             is different than the previous Measure.''',
@@ -13078,7 +13075,7 @@ class Part(Stream):
     '''
     recursionType = 'flatten'
 
-    # _DOC_ATTR = {
+    # _DOC_ATTR: t.Dict[str, str] = {
     # }
 
     def __init__(self, *args, **keywords):

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1241,7 +1241,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         returnObj.mergeAttributes(self)  # get groups, optional id
         return returnObj
 
-    def mergeAttributes(self, other):
+    def mergeAttributes(self, other: base.Music21Object):
         '''
         Merge relevant attributes from the Other stream into this one.
 
@@ -1249,13 +1249,13 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> s.append(note.Note())
         >>> s.autoSort = False
         >>> s.id = 'hi'
-        >>> t = stream.Stream()
-        >>> t.mergeAttributes(s)
-        >>> t.autoSort
+        >>> s2 = stream.Stream()
+        >>> s2.mergeAttributes(s)
+        >>> s2.autoSort
         False
-        >>> t
+        >>> s2
         <music21.stream.Stream hi>
-        >>> len(t)
+        >>> len(s2)
         0
         '''
         super().mergeAttributes(other)

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -369,9 +369,8 @@ class StreamIterator(prebase.ProtoM21Object, t.Generic[M21ObjType], t.Sequence):
 
         This behavior is often used to get an element from the Parts iterator:
 
-        >>> bach.parts['#soprano']  # notice: case insensitive
+        >>> bach.parts['#soprano']  # notice: case-insensitive retrieval
         <music21.stream.Part Soprano>
-
 
         Slices work:
 
@@ -1501,7 +1500,7 @@ class StreamIterator(prebase.ProtoM21Object, t.Generic[M21ObjType], t.Sequence):
 
 
 # -----------------------------------------------------------------------------
-class OffsetIterator(StreamIterator[M21ObjType]):
+class OffsetIterator(StreamIterator, t.Generic[M21ObjType], t.Sequence):
     '''
     An iterator that with each iteration returns a list of elements
     that are at the same offset (or all at end)
@@ -1665,7 +1664,7 @@ class OffsetIterator(StreamIterator[M21ObjType]):
 
 
 # -----------------------------------------------------------------------------
-class RecursiveIterator(StreamIterator[M21ObjType]):
+class RecursiveIterator(StreamIterator, t.Generic[M21ObjType], t.Sequence):
     '''
     One of the most powerful iterators in music21.  Generally not called
     directly, but created by being invoked on a stream with `Stream.recurse()`

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -23,6 +23,7 @@ from music21 import clef
 from music21 import common
 from music21 import chord
 from music21 import defaults
+from music21 import duration
 from music21 import environment
 from music21 import key
 from music21 import meter
@@ -1379,7 +1380,7 @@ def makeTupletBrackets(s: StreamType, *, inPlace=False) -> t.Optional[StreamType
     Changed in v1.8: `inPlace` is False by default
     Changed in v7: Legacy behavior of taking in a list of durations removed.
     '''
-    durationList = []
+    durationList: t.List[duration.Duration] = []
 
     # Stream, as it should be...
     if not inPlace:  # make a copy
@@ -1393,20 +1394,22 @@ def makeTupletBrackets(s: StreamType, *, inPlace=False) -> t.Optional[StreamType
             continue
         durationList.append(n.duration)
 
-    tupletMap = []  # a list of [tuplet obj, Duration] pairs
+    # a list of (tuplet obj, Duration) pairs
+    tupletMap: t.List[t.Tuple[t.Optional[duration.Tuplet], duration.Duration]] = []
+
     for dur in durationList:  # all Duration objects
         tupletList = dur.tuplets
         if not tupletList:  # no tuplets
-            tupletMap.append([None, dur])
+            tupletMap.append((None, dur))
         elif len(tupletList) > 1:
             # for i in range(len(tuplets)):
             #    tupletMap.append([tuplets[i],dur])
             environLocal.warn(
                 f'got multi-tuplet duration; cannot yet handle this. {tupletList!r}'
             )
-            tupletMap.append([None, dur])
+            tupletMap.append((None, dur))
         else:
-            tupletMap.append([tupletList[0], dur])
+            tupletMap.append((tupletList[0], dur))
 
     # have a list of tuplet, Duration pairs
     completionCount: t.Union[float, int, Fraction] = 0  # qLen currently filled

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -2029,7 +2029,6 @@ class Test(unittest.TestCase):
 
     def testStreamExceptions(self):
         from music21 import converter
-        from music21 import duration
         from music21 import stream
         p = converter.parse(self.allaBreveBeamTest)
         with self.assertRaises(stream.StreamException) as cm:

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -986,9 +986,9 @@ class Test(unittest.TestCase):
 
         n5 = note.Note('c4')
         s6 = Stream()
-        s6.insert([0.0, n1,
-                   1.0, n5,
-                   2.0, n2])
+        s6.insert([0.0, n1,  # C3
+                   1.0, n5,  # C4
+                   2.0, n2])  # Chord C4, E4, G4
         l12 = s6.findConsecutiveNotes(noNone=True)
         self.assertEqual(len(l12), 3)
         l13 = s6.findConsecutiveNotes(noNone=True, skipUnisons=True)

--- a/music21/style.py
+++ b/music21/style.py
@@ -59,7 +59,7 @@ class Style(ProtoM21Object):
     20.4
 
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'hideObjectOnPrint': '''
             If set to `True`, the Music21Object will not print upon output
             (only used in MusicXML output at this point and
@@ -221,7 +221,7 @@ class NoteStyle(Style):
     Beam style is stored on the Beams object.  Lyric style is stored on the Lyric
     object.
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'stemStyle': '''
             An optional style.Style object describing what the stem looks like.
 

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -183,7 +183,6 @@ class TempoText(TempoIndication):
     >>> print(tm.text)
     adagio
     '''
-
     def __init__(self, text=None):
         super().__init__()
 
@@ -291,7 +290,6 @@ class TempoText(TempoIndication):
         Return True or False if the supplied text seems like a
         plausible Tempo indications be used for this TempoText.
 
-
         >>> tt = tempo.TempoText('adagio')
         >>> tt.isCommonTempoText()
         True
@@ -355,16 +353,13 @@ class MetronomeMark(TempoIndication):
 
     Some text marks will automatically suggest a number.
 
-
     >>> mm = tempo.MetronomeMark('adagio')
     >>> mm.number
     56
     >>> mm.numberImplicit
     True
 
-
     For certain numbers, a text value can be set implicitly
-
 
     >>> tm2 = tempo.MetronomeMark(number=208)
     >>> print(tm2.text)
@@ -385,7 +380,7 @@ class MetronomeMark(TempoIndication):
     >>> tm2.number
     144
     '''
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'placement': '''
             Staff placement: 'above', 'below', or None.
 

--- a/music21/tie.py
+++ b/music21/tie.py
@@ -15,7 +15,7 @@
 The `tie` module contains a single class, `Tie` that represents the visual and
 conceptual idea of tied notes.  They can be start or stop ties.
 '''
-
+import typing as t
 import unittest
 from music21 import exceptions21
 from music21.common.objects import SlottedObjectMixin
@@ -28,7 +28,7 @@ class TieException(exceptions21.Music21Exception):
 # ------------------------------------------------------------------------------
 class Tie(prebase.ProtoM21Object, SlottedObjectMixin):
     '''
-    Object added to notes that are tied to other notes. The `type` value is one
+    An object added to Notes that are tied to other notes. The `type` value is one
     of start, stop, or continue.
 
     >>> note1 = note.Note()
@@ -58,7 +58,7 @@ class Tie(prebase.ProtoM21Object, SlottedObjectMixin):
 
     *  one tie with "continue" implies tied from and tied to.
 
-    The tie.style only applies to ties of type 'start' or 'continue' (and then
+    The tie.style only applies to Tie objects of type 'start' or 'continue' (and then
     only to the next part of the tie).  For instance, if there are two
     tied notes, and the first note has a 'dotted'-start tie, and the
     second note has a 'dashed'-stop tie, the graphical tie itself will be dotted.

--- a/music21/tie.py
+++ b/music21/tie.py
@@ -87,7 +87,7 @@ class Tie(prebase.ProtoM21Object, SlottedObjectMixin):
         'type',
     )
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'type': '''
             The tie type, can be 'start', 'stop', 'continue', 'let-ring', or 'continue-let-ring'.
             ''',

--- a/music21/tree/core.py
+++ b/music21/tree/core.py
@@ -59,7 +59,7 @@ class AVLNode(common.SlottedObjectMixin):
         'rightChild',
     )
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'balance': '''
         Returns the current state of the difference in heights of the
         two subtrees rooted on this node.

--- a/music21/tree/node.py
+++ b/music21/tree/node.py
@@ -143,7 +143,7 @@ class ElementNode(core.AVLNode):
         'subtreeElementsStopIndex',
     )
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'payloadElementIndex': r'''
             The index in a stream of the element stored in the payload of this node.
             ''',
@@ -399,7 +399,7 @@ class OffsetNode(ElementNode):
         'payloadElementsStopIndex',
     )
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'payload': r'''
             The contents of the node at this point.  Usually a list of ElementTimespans
             or PitchedTimespans.

--- a/music21/tree/node.py
+++ b/music21/tree/node.py
@@ -16,7 +16,7 @@ Internal data structures for timespan collections.
 This is an implementation detail of the TimespanTree class.  Most music21 users
 can happily ignore this module.
 '''
-
+import typing as t
 import unittest
 from music21.tree import core
 from music21.base import Music21Object

--- a/music21/tree/spans.py
+++ b/music21/tree/spans.py
@@ -297,7 +297,7 @@ class ElementTimespan(Timespan):
     '''
 
     # CLASS VARIABLES #
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'parentage': r'''
             The Stream hierarchy above the element in a ElementTimespan.
 

--- a/music21/tree/spans.py
+++ b/music21/tree/spans.py
@@ -15,10 +15,10 @@
 Tools for grouping notes and chords into a searchable tree
 organized by start and stop offsets.
 '''
-
 import copy
-import unittest
 from math import inf
+import typing as t
+import unittest
 
 from music21 import environment
 from music21 import exceptions21

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -128,7 +128,7 @@ class Verticality(prebase.ProtoM21Object):
         'stopTimespans',
     )
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'timespanTree': r'''
             Returns the timespanTree initially set.
             ''',

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -84,7 +84,7 @@ class VoiceLeadingQuartet(base.Music21Object):
     to make sense.  Most routines will work the other way still though.
     '''
 
-    _DOC_ATTR = {'vIntervals': '''list of the two harmonic intervals present,
+    _DOC_ATTR: t.Dict[str, str] = {'vIntervals': '''list of the two harmonic intervals present,
                      vn1n1 to v2n1 and v1n2 to v2n2''',
                  'hIntervals': '''list of the two melodic intervals present,
                      v1n1 to v1n2 and v2n1 to v2n2'''}
@@ -1375,7 +1375,7 @@ class Verticality(base.Music21Object):
     #  obsolete:     To create Verticalities out of a score, call
     #                by :meth:`~music21.theoryAnalyzer.getVerticalities`
 
-    _DOC_ATTR = {
+    _DOC_ATTR: t.Dict[str, str] = {
         'contentDict': '''Dictionary representing contents of Verticalities.
             the keys of the dictionary
             are the part numbers and the element at each key is a list of


### PR DESCRIPTION
Changed so that findConsecutiveNotes with skipUnisons when encountering a Chord objects only takes place if all the previous pitches are the same as the pitches of the Chord.