### PR TITLE
Prevent too large `<backup>` values in PartStaffExporter

### DIFF
--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -743,7 +743,12 @@ class PartStaffExporterMixin:
 
         # Create <backup>
         amountToBackup: int = 0
-        for dur in otherMeasure.findall('note/duration'):
+        for note in otherMeasure.findall('note'):
+            if note.find('chord') is not None:
+                continue
+            dur = note.find('duration')
+            if dur is None:
+                continue
             backupDurText = dur.text
             if backupDurText is not None:
                 amountToBackup += int(backupDurText)
@@ -1066,6 +1071,23 @@ class Test(unittest.TestCase):
         ps1[stream.Measure].last().number = 0  # was measure 2
         root = self.getET(s)
         self.assertEqual(len(root.findall('part/measure/attributes/time')), 3)
+
+    def testBackupAmount(self):
+        '''Regression test for chord members causing too-large backup amounts.'''
+        from music21 import chord
+        from music21 import defaults
+        from music21 import layout
+
+        ps1 = stream.PartStaff(chord.Chord("C E G"))
+        ps2 = stream.PartStaff(chord.Chord("D F A"))
+        sg = layout.StaffGroup([ps1, ps2])
+        s = stream.Score([sg, ps1, ps2])
+
+        root = self.getET(s)
+        self.assertEqual(
+            root.findall('part/measure/backup/duration')[0].text,
+            str(defaults.divisionsPerQuarter)
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The PartStaffExporter was producing `<duration>` values under `<backup>` tags that were too large by summing the durations of all chord members (instead of just taking one of the durations).

Adds a regression test failing on master:
```
======================================================================
FAIL: testBackupAmount (__main__.Test.testBackupAmount)
Regression test for chord members causing too-large backup amounts.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jacobwalls/music21/music21/musicxml/partStaffExporter.py", line 1079, in testBackupAmount
    self.assertEqual(
AssertionError: '30240' != '10080'
- 30240
+ 10080


----------------------------------------------------------------------
Ran 21 tests in 2.173s

FAILED (failures=1)
```