### PR TITLE
Parse double flats in RomanText

### DIFF
--- a/music21/key.py
+++ b/music21/key.py
@@ -75,7 +75,7 @@ def convertKeyStringToMusic21KeyString(textString):
     >>> key.convertKeyStringToMusic21KeyString('Ebb')
     'E--'
     '''
-    if (not textString[-1] == 'b') or textString == 'b':
+    if (not textString.endswith('b')) or textString == 'b':
         pass
     elif textString == 'bb':
         textString = 'b-'

--- a/music21/key.py
+++ b/music21/key.py
@@ -72,22 +72,19 @@ def convertKeyStringToMusic21KeyString(textString):
     'B--'
     >>> key.convertKeyStringToMusic21KeyString('bbb')
     'b--'
+    >>> key.convertKeyStringToMusic21KeyString('Ebb')
+    'E--'
     '''
-    if textString == 'bb':
+    if (not textString[-1] == 'b') or textString == 'b':
+        pass
+    elif textString == 'bb':
         textString = 'b-'
     elif textString == 'Bb':
         textString = 'B-'
     elif len(textString) == 2 and textString[-1] == 'b':
-        textString = textString[:1] + '-'
-    elif textString.endswith('b'):
-        m = re.match(r'''
-                (?P<leading_chars>.[^b]*) # matches at least one leading character
-                (?P<flats>b+)
-            ''',
-            textString,
-            flags=re.VERBOSE)
-        if m:
-            textString = m.group('leading_chars') + '-' * len(m.group('flats'))
+        textString = textString[0] + '-'
+    elif set(textString[1:]) == {'b'}:
+        textString = textString[0] + '-' * (len(textString) - 1)
     return textString
 
 

--- a/music21/key.py
+++ b/music21/key.py
@@ -68,13 +68,26 @@ def convertKeyStringToMusic21KeyString(textString):
     'b#'
     >>> key.convertKeyStringToMusic21KeyString('c')
     'c'
+    >>> key.convertKeyStringToMusic21KeyString('Bbb')
+    'B--'
+    >>> key.convertKeyStringToMusic21KeyString('bbb')
+    'b--'
     '''
     if textString == 'bb':
         textString = 'b-'
     elif textString == 'Bb':
         textString = 'B-'
-    elif textString.endswith('b') and not textString.startswith('b'):
-        textString = textString.rstrip('b') + '-'
+    elif len(textString) == 2 and textString[-1] == '-':
+        textString = textString[:1] + '-'
+    elif textString.endswith('b'):
+        m = re.match(r'''
+                (?P<leading_chars>.[^b]*) # matches at least one leading character
+                (?P<flats>b+)
+            ''',
+            textString,
+            flags=re.VERBOSE)
+        if m:
+            textString = m.group('leading_chars') + '-' * len(m.group('flats'))
     return textString
 
 

--- a/music21/key.py
+++ b/music21/key.py
@@ -77,7 +77,7 @@ def convertKeyStringToMusic21KeyString(textString):
         textString = 'b-'
     elif textString == 'Bb':
         textString = 'B-'
-    elif len(textString) == 2 and textString[-1] == '-':
+    elif len(textString) == 2 and textString[-1] == 'b':
         textString = textString[:1] + '-'
     elif textString.endswith('b'):
         m = re.match(r'''

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -308,6 +308,8 @@ def _getKeyAndPrefix(rtKeyOrString):
     (<music21.key.Key of b- minor>, 'b-: ')
     >>> romanText.translate._getKeyAndPrefix('b#')
     (<music21.key.Key of b# minor>, 'b#: ')
+    >>> romanText.translate._getKeyAndPrefix('Bbb')
+    (<music21.key.Key of B-- major>, 'B--: ')
     '''
     if isinstance(rtKeyOrString, str):
         rtKeyOrString = key.convertKeyStringToMusic21KeyString(rtKeyOrString)


### PR DESCRIPTION
Fixes #1390.

For the vast majority of cases (where there is just a single flat symbol) the regex on line 83 is overkill so we only run that if the preceding conditions don't match.