### PR TITLE
deprecate gcd in favor of C math

### DIFF
--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -37,8 +37,7 @@ __all__ = [
     'dotMultiplier', 'decimalToTuplet',
     'unitNormalizeProportion', 'unitBoundaryProportion',
     'weightedSelection',
-    'euclidGCD', 'approximateGCD',
-    'lcm',
+    'approximateGCD',
 
     'contiguousList',
 
@@ -197,10 +196,12 @@ def _preFracLimitDenominator(n: int, d: int) -> t.Tuple[int, int]:
 
     (n.b. -- nothing printed)
     '''
-    nOrg = n
-    dOrg = d
+    # TODO: when Python 3.9 is the minimum version, replace lru_cache with simply cache,
+    #     which is the same speed as lru_cache(None) (it simply calls it)
     if d <= DENOM_LIMIT:  # faster than hard-coding 65535
         return (n, d)
+    nOrg = n
+    dOrg = d
     p0, q0, p1, q1 = 0, 1, 1, 0
     while True:
         a = n // d
@@ -215,7 +216,6 @@ def _preFracLimitDenominator(n: int, d: int) -> t.Tuple[int, int]:
     bound1d = q0 + k * q1
     bound2n = p1
     bound2d = q1
-    # s = (0.0 + n)/d
     bound1minusS = (abs((bound1n * dOrg) - (nOrg * bound1d)), (dOrg * bound1d))
     bound2minusS = (abs((bound2n * dOrg) - (nOrg * bound2d)), (dOrg * bound2d))
     difference = (bound1minusS[0] * bound2minusS[1]) - (bound2minusS[0] * bound1minusS[1])
@@ -641,9 +641,9 @@ def decimalToTuplet(decNum: float) -> t.Tuple[int, int]:
         raise Exception('No such luck')
 
     jy *= multiplier
-    gcd = euclidGCD(int(jy), int(iy))
-    jy = jy / gcd
-    iy = iy / gcd
+    my_gcd = gcd(int(jy), int(iy))
+    jy = jy / my_gcd
+    iy = iy / my_gcd
 
     if flipNumerator is False:
         return (int(jy), int(iy))
@@ -742,16 +742,20 @@ def weightedSelection(values: t.List[int],
     return values[index]
 
 
+@deprecated('v8', 'v9', 'use math.gcd(a, b) instead.')
 def euclidGCD(a: int, b: int) -> int:
     '''
     use Euclid's algorithm to find the GCD of a and b
 
+    ```
     >>> common.euclidGCD(2, 4)
     2
     >>> common.euclidGCD(20, 8)
     4
     >>> common.euclidGCD(20, 16)
     4
+    ```
+
     '''
     if b == 0:
         return a
@@ -826,10 +830,12 @@ def approximateGCD(values: t.List[t.Union[int, float]], grain: float = 1e-4) -> 
     return max(commonUniqueDivisions)
 
 
+@deprecated('v8', 'v9', 'Use math.lcm(*filterList) instead.')
 def lcm(filterList: t.Iterable[int]) -> int:
     '''
     Find the least common multiple of a list of values
 
+    ```
     >>> common.lcm([3, 4, 5])
     60
     >>> common.lcm([3, 4])
@@ -838,12 +844,16 @@ def lcm(filterList: t.Iterable[int]) -> int:
     2
     >>> common.lcm([3, 6])
     6
+    ```
 
     Works with any iterable, like this set
 
+    ```
     >>> common.lcm({3, 5, 6})
     30
+    ```
 
+    Deprecated in v8 since math.lcm works in C and is faster
     '''
     def _lcm(a, b):
         '''find the least common multiple of a, b'''

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -17,7 +17,7 @@ import unittest
 import typing as t
 
 from fractions import Fraction
-from math import isclose
+from math import isclose, gcd
 
 from music21 import defaults
 from music21.common import deprecated
@@ -37,6 +37,7 @@ __all__ = [
     'dotMultiplier', 'decimalToTuplet',
     'unitNormalizeProportion', 'unitBoundaryProportion',
     'weightedSelection',
+    'lcm',
     'approximateGCD',
 
     'contiguousList',
@@ -851,12 +852,10 @@ def approximateGCD(values: t.List[t.Union[int, float]], grain: float = 1e-4) -> 
     return max(commonUniqueDivisions)
 
 
-@deprecated('v8', 'v9', 'Use math.lcm(*filterList) instead.')
 def lcm(filterList: t.Iterable[int]) -> int:
     '''
     Find the least common multiple of a list of values
 
-    ```
     >>> common.lcm([3, 4, 5])
     60
     >>> common.lcm([3, 4])
@@ -865,21 +864,19 @@ def lcm(filterList: t.Iterable[int]) -> int:
     2
     >>> common.lcm([3, 6])
     6
-    ```
 
     Works with any iterable, like this set
 
-    ```
     >>> common.lcm({3, 5, 6})
     30
-    ```
 
-    Deprecated in v8 since math.lcm works in C and is faster
+    To be deprecated in v.8 once Python 3.9 is the minimum version
+    since math.lcm works in C and is faster
     '''
     def _lcm(a, b):
         '''find the least common multiple of a, b'''
         # // forces integer style division (no remainder)
-        return abs(a * b) // euclidGCD(a, b)
+        return abs(a * b) // gcd(a, b)
 
     # derived from
     # http://www.oreillynet.com/cs/user/view/cs_msg/41022

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -767,17 +767,20 @@ def weightedSelection(values: t.List[int],
 @deprecated('v8', 'v9', 'use math.gcd(a, b) instead.')
 def euclidGCD(a: int, b: int) -> int:
     '''
-    use Euclid's algorithm to find the GCD of a and b
+    Deprecated: use math.gcd(a, b) instead
+
+    use Euclid's algorithm to find the GCD of a and b::
 
     ```
-    >>> common.euclidGCD(2, 4)
+    common.euclidGCD(2, 4)
     2
-    >>> common.euclidGCD(20, 8)
+
+    common.euclidGCD(20, 8)
     4
-    >>> common.euclidGCD(20, 16)
+
+    common.euclidGCD(20, 16)
     4
     ```
-
     '''
     if b == 0:
         return a

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -2356,7 +2356,7 @@ def hdStringToNote(contents):
             newTup.durationActual = duration.durationTupleFromTypeDots(thisObject.duration.type, 0)
             newTup.durationNormal = duration.durationTupleFromTypeDots(thisObject.duration.type, 0)
 
-            gcd = common.euclidGCD(int(dT), int(baseValue))
+            gcd = math.gcd(int(dT), int(baseValue))
             newTup.numberNotesActual = int(dT / gcd)
             newTup.numberNotesNormal = int(float(baseValue) / gcd)
 

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -16,6 +16,7 @@ as well as component objects for defining nested metrical structures,
 :class:`~music21.meter.MeterTerminal` and :class:`~music21.meter.MeterSequence` objects.
 '''
 import copy
+from math import gcd
 import fractions
 import typing as t
 
@@ -200,7 +201,7 @@ def bestTimeSignature(meas: 'music21.stream.Stream') -> 'music21.meter.TimeSigna
         floatDenominator *= multiplier
         denominator = int(floatDenominator)
         # simplifies to "simplest terms," with 4 in denominator, before testing beat strengths
-        gcdValue = common.euclidGCD(numerator, denominator)
+        gcdValue = gcd(numerator, denominator)
         numerator = numerator // gcdValue
         denominator = denominator // gcdValue
 

--- a/music21/meter/tools.py
+++ b/music21/meter/tools.py
@@ -267,7 +267,7 @@ def fractionSum(numDenomTuple: NumDenomTuple) -> NumDenom:
         return (n, d)
     else:  # there might be a better way to do this
         d = 1
-        d = math.lcm(dListUnique)
+        d = common.numberTools.lcm(dListUnique)
         # after finding d, multiply each numerator
         nShift = []
         for i in range(len(nList)):

--- a/music21/meter/tools.py
+++ b/music21/meter/tools.py
@@ -13,6 +13,7 @@
 import collections
 import fractions
 from functools import lru_cache
+import math
 import re
 import typing as t
 
@@ -266,7 +267,7 @@ def fractionSum(numDenomTuple: NumDenomTuple) -> NumDenom:
         return (n, d)
     else:  # there might be a better way to do this
         d = 1
-        d = common.lcm(dListUnique)
+        d = math.lcm(dListUnique)
         # after finding d, multiply each numerator
         nShift = []
         for i in range(len(nList)):

--- a/music21/meter/tools.py
+++ b/music21/meter/tools.py
@@ -13,7 +13,6 @@
 import collections
 import fractions
 from functools import lru_cache
-import math
 import re
 import typing as t
 

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -57,7 +57,7 @@ The :class:`music21.sieve.PitchSieve` class provides a quick generation of
 '''
 from ast import literal_eval
 import copy
-from math import lcm, gcd
+from math import gcd
 import random
 import string
 import unittest
@@ -67,6 +67,7 @@ from music21 import exceptions21
 from music21 import pitch
 from music21 import common
 from music21 import interval
+from music21.common.numberTools import lcm
 
 from music21 import environment
 environLocal = environment.Environment('sieve')

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -435,7 +435,7 @@ def _lcmRecurse(filterList):
             environLocal.printDebug(['lcm timed out'])
             lcmVal = None
             break
-        lcmVal = lcm(lcmVal, filterList[i])
+        lcmVal = lcm([lcmVal, filterList[i]])
     return lcmVal
 
 

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -57,6 +57,7 @@ The :class:`music21.sieve.PitchSieve` class provides a quick generation of
 '''
 from ast import literal_eval
 import copy
+from math import lcm, gcd
 import random
 import string
 import unittest
@@ -409,47 +410,6 @@ def unitNormStep(step, a=0, b=1, normalized=True):
 # note: some of these methods are in common, though they are slightly different algorithms;
 # need to test for compatibility
 
-def _gcd(a, b):
-    '''
-    find the greatest common divisor of a and b
-    i.e., the greatest number that is a factor of both numbers using
-    Euclid's algorithm
-
-
-    >>> sieve._gcd(20, 30)
-    10
-    '''
-    # alt implementation
-
-    # while b != 0:
-    #    a, b = b, a % b
-    # return abs(a)
-
-    # if a == 0 and b == 0:
-    #    return 1
-    # if b == 0:
-    #    return a
-    # if a == 0:
-    #    return b
-    # else:
-    #    return _gcd(b, a % b)
-
-    while b != 0:
-        a, b = b, a % b
-    return abs(a)
-
-
-def _lcm(a, b):
-    '''
-    find the lowest common multiple of a and b
-
-    >>> sieve._lcm(30, 20)
-    60
-    '''
-    # // forces integer style division (no remainder)
-    return abs(a * b) // _gcd(a, b)
-
-
 def _lcmRecurse(filterList):
     '''
     Given a list of values, find the LCM of all the values by iteratively
@@ -474,7 +434,7 @@ def _lcmRecurse(filterList):
             environLocal.printDebug(['lcm timed out'])
             lcmVal = None
             break
-        lcmVal = _lcm(lcmVal, filterList[i])
+        lcmVal = lcm(lcmVal, filterList[i])
     return lcmVal
 
 
@@ -852,7 +812,7 @@ class Residual:
         find m,n such that the intersection of two Residuals can
         be reduced to one Residual. Xenakis p 273.
         '''
-        d = _gcd(m1, m2)
+        d = gcd(m1, m2)
         c1 = m1 // d  # not sure if we need floats here
         c2 = m2 // d
         n3 = 0

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -990,7 +990,7 @@ class CompressionSegment:
 # ------------------------------------------------------------------------------
 
 # http://docs.python.org/lib/set-objects.html
-# set object precedence is places & before |
+# set object precedence: & before |
 
 # >>> a = set([3, 4])
 # >>> b = set([4, 5])


### PR DESCRIPTION
math.gcd <s>and math.lcm</s> were added and use C-speed.

math.gcd is Py3.8; ok.  lcm is Py3.9, not ok.