### PR TITLE
No transpose altered 7,9,11,13 in bII7; chord.tools

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,6 +47,7 @@ Changing this number invalidates old pickles -- do it if the old pickles create 
 '''
 __version__ = '8.2.0'
 
+
 def get_version_tuple(vv):
     v = vv.split('.')
     last_v = v[-1]
@@ -63,6 +64,8 @@ def get_version_tuple(vv):
         v.append(beta)
     return tuple(v)
 
+
 __version_info__ = get_version_tuple(__version__)
+
 
 del get_version_tuple

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -45,6 +45,7 @@ When changing, update the single test case in base.py.
 
 Changing this number invalidates old pickles -- do it if the old pickles create a problem.
 '''
+__version__ = '8.2.0'
 
 def get_version_tuple(vv):
     v = vv.split('.')
@@ -61,9 +62,6 @@ def get_version_tuple(vv):
     if beta:
         v.append(beta)
     return tuple(v)
-
-
-__version__ = '8.1.0'
 
 __version_info__ = get_version_tuple(__version__)
 

--- a/music21/analysis/harmonicFunction.py
+++ b/music21/analysis/harmonicFunction.py
@@ -101,7 +101,7 @@ functionFigureTuplesMinor = {
 
 
 def functionToRoman(thisHarmonicFunction: HarmonicFunction,
-                    keyOrScale: t.Union[key.Key, scale.Scale, str] = 'C'
+                    keyOrScale: t.Union[key.Key, scale.ConcreteScale, str] = 'C'
                     ) -> t.Optional[roman.RomanNumeral]:
     '''
     Takes harmonic function labels (such as 'T' for major tonic)

--- a/music21/base.py
+++ b/music21/base.py
@@ -27,7 +27,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'8.1.0'
+'8.2.0'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -6,7 +6,7 @@
 # Authors:      Michael Scott Asato Cuthbert
 #               Christopher Ariza
 #
-# Copyright:    Copyright © 2009-2020 Michael Scott Asato Cuthbert
+# Copyright:    Copyright © 2009-2022 Michael Scott Asato Cuthbert
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
@@ -15,7 +15,7 @@ as well as other methods, functions, and objects related to chords.
 '''
 from __future__ import annotations
 
-__all__ = ['tables', 'Chord', 'ChordException', 'fromIntervalVector', 'fromForteClass']
+__all__ = ['tools', 'tables', 'Chord', 'ChordException', 'fromIntervalVector', 'fromForteClass']
 
 import copy
 import unittest
@@ -35,6 +35,7 @@ from music21 import volume
 
 from music21 import environment
 from music21.chord import tables
+from music21.chord import tools
 from music21.common.decorators import cacheMethod
 
 environLocal = environment.Environment('chord')
@@ -1844,6 +1845,17 @@ class Chord(ChordBase):
         >>> cmaj.getChordStep(6) is None
         True
 
+        Ninths can be specified with either 9 or 2.  Similarly for elevenths
+        and thirteenths.
+
+        >>> c9 = chord.Chord('C4 E4 G4 B4 D5')
+        >>> c9.getChordStep(9)
+        <music21.pitch.Pitch D5>
+        >>> c9.getChordStep(2)
+        <music21.pitch.Pitch D5>
+
+        * Changed in v8.3 --
+
         OMIT_FROM_DOCS
 
         If `root` has been explicitly overridden as `None`, calling this raises `ChordException`:
@@ -1852,7 +1864,12 @@ class Chord(ChordBase):
         >>> cmaj.getChordStep(6)
         Traceback (most recent call last):
         music21.chord.ChordException: Cannot run getChordStep without a root
+
+        (This is in OMIT...)
         '''
+        if chordStep >= 8:
+            chordStep -= 7
+
         testRootPitch: pitch.Pitch
         if testRoot is None:
             testRootPitch = self.root()  # raises ChordException if no pitches

--- a/music21/chord/tools.py
+++ b/music21/chord/tools.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+# Name:         chord/tools.py
+# Purpose:      Chord utilities too obscure to go on the Chord object
+#
+# Authors:      Michael Scott Asato Cuthbert
+#
+# Copyright:    Copyright © 2022 Michael Scott Asato Cuthbert
+# License:      BSD, see license.txt
+# ------------------------------------------------------------------------------
+'''
+Chord utilities too obscure to go on the Chord object, yet still helpful
+enough to go in the music21 core library.
+'''
+
+from __future__ import annotations
+
+import typing as t
+
+if t.TYPE_CHECKING:
+    from music21 import chord
+    from music21 import pitch
+
+def allChordSteps(c: chord.Chord) -> t.Dict[int, pitch.Pitch]:
+    '''
+    Return a dictionary of all chordSteps in the chord.
+    If more than one pitch shares the same chordStep such as the third
+    in (C, E-, E, G), then only the first will appear in the dictionary.
+
+    The dictionary will be ordered by the order of pitches in the Chord.
+
+    More efficient than calling [getChordStep(x) for x in range(1, 8)]
+    which would be O(n^2) on number of pitches.
+
+    Requires `root()` to be defined.
+
+    >>> ch = chord.Chord('C4 E4 G4 B4 C5 D5')
+    >>> chord.tools.allChordSteps(ch)
+    {1: <music21.pitch.Pitch C4>,
+     3: <music21.pitch.Pitch E4>,
+     5: <music21.pitch.Pitch G4>,
+     7: <music21.pitch.Pitch B4>,
+     2: <music21.pitch.Pitch D5>}
+    '''
+    root_dnn = c.root().diatonicNoteNum
+    out_map: t.Dict[int, pitch.Pitch] = {}
+    for thisPitch in c.pitches:
+        diatonicDistance = ((thisPitch.diatonicNoteNum - root_dnn) % 7) + 1
+        if diatonicDistance not in out_map:
+            out_map[diatonicDistance] = thisPitch
+    return out_map
+
+
+if __name__ == '__main__':
+    import music21
+    music21.mainTest()
+

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -1276,7 +1276,9 @@ class ConcreteScale(Scale):
         # here, tonic is a pitch
         # the abstract scale defines what step the tonic is expected to be
         # found on
-        # no default tonic is defined; as such, it is mostly an abstract scale
+        # no default tonic is defined; as such, it is mostly an abstract scale, and
+        # can't be used concretely until it is created.
+        self.tonic: t.Optional[pitch.Pitch]
         if tonic is None:
             self.tonic = None  # pitch.Pitch()
         elif isinstance(tonic, str):


### PR DESCRIPTION
According to published usage, transposed chords (bII, etc.) should take their 7th from the key and not be transposed.  So in c-minor, bII7 should be D-, F, A-, C, and not with C-flat.

Assuming that this would apply to 9ths, 11ths, and 13ths as well.

Does not affect interpretation of vi7, VI7, etc., I don't believe.

Slows the creation of bII, etc. RomanNumerals because a new Chord object needs to be created temporarily and `_findRoot()` run on it.

Add a new chord.tools file for routines that are too obscure to go on Chord.  Created `chord.tools.getAllChordSteps`

Fixes #1410

Credit MalcolmSailor for the notice and research on this.