### PR TITLE
Prevent zero-duration ChordSymbols from matching stripTies algorithm

### DIFF
--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -7026,10 +7026,14 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             else:
                 return  # exit
 
-        # need to just get .notesAndRests, as there may be other objects in the Measure
+        # need to just get .notesAndRests with a nonzero duration,
+        # as there may be other objects in the Measure
         # that come before the first Note, such as a SystemLayout object
+        # or there could be ChordSymbols with zero (unrealized) durations
         f = returnObj.flatten()
-        notes_and_rests = f.notesAndRests.stream()
+        notes_and_rests = f.notesAndRests.addFilter(
+            lambda el, iterator: el.quarterLength > 0
+        ).stream()
 
         posConnected = []  # temporary storage for index of tied notes
         posDelete = []  # store deletions to be processed later

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -1549,6 +1549,29 @@ class Test(unittest.TestCase):
             + '<music21.chord.Chord G4 C5>, <music21.chord.Chord C4 F4>)'
         )  # previously was 1 element
 
+    def testStripTiesIgnoresUnrealizedChordSymbol(self):
+        from music21 import harmony
+
+        n0 = note.Note('C')
+        n0.tie = tie.Tie('start')
+        n1 = note.Note('C')
+        n1.tie = tie.Tie('stop')
+
+        # Create ChordSymbol having one pitch only
+        cs0 = harmony.ChordSymbol()
+        cs0.bass('C', allow_add=True)
+        s = Stream()
+        s.insert(0.0, n0)
+        s.insert(1.0, cs0)
+        s.insert(1.0, n1)
+        s.makeNotation(inPlace=True)
+        stripped = s.stripTies(matchByPitch=True)
+
+        self.assertEqual(len(stripped[note.Note]), 1)
+        self.assertEqual(stripped[note.Note].first().quarterLength, 2)
+        self.assertEqual(len(stripped[harmony.ChordSymbol]), 1)
+        self.assertEqual(stripped[harmony.ChordSymbol].first().quarterLength, 0)
+
     def testTwoStreamMethods(self):
         from music21.note import Note
 


### PR DESCRIPTION
Fix #1294 