### PR TITLE
Fix a regression with chord accidentals

### DIFF
--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4863,7 +4863,8 @@ class Pitch(prebase.ProtoM21Object):
             else:
                 return  # exit: nothing more to do
 
-        if (otherSimultaneousPitches
+        if (
+            otherSimultaneousPitches
             and cautionaryPitchClass
             and any(pSimult.step == self.step for pSimult in otherSimultaneousPitches)
         ):

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4734,7 +4734,7 @@ class Pitch(prebase.ProtoM21Object):
     def updateAccidentalDisplay(
         self,
         *,
-        pitchPast: t.Optional[t.List['Pitch', t.List['Pitch']]] = None,
+        pitchPast: t.Optional[t.List['Pitch']] = None,
         pitchPastMeasure: t.Optional[t.List['Pitch']] = None,
         otherSimultaneousPitches: t.Optional[t.List['Pitch']] = None,
         alteredPitches: t.Optional[t.List['Pitch']] = None,

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4733,8 +4733,10 @@ class Pitch(prebase.ProtoM21Object):
 
     def updateAccidentalDisplay(
         self,
-        pitchPast: t.Optional[t.List['Pitch']] = None,
+        *,
+        pitchPast: t.Optional[t.List['Pitch', t.List['Pitch']]] = None,
         pitchPastMeasure: t.Optional[t.List['Pitch']] = None,
+        otherSimultaneousPitches: t.Optional[t.List['Pitch']] = None,
         alteredPitches: t.Optional[t.List['Pitch']] = None,
         cautionaryPitchClass: bool = True,
         cautionaryAll: bool = False,
@@ -4784,13 +4786,13 @@ class Pitch(prebase.ProtoM21Object):
 
         >>> a = pitch.Pitch('a')
         >>> past = [pitch.Pitch('a#'), pitch.Pitch('c#'), pitch.Pitch('c')]
-        >>> a.updateAccidentalDisplay(past, cautionaryAll=True)
+        >>> a.updateAccidentalDisplay(pitchPast=past, cautionaryAll=True)
         >>> a.accidental, a.accidental.displayStatus
         (<music21.pitch.Accidental natural>, True)
 
         >>> b = pitch.Pitch('a')
         >>> past = [pitch.Pitch('a#'), pitch.Pitch('c#'), pitch.Pitch('c')]
-        >>> b.updateAccidentalDisplay(past)  # should add a natural
+        >>> b.updateAccidentalDisplay(pitchPast=past)  # should add a natural
         >>> b.accidental, b.accidental.displayStatus
         (<music21.pitch.Accidental natural>, True)
 
@@ -4799,10 +4801,11 @@ class Pitch(prebase.ProtoM21Object):
 
         >>> a4 = pitch.Pitch('a4')
         >>> past = [pitch.Pitch('a#3'), pitch.Pitch('c#'), pitch.Pitch('c')]
-        >>> a4.updateAccidentalDisplay(past, cautionaryPitchClass=False)
+        >>> a4.updateAccidentalDisplay(pitchPast=past, cautionaryPitchClass=False)
         >>> a4.accidental is None
         True
 
+        v8 -- made keyword-only and added `otherSimultaneousPitches`.
         '''
         # N.B. -- this is a very complex method
         # do not alter it without significant testing.
@@ -4826,10 +4829,6 @@ class Pitch(prebase.ProtoM21Object):
             pitchPastMeasure = []
         if alteredPitches is None:
             alteredPitches = []
-
-        # TODO: this presently deals with chords as simply a list
-        #    we might permit pitchPast to contain a list of pitches, to represent
-        #    a simultaneity?
 
         # should we display accidental if no previous accidentals have been displayed
         # i.e. if it's the first instance of an accidental after a tie
@@ -4860,6 +4859,16 @@ class Pitch(prebase.ProtoM21Object):
                 return
             else:
                 return  # exit: nothing more to do
+
+        if (otherSimultaneousPitches
+            and any(
+                pSimult.step == self.step
+                and (cautionaryPitchClass or self.octave is pSimult.octave != self.octave)
+                    for pSimult in otherSimultaneousPitches
+                )
+        ):
+            set_displayStatus(True)
+            return
 
         # no pitches in past...
         if not pitchPastAll:
@@ -5060,13 +5069,6 @@ class Pitch(prebase.ProtoM21Object):
                       and cautionaryNotImmediateRepeat is False
                       and pPastInMeasure is False):
                     set_displayStatus(True)
-
-                # Avoid making early, incorrect assumptions if this pitch is part of a chord.
-                # pPast might include this note itself, in which case we should not say
-                # "natural already in past usage". (Filtering out the current note from pPast
-                # when calling this method is not sufficient, because there could be repetitions.)
-                elif self._client is not None and self._client._chordAttached is not None:
-                    continue
 
                 # other cases: already natural in past usage, do not need
                 # natural again (and not in key sig)

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4757,6 +4757,9 @@ class Pitch(prebase.ProtoM21Object):
         `pitchPastMeasure` is a list of pitches preceding this pitch but in a
         previous measure. If None, a new list will be made.
 
+        `otherSimultaneousPitches` is a list of other pitches in this simultaneity, for use
+        when `cautionaryPitchClass` is True.
+
         The `alteredPitches` list supplies pitches from a :class:`~music21.key.KeySignature`
         object using the :attr:`~music21.key.KeySignature.alteredPitches` property.
         If None, a new list will be made.
@@ -4861,11 +4864,8 @@ class Pitch(prebase.ProtoM21Object):
                 return  # exit: nothing more to do
 
         if (otherSimultaneousPitches
-            and any(
-                pSimult.step == self.step
-                and (cautionaryPitchClass or self.octave is pSimult.octave != self.octave)
-                    for pSimult in otherSimultaneousPitches
-                )
+            and cautionaryPitchClass
+            and any(pSimult.step == self.step for pSimult in otherSimultaneousPitches)
         ):
             set_displayStatus(True)
             return

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4866,7 +4866,8 @@ class Pitch(prebase.ProtoM21Object):
         if (
             otherSimultaneousPitches
             and cautionaryPitchClass
-            and any(pSimult.step == self.step for pSimult in otherSimultaneousPitches)
+            and any(pSimult.step == self.step and pSimult.pitchClass != self.pitchClass
+                for pSimult in otherSimultaneousPitches)
         ):
             set_displayStatus(True)
             return

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -6337,7 +6337,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         `pitchPastMeasure` is a list of pitches preceding this pitch but in a previous measure.
 
-        `otherSimultaneousPitches` is a list of other pitches in this simultaneity.
+        `otherSimultaneousPitches` is a list of other pitches in this simultaneity, for use
+        when `cautionaryPitchClass` is True.
 
         If `useKeySignature` is True, a :class:`~music21.key.KeySignature` will be searched
         for in this Stream or this Stream's defined contexts. An alternative KeySignature

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -6473,7 +6473,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                     else:
                         lastNoteWasTied = False
 
-                    otherSimultaneousPitches = [other_p for other_p in e.pitches if other_p is not p]
+                    otherSimultaneousPitches = [other for other in e.pitches if other is not p]
 
                     p.updateAccidentalDisplay(
                         pitchPast=pitchPast,

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -6319,6 +6319,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         *,
         pitchPast: t.Optional[t.List[pitch.Pitch]] = None,
         pitchPastMeasure: t.Optional[t.List[pitch.Pitch]] = None,
+        otherSimultaneousPitches: t.Optional[t.List[pitch.Pitch]] = None,
         useKeySignature: t.Union[bool, key.KeySignature] = True,
         alteredPitches: t.Optional[t.List[pitch.Pitch]] = None,
         searchKeySignatureByContext: bool = False,
@@ -6336,6 +6337,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         `pitchPastMeasure` is a list of pitches preceding this pitch but in a previous measure.
 
+        `otherSimultaneousPitches` is a list of other pitches in this simultaneity.
 
         If `useKeySignature` is True, a :class:`~music21.key.KeySignature` will be searched
         for in this Stream or this Stream's defined contexts. An alternative KeySignature
@@ -6377,7 +6379,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         Changed in v.6: does not return anything if inPlace is True.
         Changed in v.7: default inPlace is False
-        Changed in v.8: altered unisons in Chords now supply clarifying naturals.
+        Changed in v.8: altered unisons/octaves in Chords now supply clarifying naturals.
 
         All arguments are keyword only.
         '''
@@ -6459,11 +6461,9 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                     tiePitchSet.add(e.pitch.nameWithOctave)
 
             elif isinstance(e, chord.Chord):
-                # add all chord elements to past first
                 # when reading a chord, this will apply an accidental
                 # if pitches in the chord suggest an accidental
                 seenPitchNames = set()
-                pitchPast += e.pitches
 
                 for n in list(e):
                     p = n.pitch
@@ -6472,9 +6472,12 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                     else:
                         lastNoteWasTied = False
 
+                    otherSimultaneousPitches = [other_p for other_p in e.pitches if other_p is not p]
+
                     p.updateAccidentalDisplay(
                         pitchPast=pitchPast,
                         pitchPastMeasure=pitchPastMeasure,
+                        otherSimultaneousPitches=otherSimultaneousPitches,
                         alteredPitches=alteredPitches,
                         cautionaryPitchClass=cautionaryPitchClass,
                         cautionaryAll=cautionaryAll,
@@ -6489,6 +6492,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                 for pName in seenPitchNames:
                     tiePitchSet.add(pName)
 
+                pitchPast += e.pitches
             else:
                 tiePitchSet.clear()
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -2613,10 +2613,8 @@ class Test(unittest.TestCase):
         self.assertTrue(c1.pitches[1].accidental.displayStatus)
         self.assertTrue(c1.pitches[2].accidental.displayStatus)
 
-        # not getting a natural here because of chord tones
-        # self.assertTrue(n3.pitch.accidental.displayStatus)
-        # self.assertEqual(n3.pitch.accidental, None)
-        # s.show()
+        # not necessary to repeat the natural afterward
+        self.assertIsNone(n3.pitch.accidental, None)
 
         s = Stream()
         n1 = note.Note('a#')
@@ -2793,6 +2791,29 @@ class Test(unittest.TestCase):
         self.assertIs(n.pitch.accidental.displayStatus, False)
 
         # TODO: other types
+
+    def testMakeAccidentalsOnChord(self):
+        c = chord.Chord('F# A# C#')
+        s = Stream(c)
+        self.assertFalse(any(n.pitch.accidental.displayStatus for n in c))
+        s.makeAccidentals(inPlace=True)
+        self.assertTrue(all(n.pitch.accidental.displayStatus for n in c))
+
+        augmented_octave = chord.Chord('F4 F#5')
+        s2 = Stream(augmented_octave)
+        self.assertIsNone(augmented_octave[0].pitch.accidental)
+        s2.makeAccidentals(inPlace=True)
+        self.assertTrue(augmented_octave[0].pitch.accidental.displayStatus)
+
+        # Repeat the test without octaves and reset state
+        low, high = augmented_octave.pitches
+        low.octave = None
+        low.accidental = None
+        high.octave = None
+        high.accidental.displayStatus = None
+
+        s2.makeAccidentals(inPlace=True)
+        self.assertTrue(all(n.pitch.accidental.displayStatus for n in augmented_octave))
 
     def testMakeNotationTiesKeyless(self):
         p = converter.parse('tinynotation: 4/4 f#1~ f#1')

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -2815,6 +2815,12 @@ class Test(unittest.TestCase):
         s2.makeAccidentals(inPlace=True)
         self.assertTrue(all(n.pitch.accidental.displayStatus for n in augmented_octave))
 
+        # Repeat the test with two F#'s in key of 1 sharp
+        two_f_sharps = chord.Chord('F#4 F#5')
+        s3 = Stream([key.KeySignature(1), two_f_sharps])
+        s3.makeAccidentals(inPlace=True)
+        self.assertTrue(all(n.pitch.accidental.displayStatus is False for n in two_f_sharps))
+
     def testMakeNotationTiesKeyless(self):
         p = converter.parse('tinynotation: 4/4 f#1~ f#1')
         # Key of no sharps/flats

--- a/music21/test/test_pitch.py
+++ b/music21/test/test_pitch.py
@@ -321,13 +321,13 @@ class Test(unittest.TestCase):
         '''
         def proc1(_pList, _past):
             for p in _pList:
-                p.updateAccidentalDisplay(_past, cautionaryPitchClass=True,
+                p.updateAccidentalDisplay(pitchPast=_past, cautionaryPitchClass=True,
                                           cautionaryNotImmediateRepeat=False)
                 _past.append(p)
 
         def proc2(_pList, _past):
             for p in _pList:
-                p.updateAccidentalDisplay(_past, cautionaryPitchClass=False,
+                p.updateAccidentalDisplay(pitchPast=_past, cautionaryPitchClass=False,
                                           cautionaryNotImmediateRepeat=False)
                 _past.append(p)
 

--- a/music21/test/test_pitch.py
+++ b/music21/test/test_pitch.py
@@ -89,7 +89,7 @@ class Test(unittest.TestCase):
         self.assertEqual(a.name, 'C')
         self.assertTrue(a.accidental.displayStatus)
 
-        a.updateAccidentalDisplay(past, overrideStatus=True)
+        a.updateAccidentalDisplay(pitchPast=past, overrideStatus=True)
         self.assertFalse(a.accidental.displayStatus)
 
         b = copy.deepcopy(a)
@@ -101,7 +101,7 @@ class Test(unittest.TestCase):
         '''
         def proc(_pList, past):
             for p in _pList:
-                p.updateAccidentalDisplay(past)
+                p.updateAccidentalDisplay(pitchPast=past)
                 past.append(p)
 
         def compare(past, _result):
@@ -206,7 +206,7 @@ class Test(unittest.TestCase):
         '''
         def proc(_pList, past, alteredPitches):
             for p in _pList:
-                p.updateAccidentalDisplay(past, alteredPitches=alteredPitches)
+                p.updateAccidentalDisplay(pitchPast=past, alteredPitches=alteredPitches)
                 past.append(p)
 
         def compare(past, _result):
@@ -366,7 +366,7 @@ class Test(unittest.TestCase):
         a4 = Pitch('a4')
         past = [Pitch('a#3'), Pitch('c#'), Pitch('c')]
         # will not add a natural because match is pitchSpace
-        a4.updateAccidentalDisplay(past, cautionaryPitchClass=False)
+        a4.updateAccidentalDisplay(pitchPast=past, cautionaryPitchClass=False)
         self.assertEqual(a4.accidental, None)
 
     def testAccidentalsCautionary(self):


### PR DESCRIPTION
Better solution than #1299. That PR caused a regression with this case:

```python
from music21 import chord
c = chord.Chord("D# F# A#")
c.show(app='Finale')
```
<img width="121" alt="Screen Shot 2022-06-06 at 4 01 46 PM" src="https://user-images.githubusercontent.com/38668450/172238690-8b514a31-9f99-426f-b5d1-3119eec9b281.png">

***
A better solution is to actually distinguish "past" from "simultaneous" rather than mixing the two notions.
