### PR TITLE
no-self-use is optional extension

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -69,7 +69,7 @@ disable=
     too-many-lines,  # yes, someday
     too-many-return-statements,  # we'll see
     too-many-instance-attributes,  # maybe later
-    no-self-use,  # it might be later.
+    # no-self-use,  # moved to optional extension.
     invalid-name,  # these are good music21 names; fix the regexp instead...
     too-few-public-methods,  # never remove or set to 1
     trailing-whitespace,  # should ignore blank lines with tabs

--- a/music21/test/testLint.py
+++ b/music21/test/testLint.py
@@ -120,7 +120,7 @@ def main(fnAccept=None, strict=False):
         'consider-using-dict-items',  # readability improvement depends on excellent variable names
 
         'invalid-name',      # these are good music21 names; fix the regexp instead...
-        'no-self-use',       # maybe later
+        # 'no-self-use',       # no-self-use was moved to an optional extension
         'too-few-public-methods',  # never remove or set to 1
 
         'trailing-whitespace',  # should ignore blank lines with tabs


### PR DESCRIPTION
@jacobtylerwalls removed it earlier, but Malcolm noticed it, so I've put it back commented out so we know to tell people to upgrade pylint if it appears.