### PR TITLE
Add TypeGuard from typing_extensions

### DIFF
--- a/music21/common/classTools.py
+++ b/music21/common/classTools.py
@@ -10,6 +10,7 @@
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 import contextlib
+import numbers
 import typing as t
 from typing_extensions import TypeGuard  # move to typing when 3.10 is minimum
 
@@ -19,10 +20,10 @@ __all__ = [
     'tempAttribute', 'saveAttributes',
 ]
 
-def isNum(usrData: t.Any) -> TypeGuard[Number]:
+def isNum(usrData: t.Any) -> TypeGuard[numbers.Number]:
     '''
     check if usrData is a number (float, int, long, Decimal),
-    return boolean
+    return boolean, and type it as a numbers.Number
 
     unlike `isinstance(usrData, Number)` does not return True for `True, False`.
 
@@ -63,7 +64,7 @@ def isNum(usrData: t.Any) -> TypeGuard[Number]:
         return False
 
 
-def isListLike(usrData: t.Any) -> TypeGuard[t.Union[List[t.Any], Tuple[t.Any, ...]]]:
+def isListLike(usrData: t.Any) -> TypeGuard[t.Union[t.List[t.Any], t.Tuple[t.Any, ...]]]:
     '''
     Returns True if is a List or Tuple or their subclasses.
 

--- a/music21/common/classTools.py
+++ b/music21/common/classTools.py
@@ -6,11 +6,12 @@
 # Authors:      Michael Scott Asato Cuthbert
 #               Christopher Ariza
 #
-# Copyright:    Copyright © 2009-2015 Michael Scott Asato Cuthbert and the music21 Project
+# Copyright:    Copyright © 2009-2022 Michael Scott Asato Cuthbert and the music21 Project
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 import contextlib
 import typing as t
+from typing_extensions import TypeGuard  # move to typing when 3.10 is minimum
 
 # from music21 import exceptions21
 __all__ = [
@@ -18,8 +19,7 @@ __all__ = [
     'tempAttribute', 'saveAttributes',
 ]
 
-
-def isNum(usrData: t.Any) -> bool:
+def isNum(usrData: t.Any) -> TypeGuard[Number]:
     '''
     check if usrData is a number (float, int, long, Decimal),
     return boolean
@@ -63,7 +63,7 @@ def isNum(usrData: t.Any) -> bool:
         return False
 
 
-def isListLike(usrData: t.Any) -> bool:
+def isListLike(usrData: t.Any) -> TypeGuard[t.Union[List[t.Any], Tuple[t.Any, ...]]]:
     '''
     Returns True if is a List or Tuple or their subclasses.
 
@@ -88,7 +88,7 @@ def isListLike(usrData: t.Any) -> bool:
     return isinstance(usrData, (list, tuple))
 
 
-def isIterable(usrData: t.Any) -> bool:
+def isIterable(usrData: t.Any) -> TypeGuard[t.Union[t.Iterable, range]]:
     '''
     Returns True if is the object can be iter'd over
     and is NOT a string
@@ -112,7 +112,7 @@ def isIterable(usrData: t.Any) -> bool:
     >>> common.isIterable(stream.Stream)
     False
 
-    Changed in v7.3 -- Classes (not instances) are not iterable
+    Changed in v7.3 -- Classes are not iterable, only instances are.
     '''
     if isinstance(usrData, (str, bytes)):
         return False
@@ -242,7 +242,6 @@ def saveAttributes(obj, *attributeList):
 
 # ------------------------------------------------------------------------------
 # define presented order in documentation
-# _DOC_ORDER = [fromRoman, toRoman]
 
 if __name__ == '__main__':
     import music21

--- a/music21/common/classTools.py
+++ b/music21/common/classTools.py
@@ -27,12 +27,13 @@ def isNum(usrData: t.Any) -> TypeGuard[numbers.Number]:
 
     unlike `isinstance(usrData, Number)` does not return True for `True, False`.
 
-    Does not use `isinstance(usrData, Number)` which is 6 times slower
+    Does not use `isinstance(usrData, Number)` which is twice as times slow
     than calling this function (except in the case of Fraction, when
-    it's 6 times faster, but that's rarer)
+    it's 6 times faster, but that's rarer).  Prior to Python 3.9, it was
+    six times slower, which was a big deal.
 
     Runs by adding 0 to the "number" -- so anything that implements
-    add to a scalar works
+    add to a scalar works:
 
     >>> common.isNum(3.0)
     True

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ more_itertools
 numpy
 webcolors>=1.5
 requests
+typing_extensions


### PR DESCRIPTION
Should help mypy with places where we use isNum, isListLike, and isIterable.