### PR TITLE
write 'slow 3/8' etc.

### DIFF
--- a/music21/romanText/writeRoman.py
+++ b/music21/romanText/writeRoman.py
@@ -249,7 +249,14 @@ class RnWriter(prebase.ProtoM21Object):
             tsThisMeasure = thisMeasure.getElementsByClass(meter.TimeSignature)
             if tsThisMeasure:
                 firstTS = tsThisMeasure[0]
-                self.combinedList.append(f'Time Signature: {firstTS.ratioString}')
+                if (firstTS.ratioString in ('3/8', '6/8')
+                        and firstTS.beatDivisionCountName == 'Simple'):
+                    tsPrefix = 'slow '
+                else:
+                    tsPrefix = ''
+                self.combinedList.append(
+                    f'Time Signature: {tsPrefix}{firstTS.ratioString}'
+                )
                 if len(tsThisMeasure) > 1:
                     unprocessedTSs = [x.ratioString for x in tsThisMeasure[1:]]
                     msg = f'further time signature change(s) unprocessed: {unprocessedTSs}'
@@ -413,7 +420,8 @@ class Test(unittest.TestCase):
     along with two test by modifying those scores.
 
     Additional tests for the standalone functions rnString and intBeat and
-    for handling the special case of opus objects.
+    for handling the special case of opus objects, plus a test to verify
+    handling of 'slow' 6/8 and 3/8.
     '''
 
     def testOpus(self):
@@ -541,6 +549,25 @@ class Test(unittest.TestCase):
 
         rn = roman.RomanNumeral('viio6', 'G')
         RnWriter(rn)  # and even (perhaps dubiously) directly on other music21 objects
+
+    def test_slow_meters(self):
+        from io import StringIO
+        from itertools import product
+        import textwrap
+        from music21 import converter
+        for ts, fast_or_slow in product(('3/8', '6/8'), ('slow ', 'fast ', '')):
+            rntxt = textwrap.dedent(f'''Time Signature: {fast_or_slow}{ts}
+                m1 C: I
+            ''')
+            text_stream = StringIO()
+            s = converter.parse(rntxt, format='romanText')
+            s.write('romanText', text_stream)
+            new_rntxt = text_stream.getvalue()
+            # Since the default is 'fast', it is not written out.
+            if fast_or_slow == 'fast ':
+                fast_or_slow = ''
+            self.assertIn(f'Time Signature: {fast_or_slow}{ts}', new_rntxt)
+
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1417.

One question might be: do we want the writer to write "fast 3/8" in the case of fast 3/8, etc? I didn't implement this since my approach is to change the existing behavior as little as possible. But I'm inclined to think it might be better to be maximally explicit and write "fast 3/8".

Another question could be: is there such thing as "slow 9/8" or "slow 12/8", etc? And what about "slow 3/16" etc.? I only check for 3/8 and 6/8 since these are the only such meters mentioned in the docs as far as I could tell. And in fact I believe I have never even seen "slow 6/8", only "slow 3/8".