### PR TITLE
optimize opFrac

### DIFF
--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -233,8 +233,8 @@ def _preFracLimitDenominator(n: int, d: int) -> t.Tuple[int, int]:
 # 2048th notes + 1-2 dots was half the speed
 
 _KNOWN_PASSES = frozenset([
- 0.0625, 0.09375, 0.125, 0.1875,
- 0.25, 0.375, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0
+    0.0625, 0.09375, 0.125, 0.1875,
+    0.25, 0.375, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0
 ])
 
 # no type checking due to accessing protected attributes (for speed)

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -218,14 +218,16 @@ def _preFracLimitDenominator(n: int, d: int) -> t.Tuple[int, int]:
     bound2n = p1
     bound2d = q1
     # s = (0.0 + n)/d
-    bound1minusS = (abs((bound1n * dOrg) - (nOrg * bound1d)), (dOrg * bound1d))
-    bound2minusS = (abs((bound2n * dOrg) - (nOrg * bound2d)), (dOrg * bound2d))
-    difference = (bound1minusS[0] * bound2minusS[1]) - (bound2minusS[0] * bound1minusS[1])
-    if difference > 0:
+    bound1minusS_n = abs((bound1n * dOrg) - (nOrg * bound1d))
+    bound1minusS_d = dOrg * bound1d
+    bound2minusS_n = abs((bound2n * dOrg) - (nOrg * bound2d))
+    bound2minusS_d = dOrg * bound2d
+    difference = (bound1minusS_n * bound2minusS_d) - (bound2minusS_n * bound1minusS_d)
+    if difference >= 0:
         # bound1 is farther from zero than bound2; return bound2
-        return (p1, q1)
+        return (bound2n, bound2d)
     else:
-        return (p0 + k * p1, q0 + k * q1)
+        return (bound1n, bound1d)
 
 
 # _KNOWN_PASSES is all values from whole to 64th notes with 0 or 1 dot


### PR DESCRIPTION
see post to music21list about details.

Switches the cache from 1024 to None -- not because we want to cache more than 1024 values, but to avoid the overhead of an LRU cache, which is significant.

Speeds up opFrac(0.5) by about 37% by giving a set of 20 values to return very quickly at a cost of adding 25% to opFrac(9/16) or 5% to opFrac(1/3) -- worth it -- though the lru_cache speedup makes the latter actually faster.

opFrac is the performance bottleneck of music21, so anything to speed it up is a big win.