### PR TITLE
transpose key of RomanNumeral

### DIFF
--- a/music21/roman.py
+++ b/music21/roman.py
@@ -42,6 +42,8 @@ environLocal = environment.Environment('roman')
 
 # TODO: setting inversion should change the figure
 
+T = t.TypeVar('T', bound='RomanNumeral')
+
 # -----------------------------------------------------------------------------
 
 
@@ -3088,6 +3090,28 @@ class RomanNumeral(harmony.Harmony):
             raise RomanNumeralException(
                 f'_updatePitches() was unable to derive pitches from the figure: {self.figure!r}'
             )  # pragma: no cover
+
+    def transpose(self, value, *, inPlace=False) -> t.Optional[T]:
+        '''
+        Overrides :meth:`~music21.harmony.Harmony.transpose` so that `key`
+        attribute is transposed as well.
+
+        >>> rn = roman.RomanNumeral('I', 'C')
+        >>> rn
+        <music21.roman.RomanNumeral I in C major>
+        >>> rn.transpose(4)
+        <music21.roman.RomanNumeral I in E major>
+        >>> rn.transpose(-4, inPlace=True)
+        >>> rn
+        <music21.roman.RomanNumeral I in A- major>
+        '''
+        post = super().transpose(value, inPlace=inPlace)
+        if not inPlace:
+            post.key = self.key.transpose(value, inPlace=False)
+            return post
+        else:
+            self.key.transpose(value, inPlace=True)
+            return None
 
 
     # PUBLIC PROPERTIES #

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -3110,7 +3110,7 @@ class RomanNumeral(harmony.Harmony):
             post.key = self.key.transpose(value, inPlace=False)
             return post
         else:
-            self.key.transpose(value, inPlace=True)
+            self.key = self.key.transpose(value, inPlace=False)
             return None
 
 

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -3091,7 +3091,7 @@ class RomanNumeral(harmony.Harmony):
                 f'_updatePitches() was unable to derive pitches from the figure: {self.figure!r}'
             )  # pragma: no cover
 
-    def transpose(self, value, *, inPlace=False) -> t.Optional[T]:
+    def transpose(self: T, value, *, inPlace=False) -> t.Optional[T]:
         '''
         Overrides :meth:`~music21.harmony.Harmony.transpose` so that `key`
         attribute is transposed as well.

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -216,7 +216,9 @@ def _copySingleMeasure(rtTagged, p, kCurrent):
                 else:
                     rnPast.key = kCurrent
                 if rnPast.secondaryRomanNumeral is not None:
-                    newRN = roman.RomanNumeral(rnPast.figure, kCurrent)
+                    newRN = roman.RomanNumeral(
+                        rnPast.figure, copy.deepcopy(kCurrent)
+                    )
                     newRN.duration = copy.deepcopy(rnPast.duration)
                     newRN.lyrics = copy.deepcopy(rnPast.lyrics)
                     m.replace(rnPast, newRN)
@@ -282,7 +284,9 @@ def _copyMultipleMeasures(rtMeasure: rtObjects.RTMeasure,
                 else:
                     rnPast.key = kCurrent
                 if rnPast.secondaryRomanNumeral is not None:
-                    newRN = roman.RomanNumeral(rnPast.figure, kCurrent)
+                    newRN = roman.RomanNumeral(
+                        rnPast.figure, copy.deepcopy(kCurrent)
+                    )
                     newRN.duration = copy.deepcopy(rnPast.duration)
                     newRN.lyrics = copy.deepcopy(rnPast.lyrics)
                     m.replace(rnPast, newRN)

--- a/music21/romanText/tsvEg_v2_measures.tsv
+++ b/music21/romanText/tsvEg_v2_measures.tsv
@@ -1,0 +1,7 @@
+mn	volta	repeats
+1			
+2	1	end
+2	2	
+3		startend
+4		start
+5		end


### PR DESCRIPTION
Fixes the issue in #1413. I closely modeled RomanNumeral.transpose() on Harmony.transpose().