### PR TITLE
Clear cache when adding notes w/o sort

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4004,6 +4004,10 @@ class Chord(ChordBase):
                                  leaveRedundantPitches=leaveRedundantPitches)
         if inPlace is True:
             c2 = self
+
+        if t.TYPE_CHECKING:
+            from music21 import stream
+            assert isinstance(c2, stream.Stream)
         # startOctave = c2.bass().octave
         remainingPitches = copy.copy(c2.pitches)  # no deepcopy needed
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4571,13 +4571,12 @@ class Chord(ChordBase):
         Changed in v.6 -- if inPlace is True do not return anything.
         '''
         if inPlace:
-            # not until pitches inform notes which inform chords when they change.
             if self._cache.get('isSortedAscendingDiatonic', False):
                 return None
             returnObj = self
             self.clearCache()
         else:
-            # cache is not copied ever.
+            # cache is not copied to the new item.
             returnObj = copy.deepcopy(self)
         returnObj._notes.sort(key=lambda x: (x.pitch.diatonicNoteNum, x.pitch.ps))
         returnObj._cache['isSortedAscendingDiatonic'] = True

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -207,6 +207,8 @@ class ChordBase(note.NotRest):
         as can use it -- it's all an optimization step to create as few duration objects
         as is necessary.
 
+        Does not clear any caches.
+
         Also requires that notes be iterable.
         '''
         # quickDuration specifies whether the duration object for the chord

--- a/music21/note.py
+++ b/music21/note.py
@@ -1538,7 +1538,7 @@ class Note(NotRest):
         '''
         After doing a deepcopy of the pitch, be sure to set the client
         '''
-        new = t.cast(type(self), super().__deepcopy__(memo=memo))
+        new = super().__deepcopy__(memo=memo)
         new.pitch.client = new
         return new
 

--- a/music21/note.py
+++ b/music21/note.py
@@ -1436,7 +1436,7 @@ class Note(NotRest):
             self.pitch = pitch.Pitch(name, **keywords)
 
         # noinspection PyProtectedMember
-        self.pitch.client = self
+        self.pitch._client = self
 
     # --------------------------------------------------------------------------
     # operators, representations, and transformations
@@ -1540,7 +1540,8 @@ class Note(NotRest):
         After doing a deepcopy of the pitch, be sure to set the client
         '''
         new = super().__deepcopy__(memo=memo)
-        new.pitch.client = new  # pylint: disable=no-member
+        # noinspection PyProtectedMember
+        new.pitch._client = new  # pylint: disable=no-member
         return new
 
     # --------------------------------------------------------------------------

--- a/music21/note.py
+++ b/music21/note.py
@@ -1538,7 +1538,7 @@ class Note(NotRest):
         '''
         After doing a deepcopy of the pitch, be sure to set the client
         '''
-        new = super().__deepcopy__(memo=memo)
+        new = t.cast(type(self), super().__deepcopy__(memo=memo))
         new.pitch.client = new
         return new
 

--- a/music21/note.py
+++ b/music21/note.py
@@ -1540,7 +1540,7 @@ class Note(NotRest):
         After doing a deepcopy of the pitch, be sure to set the client
         '''
         new = super().__deepcopy__(memo=memo)
-        new.pitch.client = new
+        new.pitch.client = new  # pylint: disable=no-member
         return new
 
     # --------------------------------------------------------------------------

--- a/music21/note.py
+++ b/music21/note.py
@@ -16,6 +16,7 @@ Classes and functions for creating Notes, Rests, and Lyrics.
 The :class:`~music21.pitch.Pitch` object is stored within,
 and used to configure, :class:`~music21.note.Note` objects.
 '''
+from __future__ import annotations
 
 import copy
 import unittest
@@ -1534,7 +1535,7 @@ class Note(NotRest):
         except AttributeError:
             return NotImplemented
 
-    def __deepcopy__(self, memo=None):
+    def __deepcopy__(self: Note, memo=None) -> Note:
         '''
         After doing a deepcopy of the pitch, be sure to set the client
         '''

--- a/music21/note.py
+++ b/music21/note.py
@@ -1434,7 +1434,7 @@ class Note(NotRest):
             self.pitch = pitch.Pitch(name, **keywords)
 
         # noinspection PyProtectedMember
-        self.pitch._client = self
+        self.pitch.client = self
 
     # --------------------------------------------------------------------------
     # operators, representations, and transformations
@@ -1532,6 +1532,14 @@ class Note(NotRest):
             return self.pitch >= other.pitch
         except AttributeError:
             return NotImplemented
+
+    def __deepcopy__(self, memo=None):
+        '''
+        After doing a deepcopy of the pitch, be sure to set the client
+        '''
+        new = super().__deepcopy__(memo=memo)
+        new.pitch.client = new
+        return new
 
     # --------------------------------------------------------------------------
     # property access

--- a/music21/percussion.py
+++ b/music21/percussion.py
@@ -56,6 +56,11 @@ class PercussionChord(chord.ChordBase):
 
     isChord = False
 
+    def __deepcopy__(self, memo=None):
+        new = super().__deepcopy__(memo=memo)
+        for n in new._notes:
+            n._chordAttached = new
+        return new
 
     @property
     def notes(self) -> tuple:

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4184,7 +4184,7 @@ class Pitch(prebase.ProtoM21Object):
         if this pitch is attached to a note, then let it know that it has changed.
         '''
         if self.client is not None:
-            self.client.pitchChanged()
+            self.client.pitchChanged()  # pylint: disable=no-member
 
 
     def getAllCommonEnharmonics(self: PitchType, alterLimit: int = 2) -> t.List[PitchType]:

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -1830,7 +1830,7 @@ class Pitch(prebase.ProtoM21Object):
         self.fundamental: t.Optional['Pitch'] = None
 
         # so that we can tell clients about changes in pitches.
-        self_.client: t.Optional['music21.note.Note'] = None
+        self.client: t.Optional['music21.note.Note'] = None
 
         # name combines step, octave, and accidental
         if name is not None:

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -1830,7 +1830,7 @@ class Pitch(prebase.ProtoM21Object):
         self.fundamental: t.Optional['Pitch'] = None
 
         # so that we can tell clients about changes in pitches.
-        self.client: t.Optional['music21.note.Note'] = None
+        self._client: t.Optional['music21.note.Note'] = None
 
         # name combines step, octave, and accidental
         if name is not None:

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -864,7 +864,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         '_displayType',
         '_modifier',
         '_name',
-        'client',
+        '_client',
         'displayLocation',
         'displaySize',
         'displayStyle',
@@ -896,8 +896,8 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         # above and below could also be useful for gruppetti, etc.
         self.displayLocation = 'normal'
 
-        # store a reference to the object that has this duration object as a property
-        self.client: t.Optional['music21.note.Note'] = None
+        # store a reference to the Pitch that has this Accidental object as a property
+        self._client: t.Optional['Pitch'] = None
         self._name = ''
         self._modifier = ''
         self._alter = 0.0     # semitones to alter step
@@ -1178,8 +1178,8 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
                 raise AccidentalException(f'{name} is not a supported accidental type')
 
         self._modifier = accidentalNameToModifier[self._name]
-        if self.client is not None:
-            self.client.informClient()
+        if self._client:
+            self._client.informClient()
 
 
     def isTwelveTone(self):
@@ -1238,8 +1238,8 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
 
         privateAttrName = '_' + attribute
         setattr(self, privateAttrName, value)
-        if self.client is not None:
-            self.client.informClient()
+        if self._client:
+            self._client.informClient()
 
     # --------------------------------------------------------------------------
     def inheritDisplay(self, other):
@@ -1830,7 +1830,7 @@ class Pitch(prebase.ProtoM21Object):
         self.fundamental: t.Optional['Pitch'] = None
 
         # so that we can tell clients about changes in pitches.
-        self.client: t.Optional['music21.note.Note'] = None
+        self_.client: t.Optional['music21.note.Note'] = None
 
         # name combines step, octave, and accidental
         if name is not None:
@@ -1929,7 +1929,7 @@ class Pitch(prebase.ProtoM21Object):
         highly optimized -- it knows exactly what can only have a scalar value and
         just sets that directly, only running deepcopy on the other bits.
 
-        And client should NOT be deepcopied.  In fact, it is cleared to nothing.
+        And _client should NOT be deepcopied.  In fact, it is cleared to nothing.
         deepcopy of note will set it back.
         '''
         if type(self) is Pitch:  # pylint: disable=unidiomatic-typecheck
@@ -1939,7 +1939,7 @@ class Pitch(prebase.ProtoM21Object):
                 if k in ('_step', '_overridden_freq440', 'defaultOctave',
                          '_octave', 'spellingIsInferred'):
                     setattr(new, k, v)
-                elif k == 'client':
+                elif k == '_client':
                     setattr(new, k, None)
                 else:
                     setattr(new, k, copy.deepcopy(v, memo))
@@ -4183,8 +4183,8 @@ class Pitch(prebase.ProtoM21Object):
         '''
         if this pitch is attached to a note, then let it know that it has changed.
         '''
-        if self.client is not None:
-            self.client.pitchChanged()  # pylint: disable=no-member
+        if self._client is not None:
+            self._client.pitchChanged()  # pylint: disable=no-member
 
 
     def getAllCommonEnharmonics(self: PitchType, alterLimit: int = 2) -> t.List[PitchType]:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1800,35 +1800,32 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                               removeFromIgnore=None
                               ) -> StreamType:
         # NOTE: this is a performance critical operation
-        defaultIgnoreSet = {'_offsetDict', 'streamStatus', '_elements', '_endElements', '_cache',
-                            }
+        defaultIgnoreSet = {
+            '_offsetDict', 'streamStatus', '_elements', '_endElements', '_cache',
+        }
         if ignoreAttributes is None:
             ignoreAttributes = defaultIgnoreSet
         else:  # pragma: no cover
             ignoreAttributes = ignoreAttributes | defaultIgnoreSet
-        new = super()._deepcopySubclassable(memo, ignoreAttributes, removeFromIgnore)
+
+        # PyCharm seems to think that this is a StreamCore
+        # noinspection PyTypeChecker
+        new: StreamType = super()._deepcopySubclassable(memo, ignoreAttributes, removeFromIgnore)
 
         if removeFromIgnore is not None:  # pragma: no cover
             ignoreAttributes = ignoreAttributes - removeFromIgnore
 
-        if '_offsetDict' in ignoreAttributes:
-            newOffsetDict: t.Dict[int, t.Tuple[OffsetQLSpecial, base.Music21Object]] = {}
-            setattr(new, '_offsetDict', newOffsetDict)
-        # all subclasses of Music21Object that define their own
-        # __deepcopy__ methods must be sure to not try to copy activeSite
-        elif '_offsetDict' in self.__dict__:
-            newOffsetDict2: t.Dict[int, t.Tuple[OffsetQLSpecial, base.Music21Object]] = {}
-            setattr(new, '_offsetDict', newOffsetDict2)
+        # new._offsetDict will get filled when ._elements is copied.
+        newOffsetDict: t.Dict[int, t.Tuple[OffsetQLSpecial, base.Music21Object]] = {}
+        new._offsetDict = newOffsetDict
 
         if 'streamStatus' in ignoreAttributes:
             # update the client
-            if self.streamStatus is not None:
-                # storedClient = self.streamStatus.client  # Should be self.
-                # self.streamStatus.client = None
-                newStreamStatus = copy.deepcopy(self.streamStatus)
-                newStreamStatus.client = new
-                setattr(new, 'streamStatus', newStreamStatus)
-                # self.streamStatus.client = storedClient
+            # self.streamStatus.client = None
+            newStreamStatus = copy.deepcopy(self.streamStatus)
+            newStreamStatus.client = new
+            setattr(new, 'streamStatus', newStreamStatus)
+            # self.streamStatus.client = storedClient
         if '_elements' in ignoreAttributes:
             # must manually add elements to new Stream
             for e in self._elements:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1794,7 +1794,11 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return self._removeIteration(elFilter)
 
     # pylint: disable=no-member
-    def _deepcopySubclassable(self, memo=None, ignoreAttributes=None, removeFromIgnore=None):
+    def _deepcopySubclassable(self: M21ObjType,
+                              memo=None,
+                              ignoreAttributes=None,
+                              removeFromIgnore=None
+                              ) -> M21ObjType:
         # NOTE: this is a performance critical operation
         defaultIgnoreSet = {'_offsetDict', 'streamStatus', '_elements', '_endElements', '_cache',
                             }
@@ -1863,7 +1867,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         return new
 
-    def __deepcopy__(self, memo=None):
+    def __deepcopy__(self: M21ObjType, memo=None) -> M21ObjType:
         '''
         Deepcopy the stream from copy.deepcopy()
         '''

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1794,11 +1794,11 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return self._removeIteration(elFilter)
 
     # pylint: disable=no-member
-    def _deepcopySubclassable(self: M21ObjType,
+    def _deepcopySubclassable(self: StreamType,
                               memo=None,
                               ignoreAttributes=None,
                               removeFromIgnore=None
-                              ) -> M21ObjType:
+                              ) -> StreamType:
         # NOTE: this is a performance critical operation
         defaultIgnoreSet = {'_offsetDict', 'streamStatus', '_elements', '_endElements', '_cache',
                             }
@@ -1812,21 +1812,22 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             ignoreAttributes = ignoreAttributes - removeFromIgnore
 
         if '_offsetDict' in ignoreAttributes:
-            newValue = {}
-            setattr(new, '_offsetDict', newValue)
+            newOffsetDict: t.Dict[int, t.Tuple[OffsetQLSpecial, base.Music21Object]] = {}
+            setattr(new, '_offsetDict', newOffsetDict)
         # all subclasses of Music21Object that define their own
         # __deepcopy__ methods must be sure to not try to copy activeSite
-        if '_offsetDict' in self.__dict__:
-            newValue = {}
-            setattr(new, '_offsetDict', newValue)
+        elif '_offsetDict' in self.__dict__:
+            newOffsetDict2: t.Dict[int, t.Tuple[OffsetQLSpecial, base.Music21Object]] = {}
+            setattr(new, '_offsetDict', newOffsetDict2)
+
         if 'streamStatus' in ignoreAttributes:
             # update the client
             if self.streamStatus is not None:
                 # storedClient = self.streamStatus.client  # Should be self.
                 # self.streamStatus.client = None
-                newValue = copy.deepcopy(self.streamStatus)
-                newValue.client = new
-                setattr(new, 'streamStatus', newValue)
+                newStreamStatus = copy.deepcopy(self.streamStatus)
+                newStreamStatus.client = new
+                setattr(new, 'streamStatus', newStreamStatus)
                 # self.streamStatus.client = storedClient
         if '_elements' in ignoreAttributes:
             # must manually add elements to new Stream

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1867,7 +1867,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         return new
 
-    def __deepcopy__(self: M21ObjType, memo=None) -> M21ObjType:
+    def __deepcopy__(self: StreamType, memo=None) -> StreamType:
         '''
         Deepcopy the stream from copy.deepcopy()
         '''


### PR DESCRIPTION
This was failing:

```
>>> c = chord.Chord('C4 E4 G4')
>>> c.isConsonant()
True

>>> c.add('C#4', runSort=False)
>>> c.isConsonant()
True
```

The cache was only being cleared during `runSort=True`, which is the default.  But needs to happen either side.

Also caches the sort status, so repeated Chord.sort(inPlace=True) should be much faster.