### PR TITLE
Fix midmeasure clef export regression involving voices

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -3113,8 +3113,8 @@ class MeasureExporter(XMLExporterBase):
             amountToMoveForward = int(round(divisions * (groupOffset
                                                              - self.offsetInMeasure)))
             if amountToMoveForward > 0 and any(
-                    isinstance(obj, note.GeneralNote) for obj in objGroup):
-                # gap in stream between GeneralNote objects: create <forward>
+                    isinstance(obj, (note.GeneralNote, clef.Clef)) for obj in objGroup):
+                # gap in stream between GeneralNote/Clef objects: create <forward>
                 mxForward = Element('forward')
                 mxDuration = SubElement(mxForward, 'duration')
                 mxDuration.text = str(amountToMoveForward)

--- a/music21/musicxml/testPrimitive.py
+++ b/music21/musicxml/testPrimitive.py
@@ -18236,6 +18236,30 @@ class Test(unittest.TestCase):
         self.assertEqual([c.classes for c in new_clefs],
                          [c.classes for c in orig_clefs])
 
+    def testMidMeasureClefs3(self):
+        '''
+        Test midmeasure clef changes outside voices
+        '''
+        from music21 import clef
+        from music21 import note
+        from music21 import musicxml
+        from music21 import stream
+
+        v1 = stream.Voice()
+        v2 = stream.Voice()
+        quarter = note.Note()
+        v1.repeatAppend(quarter, 4)
+        v2.repeatAppend(quarter, 4)
+        m = stream.Measure([v1, v2])
+        m.insert(1.0, clef.BassClef())
+        p = stream.Part(m)
+        p.makeNotation(inPlace=True)
+
+        tree = musicxml.test_m21ToXml.Test().getET(p)
+        self.assertEqual(len(tree.findall('.//clef')), 1)
+        # One backup from the clef back to voice 1, then another back to voice 2
+        self.assertEqual(len(tree.findall('.//backup')), 2)
+
 # ------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Fix a regression in #1261 with midmeasure clef changes outside voices.

From Amy Beach corpus example:

**Before**
<img width="587" alt="Screen Shot 2022-06-29 at 11 15 24 AM" src="https://user-images.githubusercontent.com/38668450/176472831-798370e6-dc14-4bf6-a981-faa6ecc4c358.png">

**After**
<img width="573" alt="Screen Shot 2022-06-29 at 11 14 58 AM" src="https://user-images.githubusercontent.com/38668450/176472889-79362d4a-cb0e-4d0b-841a-60035e957cfa.png">
