### PR TITLE
[Musicxml export] Preserve whitespace in TextBox

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1759,13 +1759,15 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         >>> SX.dump(mxCredit)
         <credit page="1">...</credit>
 
-        Changed in v.8 -- Multi-line text now exports as one credit-words element (with new lines preserved).
+        Changed in v.8 -- Multi-line text now exports as one `<credit-words>`
+        element (preserving newlines).
 
         >>> tb = text.TextBox('Snare\nCymbals')
         >>> mxCredit = SX.textBoxToXmlCredit(tb)
         >>> SX.dump(mxCredit)
         <credit page="1">
-            <credit-words default-x="500" default-y="500" halign="center" valign="top" xml:space="preserve">Snare
+            <credit-words default-x="500" default-y="500" halign="center" valign="top"
+            xml:space="preserve">Snare
             Cymbals</credit-words>
         </credit>
         '''


### PR DESCRIPTION
I found that `xml:space="preserve"` is the way to preserve the display of newlines in a `<credit-words>`.
music21 was splitting text content on newlines and creating distinct `<credit-word>` elements, but without changing the position attributes, they were superimposed:

**Before**
<img width="997" alt="Screen Shot 2022-06-29 at 11 24 24 AM" src="https://user-images.githubusercontent.com/38668450/176478201-d9882378-e58a-48bd-9eda-5bff05ff6b14.png">


**After**
<img width="1007" alt="Screen Shot 2022-06-29 at 11 24 31 AM" src="https://user-images.githubusercontent.com/38668450/176478215-41d36d8f-ae5b-4bff-a63d-e1cdf2a2c166.png">

