### PR TITLE
fixed up romanText repeats

### DIFF
--- a/music21/romanText/rtObjects.py
+++ b/music21/romanText/rtObjects.py
@@ -28,7 +28,9 @@ environLocal = environment.Environment('romanText.rtObjects')
 
 # alternate endings might end with a, b, c for
 # nonzero or more for everything after the first number
-reMeasureTag = re.compile(r'm[0-9]+[a-b]*-*[0-9]*[a-b]*')
+# letterToNumDict in romanText/translate.py implies that reMeasureTag should
+#   match a-h (at least), not a-b
+reMeasureTag = re.compile(r'm[0-9]+[a-h]*-*[0-9]*[a-h]*')
 reVariant = re.compile(r'var[0-9]+')
 reVariantLetter = re.compile(r'var([A-Z]+)')
 

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -1635,7 +1635,6 @@ m2: I :||
         _repeat_tester(end_repeat, 'end', 3.0, 2)
         _test_expanded(s, 12.0)
 
-        # TODO flake quotes
         single_bar_repeats = '''Time Signature: 2/4
 m1: ||: I :||
 '''

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -130,13 +130,16 @@ import unittest
 from music21 import bar
 from music21 import base
 from music21 import common
+from music21 import converter
 from music21 import exceptions21
 from music21 import harmony
 from music21 import key
 from music21 import metadata
 from music21 import meter
 from music21 import note
+from music21 import repeat
 from music21 import roman
+from music21 import spanner
 from music21 import stream
 from music21 import tie
 from music21.romanText import rtObjects
@@ -674,7 +677,6 @@ class PartTranslator:
         self.numberOfAtomsInCurrentMeasure = len(measureToken.atoms)
         # first RomanNumeral object after a key change should have this set to True
         self.setKeyChangeToken = False
-
         for i, a in enumerate(measureToken.atoms):
             isLastAtomInMeasure = (i == self.numberOfAtomsInCurrentMeasure - 1)
             self.translateSingleMeasureAtom(a, m, isLastAtomInMeasure=isLastAtomInMeasure)
@@ -781,15 +783,21 @@ class PartTranslator:
         elif isinstance(a, rtObjects.RTChord):
             self.processRTChord(a, m, self.currentOffsetInMeasure)
         elif isinstance(a, rtObjects.RTRepeat):
-            if self.currentOffsetInMeasure == 0:
+            if isinstance(a, rtObjects.RTRepeatStop) and isLastAtomInMeasure:
+                # This condition needs to be moved here because it is possible
+                #   and indeed likely that a end repeat will have an offset of
+                #   0 in the case that there is 0 or 1 harmonies in the measure.
+                # Is it ok, however, that this condition will match if self.tsCurrent
+                #   is None? Previously, that case was excluded below.
+                m.rightBarline = bar.Repeat(direction='end')
+            elif self.currentOffsetInMeasure == 0:
                 if isinstance(a, rtObjects.RTRepeatStart):
                     m.leftBarline = bar.Repeat(direction='start')
                 else:
                     rtt = RomanTextUnprocessedToken(a)
                     m.coreInsert(self.currentOffsetInMeasure, rtt)
             elif (self.tsCurrent is not None
-                    and (self.tsCurrent.barDuration.quarterLength == self.currentOffsetInMeasure
-                         or isLastAtomInMeasure)):
+                    and self.tsCurrent.barDuration.quarterLength == self.currentOffsetInMeasure):
                 if isinstance(a, rtObjects.RTRepeatStop):
                     m.rightBarline = bar.Repeat(direction='end')
                 else:
@@ -1041,7 +1049,6 @@ def _addRepeatsFromRepeatEndings(s, repeatEndings):
     '''
     given a Stream and the repeatEndings dict, add repeats to the stream...
     '''
-    from music21 import spanner
     consolidatedRepeats = _consolidateRepeatEndings(repeatEndings)
     for repeatEndingTuple in consolidatedRepeats:
         measureList, endingNumber = repeatEndingTuple[0], repeatEndingTuple[1]
@@ -1574,13 +1581,8 @@ m1 C: I'''
         m25 = p.getElementsByClass(stream.Measure)[24]
         self.assertEqual(m25.getOffsetBySite(p), 88.0)
 
-    def testEndings(self):
-        # has first and second endings...
-
-        from music21.romanText import testFiles
-        from music21 import converter
-        unused_s = converter.parse(testFiles.mozartK283_2_opening, format='romanText')
-        # s.show('text')
+    # testEndings (which was incomplete in any case) has been superseded by
+    #   testRepeats below
 
     def testTuplets(self):
         from music21 import converter
@@ -1604,6 +1606,93 @@ m1 C: I'''
         self.assertEqual(n1.duration.quarterLength, common.opFrac(11 / 6))
         self.assertEqual(n2.offset, common.opFrac(11 / 6))
         self.assertEqual(n2.duration.quarterLength, common.opFrac(13 / 6))
+
+    def testRepeats(self) -> None:
+        def _repeat_tester(
+            repeat_bar: bar.Repeat, direction: str, offset: float, mNumber: int
+        ) -> None:
+            self.assertEqual(repeat_bar.direction, direction)
+            self.assertEqual(repeat_bar.offset, offset)
+            self.assertEqual(repeat_bar.activeSite.number, mNumber)
+
+        def _test_expanded(s: stream.Stream, quarterLength: float) -> None:
+            # NB repeat.Expander does not work on stream, only on part. Is this
+            #   expected behavior?
+            p = next(s[stream.Part])
+            e = repeat.Expander(p)
+            self.assertTrue(e.repeatBarsAreCoherent())
+            p2 = e.process()
+            self.assertEqual(p2.quarterLength, quarterLength)
+
+        # Test simple repeats
+        simple_repeats = '''Time Signature: 3/4
+m1: ||: V
+m2: I :||
+'''
+        s = converter.parse(simple_repeats, format='romanText')
+        start_repeat, end_repeat = s[bar.Repeat]
+        _repeat_tester(start_repeat, 'start', 0.0, 1)
+        _repeat_tester(end_repeat, 'end', 3.0, 2)
+        _test_expanded(s, 12.0)
+
+        # TODO flake quotes
+        single_bar_repeats = '''Time Signature: 2/4
+m1: ||: I :||
+'''
+        s = converter.parse(single_bar_repeats, format='romanText')
+        start_repeat, end_repeat = s[bar.Repeat]
+        _repeat_tester(start_repeat, 'start', 0.0, 1)
+        _repeat_tester(end_repeat, 'end', 2.0, 1)
+        _test_expanded(s, 4.0)
+
+        empty_bars_with_repeats = '''Time Signature: 2/4
+m1: I
+m2: ||:
+m3: :||
+m4: ||: :||'''
+        s = converter.parse(empty_bars_with_repeats, format='romanText')
+        start_repeat1, end_repeat1, start_repeat2, end_repeat2 = s[bar.Repeat]
+        _repeat_tester(start_repeat1, 'start', 0.0, 2)
+        _repeat_tester(end_repeat1, 'end', 2.0, 3)
+        _repeat_tester(start_repeat2, 'start', 0.0, 4)
+        _repeat_tester(end_repeat2, 'end', 2.0, 4)
+        _test_expanded(s, 14.0)
+
+        three_endings = '''Time Signature: 3/4
+m1: ||: I
+m2a: IV :||
+m2b: V :||
+m2c: I'''
+        s = converter.parse(three_endings, format='romanText')
+        start_repeat, end_repeat1, end_repeat2 = s[bar.Repeat]
+        _repeat_tester(start_repeat, 'start', 0.0, 1)
+        _repeat_tester(end_repeat1, 'end', 3.0, 2)
+        _repeat_tester(end_repeat2, 'end', 3.0, 2)
+        first_ending, second_ending, third_ending = s[spanner.RepeatBracket]  # pylint: disable=unused-variable
+        # TODO the following tests don't work; repr(first_ending) gives
+        #   '<music21.spanner.RepeatBracket 1 <music21.stream.Measure 2a offset=3.0>>'
+        #   but first_ending.getNumberList() returns [1]
+        #   What is the correct approach to checking that the measures are as we
+        #   expect? Or should we just forget about it since _test_expanded passes?
+        # self.assertEqual(first_ending.getNumberList(), ['2a'])
+        # self.assertEqual(second_ending.getNumberList(), ['2b'])
+        _test_expanded(s, 18.0)
+
+        more_complex_example = '''TimeSignature: 3/4
+m1: ||: I
+m2a: IV
+m3a: V :||
+m2b: V :||
+m2c: IV
+m3c: V
+m4: I'''
+        s = converter.parse(more_complex_example, format='romanText')
+        start_repeat, end_repeat1, end_repeat2 = s[bar.Repeat]
+        _repeat_tester(start_repeat, 'start', 0.0, 1)
+        _repeat_tester(end_repeat1, 'end', 3.0, 3)
+        _repeat_tester(end_repeat2, 'end', 3.0, 2)
+        first_ending, second_ending, third_ending = s[spanner.RepeatBracket]  # pylint: disable=unused-variable
+        _test_expanded(s, 27.0)
 
 
 # ------------------------------------------------------------------------------

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -130,7 +130,6 @@ import unittest
 from music21 import bar
 from music21 import base
 from music21 import common
-from music21 import converter
 from music21 import exceptions21
 from music21 import harmony
 from music21 import key
@@ -1608,6 +1607,8 @@ m1 C: I'''
         self.assertEqual(n2.duration.quarterLength, common.opFrac(13 / 6))
 
     def testRepeats(self) -> None:
+        from music21 import converter
+
         def _repeat_tester(
             repeat_bar: bar.Repeat, direction: str, offset: float, mNumber: int
         ) -> None:


### PR DESCRIPTION
This PR addresses much of #858, though not (I think) the case of mid-measure repeats.

It turns out that romanText repeats were already largely implemented (by whoever wrote the romanText/translate.py, presumably), but there were a couple bugs that were preventing it from working as expected and there was no test.

I wrote some test cases and debugged the existing code. The bugs are explained in comments in the code. As far as I can tell, the repeats now work smoothly.

I also have a few (non-urgent, I think) questions in the comments. I'll repeat them here:

1. repeat.Expander does not work on stream.Stream, only on stream.Part. Is this expected behavior?
2. in the case of 1st and 2nd endings, spanner.RepeatBracket.getNumberList does not return the measure numbers I expect. What is the correct approach here?