### PR TITLE
Closing too many states should be a TNException

### DIFF
--- a/music21/tinyNotation.py
+++ b/music21/tinyNotation.py
@@ -16,7 +16,7 @@ music, but it is pretty useful for a lot of short examples, so we have
 made it a generally supported music21 format.
 
 
-N.B.: TinyNotation is not meant to expand to cover every single case.  Instead
+N.B.: TinyNotation is not meant to expand to cover every single case.  Instead,
 it is meant to be subclassable to extend to the cases *your* project needs.
 
 Here are the most important rules by default:
@@ -228,13 +228,13 @@ for details on how to do that.
 '''
 import collections
 import copy
+import fractions
 import re
-import typing
+import typing  # not importing as t, because of extensive preexisting use of `t` as token
 import unittest
 
 from music21 import note
 from music21 import duration
-from music21 import common
 from music21 import exceptions21
 from music21 import stream
 from music21 import tie
@@ -270,7 +270,7 @@ class State:
 
     def __init__(self, parent=None, stateInfo=None):
         self.affectedTokens = []
-        self.parent = common.wrapWeakref(parent)
+        self.parent = parent
         self.stateInfo = stateInfo
         # print('Adding state', self, parent.activeStates)
 
@@ -280,7 +280,7 @@ class State:
         '''
         pass
 
-    def end(self):
+    def end(self) -> None:
         '''
         called just after removing state
         '''
@@ -310,7 +310,12 @@ class State:
             if len(self.affectedTokens) == self.autoExpires:
                 self.end()
                 # this is a hack that should be done away with...
-                p = common.unwrapWeakref(self.parent)
+                p = self.parent
+
+                # I thought this was potentially O(n^2) but it's actually
+                # just O(n) on activeStates and on pop() operation.
+                # most of the time, backCount will be -1 and pop(-1)
+                # is O(1).  in fact pop(-m) seems to be O(m) not O(n)!
                 for i in range(len(p.activeStates)):
                     backCount = -1 * (i + 1)
                     if p.activeStates[backCount] is self:
@@ -395,7 +400,7 @@ class Modifier:
     def __init__(self, modifierData, modifierString, parent):
         self.modifierData = modifierData
         self.modifierString = modifierString
-        self.parent = common.wrapWeakref(parent)
+        self.parent = parent
 
     def preParse(self, tokenString):
         '''
@@ -875,10 +880,38 @@ class Converter:
        measures, Clefs, etc.
     * `raiseExceptions=True` to make errors become exceptions.
 
+    Generally, users should just use the general music21 converter (lowercase c) parse
+    function and do not need to be in this module at all:
+
+    >>> part = converter.parse('4/4 C4 D4 E2 F1', format='tinyNotation')
+    >>> part.show('text')
+    {0.0} <music21.stream.Measure 1 offset=0.0>
+        {0.0} <music21.clef.BassClef>
+        {0.0} <music21.meter.TimeSignature 4/4>
+        {0.0} <music21.note.Note C>
+        {1.0} <music21.note.Note D>
+        {2.0} <music21.note.Note E>
+    {4.0} <music21.stream.Measure 2 offset=4.0>
+        {0.0} <music21.note.Note F>
+        {4.0} <music21.bar.Barline type=final>
+
+    But for advanced work, create a tinyNotation.Converter object as shown:
 
     >>> tnc = tinyNotation.Converter('4/4 C##4 D e-8 f~ f f# g4 trip{f8 e d} C2=hello')
+
+    Run the parsing routine with `.parse()`
+
     >>> tnc.parse()
     <music21.tinyNotation.Converter object at 0x10aeefbe0>
+
+    And now the `.stream` attribute of the converter object
+    has the Stream (generally Part) ready to send out:
+
+    >>> tnc.stream
+    <music21.stream.Part 0x10acee860>
+
+    And all normal Stream methods are available on it:
+
     >>> tnc.stream.show('text')
     {0.0} <music21.stream.Measure 1 offset=0.0>
         {0.0} <music21.clef.TrebleClef>
@@ -916,14 +949,20 @@ class Converter:
     ['4/4', 'C##4', 'D', 'e-8', 'f~', 'f', 'f#', 'g4', 'trip{f8', 'e', 'd}', 'C2=hello']
     >>> tnc.setupRegularExpressions()
 
-    Then we parse the time signature:
-
+    Then we parse the time signature.
     >>> tnc.parseOne(0, tnc.preTokens[0])
     >>> tnc.stream.coreElementsChanged()
     >>> tnc.stream.show('text')
     {0.0} <music21.meter.TimeSignature 4/4>
 
-    Then the first note:
+    (Note that because we are calling
+    `show()` after each note in these docs, but TinyNotation
+    uses high efficiency `stream.core` routines, we need to set the stream
+    to a stable-state by calling `coreElementsChanged` after each call.
+    You would not need to do this in your own subclasses, since that would
+    lose the `O(n)` efficiency when parsing)
+
+    Then parse the first actual note:
 
     >>> tnc.parseOne(1, tnc.preTokens[1])
     >>> tnc.stream.coreElementsChanged()
@@ -966,6 +1005,15 @@ class Converter:
     >>> tnc.activeStates[0].affectedTokens
     [<music21.note.Note F>, <music21.note.Note E>]
 
+    The :class:`~music21.tinyNotation.TripletState` state adds
+    tuplets along the way, but does not set their type.
+
+    >>> f_starts_tuplet = tnc.activeStates[0].affectedTokens[0]
+    >>> f_starts_tuplet.duration.tuplets
+    (<music21.duration.Tuplet 3/2/eighth>,)
+    >>> f_starts_tuplet.duration.tuplets[0].type is None
+    True
+
     But the next token closes the state:
 
     >>> tnc.preTokens[10]
@@ -973,6 +1021,12 @@ class Converter:
     >>> tnc.parseOne(10, tnc.preTokens[10])
     >>> tnc.activeStates
     []
+
+    And this sets the tupet types for the F and D properly:
+
+    >>> f_starts_tuplet.duration.tuplets[0].type
+    'start'
+
     >>> tnc.stream.coreElementsChanged()
     >>> tnc.stream.show('text')
     {0.0} <music21.meter.TimeSignature 4/4>
@@ -996,7 +1050,10 @@ class Converter:
     >>> tnc.stream[-1].id
     'hello'
 
-    Then calling tnc.postParse() runs the makeNotation:
+    At this point the flattened stream is ready, if Converter.makeNotation
+    is False, then not much more needs to happen, but it is True by default.
+
+    So, then calling tnc.postParse() runs the makeNotation:
 
     >>> tnc.postParse()
     >>> tnc.stream.show('text')
@@ -1017,7 +1074,9 @@ class Converter:
         {2.0} <music21.note.Note C>
         {4.0} <music21.bar.Barline type=final>
 
-    Normally invalid notes or other tokens pass freely and drop the token:
+    Let's look at edge cases. Normally, invalid notes or
+    other bad tokens pass freely by dropping the unparseable token.
+    Here `3` is not a valid duration, so `d3` will be dropped.
 
     >>> x = converter.parse('tinyNotation: 4/4 c2 d3 e2')
     >>> x.show('text')
@@ -1029,7 +1088,7 @@ class Converter:
         {4.0} <music21.bar.Barline type=final>
 
     But with the keyword 'raiseExceptions=True' a `TinyNotationException`
-    is raised:
+    is raised if any token cannot be parsed.
 
     >>> x = converter.parse('tinyNotation: 4/4 c2 d3 e2', raiseExceptions=True)
     Traceback (most recent call last):
@@ -1046,7 +1105,14 @@ class Converter:
     _modifierSquareRe = re.compile(r'\[(.*?)]')
     _modifierUnderscoreRe = re.compile(r'_(.*)')
 
-    def __init__(self, stringRep='', **keywords):
+    def __init__(
+        self,
+        stringRep: str = '',
+        *,
+        makeNotation: bool = True,
+        raiseExceptions: bool = False,
+        **_keywords
+    ):
         self.stream = None
         self.stateDict = None
         self.stringRep = stringRep
@@ -1064,11 +1130,8 @@ class Converter:
         self.modifierSquare = None
         self.modifierUnderscore = LyricModifier
 
-        self.keywords = keywords
-
-        self.makeNotation = keywords.get('makeNotation', True)
-        self.raiseExceptions = keywords.get('raiseExceptions', False)
-
+        self.makeNotation = makeNotation
+        self.raiseExceptions = raiseExceptions
 
         self.stateDictDefault = {'currentTimeSignature': None,
                                  'lastDuration': 1.0
@@ -1077,7 +1140,7 @@ class Converter:
         # will be filled by self.setupRegularExpressions()
         self._tokenMapRe = None
 
-    def load(self, stringRep):
+    def load(self, stringRep: str):
         '''
         Loads a stringRepresentation into `.stringRep`
         and resets the parsing state.
@@ -1145,13 +1208,14 @@ class Converter:
         return self
 
 
-    def parseOne(self, i, t):
+    def parseOne(self, i: int, t: str):
         '''
         parse a single token at position i, with
         text t, possibly adding it to the stream.
 
         Checks for state changes, modifiers, tokens, and end-state brackets.
         '''
+        t_orig = t
         t = self.parseStartStates(t)
         t, numberOfStatesToEnd = self.parseEndStates(t)
         t, activeModifiers = self.parseModifiers(t)
@@ -1180,10 +1244,10 @@ class Converter:
                     break
             except TinyNotationException as excep:
                 if self.raiseExceptions:
-                    raise TinyNotationException(f'Could not parse token: {t!r}') from excep
+                    raise TinyNotationException(f'Could not parse token: {t_orig!r}') from excep
 
         if not hasMatch and self.raiseExceptions:
-            raise TinyNotationException(f'Could not parse token: {t!r}')
+            raise TinyNotationException(f'Could not parse token: {t_orig!r}')
 
         if m21Obj is not None:
             for stateObj in self.activeStates[:]:  # iterate over copy so we can remove.
@@ -1200,6 +1264,12 @@ class Converter:
         if m21Obj is not None:
             self.stream.coreAppend(m21Obj)
 
+        if numberOfStatesToEnd > len(self.activeStates):
+            if self.raiseExceptions:
+                raise TinyNotationException(f'Token {t_orig!r} closes more states than are open.')
+            else:
+                numberOfStatesToEnd = len(self.activeStates)
+
         for i in range(numberOfStatesToEnd):
             stateToRemove = self.activeStates.pop()
             possibleObj = stateToRemove.end()
@@ -1207,8 +1277,8 @@ class Converter:
                 self.stream.coreAppend(possibleObj)
 
 
-    def parseStartStates(self, t):
-        # noinspection PyShadowingNames
+    def parseStartStates(self, t: str) -> str:
+        # noinspection PyShadowingNames,GrazieInspection
         '''
         Changes the states in self.activeStates, and starts the state given the current data.
         Returns a newly processed token.
@@ -1237,9 +1307,7 @@ class Converter:
         >>> tieState
         <music21.tinyNotation.TieState object at 0x10afab048>
 
-        >>> tieState.parent
-        <weakref at 0x10adb31d8; to 'Converter' at 0x10adb42e8>
-        >>> tieState.parent() is tnc
+        >>> tieState.parent is tnc
         True
         >>> tieState.stateInfo
         '~'
@@ -1291,9 +1359,10 @@ class Converter:
 
         return t
 
-    def parseEndStates(self, t):
+    def parseEndStates(self, t: str) -> typing.Tuple[str, int]:
+        # noinspection GrazieInspection
         '''
-        Trims the endState token ('}') from the t string
+        Trims the endState token (`}`) from the t string
         and then returns a two-tuple of the new token and number
         of states to remove:
 
@@ -1458,6 +1527,20 @@ class Test(unittest.TestCase):
                 )
             )
 
+    def test_too_many_states(self):
+        c = Converter('2/4 trip{c8 d e}} f4', makeNotation=False)
+        c.parse()
+        s = c.stream
+        self.assertEqual(s.notes[-2].duration.quarterLength, fractions.Fraction(1, 3))
+        self.assertEqual(s.notes.last().duration.quarterLength, 1.0)
+
+        c = Converter('2/4 trip{c8 d e}} f4', makeNotation=False)
+        c.raiseExceptions = True
+        with self.assertRaisesRegex(
+            TinyNotationException,
+            "Token 'e}}' closes more states than are open"
+        ):
+            c.parse()
 
 
 class TestExternal(unittest.TestCase):


### PR DESCRIPTION
Previously this raised an IndexError whether or not raiseExceptions was True.  Now does the best it can if raiseExceptions is False and raises a TinyNotationException if raiseExceptions is True

Also improved docs of Converter process and added more typing.

Remove weakref wrapping from a misunderstanding from before Py2.5 that circular references will not be cleaned up.  We're moving away from handling weakref garbage collection and letting Py's C-language more efficient garbage collector clean them up.  Tradeoff -- a little more temporary memory usage when parsing for faster parses.