### PR TITLE
Fixes bug in repeat tests in romanText/translate.py; handles empty measures

### DIFF
--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -575,7 +575,7 @@ class PartTranslator:
 
         else:
             m = self.translateSingleMeasure(measureLineToken)
-            if m.barDuration.quarterLength == 0:
+            if self.tsCurrent is not None and m.barDuration.quarterLength == 0:
                 m.duration = duration.Duration(
                     self.tsCurrent.barDuration.quarterLength
                 )

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -575,7 +575,7 @@ class PartTranslator:
 
         else:
             m = self.translateSingleMeasure(measureLineToken)
-            if self.tsCurrent is not None and m.barDuration.quarterLength == 0:
+            if self.tsCurrent is not None and m.duration.quarterLength == 0:
                 m.duration = duration.Duration(
                     self.tsCurrent.barDuration.quarterLength
                 )

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -130,6 +130,7 @@ import unittest
 from music21 import bar
 from music21 import base
 from music21 import common
+from music21 import duration
 from music21 import exceptions21
 from music21 import harmony
 from music21 import key
@@ -574,6 +575,10 @@ class PartTranslator:
 
         else:
             m = self.translateSingleMeasure(measureLineToken)
+            if m.barDuration.quarterLength == 0:
+                m.duration = duration.Duration(
+                    self.tsCurrent.barDuration.quarterLength
+                )
             p.coreAppend(m)
 
     def fillToMeasureToken(self, measureToken: rtObjects.RTMeasure):
@@ -791,6 +796,10 @@ class PartTranslator:
                 # Is it ok, however, that this condition will match if self.tsCurrent
                 #   is None? Previously, that case was excluded below.
                 m.rightBarline = bar.Repeat(direction='end')
+                if self.tsCurrent is not None:
+                    m.setElementOffset(
+                        m.rightBarline, self.tsCurrent.barDuration.quarterLength
+                    )
             elif self.currentOffsetInMeasure == 0:
                 if isinstance(a, rtObjects.RTRepeatStart):
                     m.leftBarline = bar.Repeat(direction='start')
@@ -1608,6 +1617,18 @@ m1 C: I'''
         self.assertEqual(n2.offset, common.opFrac(11 / 6))
         self.assertEqual(n2.duration.quarterLength, common.opFrac(13 / 6))
 
+    def testCopyEmptyMeasures(self) -> None:
+        from music21 import converter
+        empty_measures_with_copy = textwrap.dedent(''''
+            Time Signature: 2/4
+            m1 I
+            m2 V
+            m3 = m1
+            m4-5 = m1-2
+        ''')
+        s = converter.parse(empty_measures_with_copy, format='romanText')
+        assert s.duration.quarterLength == 10
+
     def testRepeats(self) -> None:
         from music21 import converter
 
@@ -1636,8 +1657,8 @@ m1 C: I'''
         # Test simple repeats
         simple_repeats = textwrap.dedent('''
             Time Signature: 3/4
-            m1: ||: V
-            m2: I :||
+            m1 ||: V
+            m2 I :||
         ''')
         s = converter.parse(simple_repeats, format='romanText')
         br_iter = s[bar.Repeat]
@@ -1649,7 +1670,7 @@ m1 C: I'''
 
         single_bar_repeats = textwrap.dedent('''
             Time Signature: 2/4
-            m1: ||: I :||
+            m1 ||: I :||
         ''')
         s = converter.parse(single_bar_repeats, format='romanText')
         br_iter = s[bar.Repeat]
@@ -1661,10 +1682,10 @@ m1 C: I'''
 
         empty_bars_with_repeats = textwrap.dedent('''
             Time Signature: 2/4
-            m1: I
-            m2: ||:
-            m3: :||
-            m4: ||: :||
+            m1 I
+            m2 ||:
+            m3 :||
+            m4 ||: :||
         ''')
         s = converter.parse(empty_bars_with_repeats, format='romanText')
         br_iter = s[bar.Repeat]
@@ -1674,14 +1695,15 @@ m1 C: I'''
         _repeat_tester(end_repeat1, 'end', 2.0, 3)
         _repeat_tester(start_repeat2, 'start', 0.0, 4)
         _repeat_tester(end_repeat2, 'end', 2.0, 4)
+
         _test_expanded(s, 14.0)
 
         three_endings = textwrap.dedent('''
             Time Signature: 3/4
-            m1: ||: I
-            m2a: IV :||
-            m2b: V :||
-            m2c: I
+            m1 ||: I
+            m2a IV :||
+            m2b V :||
+            m2c I
         ''')
         s = converter.parse(three_endings, format='romanText')
         br_iter = s[bar.Repeat]
@@ -1700,13 +1722,13 @@ m1 C: I'''
 
         more_complex_example = textwrap.dedent('''
             TimeSignature: 3/4
-            m1: ||: I
-            m2a: IV
-            m3a: V :||
-            m2b: V :||
-            m2c: IV
-            m3c: V
-            m4: I
+            m1 ||: I
+            m2a IV
+            m3a V :||
+            m2b V :||
+            m2c IV
+            m3c V
+            m4 I
         ''')
         s = converter.parse(more_complex_example, format='romanText')
         br_iter = s[bar.Repeat]


### PR DESCRIPTION
While working on addressing #1412 I noticed that there was a syntax error in the romanText in `testRepeats` (my bad!). Each measure number was followed by a colon (i.e., "m1:" rather than "m1"). The first thing this PR fixes is removing those colons.

The colons caused the parser to insert a note in each measure. When I removed them, I discovered that the test was actually failing on measures that are empty except for forward/backward repeat bars. To fix this required two things:
1. explicitly set the offset of backward repeat bars according to the time-signature length
2. if a measure has 0 duration, explicitly set its duration according to the current time-signature

I also added a new test for the copying of empty measures.
