### PR TITLE
Add typing for contextSites, yieldSites

### DIFF
--- a/music21/base.py
+++ b/music21/base.py
@@ -1719,13 +1719,13 @@ class Music21Object(prebase.ProtoM21Object):
         self,
         *,
         returnSortTuples: t.Literal[True],
-        callerFirst = None,
-        memo = None,
+        callerFirst=None,
+        memo=None,
         offsetAppend: OffsetQL = 0.0,
         sortByCreationTime: t.Union[t.Literal['reverse'], bool] = False,
-        priorityTarget = None,
-        followDerivation = True,
-        priorityTargetOnly = False,
+        priorityTarget=None,
+        followDerivation=True,
+        priorityTargetOnly=False,
     ) -> t.Generator[ContextSortTuple, None, None]:
         pass
 
@@ -1733,14 +1733,14 @@ class Music21Object(prebase.ProtoM21Object):
     def contextSites(
         self,
         *,
-        callerFirst = None,
-        memo = None,
+        callerFirst=None,
+        memo=None,
         offsetAppend: OffsetQL = 0.0,
         sortByCreationTime: t.Union[t.Literal['reverse'], bool] = False,
-        priorityTarget = None,
+        priorityTarget=None,
         returnSortTuples: t.Literal[False] = False,
-        followDerivation = True,
-        priorityTargetOnly = False,
+        followDerivation=True,
+        priorityTargetOnly=False,
     ) -> t.Generator[ContextTuple, None, None]:
         pass
 

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -383,9 +383,9 @@ class Sites(common.SlottedObjectMixin):
     @overload
     def yieldSites(self,
                    *,
+                   excludeNone: t.Literal[True],
                    sortByCreationTime: t.Union[bool, t.Literal['reverse']] = False,
                    priorityTarget=None,
-                   excludeNone: t.Literal[True] = False
                    ) -> t.Generator['music21.stream.Stream', None, None]:
         from music21 import stream
         yield stream.Stream()
@@ -393,17 +393,17 @@ class Sites(common.SlottedObjectMixin):
     @overload
     def yieldSites(self,
                    *,
+                   excludeNone: bool = False,
                    sortByCreationTime: t.Union[bool, t.Literal['reverse']] = False,
                    priorityTarget=None,
-                   excludeNone: bool = False
                    ) -> t.Generator[t.Union['music21.stream.Stream', None], None, None]:
         yield None
 
     def yieldSites(self,
                    *,
+                   excludeNone: bool = False,
                    sortByCreationTime: t.Union[bool, t.Literal['reverse']] = False,
                    priorityTarget=None,
-                   excludeNone: bool = False
                    ) -> t.Generator[t.Union['music21.stream.Stream', None], None, None]:
         # noinspection PyDunderSlots
         '''

--- a/music21/stream/enums.py
+++ b/music21/stream/enums.py
@@ -9,6 +9,7 @@
 # License:      BSD, see license.txt
 # -----------------------------------------------------------------------------
 import enum
+from music21.common.enums import StrEnum
 
 class StaffType(enum.Enum):
     '''
@@ -38,6 +39,16 @@ class StaffType(enum.Enum):
     ALTERNATE = 'alternate'
     OTHER = 'other'
 
+
+class GivenElementsBehavior(StrEnum):
+    APPEND = 'append'
+    OFFSETS = 'offsets'
+    INSERT = 'insert'
+
+class RecursionType(StrEnum):
+    ELEMENTS_FIRST = 'elementsFirst'
+    FLATTEN = 'flatten'
+    ELEMENTS_ONLY = 'elementsOnly'
 
 if __name__ == '__main__':
     from music21 import mainTest

--- a/music21/stream/enums.py
+++ b/music21/stream/enums.py
@@ -45,10 +45,12 @@ class GivenElementsBehavior(StrEnum):
     OFFSETS = 'offsets'
     INSERT = 'insert'
 
+
 class RecursionType(StrEnum):
     ELEMENTS_FIRST = 'elementsFirst'
     FLATTEN = 'flatten'
     ELEMENTS_ONLY = 'elementsOnly'
+
 
 if __name__ == '__main__':
     from music21 import mainTest

--- a/music21/test/commonTest.py
+++ b/music21/test/commonTest.py
@@ -224,8 +224,8 @@ class ModuleGather:
                             'analysis/windowed',
                             'converter/__init__',
 
-                            'musicxml/m21ToXml',
-                            'musicxml/xmlToM21',
+                            'musicxml/test_m21ToXml',
+                            'musicxml/test_xmlToM21',
 
                             'romanText/translate',
                             'corpus/testCorpus',

--- a/music21/test/test_base.py
+++ b/music21/test/test_base.py
@@ -948,10 +948,12 @@ class Test(unittest.TestCase):
         for y in n.contextSites():
             yTup = (y.site, y.offset, y.recurseType)
             siteList.append(repr(yTup))
-        self.assertEqual(siteList,
-                         ["(<music21.stream.Measure 3 offset=9.0>, 0.5, 'elementsFirst')",
-                          "(<music21.stream.Part Alto>, 9.5, 'flatten')",
-                          "(<music21.stream.Score bach>, 9.5, 'elementsOnly')"])
+        self.assertEqual(
+            siteList,
+            ['(<music21.stream.Measure 3 offset=9.0>, 0.5, <RecursionType.ELEMENTS_FIRST>)',
+             '(<music21.stream.Part Alto>, 9.5, <RecursionType.FLATTEN>)',
+             '(<music21.stream.Score bach>, 9.5, <RecursionType.ELEMENTS_ONLY>)']
+        )
 
         m = c[2][4]
         self.assertEqual(repr(m), '<music21.stream.Measure 3 offset=9.0>')
@@ -960,10 +962,12 @@ class Test(unittest.TestCase):
         for y in m.contextSites():
             yTup = (y.site, y.offset, y.recurseType)
             siteList.append(repr(yTup))
-        self.assertEqual(siteList,
-                         ["(<music21.stream.Measure 3 offset=9.0>, 0.0, 'elementsFirst')",
-                          "(<music21.stream.Part Alto>, 9.0, 'flatten')",
-                          "(<music21.stream.Score bach>, 9.0, 'elementsOnly')"])
+        self.assertEqual(
+            siteList,
+            ['(<music21.stream.Measure 3 offset=9.0>, 0.0, <RecursionType.ELEMENTS_FIRST>)',
+             '(<music21.stream.Part Alto>, 9.0, <RecursionType.FLATTEN>)',
+             '(<music21.stream.Score bach>, 9.0, <RecursionType.ELEMENTS_ONLY>)']
+        )
 
         m2 = copy.deepcopy(m)
         m2.number = 3333
@@ -971,10 +975,12 @@ class Test(unittest.TestCase):
         for y in m2.contextSites():
             yTup = (y.site, y.offset, y.recurseType)
             siteList.append(repr(yTup))
-        self.assertEqual(siteList,
-                         ["(<music21.stream.Measure 3333 offset=0.0>, 0.0, 'elementsFirst')",
-                          "(<music21.stream.Part Alto>, 9.0, 'flatten')",
-                          "(<music21.stream.Score bach>, 9.0, 'elementsOnly')"])
+        self.assertEqual(
+            siteList,
+            ['(<music21.stream.Measure 3333 offset=0.0>, 0.0, <RecursionType.ELEMENTS_FIRST>)',
+             '(<music21.stream.Part Alto>, 9.0, <RecursionType.FLATTEN>)',
+             '(<music21.stream.Score bach>, 9.0, <RecursionType.ELEMENTS_ONLY>)']
+        )
         siteList = []
 
         cParts = c.parts.stream()  # need this otherwise it could possibly be garbage collected.
@@ -986,11 +992,13 @@ class Test(unittest.TestCase):
             yTup = (y.site, y.offset, y.recurseType)
             siteList.append(repr(yTup))
 
-        self.assertEqual(siteList,
-                         ["(<music21.stream.Measure 3 offset=9.0>, 0.0, 'elementsFirst')",
-                          "(<music21.stream.Part Alto>, 9.0, 'flatten')",
-                          "(<music21.stream.Score partStream>, 9.0, 'elementsOnly')",
-                          "(<music21.stream.Score bach>, 9.0, 'elementsOnly')"])
+        self.assertEqual(
+            siteList,
+            ['(<music21.stream.Measure 3 offset=9.0>, 0.0, <RecursionType.ELEMENTS_FIRST>)',
+             '(<music21.stream.Part Alto>, 9.0, <RecursionType.FLATTEN>)',
+             '(<music21.stream.Score partStream>, 9.0, <RecursionType.ELEMENTS_ONLY>)',
+             '(<music21.stream.Score bach>, 9.0, <RecursionType.ELEMENTS_ONLY>)']
+        )
 
     def testContextSitesB(self):
         p1 = stream.Part()

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -35,6 +35,7 @@ from music21 import meter
 from music21 import note
 from music21 import search
 from music21 import stream
+from music21.stream.enums import GivenElementsBehavior
 
 environLocal = environment.Environment('variant')
 
@@ -95,13 +96,13 @@ class Variant(base.Music21Object):
                                base.Music21Object,
                                t.Sequence[base.Music21Object]] = None,
         name: t.Optional[str] = None,
-        appendOrInsert: t.Literal['append', 'insert', 'offsets'] = 'offsets',
+        givenElementsBehavior: GivenElementsBehavior = GivenElementsBehavior.OFFSETS,
         **music21ObjectKeywords,
     ):
         super().__init__(**music21ObjectKeywords)
         self.exposeTime = False
         self._stream = stream.VariantStorage(givenElements=givenElements,
-                                             appendOrInsert=appendOrInsert)
+                                             givenElementsBehavior=givenElementsBehavior)
 
         self._replacementDuration = None
 


### PR DESCRIPTION
Add proper typing for contextSites and yieldSites
Make RecurseType a Generator

differentiate between ContextTuple and ContextSortTuple

Rename newly introduced in v8 'appendOrInsert' in stream keyword to 'givenElementsBehavior' change to an enum

Find slower tests and move them up in multiprocessTest