### PR TITLE
Fix shiftElements docs

### DIFF
--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -5512,10 +5512,9 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         .storeAtEnd() (such as right barlines) are
         not affected.
 
-        If startOffset is given then all elements before
-        that offset will be shifted.  If endOffset is given
-        then all elements at or after this offset will be
-        shifted
+        If startOffset is given then elements before
+        that offset will not be shifted.  If endOffset is given
+        then all elements at or after this offset will be not be shifted.
 
         >>> a = stream.Stream()
         >>> a.repeatInsert(note.Note('C'), list(range(10)))


### PR DESCRIPTION
`startOffset` and `endOffset` in this method work like excluding filters -- so this should read that elements outside the bounds are _not_ shifted.