### PR TITLE
MusicXML export: Make rests before making notation

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -469,6 +469,14 @@ class GeneralObjectExporter:
 
         Changed in v8 -- fills gaps with rests before calling makeNotation
         to avoid duplicating effort with :meth:`PartExporter.fixupNotationMeasured`.
+
+        >>> v = stream.Voice(note.Note())
+        >>> m = stream.Measure([meter.TimeSignature(), v])
+        >>> GEX = musicxml.m21ToXml.GeneralObjectExporter(m)
+        >>> out = GEX.parse()  # out is bytes
+        >>> outStr = out.decode('utf-8')  # now is string
+        >>> '<note print-object="no" print-spacing="yes">' in outStr
+        True
         '''
         classes = obj.classes
         outObj = None

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1688,8 +1688,6 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         Appends the PartExporter to `self.partExporterList`
         and runs .parse() on that part. Appends the PartExporter to self.
 
-        Hide rests created at this late stage.
-
         >>> v = stream.Voice(note.Note())
         >>> m = stream.Measure([meter.TimeSignature(), v])
         >>> GEX = musicxml.m21ToXml.GeneralObjectExporter(m)

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -473,7 +473,7 @@ class GeneralObjectExporter:
         classes = obj.classes
         outObj = None
 
-        if isinstance(obj, stream.Stream):
+        if isinstance(obj, stream.Stream) and self.makeNotation:
             obj.makeRests(refStreamOrTimeRange=[0.0, obj.highestTime],
                           fillGaps=True,
                           inPlace=True,

--- a/music21/musicxml/test_m21ToXml.py
+++ b/music21/musicxml/test_m21ToXml.py
@@ -419,9 +419,13 @@ class Test(unittest.TestCase):
         s = stream.Score([converter.parse('tinyNotation: 4/4 c4')])
         s[stream.Measure].first().paddingLeft = 2.0
         s[stream.Measure].first().paddingRight = 1.0
+        # workaround until getET() helper starts calling fromGeneralObject
+        s = GeneralObjectExporter().fromGeneralObject(s)
         tree = self.getET(s)
         self.assertEqual(len(tree.findall('.//rest')), 0)
         s[stream.Measure].first().paddingLeft = 1.0
+        # workaround until getET() helper starts calling fromGeneralObject
+        s = GeneralObjectExporter().fromGeneralObject(s)
         tree = self.getET(s)
         self.assertEqual(len(tree.findall('.//rest')), 1)
 
@@ -455,6 +459,7 @@ class Test(unittest.TestCase):
         m.insert(2, tempo.MetronomeMark('slow', 40))
 
         gex = GeneralObjectExporter()
+        gex.makeNotation = False
         tree = self.getET(gex.fromGeneralObject(m))
         self.assertFalse(tree.findall('.//forward'))
         self.assertEqual(
@@ -594,6 +599,7 @@ class Test(unittest.TestCase):
 
     def testExportChordSymbolsWithRealizedDurations(self):
         gex = GeneralObjectExporter()
+        gex.makeNotation = False
 
         def realizeDurationsAndAssertTags(mm: stream.Measure, forwardTag=False, offsetTag=False):
             mm = copy.deepcopy(mm)

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -840,6 +840,9 @@ def makeRests(
     else:
         returnObj = s
 
+    # Invalidate tuplet status
+    returnObj.streamStatus.tuplets = None
+
     if returnObj.iter().parts:
         for inner_part in returnObj.iter().parts:
             inner_part.makeRests(


### PR DESCRIPTION
Follow up to #1242. Didn't quite fix #904 because we need to make rests _before_ making notation (if we are to have the opportunity to re-express the rests inside tuplets). 