### PR TITLE
Music21 py3.10/11 only

### DIFF
--- a/.github/workflows/maincheck.yml
+++ b/.github/workflows/maincheck.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: [3.9, "3.10"]  # "3.10" must be in quotes to not have it eval to 3.1
+                python-version: ["3.10", "3.11.0-rc.2"]  # "3.10" must be in quotes to not have it eval to 3.1
         steps:
         - uses: actions/setup-python@v4
           with:
@@ -27,7 +27,7 @@ jobs:
         - name: Run Main Test script
           run: python -c 'from music21.test.testSingleCoreAll import ciMain as ci; ci()'
         - name: Coveralls
-          if: ${{ matrix.python-version == '3.9' }}
+          if: ${{ matrix.python-version == '3.10' }}
           env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               COVERALLS_SERVICE_NAME: github

--- a/.github/workflows/maincheck.yml
+++ b/.github/workflows/maincheck.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             matrix:
                 # "3.11.0-rc.2" waiting for scipy.
-                python-version: ["3.10"]  # "3.10" must be in quotes to not have it eval to 3.1
+                python-version: ["3.10.6", "3.10"]  # "3.10" must be in quotes to not have it eval to 3.1
         steps:
         - uses: actions/setup-python@v4
           with:
@@ -28,7 +28,7 @@ jobs:
         - name: Run Main Test script
           run: python -c 'from music21.test.testSingleCoreAll import ciMain as ci; ci()'
         - name: Coveralls
-          if: ${{ matrix.python-version == '3.10' }}
+          if: ${{ matrix.python-version == '3.10.6' }}
           env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               COVERALLS_SERVICE_NAME: github

--- a/.github/workflows/maincheck.yml
+++ b/.github/workflows/maincheck.yml
@@ -14,7 +14,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.10", "3.11.0-rc.2"]  # "3.10" must be in quotes to not have it eval to 3.1
+                # "3.11.0-rc.2" waiting for scipy.
+                python-version: ["3.10"]  # "3.10" must be in quotes to not have it eval to 3.1
         steps:
         - uses: actions/setup-python@v4
           with:

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ For more information, visit:
 https://web.mit.edu/music21
 
 To try it out, visit:
-https://tinyurl.com/m21colab
+https://tinyurl.com/m21colab (runs music21 v7)
 
 And to install, see:
 https://web.mit.edu/music21/doc/usersGuide/usersGuide_01_installing.html
 
-`Music21` runs on Python 3.9+.  Use version 4 on Python 2 or Py3.4, version 5
-on Py3.5, version 6 on Py3.6, version 7 on Py3.7, version 8 on Py3.8.
+`Music21` runs on Python 3.10+.  Use version 4 on Python 2 or Py3.4, version 5
+on Py3.5, version 6 on Py3.6, version 7 on Py3.7, version 8 on Py3.8/Py3.9.
 
 Released under the BSD (3-clause) license. See LICENSE.
 Externally provided software (including the MIT licensed Lilypond/MusicXML test Suite) and

--- a/documentation/testDocumentation.py
+++ b/documentation/testDocumentation.py
@@ -192,7 +192,7 @@ def getDocumentationFiles(runOne=False):
     return allModules
 
 
-def main(runOne: str|bool = False):
+def main(runOne: str | bool = False):
     if runOne is False:
         nbvalNotebook.runAll()
     elif '.ipynb' in runOne:

--- a/documentation/testDocumentation.py
+++ b/documentation/testDocumentation.py
@@ -192,7 +192,7 @@ def getDocumentationFiles(runOne=False):
     return allModules
 
 
-def main(runOne: t.Union[str, bool] = False):
+def main(runOne: str|bool = False):
     if runOne is False:
         nbvalNotebook.runAll()
     elif '.ipynb' in runOne:

--- a/documentation/testDocumentation.py
+++ b/documentation/testDocumentation.py
@@ -21,7 +21,6 @@ import os.path
 import re
 import sys
 import time
-import typing as t
 
 # noinspection PyPackageRequirements
 from docutils.core import publish_doctree  # pylint: disable=import-error

--- a/music21/__init__.py
+++ b/music21/__init__.py
@@ -35,18 +35,19 @@ from __future__ import annotations
 
 import sys
 
-minPythonVersion = (3, 8)
+minPythonVersion = (3, 10)
 minPythonVersionStr = '.'.join([str(x) for x in minPythonVersion])
 if sys.version_info < minPythonVersion:
     # DO NOT CHANGE THIS TO AN f-String -- it needs to run on old python.
     raise ImportError('''
-    Music21 v.8.0+ is a Python {}+ only library.
+    Music21 v.9.0+ is a Python {}+ only library.
     Use music21 v1 to run on Python 2.1-2.6.
     Use music21 v4 to run on Python 2.7.
     Use music21 v5.1 to run on Python 3.4.
     Use music21 v5.7 to run on Python 3.5.
     Use music21 v6.7 to run on Python 3.6.
     Use music21 v7.3 to run on Python 3.7
+    Use music21 v8.1 to run on Python 3.8/3.9
 
     If you have the wrong version there are several options for getting
     the right one.
@@ -61,7 +62,8 @@ if sys.version_info < minPythonVersion:
          Try running "python3" instead of "python"
 
     - 2. Upgrade pip and setuptools to the latest version
-         and then "upgrade" music21 to pre-version 5.
+         and then "upgrade" music21 to an earlier version.
+         For instance to install version 4 you'd run:
 
          $ pip install --upgrade pip setuptools
          $ pip install 'music21<5.0'

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -1307,7 +1307,7 @@ class ABCNote(ABCToken):
 
         # set to True if a modification of key signature
         # set to False if an altered tone part of a Key
-        self.accidentalDisplayStatus: t.Union[bool, None] = None
+        self.accidentalDisplayStatus: bool|None = None
 
         # determined during parse() based on if pitch chars are present
         self.isRest: bool = False

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -606,7 +606,7 @@ class ABCMetadata(ABCToken):
 
         # placing this import in method for now; clef.py may import this module UNLIKELY
         from music21 import clef
-        clefObj: t.Optional[clef.Clef] = None
+        clefObj: clef.Clef|None = None
         transposeSemitones = None
 
         if '-8va' in self.data.lower():
@@ -676,7 +676,7 @@ class ABCMetadata(ABCToken):
 
         # get a symbolic and numerical value if available
         number: float = -1  # sentinel = None
-        referent: t.Optional[float] = None
+        referent: float|None = None
         if nonText:
             if '=' in nonText:
                 durs, numberStr = nonText.split('=')
@@ -943,11 +943,11 @@ class ABCTuplet(ABCToken):
         self.numberNotesNormal: int = 1
 
         # store an m21 tuplet object
-        self.tupletObj: t.Optional[duration.Tuplet] = None
+        self.tupletObj: duration.Tuplet|None = None
 
     def updateRatio(
         self,
-        timeSignatureObj: t.Optional[meter.TimeSignature] = None
+        timeSignatureObj: meter.TimeSignature|None = None
     ) -> None:
         # noinspection PyShadowingNames
         '''
@@ -1031,7 +1031,7 @@ class ABCTuplet(ABCToken):
         splitTuplet = self.src.strip().split(':')
 
         tupletNumber = splitTuplet[0]
-        normalNotes: t.Optional[int] = None
+        normalNotes: int|None = None
 
         if len(splitTuplet) >= 2 and splitTuplet[1] != '':
             normalNotes = int(splitTuplet[1])
@@ -1130,7 +1130,7 @@ class ABCSlurStart(ABCToken):
     '''
     def __init__(self, src=''):
         super().__init__(src)
-        self.slurObj: t.Optional[spanner.Slur] = None
+        self.slurObj: spanner.Slur|None = None
 
     def fillSlur(self):
         '''
@@ -1157,7 +1157,7 @@ class ABCCrescStart(ABCToken):
 
     def __init__(self, src=''):
         super().__init__(src)
-        self.crescObj: t.Optional[dynamics.Crescendo] = None
+        self.crescObj: dynamics.Crescendo|None = None
 
     def fillCresc(self):
         from music21 import dynamics
@@ -1171,7 +1171,7 @@ class ABCDimStart(ABCToken):
     '''
     def __init__(self, src=''):
         super().__init__(src)
-        self.dimObj: t.Optional[dynamics.Diminuendo] = None
+        self.dimObj: dynamics.Diminuendo|None = None
 
     def fillDim(self):
         from music21 import dynamics
@@ -1240,7 +1240,7 @@ class ABCBrokenRhythmMarker(ABCToken):
     '''
     def __init__(self, src=''):
         super().__init__(src)
-        self.data: t.Optional[str] = None
+        self.data: str|None = None
 
     def preParse(self):
         '''Called before context adjustments: need to have access to data
@@ -1286,7 +1286,7 @@ class ABCNote(ABCToken):
         self.inGrace = None
 
         # provide default duration from handler; may change during piece
-        self.activeDefaultQuarterLength: t.Optional[float] = None
+        self.activeDefaultQuarterLength: float|None = None
         # store if a broken symbol applies; a pair of symbols, position (left, right)
         self.brokenRhythmMarker = None
 
@@ -1314,7 +1314,7 @@ class ABCNote(ABCToken):
 
         # Pitch and duration attributes for m21 conversion
         # they are set via parse() based on other contextual information.
-        self.pitchName: t.Optional[str] = None  # if None, a rest or chord
+        self.pitchName: str|None = None  # if None, a rest or chord
         self.quarterLength: float = 0.0
 
     @staticmethod
@@ -1509,7 +1509,7 @@ class ABCNote(ABCToken):
 
     def getQuarterLength(self,
                          strSrc: str,
-                         forceDefaultQuarterLength: t.Optional[float] = None) -> float:
+                         forceDefaultQuarterLength: float|None = None) -> float:
         '''
         Called with parse(), after context processing, to calculate duration
 
@@ -1639,8 +1639,8 @@ class ABCNote(ABCToken):
 
     def parse(
         self,
-        forceDefaultQuarterLength: t.Optional[float] = None,
-        forceKeySignature: t.Optional[key.KeySignature] = None
+        forceDefaultQuarterLength: float|None = None,
+        forceKeySignature: key.KeySignature|None = None
     ) -> None:
         # environLocal.printDebug(['parse', self.src])
         self.chordSymbols, nonChordSymStr = self._splitChordSymbols(self.src)
@@ -2468,8 +2468,8 @@ class ABCHandler:
         lastDefaultQL = None
         lastKeySignature = None
         lastTimeSignatureObj = None  # an m21 object
-        lastTupletToken: t.Optional[ABCTuplet] = None  # a token obj; keeps count of usage
-        lastTieToken: t.Optional[ABCTie] = None
+        lastTupletToken: ABCTuplet|None = None  # a token obj; keeps count of usage
+        lastTieToken: ABCTie|None = None
         lastStaccToken = None
         lastUpToken = None
         lastDownToken = None
@@ -3199,8 +3199,8 @@ class ABCHandlerBar(ABCHandler):
         # tokens are ABC objects in a linear stream
         super().__init__()
 
-        self.leftBarToken: t.Optional[ABCBar] = None
-        self.rightBarToken: t.Optional[ABCBar] = None
+        self.leftBarToken: ABCBar|None = None
+        self.rightBarToken: ABCBar|None = None
 
     def __add__(self, other):
         ah = self.__class__()  # will get the same class type
@@ -3390,7 +3390,7 @@ class ABCFile(prebase.ProtoM21Object):
         referenceNumbers = '\n'.join(collect)
         return referenceNumbers
 
-    def readstr(self, strSrc: str, number: t.Optional[int] = None) -> ABCHandler:
+    def readstr(self, strSrc: str, number: int|None = None) -> ABCHandler:
         '''
         Read a string and process all Tokens.
         Returns a ABCHandler instance.

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -108,7 +108,7 @@ ABC_BARS = [
 # store a mapping of ABC representation to pitch values
 # key is (srcStr, carriedAccidental, str(keySignature)
 # value is (pitchName (m21), accidentalDisplayStatus)
-_pitchTranslationCache: dict[tuple[str, str, str], tuple[str, bool|None]] = {}
+_pitchTranslationCache: dict[tuple[str, str, str], tuple[str, bool | None]] = {}
 
 
 # ------------------------------------------------------------------------------
@@ -337,7 +337,7 @@ class ABCMetadata(ABCToken):
             return True
         return False
 
-    def getTimeSignatureParameters(self) -> tuple[int, int, str]|None:
+    def getTimeSignatureParameters(self) -> tuple[int, int, str] | None:
         '''
         If there is a time signature representation available,
         get a numerator, denominator and an abbreviation symbol.
@@ -389,7 +389,7 @@ class ABCMetadata(ABCToken):
             symbol = 'normal'  # m21 compat
         return n, d, symbol
 
-    def getTimeSignatureObject(self) -> meter.TimeSignature|None:
+    def getTimeSignatureObject(self) -> meter.TimeSignature | None:
         '''
         Return a music21 :class:`~music21.meter.TimeSignature`
         object for this metadata tag, if isMeter is True, otherwise raise exception.
@@ -423,7 +423,7 @@ class ABCMetadata(ABCToken):
             numerator, denominator, unused_symbol = parameters
             return meter.TimeSignature(f'{numerator}/{denominator}')
 
-    def getKeySignatureParameters(self) -> tuple[int, str|None]:
+    def getKeySignatureParameters(self) -> tuple[int, str | None]:
         # noinspection SpellCheckingInspection
         '''
         Extract key signature parameters,
@@ -587,7 +587,7 @@ class ABCMetadata(ABCToken):
         else:
             return ks.asKey(mode)
 
-    def getClefObject(self) -> tuple[clef.Clef|None, int|None]:
+    def getClefObject(self) -> tuple[clef.Clef | None, int | None]:
         '''
         Extract any clef parameters stored in the key metadata token.
         Assume that a clef definition suggests a transposition.
@@ -606,7 +606,7 @@ class ABCMetadata(ABCToken):
 
         # placing this import in method for now; clef.py may import this module UNLIKELY
         from music21 import clef
-        clefObj: clef.Clef|None = None
+        clefObj: clef.Clef | None = None
         transposeSemitones = None
 
         if '-8va' in self.data.lower():
@@ -619,7 +619,7 @@ class ABCMetadata(ABCToken):
         # if not defined, returns None, None
         return clefObj, transposeSemitones
 
-    def getMetronomeMarkObject(self) -> tempo.MetronomeMark|None:
+    def getMetronomeMarkObject(self) -> tempo.MetronomeMark | None:
         '''
         Extract any tempo parameters stored in a tempo metadata token.
 
@@ -676,7 +676,7 @@ class ABCMetadata(ABCToken):
 
         # get a symbolic and numerical value if available
         number: float = -1  # sentinel = None
-        referent: float|None = None
+        referent: float | None = None
         if nonText:
             if '=' in nonText:
                 durs, numberStr = nonText.split('=')
@@ -872,7 +872,7 @@ class ABCBar(ABCToken):
         else:
             return False
 
-    def isRepeatBracket(self) -> int|t.Literal[False]:
+    def isRepeatBracket(self) -> int | t.Literal[False]:
         '''
         Return a number if this defines a repeat bracket for an alternate ending
         otherwise returns False.
@@ -891,7 +891,7 @@ class ABCBar(ABCToken):
         else:
             return False
 
-    def getBarObject(self) -> bar.Barline|None:
+    def getBarObject(self) -> bar.Barline | None:
         '''
         Return a music21 bar object
 
@@ -902,7 +902,7 @@ class ABCBar(ABCToken):
          <music21.bar.Repeat direction=start>
         '''
         from music21 import bar
-        m21bar: bar.Barline|None
+        m21bar: bar.Barline | None
         if self.isRepeat():
             if self.repeatForm in ('end', 'start'):
                 m21bar = bar.Repeat(direction=self.repeatForm)
@@ -943,11 +943,11 @@ class ABCTuplet(ABCToken):
         self.numberNotesNormal: int = 1
 
         # store an m21 tuplet object
-        self.tupletObj: duration.Tuplet|None = None
+        self.tupletObj: duration.Tuplet | None = None
 
     def updateRatio(
         self,
-        timeSignatureObj: meter.TimeSignature|None = None
+        timeSignatureObj: meter.TimeSignature | None = None
     ) -> None:
         # noinspection PyShadowingNames
         '''
@@ -1031,7 +1031,7 @@ class ABCTuplet(ABCToken):
         splitTuplet = self.src.strip().split(':')
 
         tupletNumber = splitTuplet[0]
-        normalNotes: int|None = None
+        normalNotes: int | None = None
 
         if len(splitTuplet) >= 2 and splitTuplet[1] != '':
             normalNotes = int(splitTuplet[1])
@@ -1130,7 +1130,7 @@ class ABCSlurStart(ABCToken):
     '''
     def __init__(self, src=''):
         super().__init__(src)
-        self.slurObj: spanner.Slur|None = None
+        self.slurObj: spanner.Slur | None = None
 
     def fillSlur(self):
         '''
@@ -1157,7 +1157,7 @@ class ABCCrescStart(ABCToken):
 
     def __init__(self, src=''):
         super().__init__(src)
-        self.crescObj: dynamics.Crescendo|None = None
+        self.crescObj: dynamics.Crescendo | None = None
 
     def fillCresc(self):
         from music21 import dynamics
@@ -1171,7 +1171,7 @@ class ABCDimStart(ABCToken):
     '''
     def __init__(self, src=''):
         super().__init__(src)
-        self.dimObj: dynamics.Diminuendo|None = None
+        self.dimObj: dynamics.Diminuendo | None = None
 
     def fillDim(self):
         from music21 import dynamics
@@ -1240,7 +1240,7 @@ class ABCBrokenRhythmMarker(ABCToken):
     '''
     def __init__(self, src=''):
         super().__init__(src)
-        self.data: str|None = None
+        self.data: str | None = None
 
     def preParse(self):
         '''Called before context adjustments: need to have access to data
@@ -1286,7 +1286,7 @@ class ABCNote(ABCToken):
         self.inGrace = None
 
         # provide default duration from handler; may change during piece
-        self.activeDefaultQuarterLength: float|None = None
+        self.activeDefaultQuarterLength: float | None = None
         # store if a broken symbol applies; a pair of symbols, position (left, right)
         self.brokenRhythmMarker = None
 
@@ -1307,14 +1307,14 @@ class ABCNote(ABCToken):
 
         # set to True if a modification of key signature
         # set to False if an altered tone part of a Key
-        self.accidentalDisplayStatus: bool|None = None
+        self.accidentalDisplayStatus: bool | None = None
 
         # determined during parse() based on if pitch chars are present
         self.isRest: bool = False
 
         # Pitch and duration attributes for m21 conversion
         # they are set via parse() based on other contextual information.
-        self.pitchName: str|None = None  # if None, a rest or chord
+        self.pitchName: str | None = None  # if None, a rest or chord
         self.quarterLength: float = 0.0
 
     @staticmethod
@@ -1348,7 +1348,7 @@ class ABCNote(ABCToken):
         self,
         strSrc: str,
         forceKeySignature=None
-    ) -> tuple[str|None, bool|None]:
+    ) -> tuple[str | None, bool | None]:
         '''
         Given a note or rest string without a chord symbol,
         return a music21 pitch string or None (if a rest),
@@ -1464,7 +1464,7 @@ class ABCNote(ABCToken):
             raise ABCHandlerException('Carried accidentals not rendered moot.')
         # if there is an explicit accidental, regardless of key, it should
         # be shown: this will work for naturals well
-        accidentalDisplayStatus: bool|None
+        accidentalDisplayStatus: bool | None
         if carriedAccString:
             # An accidental carrying through the measure is supposed to be applied.
             # This will be set iff no explicit accidental is attached to the note.
@@ -1509,7 +1509,7 @@ class ABCNote(ABCToken):
 
     def getQuarterLength(self,
                          strSrc: str,
-                         forceDefaultQuarterLength: float|None = None) -> float:
+                         forceDefaultQuarterLength: float | None = None) -> float:
         '''
         Called with parse(), after context processing, to calculate duration
 
@@ -1557,7 +1557,7 @@ class ABCNote(ABCToken):
         >>> an.getQuarterLength('A', forceDefaultQuarterLength=1.0)
         1.875
         '''
-        activeDefaultQuarterLength: float|None
+        activeDefaultQuarterLength: float | None
         if forceDefaultQuarterLength is not None:
             activeDefaultQuarterLength = forceDefaultQuarterLength
         else:  # may be None
@@ -1639,16 +1639,16 @@ class ABCNote(ABCToken):
 
     def parse(
         self,
-        forceDefaultQuarterLength: float|None = None,
-        forceKeySignature: key.KeySignature|None = None
+        forceDefaultQuarterLength: float | None = None,
+        forceKeySignature: key.KeySignature | None = None
     ) -> None:
         # environLocal.printDebug(['parse', self.src])
         self.chordSymbols, nonChordSymStr = self._splitChordSymbols(self.src)
         # get pitch name form remaining string
         # rests will have a pitch name of None
 
-        pn: str|None
-        accDisp: bool|None
+        pn: str | None
+        accDisp: bool | None
         try:
             pn, accDisp = self.getPitchName(nonChordSymStr,
                                             forceKeySignature=forceKeySignature)
@@ -1769,10 +1769,10 @@ class ABCHandler:
     New in v6.3 -- lineBreaksDefinePhrases -- does not yet do anything
     '''
     def __init__(self,
-                 abcVersion: tuple[int, ...]|None = None,
+                 abcVersion: tuple[int, ...] | None = None,
                  lineBreaksDefinePhrases=False):
         # tokens are ABC objects import n a linear stream
-        self.abcVersion: tuple[int, ...]|None = abcVersion
+        self.abcVersion: tuple[int, ...] | None = abcVersion
         self.abcDirectives: dict[str, str] = {}
         self.tokens: list[ABCToken] = []
         self.activeParens: list[str] = []  # e.g. ['Crescendo', 'Slur']
@@ -1787,7 +1787,7 @@ class ABCHandler:
 
     @staticmethod
     def _getLinearContext(source: Sequence[_T],
-                          i: int) -> tuple[_T|None, _T, _T|None, _T|None]:
+                          i: int) -> tuple[_T | None, _T, _T | None, _T | None]:
         '''
         Find the local context of a string or iterable of objects
         beginning at a particular index.
@@ -2010,8 +2010,8 @@ class ABCHandler:
 
     @staticmethod
     def startsMetadata(c: str,
-                       cNext: str|None,
-                       cNextNext: str|None) -> bool:
+                       cNext: str | None,
+                       cNextNext: str | None) -> bool:
         '''
         Returns True if this context describes the start of a metadata section, like
 
@@ -2468,8 +2468,8 @@ class ABCHandler:
         lastDefaultQL = None
         lastKeySignature = None
         lastTimeSignatureObj = None  # an m21 object
-        lastTupletToken: ABCTuplet|None = None  # a token obj; keeps count of usage
-        lastTieToken: ABCTie|None = None
+        lastTupletToken: ABCTuplet | None = None  # a token obj; keeps count of usage
+        lastTieToken: ABCTie | None = None
         lastStaccToken = None
         lastUpToken = None
         lastDownToken = None
@@ -3172,7 +3172,7 @@ class ABCHandler:
         else:
             return False
 
-    def getTitle(self) -> str|None:
+    def getTitle(self) -> str | None:
         '''
         Get the first title tag. Used for testing.
 
@@ -3199,8 +3199,8 @@ class ABCHandlerBar(ABCHandler):
         # tokens are ABC objects in a linear stream
         super().__init__()
 
-        self.leftBarToken: ABCBar|None = None
-        self.rightBarToken: ABCBar|None = None
+        self.leftBarToken: ABCBar | None = None
+        self.rightBarToken: ABCBar | None = None
 
     def __add__(self, other):
         ah = self.__class__()  # will get the same class type
@@ -3390,7 +3390,7 @@ class ABCFile(prebase.ProtoM21Object):
         referenceNumbers = '\n'.join(collect)
         return referenceNumbers
 
-    def readstr(self, strSrc: str, number: int|None = None) -> ABCHandler:
+    def readstr(self, strSrc: str, number: int | None = None) -> ABCHandler:
         '''
         Read a string and process all Tokens.
         Returns a ABCHandler instance.

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -108,7 +108,7 @@ ABC_BARS = [
 # store a mapping of ABC representation to pitch values
 # key is (srcStr, carriedAccidental, str(keySignature)
 # value is (pitchName (m21), accidentalDisplayStatus)
-_pitchTranslationCache: dict[tuple[str, str, str], tuple[str, t.Union[bool, None]]] = {}
+_pitchTranslationCache: dict[tuple[str, str, str], tuple[str, bool|None]] = {}
 
 
 # ------------------------------------------------------------------------------

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -337,7 +337,7 @@ class ABCMetadata(ABCToken):
             return True
         return False
 
-    def getTimeSignatureParameters(self) -> t.Optional[tuple[int, int, str]]:
+    def getTimeSignatureParameters(self) -> tuple[int, int, str]|None:
         '''
         If there is a time signature representation available,
         get a numerator, denominator and an abbreviation symbol.
@@ -389,7 +389,7 @@ class ABCMetadata(ABCToken):
             symbol = 'normal'  # m21 compat
         return n, d, symbol
 
-    def getTimeSignatureObject(self) -> t.Optional[meter.TimeSignature]:
+    def getTimeSignatureObject(self) -> meter.TimeSignature|None:
         '''
         Return a music21 :class:`~music21.meter.TimeSignature`
         object for this metadata tag, if isMeter is True, otherwise raise exception.
@@ -423,7 +423,7 @@ class ABCMetadata(ABCToken):
             numerator, denominator, unused_symbol = parameters
             return meter.TimeSignature(f'{numerator}/{denominator}')
 
-    def getKeySignatureParameters(self) -> tuple[int, t.Optional[str]]:
+    def getKeySignatureParameters(self) -> tuple[int, str|None]:
         # noinspection SpellCheckingInspection
         '''
         Extract key signature parameters,
@@ -587,7 +587,7 @@ class ABCMetadata(ABCToken):
         else:
             return ks.asKey(mode)
 
-    def getClefObject(self) -> tuple[t.Optional[clef.Clef], t.Optional[int]]:
+    def getClefObject(self) -> tuple[clef.Clef|None, int|None]:
         '''
         Extract any clef parameters stored in the key metadata token.
         Assume that a clef definition suggests a transposition.
@@ -619,7 +619,7 @@ class ABCMetadata(ABCToken):
         # if not defined, returns None, None
         return clefObj, transposeSemitones
 
-    def getMetronomeMarkObject(self) -> t.Optional[tempo.MetronomeMark]:
+    def getMetronomeMarkObject(self) -> tempo.MetronomeMark|None:
         '''
         Extract any tempo parameters stored in a tempo metadata token.
 
@@ -872,7 +872,7 @@ class ABCBar(ABCToken):
         else:
             return False
 
-    def isRepeatBracket(self) -> t.Union[int, t.Literal[False]]:
+    def isRepeatBracket(self) -> int|t.Literal[False]:
         '''
         Return a number if this defines a repeat bracket for an alternate ending
         otherwise returns False.
@@ -891,7 +891,7 @@ class ABCBar(ABCToken):
         else:
             return False
 
-    def getBarObject(self) -> t.Optional[bar.Barline]:
+    def getBarObject(self) -> bar.Barline|None:
         '''
         Return a music21 bar object
 
@@ -902,7 +902,7 @@ class ABCBar(ABCToken):
          <music21.bar.Repeat direction=start>
         '''
         from music21 import bar
-        m21bar: t.Optional[bar.Barline]
+        m21bar: bar.Barline|None
         if self.isRepeat():
             if self.repeatForm in ('end', 'start'):
                 m21bar = bar.Repeat(direction=self.repeatForm)
@@ -1348,7 +1348,7 @@ class ABCNote(ABCToken):
         self,
         strSrc: str,
         forceKeySignature=None
-    ) -> tuple[t.Optional[str], t.Union[bool, None]]:
+    ) -> tuple[str|None, bool|None]:
         '''
         Given a note or rest string without a chord symbol,
         return a music21 pitch string or None (if a rest),
@@ -1464,7 +1464,7 @@ class ABCNote(ABCToken):
             raise ABCHandlerException('Carried accidentals not rendered moot.')
         # if there is an explicit accidental, regardless of key, it should
         # be shown: this will work for naturals well
-        accidentalDisplayStatus: t.Union[bool, None]
+        accidentalDisplayStatus: bool|None
         if carriedAccString:
             # An accidental carrying through the measure is supposed to be applied.
             # This will be set iff no explicit accidental is attached to the note.
@@ -1557,7 +1557,7 @@ class ABCNote(ABCToken):
         >>> an.getQuarterLength('A', forceDefaultQuarterLength=1.0)
         1.875
         '''
-        activeDefaultQuarterLength: t.Optional[float]
+        activeDefaultQuarterLength: float|None
         if forceDefaultQuarterLength is not None:
             activeDefaultQuarterLength = forceDefaultQuarterLength
         else:  # may be None
@@ -1647,8 +1647,8 @@ class ABCNote(ABCToken):
         # get pitch name form remaining string
         # rests will have a pitch name of None
 
-        pn: t.Optional[str]
-        accDisp: t.Union[bool, None]
+        pn: str|None
+        accDisp: bool|None
         try:
             pn, accDisp = self.getPitchName(nonChordSymStr,
                                             forceKeySignature=forceKeySignature)
@@ -1769,10 +1769,10 @@ class ABCHandler:
     New in v6.3 -- lineBreaksDefinePhrases -- does not yet do anything
     '''
     def __init__(self,
-                 abcVersion: t.Optional[tuple[int, ...]] = None,
+                 abcVersion: tuple[int, ...]|None = None,
                  lineBreaksDefinePhrases=False):
         # tokens are ABC objects import n a linear stream
-        self.abcVersion: t.Optional[tuple[int, ...]] = abcVersion
+        self.abcVersion: tuple[int, ...]|None = abcVersion
         self.abcDirectives: dict[str, str] = {}
         self.tokens: list[ABCToken] = []
         self.activeParens: list[str] = []  # e.g. ['Crescendo', 'Slur']
@@ -1787,7 +1787,7 @@ class ABCHandler:
 
     @staticmethod
     def _getLinearContext(source: Sequence[_T],
-                          i: int) -> tuple[t.Optional[_T], _T, t.Optional[_T], t.Optional[_T]]:
+                          i: int) -> tuple[_T|None, _T, _T|None, _T|None]:
         '''
         Find the local context of a string or iterable of objects
         beginning at a particular index.
@@ -2010,8 +2010,8 @@ class ABCHandler:
 
     @staticmethod
     def startsMetadata(c: str,
-                       cNext: t.Optional[str],
-                       cNextNext: t.Optional[str]) -> bool:
+                       cNext: str|None,
+                       cNextNext: str|None) -> bool:
         '''
         Returns True if this context describes the start of a metadata section, like
 
@@ -3172,7 +3172,7 @@ class ABCHandler:
         else:
             return False
 
-    def getTitle(self) -> t.Optional[str]:
+    def getTitle(self) -> str|None:
         '''
         Get the first title tag. Used for testing.
 

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -549,7 +549,7 @@ X:2
 T:Kitchen Girl
 C:Trad.
 K:D
-[c4a4] [B4g4]|efed c2cd|e2f2 gaba|g2e2 e2fg|
+[c4a4] [B4g4] | efed c2cd|e2f2 gaba|g2e2 e2fg|
 a4 g4|efed cdef|g2d2 efed|c2A2 A4:|
 K:G
 ABcA BAGB|ABAG EDEG|A2AB c2d2|e3f edcB|ABcA BAGB|

--- a/music21/alpha/analysis/fixer.py
+++ b/music21/alpha/analysis/fixer.py
@@ -351,7 +351,7 @@ class OrnamentFixer(OMRMidiFixer):
             self.recognizers = recognizers
         self.markChangeColor = markChangeColor
 
-    def findOrnament(self, busyNotes, simpleNotes) -> t.Optional[expressions.Ornament]:
+    def findOrnament(self, busyNotes, simpleNotes) -> expressions.Ornament|None:
         '''
         Finds an ornament in busyNotes based from simpleNote
         using provided recognizers.
@@ -390,7 +390,7 @@ class OrnamentFixer(OMRMidiFixer):
             return True
         return False
 
-    def fix(self, *, show=False, inPlace=True) -> t.Optional[OMRMidiFixer]:
+    def fix(self, *, show=False, inPlace=True) -> OMRMidiFixer|None:
         '''
         Corrects missed ornaments in omrStream according to midiStream
         :param show: Whether to show results

--- a/music21/alpha/analysis/fixer.py
+++ b/music21/alpha/analysis/fixer.py
@@ -351,7 +351,7 @@ class OrnamentFixer(OMRMidiFixer):
             self.recognizers = recognizers
         self.markChangeColor = markChangeColor
 
-    def findOrnament(self, busyNotes, simpleNotes) -> expressions.Ornament|None:
+    def findOrnament(self, busyNotes, simpleNotes) -> expressions.Ornament | None:
         '''
         Finds an ornament in busyNotes based from simpleNote
         using provided recognizers.
@@ -390,7 +390,7 @@ class OrnamentFixer(OMRMidiFixer):
             return True
         return False
 
-    def fix(self, *, show=False, inPlace=True) -> OMRMidiFixer|None:
+    def fix(self, *, show=False, inPlace=True) -> OMRMidiFixer | None:
         '''
         Corrects missed ornaments in omrStream according to midiStream
         :param show: Whether to show results
@@ -398,7 +398,7 @@ class OrnamentFixer(OMRMidiFixer):
         return a new OrnamentFixer with changes
         '''
         changes = self.changes
-        sa: aligner.StreamAligner|None = None
+        sa: aligner.StreamAligner | None = None
         omrNotesLabeledOrnament = []
         midiNotesAlreadyFixedForOrnament = []
 

--- a/music21/alpha/analysis/fixer.py
+++ b/music21/alpha/analysis/fixer.py
@@ -398,7 +398,7 @@ class OrnamentFixer(OMRMidiFixer):
         return a new OrnamentFixer with changes
         '''
         changes = self.changes
-        sa: t.Optional[aligner.StreamAligner] = None
+        sa: aligner.StreamAligner|None = None
         omrNotesLabeledOrnament = []
         midiNotesAlreadyFixedForOrnament = []
 

--- a/music21/alpha/analysis/fixer.py
+++ b/music21/alpha/analysis/fixer.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 from copy import deepcopy
-import typing as t
 import unittest
 
 from music21 import duration

--- a/music21/alpha/analysis/ornamentRecognizer.py
+++ b/music21/alpha/analysis/ornamentRecognizer.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 from copy import deepcopy
-import typing as t
 import unittest
 
 from music21.common.numberTools import opFrac

--- a/music21/alpha/analysis/ornamentRecognizer.py
+++ b/music21/alpha/analysis/ornamentRecognizer.py
@@ -49,7 +49,7 @@ class OrnamentRecognizer:
     def calculateOrnamentTotalQl(
         self,
         busyNotes: list[note.GeneralNote],
-        simpleNotes: list[note.GeneralNote]|None = None
+        simpleNotes: list[note.GeneralNote] | None = None
     ) -> OffsetQL:
         '''
         Returns total length of trill assuming busy notes are all an expanded trill.
@@ -78,7 +78,7 @@ class TrillRecognizer(OrnamentRecognizer):
         self.acceptableInterval = 3
         self.minimumLengthForNachschlag = 5
 
-    def recognize(self, busyNotes, simpleNotes=None) -> bool|expressions.Trill:
+    def recognize(self, busyNotes, simpleNotes=None) -> bool | expressions.Trill:
         '''
         Tries to identify the busy notes as a trill.
 
@@ -178,7 +178,7 @@ class TurnRecognizer(OrnamentRecognizer):
         self,
         busyNotes,
         simpleNotes=None,
-    ) -> bool|expressions.Turn|expressions.InvertedTurn:
+    ) -> bool | expressions.Turn | expressions.InvertedTurn:
         '''
         Tries to identify the busy notes as a turn or inverted turn.
 

--- a/music21/alpha/analysis/ornamentRecognizer.py
+++ b/music21/alpha/analysis/ornamentRecognizer.py
@@ -49,7 +49,7 @@ class OrnamentRecognizer:
     def calculateOrnamentTotalQl(
         self,
         busyNotes: list[note.GeneralNote],
-        simpleNotes: t.Optional[list[note.GeneralNote]] = None
+        simpleNotes: list[note.GeneralNote]|None = None
     ) -> OffsetQL:
         '''
         Returns total length of trill assuming busy notes are all an expanded trill.
@@ -78,7 +78,7 @@ class TrillRecognizer(OrnamentRecognizer):
         self.acceptableInterval = 3
         self.minimumLengthForNachschlag = 5
 
-    def recognize(self, busyNotes, simpleNotes=None) -> t.Union[bool, expressions.Trill]:
+    def recognize(self, busyNotes, simpleNotes=None) -> bool|expressions.Trill:
         '''
         Tries to identify the busy notes as a trill.
 
@@ -178,7 +178,7 @@ class TurnRecognizer(OrnamentRecognizer):
         self,
         busyNotes,
         simpleNotes=None,
-    ) -> t.Union[bool, expressions.Turn, expressions.InvertedTurn]:
+    ) -> bool|expressions.Turn|expressions.InvertedTurn:
         '''
         Tries to identify the busy notes as a turn or inverted turn.
 

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -81,7 +81,7 @@ class DiscreteAnalysis:
         # store alternative solutions, which may be sorted or not
         self.alternativeSolutions = []
 
-    def _rgbToHex(self, rgb: Sequence[float|int]) -> str:
+    def _rgbToHex(self, rgb: Sequence[float | int]) -> str:
         '''
         Utility conversion method
 
@@ -418,7 +418,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
         if keyResults is None:
             return None
 
-        solution: list[int|float] = [0.0] * 12
+        solution: list[int | float] = [0.0] * 12
         top = [0.0] * 12
         bottomRight = [0.0] * 12
         bottomLeft = [0.0] * 12
@@ -956,8 +956,8 @@ class Ambitus(DiscreteAnalysis):
         super().__init__(referenceStream=referenceStream)
         # Store the min and max Pitch instances for referenceStream
         # set by getPitchSpan(), which is called by _generateColors()
-        self.minPitchObj: pitch.Pitch|None = None
-        self.maxPitchObj: pitch.Pitch|None = None
+        self.minPitchObj: pitch.Pitch | None = None
+        self.maxPitchObj: pitch.Pitch | None = None
 
         self._pitchSpanColors = OrderedDict()
         self._generateColors()
@@ -1002,7 +1002,7 @@ class Ambitus(DiscreteAnalysis):
 
         # environLocal.printDebug([self._pitchSpanColors])
 
-    def getPitchSpan(self, subStream) -> tuple[pitch.Pitch, pitch.Pitch]|None:
+    def getPitchSpan(self, subStream) -> tuple[pitch.Pitch, pitch.Pitch] | None:
         '''
         For a given subStream, return a tuple consisting of the two pitches
         with the minimum and maximum pitch space value.
@@ -1334,7 +1334,7 @@ def analyzeStream(
         # this synonym is being added for compatibility
         method = 'span'
 
-    analysisClassName: type[DiscreteAnalysis]|None = analysisClassFromMethodName(method)
+    analysisClassName: type[DiscreteAnalysis] | None = analysisClassFromMethodName(method)
 
     if analysisClassName is not None:
         obj = analysisClassName()

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -956,8 +956,8 @@ class Ambitus(DiscreteAnalysis):
         super().__init__(referenceStream=referenceStream)
         # Store the min and max Pitch instances for referenceStream
         # set by getPitchSpan(), which is called by _generateColors()
-        self.minPitchObj: t.Optional[pitch.Pitch] = None
-        self.maxPitchObj: t.Optional[pitch.Pitch] = None
+        self.minPitchObj: pitch.Pitch|None = None
+        self.maxPitchObj: pitch.Pitch|None = None
 
         self._pitchSpanColors = OrderedDict()
         self._generateColors()

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -81,7 +81,7 @@ class DiscreteAnalysis:
         # store alternative solutions, which may be sorted or not
         self.alternativeSolutions = []
 
-    def _rgbToHex(self, rgb: Sequence[t.Union[float, int]]) -> str:
+    def _rgbToHex(self, rgb: Sequence[float|int]) -> str:
         '''
         Utility conversion method
 
@@ -418,7 +418,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
         if keyResults is None:
             return None
 
-        solution: list[t.Union[int, float]] = [0.0] * 12
+        solution: list[int|float] = [0.0] * 12
         top = [0.0] * 12
         bottomRight = [0.0] * 12
         bottomLeft = [0.0] * 12
@@ -1002,7 +1002,7 @@ class Ambitus(DiscreteAnalysis):
 
         # environLocal.printDebug([self._pitchSpanColors])
 
-    def getPitchSpan(self, subStream) -> t.Optional[tuple[pitch.Pitch, pitch.Pitch]]:
+    def getPitchSpan(self, subStream) -> tuple[pitch.Pitch, pitch.Pitch]|None:
         '''
         For a given subStream, return a tuple consisting of the two pitches
         with the minimum and maximum pitch space value.
@@ -1334,7 +1334,7 @@ def analyzeStream(
         # this synonym is being added for compatibility
         method = 'span'
 
-    analysisClassName: t.Optional[type[DiscreteAnalysis]] = analysisClassFromMethodName(method)
+    analysisClassName: type[DiscreteAnalysis]|None = analysisClassFromMethodName(method)
 
     if analysisClassName is not None:
         obj = analysisClassName()
@@ -1346,7 +1346,7 @@ def analyzeStream(
 
 
 # noinspection SpellCheckingInspection
-def analysisClassFromMethodName(method: str) -> t.Optional[type[DiscreteAnalysis]]:
+def analysisClassFromMethodName(method: str) -> type[DiscreteAnalysis] | None:
     '''
     Returns an analysis class given a method name, or None if none can be found
 
@@ -1375,7 +1375,7 @@ def analysisClassFromMethodName(method: str) -> t.Optional[type[DiscreteAnalysis
         BellmanBudge,
         TemperleyKostkaPayne,
     ]
-    match: t.Optional[type[DiscreteAnalysis]] = None
+    match: type[DiscreteAnalysis] | None = None
     for analysisClass in analysisClasses:
         # this is a very loose matching, as there are few classes now
         if (method.lower() in analysisClass.__name__.lower()

--- a/music21/analysis/harmonicFunction.py
+++ b/music21/analysis/harmonicFunction.py
@@ -104,7 +104,7 @@ functionFigureTuplesMinor = {
 
 def functionToRoman(thisHarmonicFunction: HarmonicFunction,
                     keyOrScale: key.Key|scale.ConcreteScale|str = 'C'
-                    ) -> t.Optional[roman.RomanNumeral]:
+                    ) -> roman.RomanNumeral|None:
     '''
     Takes harmonic function labels (such as 'T' for major tonic)
     with a key (keyOrScale, default = 'C') and
@@ -198,7 +198,7 @@ def functionToRoman(thisHarmonicFunction: HarmonicFunction,
 
 def romanToFunction(rn: roman.RomanNumeral,
                     onlyHauptHarmonicFunction: bool = False
-                    ) -> t.Optional[HarmonicFunction]:
+                    ) -> HarmonicFunction|None:
     '''
     Takes a Roman numeral and returns a corresponding harmonic function label.
 

--- a/music21/analysis/harmonicFunction.py
+++ b/music21/analysis/harmonicFunction.py
@@ -103,8 +103,8 @@ functionFigureTuplesMinor = {
 
 
 def functionToRoman(thisHarmonicFunction: HarmonicFunction,
-                    keyOrScale: key.Key|scale.ConcreteScale|str = 'C'
-                    ) -> roman.RomanNumeral|None:
+                    keyOrScale: key.Key | scale.ConcreteScale | str = 'C'
+                    ) -> roman.RomanNumeral | None:
     '''
     Takes harmonic function labels (such as 'T' for major tonic)
     with a key (keyOrScale, default = 'C') and
@@ -198,7 +198,7 @@ def functionToRoman(thisHarmonicFunction: HarmonicFunction,
 
 def romanToFunction(rn: roman.RomanNumeral,
                     onlyHauptHarmonicFunction: bool = False
-                    ) -> HarmonicFunction|None:
+                    ) -> HarmonicFunction | None:
     '''
     Takes a Roman numeral and returns a corresponding harmonic function label.
 

--- a/music21/analysis/harmonicFunction.py
+++ b/music21/analysis/harmonicFunction.py
@@ -103,7 +103,7 @@ functionFigureTuplesMinor = {
 
 
 def functionToRoman(thisHarmonicFunction: HarmonicFunction,
-                    keyOrScale: t.Union[key.Key, scale.ConcreteScale, str] = 'C'
+                    keyOrScale: key.Key|scale.ConcreteScale|str = 'C'
                     ) -> t.Optional[roman.RomanNumeral]:
     '''
     Takes harmonic function labels (such as 'T' for major tonic)

--- a/music21/analysis/harmonicFunction.py
+++ b/music21/analysis/harmonicFunction.py
@@ -10,7 +10,6 @@
 # ------------------------------------------------------------------------------
 from __future__ import annotations
 
-import typing as t
 import unittest
 
 from music21 import common

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -467,7 +467,7 @@ class PartReduction:
     def __init__(self,
                  srcScore=None,
                  *,
-                 partGroups: t.Optional[list[dict[str, t.Any]]] = None,
+                 partGroups: list[dict[str, t.Any]]|None = None,
                  fillByMeasure: bool = True,
                  segmentByTarget: bool = True,
                  normalize: bool = True,
@@ -483,7 +483,7 @@ class PartReduction:
         # TODO: typed dict
         self._partBundles: list[dict[str, t.Any]] = []
         # a dictionary of part id to a list of events
-        self._eventSpans: dict[t.Union[str, int], list[t.Any]] = {}
+        self._eventSpans: dict[str|int, list[t.Any]] = {}
 
         # define how parts are grouped
         # a list of dictionaries, with keys for name, color, and a match list

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -467,7 +467,7 @@ class PartReduction:
     def __init__(self,
                  srcScore=None,
                  *,
-                 partGroups: list[dict[str, t.Any]]|None = None,
+                 partGroups: list[dict[str, t.Any]] | None = None,
                  fillByMeasure: bool = True,
                  segmentByTarget: bool = True,
                  normalize: bool = True,
@@ -483,7 +483,7 @@ class PartReduction:
         # TODO: typed dict
         self._partBundles: list[dict[str, t.Any]] = []
         # a dictionary of part id to a list of events
-        self._eventSpans: dict[str|int, list[t.Any]] = {}
+        self._eventSpans: dict[str | int, list[t.Any]] = {}
 
         # define how parts are grouped
         # a list of dictionaries, with keys for name, color, and a match list

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -21,7 +21,6 @@ and :class:`music21.analysis.discrete.Ambitus` (for pitch range analysis) classe
 '''
 from __future__ import annotations
 
-import typing as t
 import unittest
 import warnings
 

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -244,9 +244,9 @@ class WindowedAnalysis:
 
 
     def process(self,
-                minWindow: int|None = 1,
-                maxWindow: int|None = 1,
-                windowStepSize: int|str = 1,
+                minWindow: int | None = 1,
+                maxWindow: int | None = 1,
+                windowStepSize: int | str = 1,
                 windowType='overlap',
                 includeTotalWindow=True):
         # noinspection PyShadowingNames

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -245,9 +245,9 @@ class WindowedAnalysis:
 
 
     def process(self,
-                minWindow: t.Union[int, None] = 1,
-                maxWindow: t.Union[int, None] = 1,
-                windowStepSize: t.Union[int, str] = 1,
+                minWindow: int|None = 1,
+                maxWindow: int|None = 1,
+                windowStepSize: int|str = 1,
                 windowType='overlap',
                 includeTotalWindow=True):
         # noinspection PyShadowingNames

--- a/music21/articulations.py
+++ b/music21/articulations.py
@@ -118,7 +118,7 @@ class Articulation(base.Music21Object):
         self._volumeShift: float = 0.0
         self.lengthShift: float = 1.0
         self.tieAttach: str = 'first'  # attach to first or last or all notes after split
-        self.displayText: str|None = None
+        self.displayText: str | None = None
 
     def _reprInternal(self):
         return ''
@@ -592,7 +592,7 @@ class PullOff(FretIndication):
     pass
 
 class FretBend(FretIndication):
-    bendAlter: interval.IntervalBase|None = None
+    bendAlter: interval.IntervalBase | None = None
     preBend: t.Any = None
     release: t.Any = None
     withBar: t.Any = None

--- a/music21/articulations.py
+++ b/music21/articulations.py
@@ -118,7 +118,7 @@ class Articulation(base.Music21Object):
         self._volumeShift: float = 0.0
         self.lengthShift: float = 1.0
         self.tieAttach: str = 'first'  # attach to first or last or all notes after split
-        self.displayText: t.Optional[str] = None
+        self.displayText: str|None = None
 
     def _reprInternal(self):
         return ''
@@ -592,7 +592,7 @@ class PullOff(FretIndication):
     pass
 
 class FretBend(FretIndication):
-    bendAlter: t.Optional[interval.IntervalBase] = None
+    bendAlter: interval.IntervalBase|None = None
     preBend: t.Any = None
     release: t.Any = None
     withBar: t.Any = None

--- a/music21/audioSearch/__init__.py
+++ b/music21/audioSearch/__init__.py
@@ -43,8 +43,6 @@ import wave
 import warnings
 import unittest
 
-import typing as t
-
 # cannot call this base, because when audioSearch.__init__.py
 # imports * from base, it overwrites audioSearch!
 from music21 import base
@@ -531,7 +529,7 @@ def smoothFrequencies(
     *,
     smoothLevels=7,
     inPlace=False
-) -> t.Union[list[int], None]:
+) -> list[int] | None:
     '''
     Smooths the shape of the signal in order to avoid false detections in the fundamental
     frequency.  Takes in a list of ints or floats.

--- a/music21/audioSearch/__init__.py
+++ b/music21/audioSearch/__init__.py
@@ -527,7 +527,7 @@ def detectPitchFrequencies(freqFromAQList, useScale=None):
 
 
 def smoothFrequencies(
-    frequencyList: list[int|float],
+    frequencyList: list[int | float],
     *,
     smoothLevels=7,
     inPlace=False

--- a/music21/audioSearch/__init__.py
+++ b/music21/audioSearch/__init__.py
@@ -527,7 +527,7 @@ def detectPitchFrequencies(freqFromAQList, useScale=None):
 
 
 def smoothFrequencies(
-    frequencyList: list[t.Union[int, float]],
+    frequencyList: list[int|float],
     *,
     smoothLevels=7,
     inPlace=False

--- a/music21/bar.py
+++ b/music21/bar.py
@@ -14,7 +14,6 @@ Object models of barlines, including repeat barlines.
 '''
 from __future__ import annotations
 
-import typing as t
 import unittest
 
 from music21 import base

--- a/music21/bar.py
+++ b/music21/bar.py
@@ -272,8 +272,8 @@ class Repeat(repeat.RepeatMark, Barline):
             barType = 'final'
         Barline.__init__(self, type=barType)
 
-        self._direction: str|None = None  # either start or end
-        self._times: int|None = None  # if an end, how many repeats
+        self._direction: str | None = None  # either start or end
+        self._times: int | None = None  # if an end, how many repeats
 
         # start is forward, end is backward in musicxml
         self.direction = direction  # start, end
@@ -309,7 +309,7 @@ class Repeat(repeat.RepeatMark, Barline):
             raise BarException(f'cannot set repeat direction to: {value}')
 
     @property
-    def times(self) -> int|None:
+    def times(self) -> int | None:
         '''
         Get or set the "times" property of this barline. This
         defines how many times the repeat happens. A standard repeat

--- a/music21/bar.py
+++ b/music21/bar.py
@@ -273,8 +273,8 @@ class Repeat(repeat.RepeatMark, Barline):
             barType = 'final'
         Barline.__init__(self, type=barType)
 
-        self._direction: t.Optional[str] = None  # either start or end
-        self._times: t.Optional[int] = None  # if an end, how many repeats
+        self._direction: str|None = None  # either start or end
+        self._times: int|None = None  # if an end, how many repeats
 
         # start is forward, end is backward in musicxml
         self.direction = direction  # start, end
@@ -310,7 +310,7 @@ class Repeat(repeat.RepeatMark, Barline):
             raise BarException(f'cannot set repeat direction to: {value}')
 
     @property
-    def times(self) -> t.Optional[int]:
+    def times(self) -> int|None:
         '''
         Get or set the "times" property of this barline. This
         defines how many times the repeat happens. A standard repeat

--- a/music21/base.py
+++ b/music21/base.py
@@ -299,7 +299,7 @@ class Music21Object(prebase.ProtoM21Object):
     within Note)
     '''
 
-    classSortOrder: t.Union[int, float] = 20  # default classSortOrder
+    classSortOrder: int|float = 20  # default classSortOrder
     # these values permit fast class comparisons for performance critical cases
     isStream = False
 
@@ -352,7 +352,7 @@ class Music21Object(prebase.ProtoM21Object):
     }
 
     def __init__(self,
-                 id: t.Union[str, int, None] = None,  # pylint: disable=redefined-builtin
+                 id: str|int|None = None,  # pylint: disable=redefined-builtin
                  groups: Groups|None = None,
                  sites: Sites|None = None,
                  duration: Duration|None = None,
@@ -363,16 +363,16 @@ class Music21Object(prebase.ProtoM21Object):
                  quarterLength: OffsetQLIn|None = None,
                  **keywords):
         # do not call super().__init__() since it just wastes time
-        self._id: t.Union[str, int, None] = id
+        self._id: str|int|None = id
         # None is stored as the internal location of an obj w/o any sites
-        self._activeSite: t.Union[stream.Stream, weakref.ReferenceType, None] = None
+        self._activeSite: stream.Stream|weakref.ReferenceType|None = None
         # offset when no activeSite is available
         self._naiveOffset: OffsetQL = offset
 
         # offset when activeSite is already garbage collected/dead,
         # as in short-lived sites
         # like .getElementsByClass().stream()
-        self._activeSiteStoredOffset: t.Union[float, fractions.Fraction, None] = None
+        self._activeSiteStoredOffset: float|fractions.Fraction|None = None
 
         # store a derivation object to track derivations from other Streams
         # pass a reference to this object

--- a/music21/base.py
+++ b/music21/base.py
@@ -742,7 +742,7 @@ class Music21Object(prebase.ProtoM21Object):
         return self._style
 
     @style.setter
-    def style(self, newStyle: t.Optional[Style]):
+    def style(self, newStyle: Style|None):
         # Dev note: because property style shadows module style,
         # typing has to be in quotes.
         self._style = newStyle
@@ -801,7 +801,7 @@ class Music21Object(prebase.ProtoM21Object):
         return self._derivation
 
     @derivation.setter
-    def derivation(self, newDerivation: t.Optional[Derivation]) -> None:
+    def derivation(self, newDerivation: Derivation|None) -> None:
         self._derivation = newDerivation
 
     def clearCache(self, **keywords):
@@ -965,7 +965,7 @@ class Music21Object(prebase.ProtoM21Object):
             ) from se
 
     def setOffsetBySite(self,
-                        site: t.Optional[stream.Stream],
+                        site: stream.Stream|None,
                         value: OffsetQLIn):
         '''
         Change the offset for a site.  These are equivalent:
@@ -1019,7 +1019,7 @@ class Music21Object(prebase.ProtoM21Object):
 
     def getOffsetInHierarchy(
         self,
-        site: t.Optional[stream.Stream]
+        site: stream.Stream|None
     ) -> OffsetQL:
         '''
         For an element which may not be in site, but might be in a Stream in site (or further
@@ -1233,7 +1233,7 @@ class Music21Object(prebase.ProtoM21Object):
         sortByCreationTime=False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> t.Union[_M21T, None]:
+    ) -> _M21T|None:
         return None  # until Astroid #1015
 
     @overload
@@ -1245,19 +1245,19 @@ class Music21Object(prebase.ProtoM21Object):
         sortByCreationTime=False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> t.Union[Music21Object, None]:
+    ) -> Music21Object|None:
         return None  # until Astroid #1015
 
 
     def getContextByClass(
         self,
-        className: t.Union[type[_M21T], str, None],
+        className: type[_M21T] | str | None,
         *,
         getElementMethod: ElementSearch = ElementSearch.AT_OR_BEFORE,
         sortByCreationTime=False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> t.Union[_M21T, Music21Object, None]:
+    ) -> _M21T|Music21Object|None:
         # noinspection PyShadowingNames
         '''
         A very powerful method in music21 of fundamental importance: Returns
@@ -1726,7 +1726,7 @@ class Music21Object(prebase.ProtoM21Object):
         callerFirst=None,
         memo=None,
         offsetAppend: OffsetQL = 0.0,
-        sortByCreationTime: t.Union[t.Literal['reverse'], bool] = False,
+        sortByCreationTime: t.Literal['reverse']|bool = False,
         priorityTarget=None,
         followDerivation=True,
         priorityTargetOnly=False,
@@ -1740,7 +1740,7 @@ class Music21Object(prebase.ProtoM21Object):
         callerFirst=None,
         memo=None,
         offsetAppend: OffsetQL = 0.0,
-        sortByCreationTime: t.Union[t.Literal['reverse'], bool] = False,
+        sortByCreationTime: t.Literal['reverse']|bool = False,
         priorityTarget=None,
         returnSortTuples: t.Literal[False] = False,
         followDerivation=True,
@@ -1755,7 +1755,7 @@ class Music21Object(prebase.ProtoM21Object):
         callerFirst=None,
         memo=None,
         offsetAppend: OffsetQL = 0.0,
-        sortByCreationTime: t.Union[t.Literal['reverse'], bool] = False,
+        sortByCreationTime: t.Literal['reverse']|bool = False,
         priorityTarget=None,
         returnSortTuples: bool = False,
         followDerivation=True,
@@ -2104,7 +2104,7 @@ class Music21Object(prebase.ProtoM21Object):
     # -------------------------------------------------------------------------
 
     def next(self,
-             className: t.Union[type[Music21Object], str, None] = None,
+             className: type[Music21Object]|str|None = None,
              *,
              activeSiteOnly=False):
         '''
@@ -2224,7 +2224,7 @@ class Music21Object(prebase.ProtoM21Object):
             raise Music21Exception('Maximum recursion!')
 
     def previous(self,
-                 className: t.Union[type[Music21Object], str, None] = None,
+                 className: type[Music21Object]|str|None = None,
                  *,
                  activeSiteOnly=False):
         '''
@@ -2530,11 +2530,7 @@ class Music21Object(prebase.ProtoM21Object):
             self._naiveOffset = offset
 
     def sortTuple(self,
-                  useSite: t.Union[
-                      t.Literal[False],
-                      None,
-                      stream.Stream,
-                  ] = False,
+                  useSite: t.Literal[False]|stream.Stream|None = False,
                   raiseExceptionOnMiss: bool = False
                   ) -> SortTuple:
         '''
@@ -2640,7 +2636,7 @@ class Music21Object(prebase.ProtoM21Object):
         music21.sites.SitesException: an entry for this object 0x... is not stored in
             stream <music21.stream.Stream aloneStream>
         '''
-        useSiteNoFalse: t.Optional[stream.Stream]
+        useSiteNoFalse: stream.Stream|None
         if useSite is False:  # False or a Site; since None is a valid site, default is False
             useSiteNoFalse = self.activeSite
         else:
@@ -3419,7 +3415,7 @@ class Music21Object(prebase.ProtoM21Object):
     # temporal and beat based positioning
 
     @property
-    def measureNumber(self) -> t.Optional[int]:
+    def measureNumber(self) -> int|None:
         # noinspection PyShadowingNames
         '''
         Return the measure number of a :class:`~music21.stream.Measure` that contains this

--- a/music21/base.py
+++ b/music21/base.py
@@ -401,7 +401,7 @@ class Music21Object(prebase.ProtoM21Object):
             self.duration = duration
 
     @property
-    def id(self) -> t.Union[int, str]:
+    def id(self) -> int|str:
         '''
         A unique identification string or int; not to be confused with Python's
         built-in `id()` method. However, if not set, will return
@@ -417,7 +417,7 @@ class Music21Object(prebase.ProtoM21Object):
         return builtins.id(self)
 
     @id.setter
-    def id(self, new_id: t.Union[int, str]):
+    def id(self, new_id: int|str):
         if isinstance(new_id, int) and new_id > defaults.minIdNumberToConsiderMemoryLocation:
             msg = 'Setting an ID that could be mistaken for a memory location '
             msg += f'is discouraged: got {new_id}'
@@ -829,7 +829,7 @@ class Music21Object(prebase.ProtoM21Object):
     @overload
     def getOffsetBySite(
         self,
-        site: t.Union[stream.Stream, None],
+        site: stream.Stream|None,
         *,
         returnSpecial: t.Literal[False] = False,
     ) -> OffsetQL:
@@ -838,19 +838,19 @@ class Music21Object(prebase.ProtoM21Object):
     @overload
     def getOffsetBySite(
         self,
-        site: t.Union[stream.Stream, None],
+        site: stream.Stream|None,
         *,
         returnSpecial: bool = False,
-    ) -> t.Union[OffsetQL, OffsetSpecial]:
+    ) -> OffsetQL|OffsetSpecial:
         return 0.0  # dummy until Astroid #1015 is fixed.  Replace with ...
         # using bool instead of t.Literal[True] because of
 
     def getOffsetBySite(
         self,
-        site: t.Union[stream.Stream, None],
+        site: stream.Stream|None,
         *,
         returnSpecial: bool = False,
-    ) -> t.Union[OffsetQL, OffsetSpecial]:
+    ) -> OffsetQL|OffsetSpecial:
         '''
         If this class has been registered in a container such as a Stream,
         that container can be provided here, and the offset in that object
@@ -1239,7 +1239,7 @@ class Music21Object(prebase.ProtoM21Object):
     @overload
     def getContextByClass(
         self,
-        className: t.Union[str, None],
+        className: str|None,
         *,
         getElementMethod=ElementSearch.AT_OR_BEFORE,
         sortByCreationTime=False,
@@ -1760,7 +1760,7 @@ class Music21Object(prebase.ProtoM21Object):
         returnSortTuples: bool = False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> Generator[t.Union[ContextTuple, ContextSortTuple], None, None]:
+    ) -> Generator[ContextTuple|ContextSortTuple, None, None]:
         '''
         A generator that returns a list of namedtuples of sites to search for a context...
 
@@ -2331,7 +2331,7 @@ class Music21Object(prebase.ProtoM21Object):
         else:  # pragma: no cover
             return self._activeSite
 
-    def _setActiveSite(self, site: t.Union[stream.Stream, None]):
+    def _setActiveSite(self, site: stream.Stream|None):
         # environLocal.printDebug(['_setActiveSite() called:', 'self', self, 'site', site])
 
         # NOTE: this is a performance intensive call
@@ -2646,7 +2646,7 @@ class Music21Object(prebase.ProtoM21Object):
         else:
             useSiteNoFalse = useSite
 
-        foundOffset: t.Union[OffsetQL, OffsetSpecial]
+        foundOffset: OffsetQL|OffsetSpecial
         if useSiteNoFalse is None:
             foundOffset = self.offset
         else:
@@ -3251,7 +3251,7 @@ class Music21Object(prebase.ProtoM21Object):
 
     def splitByQuarterLengths(
         self,
-        quarterLengthList: list[t.Union[int, float]],
+        quarterLengthList: list[int|float],
         addTies=True,
         displayTiedAccidentals=False
     ) -> _SplitTuple:
@@ -3492,7 +3492,7 @@ class Music21Object(prebase.ProtoM21Object):
                     mNumber = m.number  # type: ignore
         return mNumber
 
-    def _getMeasureOffset(self, includeMeasurePadding=True) -> t.Union[float, fractions.Fraction]:
+    def _getMeasureOffset(self, includeMeasurePadding=True) -> float|fractions.Fraction:
         # noinspection PyShadowingNames
         '''
         Try to obtain the nearest Measure that contains this object,
@@ -3569,7 +3569,7 @@ class Music21Object(prebase.ProtoM21Object):
         return ts
 
     @property
-    def beat(self) -> t.Union[fractions.Fraction, float]:
+    def beat(self) -> fractions.Fraction|float:
         # noinspection PyShadowingNames
         '''
         Return the beat of this object as found in the most
@@ -3872,7 +3872,7 @@ class Music21Object(prebase.ProtoM21Object):
         # once we have mm, simply pass in this duration
         return mm.durationToSeconds(self.duration)
 
-    def _setSeconds(self, value: t.Union[int, float]) -> None:
+    def _setSeconds(self, value: int|float) -> None:
         from music21 import tempo
         ti = self.getContextByClass(tempo.TempoIndication)
         if ti is None:

--- a/music21/base.py
+++ b/music21/base.py
@@ -299,7 +299,7 @@ class Music21Object(prebase.ProtoM21Object):
     within Note)
     '''
 
-    classSortOrder: int|float = 20  # default classSortOrder
+    classSortOrder: int | float = 20  # default classSortOrder
     # these values permit fast class comparisons for performance critical cases
     isStream = False
 
@@ -352,37 +352,37 @@ class Music21Object(prebase.ProtoM21Object):
     }
 
     def __init__(self,
-                 id: str|int|None = None,  # pylint: disable=redefined-builtin
-                 groups: Groups|None = None,
-                 sites: Sites|None = None,
-                 duration: Duration|None = None,
-                 activeSite: stream.Stream|None = None,
-                 style: Style|None = None,
-                 editorial: Editorial|None = None,
+                 id: str | int | None = None,  # pylint: disable=redefined-builtin
+                 groups: Groups | None = None,
+                 sites: Sites | None = None,
+                 duration: Duration | None = None,
+                 activeSite: stream.Stream | None = None,
+                 style: Style | None = None,
+                 editorial: Editorial | None = None,
                  offset: OffsetQL = 0.0,
-                 quarterLength: OffsetQLIn|None = None,
+                 quarterLength: OffsetQLIn | None = None,
                  **keywords):
         # do not call super().__init__() since it just wastes time
-        self._id: str|int|None = id
+        self._id: str | int | None = id
         # None is stored as the internal location of an obj w/o any sites
-        self._activeSite: stream.Stream|weakref.ReferenceType|None = None
+        self._activeSite: stream.Stream | weakref.ReferenceType | None = None
         # offset when no activeSite is available
         self._naiveOffset: OffsetQL = offset
 
         # offset when activeSite is already garbage collected/dead,
         # as in short-lived sites
         # like .getElementsByClass().stream()
-        self._activeSiteStoredOffset: float|fractions.Fraction|None = None
+        self._activeSiteStoredOffset: float | fractions.Fraction | None = None
 
         # store a derivation object to track derivations from other Streams
         # pass a reference to this object
-        self._derivation: Derivation|None = None
+        self._derivation: Derivation | None = None
 
-        self._style: Style|None = style
-        self._editorial: Editorial|None = None
+        self._style: Style | None = style
+        self._editorial: Editorial | None = None
 
         # private duration storage; managed by property
-        self._duration: Duration|None = None
+        self._duration: Duration | None = None
         self._priority = 0  # default is zero
 
         # store cached values here:
@@ -401,7 +401,7 @@ class Music21Object(prebase.ProtoM21Object):
             self.duration = duration
 
     @property
-    def id(self) -> int|str:
+    def id(self) -> int | str:
         '''
         A unique identification string or int; not to be confused with Python's
         built-in `id()` method. However, if not set, will return
@@ -417,7 +417,7 @@ class Music21Object(prebase.ProtoM21Object):
         return builtins.id(self)
 
     @id.setter
-    def id(self, new_id: int|str):
+    def id(self, new_id: int | str):
         if isinstance(new_id, int) and new_id > defaults.minIdNumberToConsiderMemoryLocation:
             msg = 'Setting an ID that could be mistaken for a memory location '
             msg += f'is discouraged: got {new_id}'
@@ -557,7 +557,7 @@ class Music21Object(prebase.ProtoM21Object):
 
         return new
 
-    def __deepcopy__(self: _M21T, memo: dict[int, t.Any]|None = None) -> _M21T:
+    def __deepcopy__(self: _M21T, memo: dict[int, t.Any] | None = None) -> _M21T:
         '''
         Helper method to copy.py's deepcopy function.  Call it from there.
 
@@ -742,7 +742,7 @@ class Music21Object(prebase.ProtoM21Object):
         return self._style
 
     @style.setter
-    def style(self, newStyle: Style|None):
+    def style(self, newStyle: Style | None):
         # Dev note: because property style shadows module style,
         # typing has to be in quotes.
         self._style = newStyle
@@ -801,7 +801,7 @@ class Music21Object(prebase.ProtoM21Object):
         return self._derivation
 
     @derivation.setter
-    def derivation(self, newDerivation: Derivation|None) -> None:
+    def derivation(self, newDerivation: Derivation | None) -> None:
         self._derivation = newDerivation
 
     def clearCache(self, **keywords):
@@ -829,7 +829,7 @@ class Music21Object(prebase.ProtoM21Object):
     @overload
     def getOffsetBySite(
         self,
-        site: stream.Stream|None,
+        site: stream.Stream | None,
         *,
         returnSpecial: t.Literal[False] = False,
     ) -> OffsetQL:
@@ -838,19 +838,19 @@ class Music21Object(prebase.ProtoM21Object):
     @overload
     def getOffsetBySite(
         self,
-        site: stream.Stream|None,
+        site: stream.Stream | None,
         *,
         returnSpecial: bool = False,
-    ) -> OffsetQL|OffsetSpecial:
+    ) -> OffsetQL | OffsetSpecial:
         return 0.0  # dummy until Astroid #1015 is fixed.  Replace with ...
         # using bool instead of t.Literal[True] because of
 
     def getOffsetBySite(
         self,
-        site: stream.Stream|None,
+        site: stream.Stream | None,
         *,
         returnSpecial: bool = False,
-    ) -> OffsetQL|OffsetSpecial:
+    ) -> OffsetQL | OffsetSpecial:
         '''
         If this class has been registered in a container such as a Stream,
         that container can be provided here, and the offset in that object
@@ -965,7 +965,7 @@ class Music21Object(prebase.ProtoM21Object):
             ) from se
 
     def setOffsetBySite(self,
-                        site: stream.Stream|None,
+                        site: stream.Stream | None,
                         value: OffsetQLIn):
         '''
         Change the offset for a site.  These are equivalent:
@@ -1019,7 +1019,7 @@ class Music21Object(prebase.ProtoM21Object):
 
     def getOffsetInHierarchy(
         self,
-        site: stream.Stream|None
+        site: stream.Stream | None
     ) -> OffsetQL:
         '''
         For an element which may not be in site, but might be in a Stream in site (or further
@@ -1091,7 +1091,7 @@ class Music21Object(prebase.ProtoM21Object):
         raise SitesException(f'Element {self} is not in hierarchy of {site}')
 
     def getSpannerSites(self,
-                        spannerClassList: Iterable|None = None
+                        spannerClassList: Iterable | None = None
                         ) -> list[spanner.Spanner]:
         '''
         Return a list of all :class:`~music21.spanner.Spanner` objects
@@ -1233,19 +1233,19 @@ class Music21Object(prebase.ProtoM21Object):
         sortByCreationTime=False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> _M21T|None:
+    ) -> _M21T | None:
         return None  # until Astroid #1015
 
     @overload
     def getContextByClass(
         self,
-        className: str|None,
+        className: str | None,
         *,
         getElementMethod=ElementSearch.AT_OR_BEFORE,
         sortByCreationTime=False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> Music21Object|None:
+    ) -> Music21Object | None:
         return None  # until Astroid #1015
 
 
@@ -1257,7 +1257,7 @@ class Music21Object(prebase.ProtoM21Object):
         sortByCreationTime=False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> _M21T|Music21Object|None:
+    ) -> _M21T | Music21Object | None:
         # noinspection PyShadowingNames
         '''
         A very powerful method in music21 of fundamental importance: Returns
@@ -1726,7 +1726,7 @@ class Music21Object(prebase.ProtoM21Object):
         callerFirst=None,
         memo=None,
         offsetAppend: OffsetQL = 0.0,
-        sortByCreationTime: t.Literal['reverse']|bool = False,
+        sortByCreationTime: t.Literal['reverse'] | bool = False,
         priorityTarget=None,
         followDerivation=True,
         priorityTargetOnly=False,
@@ -1740,7 +1740,7 @@ class Music21Object(prebase.ProtoM21Object):
         callerFirst=None,
         memo=None,
         offsetAppend: OffsetQL = 0.0,
-        sortByCreationTime: t.Literal['reverse']|bool = False,
+        sortByCreationTime: t.Literal['reverse'] | bool = False,
         priorityTarget=None,
         returnSortTuples: t.Literal[False] = False,
         followDerivation=True,
@@ -1755,12 +1755,12 @@ class Music21Object(prebase.ProtoM21Object):
         callerFirst=None,
         memo=None,
         offsetAppend: OffsetQL = 0.0,
-        sortByCreationTime: t.Literal['reverse']|bool = False,
+        sortByCreationTime: t.Literal['reverse'] | bool = False,
         priorityTarget=None,
         returnSortTuples: bool = False,
         followDerivation=True,
         priorityTargetOnly=False,
-    ) -> Generator[ContextTuple|ContextSortTuple, None, None]:
+    ) -> Generator[ContextTuple | ContextSortTuple, None, None]:
         '''
         A generator that returns a list of namedtuples of sites to search for a context...
 
@@ -2104,7 +2104,7 @@ class Music21Object(prebase.ProtoM21Object):
     # -------------------------------------------------------------------------
 
     def next(self,
-             className: type[Music21Object]|str|None = None,
+             className: type[Music21Object] | str | None = None,
              *,
              activeSiteOnly=False):
         '''
@@ -2224,7 +2224,7 @@ class Music21Object(prebase.ProtoM21Object):
             raise Music21Exception('Maximum recursion!')
 
     def previous(self,
-                 className: type[Music21Object]|str|None = None,
+                 className: type[Music21Object] | str | None = None,
                  *,
                  activeSiteOnly=False):
         '''
@@ -2331,7 +2331,7 @@ class Music21Object(prebase.ProtoM21Object):
         else:  # pragma: no cover
             return self._activeSite
 
-    def _setActiveSite(self, site: stream.Stream|None):
+    def _setActiveSite(self, site: stream.Stream | None):
         # environLocal.printDebug(['_setActiveSite() called:', 'self', self, 'site', site])
 
         # NOTE: this is a performance intensive call
@@ -2530,7 +2530,7 @@ class Music21Object(prebase.ProtoM21Object):
             self._naiveOffset = offset
 
     def sortTuple(self,
-                  useSite: t.Literal[False]|stream.Stream|None = False,
+                  useSite: t.Literal[False] | stream.Stream | None = False,
                   raiseExceptionOnMiss: bool = False
                   ) -> SortTuple:
         '''
@@ -2636,13 +2636,13 @@ class Music21Object(prebase.ProtoM21Object):
         music21.sites.SitesException: an entry for this object 0x... is not stored in
             stream <music21.stream.Stream aloneStream>
         '''
-        useSiteNoFalse: stream.Stream|None
+        useSiteNoFalse: stream.Stream | None
         if useSite is False:  # False or a Site; since None is a valid site, default is False
             useSiteNoFalse = self.activeSite
         else:
             useSiteNoFalse = useSite
 
-        foundOffset: OffsetQL|OffsetSpecial
+        foundOffset: OffsetQL | OffsetSpecial
         if useSiteNoFalse is None:
             foundOffset = self.offset
         else:
@@ -3247,7 +3247,7 @@ class Music21Object(prebase.ProtoM21Object):
 
     def splitByQuarterLengths(
         self,
-        quarterLengthList: list[int|float],
+        quarterLengthList: list[int | float],
         addTies=True,
         displayTiedAccidentals=False
     ) -> _SplitTuple:
@@ -3415,7 +3415,7 @@ class Music21Object(prebase.ProtoM21Object):
     # temporal and beat based positioning
 
     @property
-    def measureNumber(self) -> int|None:
+    def measureNumber(self) -> int | None:
         # noinspection PyShadowingNames
         '''
         Return the measure number of a :class:`~music21.stream.Measure` that contains this
@@ -3488,7 +3488,7 @@ class Music21Object(prebase.ProtoM21Object):
                     mNumber = m.number  # type: ignore
         return mNumber
 
-    def _getMeasureOffset(self, includeMeasurePadding=True) -> float|fractions.Fraction:
+    def _getMeasureOffset(self, includeMeasurePadding=True) -> float | fractions.Fraction:
         # noinspection PyShadowingNames
         '''
         Try to obtain the nearest Measure that contains this object,
@@ -3556,7 +3556,7 @@ class Music21Object(prebase.ProtoM21Object):
         extracted to make sure that all three of the routines use the same one.
         '''
         from music21 import meter
-        ts: meter.TimeSignature|None = self.getContextByClass(
+        ts: meter.TimeSignature | None = self.getContextByClass(
             meter.TimeSignature,
             getElementMethod=ElementSearch.AT_OR_BEFORE_OFFSET
         )
@@ -3565,7 +3565,7 @@ class Music21Object(prebase.ProtoM21Object):
         return ts
 
     @property
-    def beat(self) -> fractions.Fraction|float:
+    def beat(self) -> fractions.Fraction | float:
         # noinspection PyShadowingNames
         '''
         Return the beat of this object as found in the most
@@ -3868,7 +3868,7 @@ class Music21Object(prebase.ProtoM21Object):
         # once we have mm, simply pass in this duration
         return mm.durationToSeconds(self.duration)
 
-    def _setSeconds(self, value: int|float) -> None:
+    def _setSeconds(self, value: int | float) -> None:
         from music21 import tempo
         ti = self.getContextByClass(tempo.TempoIndication)
         if ti is None:

--- a/music21/base.py
+++ b/music21/base.py
@@ -353,14 +353,14 @@ class Music21Object(prebase.ProtoM21Object):
 
     def __init__(self,
                  id: t.Union[str, int, None] = None,  # pylint: disable=redefined-builtin
-                 groups: t.Optional[Groups] = None,
-                 sites: t.Optional[Sites] = None,
-                 duration: t.Optional[Duration] = None,
-                 activeSite: t.Optional[stream.Stream] = None,
-                 style: t.Optional[Style] = None,
-                 editorial: t.Optional[Editorial] = None,
+                 groups: Groups|None = None,
+                 sites: Sites|None = None,
+                 duration: Duration|None = None,
+                 activeSite: stream.Stream|None = None,
+                 style: Style|None = None,
+                 editorial: Editorial|None = None,
                  offset: OffsetQL = 0.0,
-                 quarterLength: t.Optional[OffsetQLIn] = None,
+                 quarterLength: OffsetQLIn|None = None,
                  **keywords):
         # do not call super().__init__() since it just wastes time
         self._id: t.Union[str, int, None] = id
@@ -376,13 +376,13 @@ class Music21Object(prebase.ProtoM21Object):
 
         # store a derivation object to track derivations from other Streams
         # pass a reference to this object
-        self._derivation: t.Optional[Derivation] = None
+        self._derivation: Derivation|None = None
 
-        self._style: t.Optional[Style] = style
-        self._editorial: t.Optional[Editorial] = None
+        self._style: Style|None = style
+        self._editorial: Editorial|None = None
 
         # private duration storage; managed by property
-        self._duration: t.Optional[Duration] = None
+        self._duration: Duration|None = None
         self._priority = 0  # default is zero
 
         # store cached values here:
@@ -557,7 +557,7 @@ class Music21Object(prebase.ProtoM21Object):
 
         return new
 
-    def __deepcopy__(self: _M21T, memo: t.Optional[dict[int, t.Any]] = None) -> _M21T:
+    def __deepcopy__(self: _M21T, memo: dict[int, t.Any]|None = None) -> _M21T:
         '''
         Helper method to copy.py's deepcopy function.  Call it from there.
 
@@ -1091,7 +1091,7 @@ class Music21Object(prebase.ProtoM21Object):
         raise SitesException(f'Element {self} is not in hierarchy of {site}')
 
     def getSpannerSites(self,
-                        spannerClassList: t.Optional[Iterable] = None
+                        spannerClassList: Iterable|None = None
                         ) -> list[spanner.Spanner]:
         '''
         Return a list of all :class:`~music21.spanner.Spanner` objects
@@ -3560,7 +3560,7 @@ class Music21Object(prebase.ProtoM21Object):
         extracted to make sure that all three of the routines use the same one.
         '''
         from music21 import meter
-        ts: t.Optional[meter.TimeSignature] = self.getContextByClass(
+        ts: meter.TimeSignature|None = self.getContextByClass(
             meter.TimeSignature,
             getElementMethod=ElementSearch.AT_OR_BEFORE_OFFSET
         )

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -270,7 +270,7 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
                      2/None>/<music21.beam.Beam 3/None>>,
          None]
         '''
-        beamsList: list[Beams|None] = []
+        beamsList: list[Beams | None] = []
         for el in srcList:
             # if a dur cannot be beamable under any circumstance, replace
             # it with None; this includes Rests
@@ -289,7 +289,7 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
         return beamsList
 
     @staticmethod
-    def removeSandwichedUnbeamables(beamsList: list[Beams|None]):
+    def removeSandwichedUnbeamables(beamsList: list[Beams | None]):
         # noinspection PyShadowingNames
         '''
         Go through the naiveBeamsList and remove beams from objects surrounded

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -75,7 +75,6 @@ To get rid of beams on a note do:
 from __future__ import annotations
 
 from collections.abc import Iterable
-import typing as t
 from typing import TYPE_CHECKING  # pylint bug
 import unittest
 

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -270,7 +270,7 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
                      2/None>/<music21.beam.Beam 3/None>>,
          None]
         '''
-        beamsList: list[t.Optional[Beams]] = []
+        beamsList: list[Beams|None] = []
         for el in srcList:
             # if a dur cannot be beamable under any circumstance, replace
             # it with None; this includes Rests
@@ -289,7 +289,7 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
         return beamsList
 
     @staticmethod
-    def removeSandwichedUnbeamables(beamsList: list[t.Union['Beams', None]]):
+    def removeSandwichedUnbeamables(beamsList: list[Beams|None]):
         # noinspection PyShadowingNames
         '''
         Go through the naiveBeamsList and remove beams from objects surrounded

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -120,8 +120,8 @@ excludeFromBrailleElements: list[type[base.Music21Object]] = [
 ]
 
 class GroupingGlobals(t.TypedDict):
-    keySignature: t.Optional[key.KeySignature]
-    timeSignature: t.Optional[meter.TimeSignature]
+    keySignature: key.KeySignature|None
+    timeSignature: meter.TimeSignature|None
 
 
 GROUPING_GLOBALS: GroupingGlobals = {
@@ -1092,8 +1092,8 @@ class BrailleGrandSegment(BrailleSegment, text.BrailleKeyboard):
     def __init__(self, lineLength: int = 40):
         BrailleSegment.__init__(self, lineLength=lineLength)
         text.BrailleKeyboard.__init__(self, lineLength=lineLength)
-        self.allKeyPairs: list[tuple[t.Optional[SegmentKey],
-                                     t.Optional[SegmentKey]]] = []
+        self.allKeyPairs: list[tuple[SegmentKey|None,
+                                     SegmentKey|None]] = []
         self.previousGroupingPair = None
         self.currentGroupingPair = None
 
@@ -1980,7 +1980,7 @@ def getRawSegments(music21Part,
     return allSegments
 
 
-def extractBrailleElements(music21MeasureOrVoice: t.Union[stream.Measure, stream.Voice]):
+def extractBrailleElements(music21MeasureOrVoice: stream.Measure|stream.Voice):
     '''
     Takes in a :class:`~music21.stream.Measure` or :class:`~music21.stream.Voice`
     and returns a :class:`~music21.braille.segment.BrailleElementGrouping` of correctly ordered

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -120,8 +120,8 @@ excludeFromBrailleElements: list[type[base.Music21Object]] = [
 ]
 
 class GroupingGlobals(t.TypedDict):
-    keySignature: key.KeySignature|None
-    timeSignature: meter.TimeSignature|None
+    keySignature: key.KeySignature | None
+    timeSignature: meter.TimeSignature | None
 
 
 GROUPING_GLOBALS: GroupingGlobals = {
@@ -359,8 +359,8 @@ class BrailleSegment(text.BrailleText):
         self._groupingDict: dict[SegmentKey, BrailleElementGrouping] = {}
 
         self.groupingKeysToProcess: list[SegmentKey] = []
-        self.currentGroupingKey: SegmentKey|None = None
-        self.previousGroupingKey: SegmentKey|None = None
+        self.currentGroupingKey: SegmentKey | None = None
+        self.previousGroupingKey: SegmentKey | None = None
         self.lastNote = None
 
         self.showClefSigns: bool = False
@@ -593,7 +593,7 @@ class BrailleSegment(text.BrailleText):
 
     def extractInaccordGrouping(self):
         inaccords = self._groupingDict.get(self.currentGroupingKey)
-        last_clef: clef.Clef|None = None
+        last_clef: clef.Clef | None = None
         seen_voice: bool = False
         for music21VoiceOrClef in inaccords:
             if isinstance(music21VoiceOrClef, clef.Clef):
@@ -1092,8 +1092,8 @@ class BrailleGrandSegment(BrailleSegment, text.BrailleKeyboard):
     def __init__(self, lineLength: int = 40):
         BrailleSegment.__init__(self, lineLength=lineLength)
         text.BrailleKeyboard.__init__(self, lineLength=lineLength)
-        self.allKeyPairs: list[tuple[SegmentKey|None,
-                                     SegmentKey|None]] = []
+        self.allKeyPairs: list[tuple[SegmentKey | None,
+                                     SegmentKey | None]] = []
         self.previousGroupingPair = None
         self.currentGroupingPair = None
 
@@ -1403,7 +1403,7 @@ def findSegments(music21Part,
                  showFirstMeasureNumber=True,
                  showHand=None,
                  showHeading=True,
-                 showLongSlursAndTiesTogether: bool|None = None,
+                 showLongSlursAndTiesTogether: bool | None = None,
                  showShortSlursAndTiesTogether=False,
                  slurLongPhraseWithBrackets=True,
                  suppressOctaveMarks=False,
@@ -1579,7 +1579,7 @@ def prepareSlurredNotes(music21Part,
                         *,
                         slurLongPhraseWithBrackets=True,
                         showShortSlursAndTiesTogether=False,
-                        showLongSlursAndTiesTogether: bool|None = None,
+                        showLongSlursAndTiesTogether: bool | None = None,
                         ):
     '''
     Takes in a :class:`~music21.stream.Part` and three keywords:
@@ -1980,7 +1980,7 @@ def getRawSegments(music21Part,
     return allSegments
 
 
-def extractBrailleElements(music21MeasureOrVoice: stream.Measure|stream.Voice):
+def extractBrailleElements(music21MeasureOrVoice: stream.Measure | stream.Voice):
     '''
     Takes in a :class:`~music21.stream.Measure` or :class:`~music21.stream.Voice`
     and returns a :class:`~music21.braille.segment.BrailleElementGrouping` of correctly ordered
@@ -2024,7 +2024,7 @@ def extractBrailleElements(music21MeasureOrVoice: stream.Measure|stream.Voice):
     <music21.bar.Barline type=final>
     '''
     allElements = BrailleElementGrouping()
-    last_clef: clef.Clef|None = None
+    last_clef: clef.Clef | None = None
     for music21Object in music21MeasureOrVoice:
         # Hold the clef in memory in case the next object is a voice
         if isinstance(music21Object, clef.Clef):

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -359,8 +359,8 @@ class BrailleSegment(text.BrailleText):
         self._groupingDict: dict[SegmentKey, BrailleElementGrouping] = {}
 
         self.groupingKeysToProcess: list[SegmentKey] = []
-        self.currentGroupingKey: t.Optional[SegmentKey] = None
-        self.previousGroupingKey: t.Optional[SegmentKey] = None
+        self.currentGroupingKey: SegmentKey|None = None
+        self.previousGroupingKey: SegmentKey|None = None
         self.lastNote = None
 
         self.showClefSigns: bool = False
@@ -593,7 +593,7 @@ class BrailleSegment(text.BrailleText):
 
     def extractInaccordGrouping(self):
         inaccords = self._groupingDict.get(self.currentGroupingKey)
-        last_clef: t.Optional[clef.Clef] = None
+        last_clef: clef.Clef|None = None
         seen_voice: bool = False
         for music21VoiceOrClef in inaccords:
             if isinstance(music21VoiceOrClef, clef.Clef):
@@ -1403,7 +1403,7 @@ def findSegments(music21Part,
                  showFirstMeasureNumber=True,
                  showHand=None,
                  showHeading=True,
-                 showLongSlursAndTiesTogether: t.Optional[bool] = None,
+                 showLongSlursAndTiesTogether: bool|None = None,
                  showShortSlursAndTiesTogether=False,
                  slurLongPhraseWithBrackets=True,
                  suppressOctaveMarks=False,
@@ -1579,7 +1579,7 @@ def prepareSlurredNotes(music21Part,
                         *,
                         slurLongPhraseWithBrackets=True,
                         showShortSlursAndTiesTogether=False,
-                        showLongSlursAndTiesTogether: t.Optional[bool] = None,
+                        showLongSlursAndTiesTogether: bool|None = None,
                         ):
     '''
     Takes in a :class:`~music21.stream.Part` and three keywords:
@@ -2024,7 +2024,7 @@ def extractBrailleElements(music21MeasureOrVoice: t.Union[stream.Measure, stream
     <music21.bar.Barline type=final>
     '''
     allElements = BrailleElementGrouping()
-    last_clef: t.Optional[clef.Clef] = None
+    last_clef: clef.Clef|None = None
     for music21Object in music21MeasureOrVoice:
         # Hold the clef in memory in case the next object is a voice
         if isinstance(music21Object, clef.Clef):

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -92,7 +92,6 @@ memorization" (BMTM, 71). Some of these keywords are changed automatically in co
 from __future__ import annotations
 
 import re
-import typing as t
 import unittest
 
 from music21 import base

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -222,7 +222,7 @@ def objectToBraille(music21Obj: base.Music21Object,
                                 upperFirstInNoteFingering=upperFirstInNoteFingering,
                                 )
 
-def streamToBraille(music21Stream: t.Union[stream.Measure, stream.Part, stream.Score, stream.Opus],
+def streamToBraille(music21Stream: stream.Measure|stream.Part|stream.Score|stream.Opus,
                     *,
                     inPlace=False,
                     debug=False,

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -119,7 +119,7 @@ def objectToBraille(music21Obj: base.Music21Object,
                     showFirstMeasureNumber=True,
                     showHand=None,
                     showHeading=True,
-                    showLongSlursAndTiesTogether: t.Optional[bool] = None,
+                    showLongSlursAndTiesTogether: bool|None = None,
                     showShortSlursAndTiesTogether=False,
                     slurLongPhraseWithBrackets=True,
                     suppressOctaveMarks=False,
@@ -235,7 +235,7 @@ def streamToBraille(music21Stream: t.Union[stream.Measure, stream.Part, stream.S
                     showFirstMeasureNumber=True,
                     showHand=None,
                     showHeading=True,
-                    showLongSlursAndTiesTogether: t.Optional[bool] = None,
+                    showLongSlursAndTiesTogether: bool|None = None,
                     showShortSlursAndTiesTogether=False,
                     slurLongPhraseWithBrackets=True,
                     suppressOctaveMarks=False,
@@ -370,7 +370,7 @@ def scoreToBraille(music21Score,
                    showFirstMeasureNumber=True,
                    showHand=None,
                    showHeading=True,
-                   showLongSlursAndTiesTogether: t.Optional[bool] = None,
+                   showLongSlursAndTiesTogether: bool|None = None,
                    showShortSlursAndTiesTogether=False,
                    slurLongPhraseWithBrackets=True,
                    suppressOctaveMarks=False,
@@ -383,7 +383,7 @@ def scoreToBraille(music21Score,
     for music21Metadata in music21Score.getElementsByClass(metadata.Metadata):
         allBrailleLines.append(metadataToString(music21Metadata, returnBrailleUnicode=not debug))
 
-    unprocessed_partStaff: t.Optional[stream.PartStaff] = None
+    unprocessed_partStaff: stream.PartStaff|None = None
 
     def process_unmatched_part_staff_as_single_part():
         nonlocal unprocessed_partStaff
@@ -491,7 +491,7 @@ def metadataToString(music21Metadata, returnBrailleUnicode=False):
             # we don't put software versions in braille output
             continue
 
-        namespaceName: t.Optional[str] = music21Metadata.uniqueNameToNamespaceName(uniqueName)
+        namespaceName: str|None = music21Metadata.uniqueNameToNamespaceName(uniqueName)
         if not namespaceName:
             # we don't put custom metadata in braille output
             continue
@@ -524,7 +524,7 @@ def opusToBraille(music21Opus,
                   showFirstMeasureNumber=True,
                   showHand=None,
                   showHeading=True,
-                  showLongSlursAndTiesTogether: t.Optional[bool] = None,
+                  showLongSlursAndTiesTogether: bool|None = None,
                   showShortSlursAndTiesTogether=False,
                   slurLongPhraseWithBrackets=True,
                   suppressOctaveMarks=False,
@@ -571,7 +571,7 @@ def measureToBraille(music21Measure,
                      showFirstMeasureNumber=False,  # observe False!
                      showHand=None,
                      showHeading=False,  # observe False!
-                     showLongSlursAndTiesTogether: t.Optional[bool] = None,
+                     showLongSlursAndTiesTogether: bool|None = None,
                      showShortSlursAndTiesTogether=False,
                      slurLongPhraseWithBrackets=True,
                      suppressOctaveMarks=False,
@@ -633,7 +633,7 @@ def partToBraille(music21Part,
                   showFirstMeasureNumber=True,
                   showHand=None,
                   showHeading=True,
-                  showLongSlursAndTiesTogether: t.Optional[bool] = None,
+                  showLongSlursAndTiesTogether: bool|None = None,
                   showShortSlursAndTiesTogether=False,
                   slurLongPhraseWithBrackets=True,
                   suppressOctaveMarks=False,
@@ -693,7 +693,7 @@ def keyboardPartsToBraille(keyboardScore,
                            showFirstMeasureNumber=True,
                            showHand=None,
                            showHeading=True,
-                           showLongSlursAndTiesTogether: t.Optional[bool] = None,
+                           showLongSlursAndTiesTogether: bool|None = None,
                            showShortSlursAndTiesTogether=False,
                            slurLongPhraseWithBrackets=True,
                            suppressOctaveMarks=False,

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -119,7 +119,7 @@ def objectToBraille(music21Obj: base.Music21Object,
                     showFirstMeasureNumber=True,
                     showHand=None,
                     showHeading=True,
-                    showLongSlursAndTiesTogether: bool|None = None,
+                    showLongSlursAndTiesTogether: bool | None = None,
                     showShortSlursAndTiesTogether=False,
                     slurLongPhraseWithBrackets=True,
                     suppressOctaveMarks=False,
@@ -222,7 +222,7 @@ def objectToBraille(music21Obj: base.Music21Object,
                                 upperFirstInNoteFingering=upperFirstInNoteFingering,
                                 )
 
-def streamToBraille(music21Stream: stream.Measure|stream.Part|stream.Score|stream.Opus,
+def streamToBraille(music21Stream: stream.Measure | stream.Part | stream.Score | stream.Opus,
                     *,
                     inPlace=False,
                     debug=False,
@@ -235,7 +235,7 @@ def streamToBraille(music21Stream: stream.Measure|stream.Part|stream.Score|strea
                     showFirstMeasureNumber=True,
                     showHand=None,
                     showHeading=True,
-                    showLongSlursAndTiesTogether: bool|None = None,
+                    showLongSlursAndTiesTogether: bool | None = None,
                     showShortSlursAndTiesTogether=False,
                     slurLongPhraseWithBrackets=True,
                     suppressOctaveMarks=False,
@@ -370,7 +370,7 @@ def scoreToBraille(music21Score,
                    showFirstMeasureNumber=True,
                    showHand=None,
                    showHeading=True,
-                   showLongSlursAndTiesTogether: bool|None = None,
+                   showLongSlursAndTiesTogether: bool | None = None,
                    showShortSlursAndTiesTogether=False,
                    slurLongPhraseWithBrackets=True,
                    suppressOctaveMarks=False,
@@ -383,7 +383,7 @@ def scoreToBraille(music21Score,
     for music21Metadata in music21Score.getElementsByClass(metadata.Metadata):
         allBrailleLines.append(metadataToString(music21Metadata, returnBrailleUnicode=not debug))
 
-    unprocessed_partStaff: stream.PartStaff|None = None
+    unprocessed_partStaff: stream.PartStaff | None = None
 
     def process_unmatched_part_staff_as_single_part():
         nonlocal unprocessed_partStaff
@@ -491,7 +491,7 @@ def metadataToString(music21Metadata, returnBrailleUnicode=False):
             # we don't put software versions in braille output
             continue
 
-        namespaceName: str|None = music21Metadata.uniqueNameToNamespaceName(uniqueName)
+        namespaceName: str | None = music21Metadata.uniqueNameToNamespaceName(uniqueName)
         if not namespaceName:
             # we don't put custom metadata in braille output
             continue
@@ -524,7 +524,7 @@ def opusToBraille(music21Opus,
                   showFirstMeasureNumber=True,
                   showHand=None,
                   showHeading=True,
-                  showLongSlursAndTiesTogether: bool|None = None,
+                  showLongSlursAndTiesTogether: bool | None = None,
                   showShortSlursAndTiesTogether=False,
                   slurLongPhraseWithBrackets=True,
                   suppressOctaveMarks=False,
@@ -571,7 +571,7 @@ def measureToBraille(music21Measure,
                      showFirstMeasureNumber=False,  # observe False!
                      showHand=None,
                      showHeading=False,  # observe False!
-                     showLongSlursAndTiesTogether: bool|None = None,
+                     showLongSlursAndTiesTogether: bool | None = None,
                      showShortSlursAndTiesTogether=False,
                      slurLongPhraseWithBrackets=True,
                      suppressOctaveMarks=False,
@@ -633,7 +633,7 @@ def partToBraille(music21Part,
                   showFirstMeasureNumber=True,
                   showHand=None,
                   showHeading=True,
-                  showLongSlursAndTiesTogether: bool|None = None,
+                  showLongSlursAndTiesTogether: bool | None = None,
                   showShortSlursAndTiesTogether=False,
                   slurLongPhraseWithBrackets=True,
                   suppressOctaveMarks=False,
@@ -693,7 +693,7 @@ def keyboardPartsToBraille(keyboardScore,
                            showFirstMeasureNumber=True,
                            showHand=None,
                            showHeading=True,
-                           showLongSlursAndTiesTogether: bool|None = None,
+                           showLongSlursAndTiesTogether: bool | None = None,
                            showShortSlursAndTiesTogether=False,
                            slurLongPhraseWithBrackets=True,
                            suppressOctaveMarks=False,

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -193,7 +193,7 @@ class CapellaImporter:
                 newPart.coreElementsChanged()
         newScore = stream.Score()
         # ORDERED DICT
-        parts: list[stream.Part|None] = [None for i in range(len(partDictById))]
+        parts: list[stream.Part | None] = [None for i in range(len(partDictById))]
         for partId in partDictById:
             partDict = partDictById[partId]
             parts[partDict['number']] = partDict['part']

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -20,7 +20,6 @@ Does not handle pickup notes, which are defined simply with an early barline
 from __future__ import annotations
 
 from io import StringIO
-import typing as t
 import unittest
 import xml.etree.ElementTree
 import zipfile

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -193,7 +193,7 @@ class CapellaImporter:
                 newPart.coreElementsChanged()
         newScore = stream.Score()
         # ORDERED DICT
-        parts: list[t.Optional[stream.Part]] = [None for i in range(len(partDictById))]
+        parts: list[stream.Part|None] = [None for i in range(len(partDictById))]
         for partId in partDictById:
             partDict = partDictById[partId]
             parts[partDict['number']] = partDict['part']

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -1464,7 +1464,7 @@ class Chord(ChordBase):
     def closedPosition(
         self: _ChordType,
         *,
-        forceOctave: t.Optional[int] = None,
+        forceOctave: int|None = None,
         inPlace: t.Literal[False] = False,
         leaveRedundantPitches: bool = False
     ) -> _ChordType:
@@ -1474,7 +1474,7 @@ class Chord(ChordBase):
     def closedPosition(
         self: _ChordType,
         *,
-        forceOctave: t.Optional[int] = None,
+        forceOctave: int|None = None,
         inPlace: t.Union[t.Literal[True], t.Literal[False]] = False,
         leaveRedundantPitches: bool = False
     ) -> t.Optional[_ChordType]:
@@ -2259,7 +2259,7 @@ class Chord(ChordBase):
         newInversion: int,
         *,
         find: bool = True,
-        testRoot: t.Optional[pitch.Pitch] = None,
+        testRoot: pitch.Pitch|None = None,
         transposeOnSet: bool = True
     ) -> None:
         return None  # dummy until Astroid 1015 is fixed
@@ -2270,17 +2270,17 @@ class Chord(ChordBase):
         newInversion: None = None,
         *,
         find: bool = True,
-        testRoot: t.Optional[pitch.Pitch] = None,
+        testRoot: pitch.Pitch|None = None,
         transposeOnSet: bool = True
     ) -> int:
         return -1  # dummy until Astroid 1015 is fixed
 
     def inversion(
         self,
-        newInversion: t.Optional[int] = None,
+        newInversion: int|None = None,
         *,
         find: bool = True,
-        testRoot: t.Optional[pitch.Pitch] = None,
+        testRoot: pitch.Pitch|None = None,
         transposeOnSet: bool = True
     ) -> t.Union[int, None]:
         '''
@@ -3988,7 +3988,7 @@ class Chord(ChordBase):
     def semiClosedPosition(
         self: _ChordType,
         *,
-        forceOctave: t.Optional[int] = None,
+        forceOctave: int|None = None,
         inPlace: t.Union[t.Literal[True], t.Literal[False]] = False,
         leaveRedundantPitches: bool = False
     ) -> t.Union[None, _ChordType]:

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -1835,7 +1835,7 @@ class Chord(ChordBase):
         self,
         chordStep: int,
         *,
-        testRoot: t.Optional[t.Union[note.Note, pitch.Pitch]] = None
+        testRoot: t.Optional[note.Note|pitch.Pitch] = None
     ) -> t.Optional[pitch.Pitch]:
         '''
         Returns the (first) pitch at the provided scaleDegree (Thus, it's
@@ -2282,7 +2282,7 @@ class Chord(ChordBase):
         find: bool = True,
         testRoot: pitch.Pitch|None = None,
         transposeOnSet: bool = True
-    ) -> t.Union[int, None]:
+    ) -> int|None:
         '''
         Find the chord's inversion or (if called with a number) set the chord to
         the new inversion.

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -197,7 +197,7 @@ class ChordBase(note.NotRest):
     def _add_core_or_init(self,
                           notes,
                           *,
-                          useDuration: None|t.Literal[False]|Duration = None):
+                          useDuration: None | t.Literal[False] | Duration = None):
         '''
         This is the private append method called by .add and called by __init__.
 
@@ -387,7 +387,7 @@ class ChordBase(note.NotRest):
         return ()
 
     @property
-    def tie(self) -> tie.Tie|None:
+    def tie(self) -> tie.Tie | None:
         '''
         Get or set a single tie based on all the ties in this Chord.
 
@@ -411,7 +411,7 @@ class ChordBase(note.NotRest):
         return None
 
     @tie.setter
-    def tie(self, value: tie.Tie|None):
+    def tie(self, value: tie.Tie | None):
         for d in self._notes:
             d.tie = value
             # set the same instance for each pitch
@@ -470,7 +470,7 @@ class ChordBase(note.NotRest):
 
 
     @volume.setter
-    def volume(self, expr: None|'music21.volume.Volume'|int|float):
+    def volume(self, expr: None | 'music21.volume.Volume' | int | float):
         # Do NOT change typing to volume.Volume because it will take the property as
         # its name
         if isinstance(expr, volume.Volume):
@@ -539,7 +539,7 @@ class ChordBase(note.NotRest):
     # --------------------------------------------------------------------------
     # volume per pitch ??
     # --------------------------------------------------------------------------
-    def setVolumes(self, volumes: Sequence['music21.volume.Volume'|int|float]):
+    def setVolumes(self, volumes: Sequence['music21.volume.Volume' | int | float]):
         # do not change typing to volume.Volume -- will get the property of same name.
         # noinspection PyShadowingNames
         '''
@@ -775,7 +775,7 @@ class Chord(ChordBase):
             return False
         return True
 
-    def __getitem__(self, key: int|str|note.Note|pitch.Pitch):
+    def __getitem__(self, key: int | str | note.Note | pitch.Pitch):
         '''
         Get item makes accessing pitch components for the Chord easier
 
@@ -989,7 +989,7 @@ class Chord(ChordBase):
         return ''.join(msg)
 
     # PRIVATE METHODS #
-    def _findBass(self) -> pitch.Pitch|None:
+    def _findBass(self) -> pitch.Pitch | None:
         '''
         Returns the lowest Pitch in the chord.
 
@@ -1015,7 +1015,7 @@ class Chord(ChordBase):
         attribute: str,
         *,
         inPlace=False
-    ) -> _ChordType|list[pitch.Pitch]:
+    ) -> _ChordType | list[pitch.Pitch]:
         '''
         Common method for stripping pitches based on redundancy of one pitch
         attribute. The `attribute` is provided by a string.
@@ -1246,26 +1246,26 @@ class Chord(ChordBase):
     def bass(self,
              newbass: None = None,
              *,
-             find: bool|None = None,
+             find: bool | None = None,
              allow_add: bool = False,
              ) -> pitch.Pitch:
         return self.pitches[0]  # dummy until Astroid 1015 is fixed.
 
     @overload
     def bass(self,
-             newbass: str|pitch.Pitch|note.Note,
+             newbass: str | pitch.Pitch | note.Note,
              *,
-             find: bool|None = None,
+             find: bool | None = None,
              allow_add: bool = False,
              ) -> None:
         return None
 
     def bass(self,
-             newbass: None|str|pitch.Pitch|note.Note = None,
+             newbass: None | str | pitch.Pitch | note.Note = None,
              *,
-             find: bool|None = None,
+             find: bool | None = None,
              allow_add: bool = False,
-             ) -> pitch.Pitch|None:
+             ) -> pitch.Pitch | None:
         '''
         Generally used to find and return the bass Pitch:
 
@@ -1453,7 +1453,7 @@ class Chord(ChordBase):
     def closedPosition(
         self: _ChordType,
         *,
-        forceOctave: int|None,
+        forceOctave: int | None,
         inPlace: t.Literal[True],
         leaveRedundantPitches=False
     ) -> None:
@@ -1464,7 +1464,7 @@ class Chord(ChordBase):
     def closedPosition(
         self: _ChordType,
         *,
-        forceOctave: int|None = None,
+        forceOctave: int | None = None,
         inPlace: t.Literal[False] = False,
         leaveRedundantPitches: bool = False
     ) -> _ChordType:
@@ -1474,10 +1474,10 @@ class Chord(ChordBase):
     def closedPosition(
         self: _ChordType,
         *,
-        forceOctave: int|None = None,
-        inPlace: t.Literal[True]|t.Literal[False] = False,
+        forceOctave: int | None = None,
+        inPlace: t.Literal[True] | t.Literal[False] = False,
         leaveRedundantPitches: bool = False
-    ) -> _ChordType|None:
+    ) -> _ChordType | None:
         '''
         Returns a new Chord object with the same pitch classes,
         but now in closed position.
@@ -1835,8 +1835,8 @@ class Chord(ChordBase):
         self,
         chordStep: int,
         *,
-        testRoot: note.Note|pitch.Pitch|None = None
-    ) -> pitch.Pitch|None:
+        testRoot: note.Note | pitch.Pitch | None = None
+    ) -> pitch.Pitch | None:
         '''
         Returns the (first) pitch at the provided scaleDegree (Thus, it's
         exactly like semitonesFromChordStep, except it instead of the number of
@@ -2112,7 +2112,7 @@ class Chord(ChordBase):
         except KeyError:
             raise ChordException(f'the given pitch is not in the Chord: {p}')
 
-    def getZRelation(self) -> Chord|None:
+    def getZRelation(self) -> Chord | None:
         '''
         Return a Z relation if it exists, otherwise return None.
 
@@ -2259,7 +2259,7 @@ class Chord(ChordBase):
         newInversion: int,
         *,
         find: bool = True,
-        testRoot: pitch.Pitch|None = None,
+        testRoot: pitch.Pitch | None = None,
         transposeOnSet: bool = True
     ) -> None:
         return None  # dummy until Astroid 1015 is fixed
@@ -2270,19 +2270,19 @@ class Chord(ChordBase):
         newInversion: None = None,
         *,
         find: bool = True,
-        testRoot: pitch.Pitch|None = None,
+        testRoot: pitch.Pitch | None = None,
         transposeOnSet: bool = True
     ) -> int:
         return -1  # dummy until Astroid 1015 is fixed
 
     def inversion(
         self,
-        newInversion: int|None = None,
+        newInversion: int | None = None,
         *,
         find: bool = True,
-        testRoot: pitch.Pitch|None = None,
+        testRoot: pitch.Pitch | None = None,
         transposeOnSet: bool = True
-    ) -> int|None:
+    ) -> int | None:
         '''
         Find the chord's inversion or (if called with a number) set the chord to
         the new inversion.
@@ -3760,23 +3760,23 @@ class Chord(ChordBase):
     def root(self,
              newroot: None = None,
              *,
-             find: bool|None = None
+             find: bool | None = None
              ) -> pitch.Pitch:
         return self.pitches[0]  # dummy until Astroid 1015 is fixed.
 
     @overload
     def root(self,
-             newroot: str|pitch.Pitch|note.Note,
+             newroot: str | pitch.Pitch | note.Note,
              *,
-             find: bool|None = None
+             find: bool | None = None
              ) -> None:
         return None  # dummy until Astroid 1015 is fixed.
 
     def root(self,
-             newroot: None|str|pitch.Pitch|note.Note = None,
+             newroot: None | str | pitch.Pitch | note.Note = None,
              *,
-             find: bool|None = None
-             ) -> pitch.Pitch|None:
+             find: bool | None = None
+             ) -> pitch.Pitch | None:
         # noinspection PyShadowingNames
         '''
         Returns the root of the chord.  Or if given a Pitch as the
@@ -3988,8 +3988,8 @@ class Chord(ChordBase):
     def semiClosedPosition(
         self: _ChordType,
         *,
-        forceOctave: int|None = None,
-        inPlace: t.Literal[True]|t.Literal[False] = False,
+        forceOctave: int | None = None,
+        inPlace: t.Literal[True] | t.Literal[False] = False,
         leaveRedundantPitches: bool = False
     ) -> None|_ChordType:
         # noinspection PyShadowingNames
@@ -4425,7 +4425,7 @@ class Chord(ChordBase):
             raise ChordException(
                 f'the given pitch is not in the Chord: {pitchTarget}')
 
-    def setTie(self, tieObjOrStr: tie.Tie|str, pitchTarget):
+    def setTie(self, tieObjOrStr: tie.Tie | str, pitchTarget):
         '''
         Given a tie object (or a tie type string) and a pitch or Note in this Chord,
         set the pitch's tie attribute in this chord to that tie type.
@@ -4496,7 +4496,7 @@ class Chord(ChordBase):
 
     def setVolume(self,
                   vol: volume.Volume,
-                  target: str|note.Note|pitch.Pitch):
+                  target: str | note.Note | pitch.Pitch):
         '''
         Set the :class:`~music21.volume.Volume` object of a specific Pitch.
 
@@ -4986,7 +4986,7 @@ class Chord(ChordBase):
         >>> c.duration is d
         True
         '''
-        d = t.cast(Duration|None, self._duration)  # type: ignore
+        d = t.cast(Duration | None, self._duration)  # type: ignore
         if d is None and self._notes:
             # pitchZeroDuration = self._notes[0]['pitch'].duration
             pitchZeroDuration = self._notes[0].duration
@@ -5010,7 +5010,7 @@ class Chord(ChordBase):
 
     @property  # type: ignore
     @cacheMethod
-    def fifth(self) -> pitch.Pitch|None:
+    def fifth(self) -> pitch.Pitch | None:
         '''
         Shortcut for getChordStep(5), but caches it and does not raise exceptions
 
@@ -5667,7 +5667,7 @@ class Chord(ChordBase):
         return pitches
 
     @pitches.setter
-    def pitches(self, value: Sequence[str|pitch.Pitch|int]):
+    def pitches(self, value: Sequence[str | pitch.Pitch | int]):
         self._notes = []
         self.clearCache()
         # TODO: individual ties are not being retained here
@@ -5930,7 +5930,7 @@ class Chord(ChordBase):
 
     @property  # type: ignore
     @cacheMethod
-    def third(self) -> pitch.Pitch|None:
+    def third(self) -> pitch.Pitch | None:
         '''
         Shortcut for getChordStep(3), but caches the value, and returns
         None on errors.
@@ -5955,7 +5955,7 @@ class Chord(ChordBase):
 
 
 
-def fromForteClass(notation: str|Sequence[int]) -> Chord:
+def fromForteClass(notation: str | Sequence[int]) -> Chord:
     '''
     Return a Chord given a Forte-class notation. The Forte class can be
     specified as string (e.g., 3-11) or as a list of cardinality and number

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -1246,7 +1246,7 @@ class Chord(ChordBase):
     def bass(self,
              newbass: None = None,
              *,
-             find: t.Union[bool, None] = None,
+             find: bool|None = None,
              allow_add: bool = False,
              ) -> pitch.Pitch:
         return self.pitches[0]  # dummy until Astroid 1015 is fixed.
@@ -1255,15 +1255,15 @@ class Chord(ChordBase):
     def bass(self,
              newbass: t.Union[str, pitch.Pitch, note.Note],
              *,
-             find: t.Union[bool, None] = None,
+             find: bool|None = None,
              allow_add: bool = False,
              ) -> None:
         return None
 
     def bass(self,
-             newbass: t.Union[None, str, pitch.Pitch, note.Note] = None,
+             newbass: None|str|pitch.Pitch|note.Note = None,
              *,
-             find: t.Union[bool, None] = None,
+             find: bool|None = None,
              allow_add: bool = False,
              ) -> t.Optional[pitch.Pitch]:
         '''
@@ -3760,7 +3760,7 @@ class Chord(ChordBase):
     def root(self,
              newroot: None = None,
              *,
-             find: t.Union[bool, None] = None
+             find: bool|None = None
              ) -> pitch.Pitch:
         return self.pitches[0]  # dummy until Astroid 1015 is fixed.
 
@@ -3768,14 +3768,14 @@ class Chord(ChordBase):
     def root(self,
              newroot: t.Union[str, pitch.Pitch, note.Note],
              *,
-             find: t.Union[bool, None] = None
+             find: bool|None = None
              ) -> None:
         return None  # dummy until Astroid 1015 is fixed.
 
     def root(self,
-             newroot: t.Union[None, str, pitch.Pitch, note.Note] = None,
+             newroot: None|str|pitch.Pitch|note.Note = None,
              *,
-             find: t.Union[bool, None] = None
+             find: bool|None = None
              ) -> t.Optional[pitch.Pitch]:
         # noinspection PyShadowingNames
         '''

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -197,7 +197,7 @@ class ChordBase(note.NotRest):
     def _add_core_or_init(self,
                           notes,
                           *,
-                          useDuration: t.Union[None, t.Literal[False], Duration] = None):
+                          useDuration: None|t.Literal[False]|Duration = None):
         '''
         This is the private append method called by .add and called by __init__.
 
@@ -387,7 +387,7 @@ class ChordBase(note.NotRest):
         return ()
 
     @property
-    def tie(self) -> t.Optional[tie.Tie]:
+    def tie(self) -> tie.Tie|None:
         '''
         Get or set a single tie based on all the ties in this Chord.
 
@@ -411,7 +411,7 @@ class ChordBase(note.NotRest):
         return None
 
     @tie.setter
-    def tie(self, value: t.Optional[tie.Tie]):
+    def tie(self, value: tie.Tie|None):
         for d in self._notes:
             d.tie = value
             # set the same instance for each pitch
@@ -470,7 +470,7 @@ class ChordBase(note.NotRest):
 
 
     @volume.setter
-    def volume(self, expr: t.Union[None, 'music21.volume.Volume', int, float]):
+    def volume(self, expr: None|'music21.volume.Volume'|int|float):
         # Do NOT change typing to volume.Volume because it will take the property as
         # its name
         if isinstance(expr, volume.Volume):
@@ -539,7 +539,7 @@ class ChordBase(note.NotRest):
     # --------------------------------------------------------------------------
     # volume per pitch ??
     # --------------------------------------------------------------------------
-    def setVolumes(self, volumes: Sequence[t.Union['music21.volume.Volume', int, float]]):
+    def setVolumes(self, volumes: Sequence['music21.volume.Volume'|int|float]):
         # do not change typing to volume.Volume -- will get the property of same name.
         # noinspection PyShadowingNames
         '''
@@ -775,7 +775,7 @@ class Chord(ChordBase):
             return False
         return True
 
-    def __getitem__(self, key: t.Union[int, str, note.Note, pitch.Pitch]):
+    def __getitem__(self, key: int|str|note.Note|pitch.Pitch):
         '''
         Get item makes accessing pitch components for the Chord easier
 
@@ -989,7 +989,7 @@ class Chord(ChordBase):
         return ''.join(msg)
 
     # PRIVATE METHODS #
-    def _findBass(self) -> t.Optional[pitch.Pitch]:
+    def _findBass(self) -> pitch.Pitch|None:
         '''
         Returns the lowest Pitch in the chord.
 
@@ -1015,7 +1015,7 @@ class Chord(ChordBase):
         attribute: str,
         *,
         inPlace=False
-    ) -> t.Union[_ChordType, list[pitch.Pitch]]:
+    ) -> _ChordType|list[pitch.Pitch]:
         '''
         Common method for stripping pitches based on redundancy of one pitch
         attribute. The `attribute` is provided by a string.
@@ -1253,7 +1253,7 @@ class Chord(ChordBase):
 
     @overload
     def bass(self,
-             newbass: t.Union[str, pitch.Pitch, note.Note],
+             newbass: str|pitch.Pitch|note.Note,
              *,
              find: bool|None = None,
              allow_add: bool = False,
@@ -1265,7 +1265,7 @@ class Chord(ChordBase):
              *,
              find: bool|None = None,
              allow_add: bool = False,
-             ) -> t.Optional[pitch.Pitch]:
+             ) -> pitch.Pitch|None:
         '''
         Generally used to find and return the bass Pitch:
 
@@ -1453,7 +1453,7 @@ class Chord(ChordBase):
     def closedPosition(
         self: _ChordType,
         *,
-        forceOctave: t.Optional[int],
+        forceOctave: int|None,
         inPlace: t.Literal[True],
         leaveRedundantPitches=False
     ) -> None:
@@ -1475,9 +1475,9 @@ class Chord(ChordBase):
         self: _ChordType,
         *,
         forceOctave: int|None = None,
-        inPlace: t.Union[t.Literal[True], t.Literal[False]] = False,
+        inPlace: t.Literal[True]|t.Literal[False] = False,
         leaveRedundantPitches: bool = False
-    ) -> t.Optional[_ChordType]:
+    ) -> _ChordType|None:
         '''
         Returns a new Chord object with the same pitch classes,
         but now in closed position.
@@ -1835,8 +1835,8 @@ class Chord(ChordBase):
         self,
         chordStep: int,
         *,
-        testRoot: t.Optional[note.Note|pitch.Pitch] = None
-    ) -> t.Optional[pitch.Pitch]:
+        testRoot: note.Note|pitch.Pitch|None = None
+    ) -> pitch.Pitch|None:
         '''
         Returns the (first) pitch at the provided scaleDegree (Thus, it's
         exactly like semitonesFromChordStep, except it instead of the number of
@@ -2112,7 +2112,7 @@ class Chord(ChordBase):
         except KeyError:
             raise ChordException(f'the given pitch is not in the Chord: {p}')
 
-    def getZRelation(self) -> t.Optional[Chord]:
+    def getZRelation(self) -> Chord|None:
         '''
         Return a Z relation if it exists, otherwise return None.
 
@@ -3766,7 +3766,7 @@ class Chord(ChordBase):
 
     @overload
     def root(self,
-             newroot: t.Union[str, pitch.Pitch, note.Note],
+             newroot: str|pitch.Pitch|note.Note,
              *,
              find: bool|None = None
              ) -> None:
@@ -3776,7 +3776,7 @@ class Chord(ChordBase):
              newroot: None|str|pitch.Pitch|note.Note = None,
              *,
              find: bool|None = None
-             ) -> t.Optional[pitch.Pitch]:
+             ) -> pitch.Pitch|None:
         # noinspection PyShadowingNames
         '''
         Returns the root of the chord.  Or if given a Pitch as the
@@ -3989,9 +3989,9 @@ class Chord(ChordBase):
         self: _ChordType,
         *,
         forceOctave: int|None = None,
-        inPlace: t.Union[t.Literal[True], t.Literal[False]] = False,
+        inPlace: t.Literal[True]|t.Literal[False] = False,
         leaveRedundantPitches: bool = False
-    ) -> t.Union[None, _ChordType]:
+    ) -> None|_ChordType:
         # noinspection PyShadowingNames
         '''
         Similar to :meth:`~music21.chord.Chord.ClosedPosition` in that it
@@ -4425,7 +4425,7 @@ class Chord(ChordBase):
             raise ChordException(
                 f'the given pitch is not in the Chord: {pitchTarget}')
 
-    def setTie(self, tieObjOrStr: t.Union[tie.Tie, str], pitchTarget):
+    def setTie(self, tieObjOrStr: tie.Tie|str, pitchTarget):
         '''
         Given a tie object (or a tie type string) and a pitch or Note in this Chord,
         set the pitch's tie attribute in this chord to that tie type.
@@ -4496,7 +4496,7 @@ class Chord(ChordBase):
 
     def setVolume(self,
                   vol: volume.Volume,
-                  target: t.Union[str, note.Note, pitch.Pitch]):
+                  target: str|note.Note|pitch.Pitch):
         '''
         Set the :class:`~music21.volume.Volume` object of a specific Pitch.
 
@@ -4986,7 +4986,7 @@ class Chord(ChordBase):
         >>> c.duration is d
         True
         '''
-        d = t.cast(t.Union[Duration, None], self._duration)  # type: ignore
+        d = t.cast(Duration|None, self._duration)  # type: ignore
         if d is None and self._notes:
             # pitchZeroDuration = self._notes[0]['pitch'].duration
             pitchZeroDuration = self._notes[0].duration
@@ -5010,7 +5010,7 @@ class Chord(ChordBase):
 
     @property  # type: ignore
     @cacheMethod
-    def fifth(self) -> t.Optional[pitch.Pitch]:
+    def fifth(self) -> pitch.Pitch|None:
         '''
         Shortcut for getChordStep(5), but caches it and does not raise exceptions
 
@@ -5667,7 +5667,7 @@ class Chord(ChordBase):
         return pitches
 
     @pitches.setter
-    def pitches(self, value: Sequence[t.Union[str, pitch.Pitch, int]]):
+    def pitches(self, value: Sequence[str|pitch.Pitch|int]):
         self._notes = []
         self.clearCache()
         # TODO: individual ties are not being retained here
@@ -5930,7 +5930,7 @@ class Chord(ChordBase):
 
     @property  # type: ignore
     @cacheMethod
-    def third(self) -> t.Optional[pitch.Pitch]:
+    def third(self) -> pitch.Pitch|None:
         '''
         Shortcut for getChordStep(3), but caches the value, and returns
         None on errors.
@@ -5955,7 +5955,7 @@ class Chord(ChordBase):
 
 
 
-def fromForteClass(notation: t.Union[str, Sequence[int]]) -> Chord:
+def fromForteClass(notation: str|Sequence[int]) -> Chord:
     '''
     Return a Chord given a Forte-class notation. The Forte class can be
     specified as string (e.g., 3-11) or as a list of cardinality and number

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -3991,7 +3991,7 @@ class Chord(ChordBase):
         forceOctave: int | None = None,
         inPlace: t.Literal[True] | t.Literal[False] = False,
         leaveRedundantPitches: bool = False
-    ) -> None|_ChordType:
+    ) -> None | _ChordType:
         # noinspection PyShadowingNames
         '''
         Similar to :meth:`~music21.chord.Chord.ClosedPosition` in that it

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -105,9 +105,9 @@ class Clef(base.Music21Object):
 
     def __init__(self):
         super().__init__()
-        self.sign: str|None = None
+        self.sign: str | None = None
         # line counts start from the bottom up, the reverse of musedata
-        self.line: int|None = None
+        self.line: int | None = None
         self._octaveChange: int = 0  # set to zero as default
         # musicxml has an attribute for clefOctaveChange,
         # an integer to show transposing clef
@@ -191,7 +191,7 @@ class Clef(base.Music21Object):
 
     def getStemDirectionForPitches(
         self,
-        pitches: pitch.Pitch|Sequence[pitch.Pitch],
+        pitches: pitch.Pitch | Sequence[pitch.Pitch],
         *,
         firstLastOnly: bool = True,
         extremePitchOnly: bool = False,
@@ -404,7 +404,7 @@ class TabClef(PitchClef):
 
     def getStemDirectionForPitches(
         self,
-        pitchList: pitch.Pitch|Iterable[pitch.Pitch],
+        pitchList: pitch.Pitch | Iterable[pitch.Pitch],
         *,
         firstLastOnly: bool = True,
         extremePitchOnly: bool = False,
@@ -735,7 +735,7 @@ class SubBassClef(FClef):
 
 
 # ------------------------------------------------------------------------------
-CLASS_FROM_TYPE: dict[str, list[type[Clef]|None]] = {
+CLASS_FROM_TYPE: dict[str, list[type[Clef] | None]] = {
     'G': [None, FrenchViolinClef, TrebleClef, GSopranoClef, None, None],
     'C': [None, SopranoClef, MezzoSopranoClef, AltoClef, TenorClef, CBaritoneClef],
     'F': [None, None, None, FBaritoneClef, BassClef, SubBassClef],

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -191,7 +191,7 @@ class Clef(base.Music21Object):
 
     def getStemDirectionForPitches(
         self,
-        pitches: t.Union[pitch.Pitch, Sequence[pitch.Pitch]],
+        pitches: pitch.Pitch|Sequence[pitch.Pitch],
         *,
         firstLastOnly: bool = True,
         extremePitchOnly: bool = False,
@@ -404,7 +404,7 @@ class TabClef(PitchClef):
 
     def getStemDirectionForPitches(
         self,
-        pitchList: t.Union[pitch.Pitch, Iterable[pitch.Pitch]],
+        pitchList: pitch.Pitch|Iterable[pitch.Pitch],
         *,
         firstLastOnly: bool = True,
         extremePitchOnly: bool = False,
@@ -735,7 +735,7 @@ class SubBassClef(FClef):
 
 
 # ------------------------------------------------------------------------------
-CLASS_FROM_TYPE: dict[str, list[t.Optional[type[Clef]]]] = {
+CLASS_FROM_TYPE: dict[str, list[type[Clef]|None]] = {
     'G': [None, FrenchViolinClef, TrebleClef, GSopranoClef, None, None],
     'C': [None, SopranoClef, MezzoSopranoClef, AltoClef, TenorClef, CBaritoneClef],
     'F': [None, None, None, FBaritoneClef, BassClef, SubBassClef],

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -105,9 +105,9 @@ class Clef(base.Music21Object):
 
     def __init__(self):
         super().__init__()
-        self.sign: t.Optional[str] = None
+        self.sign: str|None = None
         # line counts start from the bottom up, the reverse of musedata
-        self.line: t.Optional[int] = None
+        self.line: int|None = None
         self._octaveChange: int = 0  # set to zero as default
         # musicxml has an attribute for clefOctaveChange,
         # an integer to show transposing clef

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -19,7 +19,6 @@ within :class:`~music21.stream.Measure` objects.
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-import typing as t
 from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 

--- a/music21/common/fileTools.py
+++ b/music21/common/fileTools.py
@@ -53,7 +53,7 @@ def cd(targetDir):
         os.chdir(cwd)
 
 
-def readPickleGzip(filePath: str|pathlib.Path) -> t.Any:
+def readPickleGzip(filePath: str | pathlib.Path) -> t.Any:
     '''
     Read a gzip-compressed pickle file, uncompress it, unpickle it, and
     return the contents.

--- a/music21/common/fileTools.py
+++ b/music21/common/fileTools.py
@@ -53,7 +53,7 @@ def cd(targetDir):
         os.chdir(cwd)
 
 
-def readPickleGzip(filePath: t.Union[str, pathlib.Path]) -> t.Any:
+def readPickleGzip(filePath: str|pathlib.Path) -> t.Any:
     '''
     Read a gzip-compressed pickle file, uncompress it, unpickle it, and
     return the contents.

--- a/music21/common/misc.py
+++ b/music21/common/misc.py
@@ -54,7 +54,7 @@ def flattenList(originalList: list) -> list:
     return [item for sublist in originalList for item in sublist]
 
 
-def unique(originalList: Iterable, *, key: Callable|None = None) -> list:
+def unique(originalList: Iterable, *, key: Callable | None = None) -> list:
     '''
     Return a List of unique items from an iterable, preserving order.
     (unlike casting to a set and back)

--- a/music21/common/misc.py
+++ b/music21/common/misc.py
@@ -54,7 +54,7 @@ def flattenList(originalList: list) -> list:
     return [item for sublist in originalList for item in sublist]
 
 
-def unique(originalList: Iterable, *, key: t.Optional[Callable] = None) -> list:
+def unique(originalList: Iterable, *, key: Callable|None = None) -> list:
     '''
     Return a List of unique items from an iterable, preserving order.
     (unlike casting to a set and back)

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -66,7 +66,7 @@ musicOrdinals[22] = 'Triple-octave'
 # Number methods...
 
 
-def numToIntOrFloat(value: t.Union[int, float]) -> t.Union[int, float]:
+def numToIntOrFloat(value: int|float) -> int|float:
     '''
     Given a number, return an integer if it is very close to an integer,
     otherwise, return a float.
@@ -210,7 +210,7 @@ _KNOWN_PASSES = frozenset([
 
 # no type checking due to accessing protected attributes (for speed)
 @t.no_type_check
-def opFrac(num: t.Union[OffsetQLIn, None]) -> t.Union[OffsetQL, None]:
+def opFrac(num: OffsetQLIn|None) -> OffsetQL|None:
     '''
     opFrac -> optionally convert a number to a fraction or back.
 
@@ -376,7 +376,7 @@ def mixedNumeral(expr: numbers.Real,
     return str(0)
 
 
-def roundToHalfInteger(num: t.Union[float, int]) -> t.Union[float, int]:
+def roundToHalfInteger(num: float|int) -> float|int:
     '''
     Given a floating-point number, round to the nearest half-integer. Returns int or float
 
@@ -424,7 +424,7 @@ def roundToHalfInteger(num: t.Union[float, int]) -> t.Union[float, int]:
     return intVal + floatVal
 
 
-def addFloatPrecision(x, grain=1e-2) -> t.Union[float, Fraction]:
+def addFloatPrecision(x, grain=1e-2) -> float|Fraction:
     '''
     Given a value that suggests a floating point fraction, like 0.33,
     return a Fraction or float that provides greater specification, such as Fraction(1, 3)
@@ -642,7 +642,7 @@ def decimalToTuplet(decNum: float) -> tuple[int, int]:
         return (int(iy), int(jy))
 
 
-def unitNormalizeProportion(values: Sequence[t.Union[int, float]]) -> list[float]:
+def unitNormalizeProportion(values: Sequence[int|float]) -> list[float]:
     '''
     Normalize values within the unit interval, where max is determined by the sum of the series.
 
@@ -681,8 +681,8 @@ def unitNormalizeProportion(values: Sequence[t.Union[int, float]]) -> list[float
 
 
 def unitBoundaryProportion(
-    series: Sequence[t.Union[int, float]]
-) -> list[tuple[t.Union[int, float], float]]:
+    series: Sequence[int|float]
+) -> list[tuple[int|float, float]]:
     '''
     Take a series of parts with an implied sum, and create
     unit-interval boundaries proportional to the series components.
@@ -705,7 +705,7 @@ def unitBoundaryProportion(
 
 
 def weightedSelection(values: list[int],
-                      weights: list[t.Union[int, float]],
+                      weights: list[int|float],
                       randomGenerator=None) -> int:
     '''
     Given a list of values and an equal-sized list of weights,
@@ -733,7 +733,7 @@ def weightedSelection(values: list[int],
     return values[index]
 
 
-def approximateGCD(values: list[t.Union[int, float]], grain: float = 1e-4) -> float:
+def approximateGCD(values: list[int|float], grain: float = 1e-4) -> float:
     '''Given a list of values, find the lowest common divisor of floating point values.
 
     >>> common.approximateGCD([2.5, 10, 0.25])

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -66,7 +66,7 @@ musicOrdinals[22] = 'Triple-octave'
 # Number methods...
 
 
-def numToIntOrFloat(value: int|float) -> int|float:
+def numToIntOrFloat(value: int | float) -> int | float:
     '''
     Given a number, return an integer if it is very close to an integer,
     otherwise, return a float.
@@ -210,7 +210,7 @@ _KNOWN_PASSES = frozenset([
 
 # no type checking due to accessing protected attributes (for speed)
 @t.no_type_check
-def opFrac(num: OffsetQLIn|None) -> OffsetQL|None:
+def opFrac(num: OffsetQLIn | None) -> OffsetQL | None:
     '''
     opFrac -> optionally convert a number to a fraction or back.
 
@@ -376,7 +376,7 @@ def mixedNumeral(expr: numbers.Real,
     return str(0)
 
 
-def roundToHalfInteger(num: float|int) -> float|int:
+def roundToHalfInteger(num: float | int) -> float | int:
     '''
     Given a floating-point number, round to the nearest half-integer. Returns int or float
 
@@ -424,7 +424,7 @@ def roundToHalfInteger(num: float|int) -> float|int:
     return intVal + floatVal
 
 
-def addFloatPrecision(x, grain=1e-2) -> float|Fraction:
+def addFloatPrecision(x, grain=1e-2) -> float | Fraction:
     '''
     Given a value that suggests a floating point fraction, like 0.33,
     return a Fraction or float that provides greater specification, such as Fraction(1, 3)
@@ -642,7 +642,7 @@ def decimalToTuplet(decNum: float) -> tuple[int, int]:
         return (int(iy), int(jy))
 
 
-def unitNormalizeProportion(values: Sequence[int|float]) -> list[float]:
+def unitNormalizeProportion(values: Sequence[int | float]) -> list[float]:
     '''
     Normalize values within the unit interval, where max is determined by the sum of the series.
 
@@ -681,8 +681,8 @@ def unitNormalizeProportion(values: Sequence[int|float]) -> list[float]:
 
 
 def unitBoundaryProportion(
-    series: Sequence[int|float]
-) -> list[tuple[int|float, float]]:
+    series: Sequence[int | float]
+) -> list[tuple[int | float, float]]:
     '''
     Take a series of parts with an implied sum, and create
     unit-interval boundaries proportional to the series components.
@@ -705,7 +705,7 @@ def unitBoundaryProportion(
 
 
 def weightedSelection(values: list[int],
-                      weights: list[int|float],
+                      weights: list[int | float],
                       randomGenerator=None) -> int:
     '''
     Given a list of values and an equal-sized list of weights,
@@ -733,7 +733,7 @@ def weightedSelection(values: list[int],
     return values[index]
 
 
-def approximateGCD(values: list[int|float], grain: float = 1e-4) -> float:
+def approximateGCD(values: list[int | float], grain: float = 1e-4) -> float:
     '''Given a list of values, find the lowest common divisor of floating point values.
 
     >>> common.approximateGCD([2.5, 10, 0.25])

--- a/music21/common/pathTools.py
+++ b/music21/common/pathTools.py
@@ -169,7 +169,7 @@ def cleanpath(path: t.Union[str, pathlib.Path], *,
     return '/'  # dummy until Astroid #1015 is fixed.
 
 def cleanpath(path: t.Union[str, pathlib.Path], *,
-              returnPathlib: t.Union[bool, None] = None) -> t.Union[str, pathlib.Path]:
+              returnPathlib: bool|None = None) -> t.Union[str, pathlib.Path]:
     '''
     Normalizes the path by expanding ~user on Unix, ${var} environmental vars
     (is this a good idea?), expanding %name% on Windows, normalizing path names

--- a/music21/common/pathTools.py
+++ b/music21/common/pathTools.py
@@ -28,7 +28,7 @@ import os
 import pathlib
 import unittest
 
-StrOrPath = t.TypeVar('StrOrPath', bound=str|pathlib.Path)
+StrOrPath = t.TypeVar('StrOrPath', bound=str | pathlib.Path)
 
 # ------------------------------------------------------------------------------
 def getSourceFilePath() -> pathlib.Path:
@@ -134,7 +134,7 @@ def getRootFilePath() -> pathlib.Path:
     return fpParent
 
 
-def relativepath(path: StrOrPath, start: str|None = None) -> StrOrPath|str:
+def relativepath(path: StrOrPath, start: str | None = None) -> StrOrPath | str:
     '''
     A cross-platform wrapper for `os.path.relpath()`, which returns `path` if
     under Windows, otherwise returns the relative path of `path`.
@@ -159,17 +159,17 @@ def cleanpath(path: str, *,
     return '/'  # dummy until Astroid #1015 is fixed.
 
 @overload
-def cleanpath(path: str|pathlib.Path, *,
+def cleanpath(path: str | pathlib.Path, *,
               returnPathlib: t.Literal[True]) -> pathlib.Path:
     return pathlib.Path('/')  # dummy until Astroid #1015 is fixed.
 
 @overload
-def cleanpath(path: str|pathlib.Path, *,
+def cleanpath(path: str | pathlib.Path, *,
               returnPathlib: t.Literal[False]) -> str:
     return '/'  # dummy until Astroid #1015 is fixed.
 
-def cleanpath(path: str|pathlib.Path, *,
-              returnPathlib: bool|None = None) -> str|pathlib.Path:
+def cleanpath(path: str | pathlib.Path, *,
+              returnPathlib: bool | None = None) -> str | pathlib.Path:
     '''
     Normalizes the path by expanding ~user on Unix, ${var} environmental vars
     (is this a good idea?), expanding %name% on Windows, normalizing path names

--- a/music21/common/pathTools.py
+++ b/music21/common/pathTools.py
@@ -28,7 +28,7 @@ import os
 import pathlib
 import unittest
 
-StrOrPath = t.TypeVar('StrOrPath', bound=t.Union[str, pathlib.Path])
+StrOrPath = t.TypeVar('StrOrPath', bound=str|pathlib.Path)
 
 # ------------------------------------------------------------------------------
 def getSourceFilePath() -> pathlib.Path:
@@ -134,7 +134,7 @@ def getRootFilePath() -> pathlib.Path:
     return fpParent
 
 
-def relativepath(path: StrOrPath, start: str|None = None) -> t.Union[StrOrPath, str]:
+def relativepath(path: StrOrPath, start: str|None = None) -> StrOrPath|str:
     '''
     A cross-platform wrapper for `os.path.relpath()`, which returns `path` if
     under Windows, otherwise returns the relative path of `path`.
@@ -159,17 +159,17 @@ def cleanpath(path: str, *,
     return '/'  # dummy until Astroid #1015 is fixed.
 
 @overload
-def cleanpath(path: t.Union[str, pathlib.Path], *,
+def cleanpath(path: str|pathlib.Path, *,
               returnPathlib: t.Literal[True]) -> pathlib.Path:
     return pathlib.Path('/')  # dummy until Astroid #1015 is fixed.
 
 @overload
-def cleanpath(path: t.Union[str, pathlib.Path], *,
+def cleanpath(path: str|pathlib.Path, *,
               returnPathlib: t.Literal[False]) -> str:
     return '/'  # dummy until Astroid #1015 is fixed.
 
-def cleanpath(path: t.Union[str, pathlib.Path], *,
-              returnPathlib: bool|None = None) -> t.Union[str, pathlib.Path]:
+def cleanpath(path: str|pathlib.Path, *,
+              returnPathlib: bool|None = None) -> str|pathlib.Path:
     '''
     Normalizes the path by expanding ~user on Unix, ${var} environmental vars
     (is this a good idea?), expanding %name% on Windows, normalizing path names

--- a/music21/common/pathTools.py
+++ b/music21/common/pathTools.py
@@ -134,7 +134,7 @@ def getRootFilePath() -> pathlib.Path:
     return fpParent
 
 
-def relativepath(path: StrOrPath, start: t.Optional[str] = None) -> t.Union[StrOrPath, str]:
+def relativepath(path: StrOrPath, start: str|None = None) -> t.Union[StrOrPath, str]:
     '''
     A cross-platform wrapper for `os.path.relpath()`, which returns `path` if
     under Windows, otherwise returns the relative path of `path`.

--- a/music21/common/types.py
+++ b/music21/common/types.py
@@ -20,15 +20,15 @@ from music21.common.enums import OffsetSpecial
 if TYPE_CHECKING:
     import music21  # pylint: disable=unused-import
 
-DocOrder = list[t.Union[str, Callable]]
-OffsetQL = t.Union[float, Fraction]
-OffsetQLSpecial = t.Union[float, Fraction, OffsetSpecial]
-OffsetQLIn = t.Union[int, float, Fraction]
+DocOrder = list[str|Callable]
+OffsetQL = float|Fraction
+OffsetQLSpecial = float|Fraction|OffsetSpecial
+OffsetQLIn = int|float|Fraction
 
 StreamType = t.TypeVar('StreamType', bound='music21.stream.Stream')
 StreamType2 = t.TypeVar('StreamType2', bound='music21.stream.Stream')
 M21ObjType = t.TypeVar('M21ObjType', bound='music21.base.Music21Object')
 M21ObjType2 = t.TypeVar('M21ObjType2', bound='music21.base.Music21Object')  # when you need another
 
-ClassListType = t.Union[str, Iterable[str], type[M21ObjType], Iterable[type[M21ObjType]]]
+ClassListType = str | Iterable[str] | type[M21ObjType] | Iterable[type[M21ObjType]]
 StepName = t.Literal['C', 'D', 'E', 'F', 'G', 'A', 'B']

--- a/music21/common/types.py
+++ b/music21/common/types.py
@@ -20,10 +20,10 @@ from music21.common.enums import OffsetSpecial
 if TYPE_CHECKING:
     import music21  # pylint: disable=unused-import
 
-DocOrder = list[str|Callable]
-OffsetQL = float|Fraction
-OffsetQLSpecial = float|Fraction|OffsetSpecial
-OffsetQLIn = int|float|Fraction
+DocOrder = list[str | Callable]
+OffsetQL = float | Fraction
+OffsetQLSpecial = float | Fraction | OffsetSpecial
+OffsetQLIn = int | float | Fraction
 
 StreamType = t.TypeVar('StreamType', bound='music21.stream.Stream')
 StreamType2 = t.TypeVar('StreamType2', bound='music21.stream.Stream')

--- a/music21/common/types.py
+++ b/music21/common/types.py
@@ -30,5 +30,6 @@ StreamType2 = t.TypeVar('StreamType2', bound='music21.stream.Stream')
 M21ObjType = t.TypeVar('M21ObjType', bound='music21.base.Music21Object')
 M21ObjType2 = t.TypeVar('M21ObjType2', bound='music21.base.Music21Object')  # when you need another
 
-ClassListType = str | Iterable[str] | type[M21ObjType] | Iterable[type[M21ObjType]]
+# does not seem to like the | way of spelling
+ClassListType = t.Union[str, Iterable[str], type[M21ObjType], Iterable[type[M21ObjType]]]
 StepName = t.Literal['C', 'D', 'E', 'F', 'G', 'A', 'B']

--- a/music21/common/weakrefTools.py
+++ b/music21/common/weakrefTools.py
@@ -20,7 +20,7 @@ _T = t.TypeVar('_T')
 # ------------------------------------------------------------------------------
 
 
-def wrapWeakref(referent: _T) -> weakref.ReferenceType|_T:
+def wrapWeakref(referent: _T) -> weakref.ReferenceType | _T:
     '''
     utility function that wraps objects as weakrefs but does not wrap
     already wrapped objects; also prevents wrapping the unwrappable "None" type, etc.

--- a/music21/common/weakrefTools.py
+++ b/music21/common/weakrefTools.py
@@ -20,7 +20,7 @@ _T = t.TypeVar('_T')
 # ------------------------------------------------------------------------------
 
 
-def wrapWeakref(referent: _T) -> t.Union[weakref.ReferenceType, _T]:
+def wrapWeakref(referent: _T) -> weakref.ReferenceType|_T:
     '''
     utility function that wraps objects as weakrefs but does not wrap
     already wrapped objects; also prevents wrapping the unwrappable "None" type, etc.

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -275,7 +275,7 @@ class PickleFilter:
         # environLocal.printDebug(['creating pickle filter'])
 
     def getPickleFp(self,
-                    directory: t.Union[pathlib.Path, str, None] = None,
+                    directory: pathlib.Path|str|None = None,
                     zipType: str|None = None) -> pathlib.Path:
         '''
         Returns the file path of the pickle file for this file.
@@ -492,7 +492,7 @@ class Converter:
     def __init__(self):
         self.subConverter: subConverters.SubConverter|None = None
         # a stream object unthawed
-        self._thawedStream: t.Union[stream.Score, stream.Part, stream.Opus, None] = None
+        self._thawedStream: stream.Score|stream.Part|stream.Opus|None = None
 
     def _getDownloadFp(
         self,

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -75,7 +75,7 @@ __all__ = [
 
 environLocal = environment.Environment('converter')
 
-_StrOrBytes = t.TypeVar('_StrOrBytes', bound=str|bytes)
+_StrOrBytes = t.TypeVar('_StrOrBytes', bound=str | bytes)
 
 # ------------------------------------------------------------------------------
 class ArchiveManagerException(exceptions21.Music21Exception):
@@ -123,7 +123,7 @@ class ArchiveManager:
     # for info on mxl files, see
     # http://www.recordare.com/xml/compressed-mxl.html
 
-    def __init__(self, fp: str|pathlib.Path, archiveType='zip'):
+    def __init__(self, fp: str | pathlib.Path, archiveType='zip'):
         self.fp: pathlib.Path = common.cleanpath(fp, returnPathlib=True)
         self.archiveType: str = archiveType
 
@@ -262,21 +262,21 @@ class PickleFilter:
     '''
 
     def __init__(self,
-                 fp: str|pathlib.Path,
+                 fp: str | pathlib.Path,
                  forceSource: bool = False,
-                 number: int|None = None,
+                 number: int | None = None,
                  # quantizePost: bool = False,
-                 # quarterLengthDivisors: Iterable[int]|None = None,
+                 # quarterLengthDivisors: Iterable[int] | None = None,
                  **keywords):
         self.fp: pathlib.Path = common.cleanpath(fp, returnPathlib=True)
         self.forceSource: bool = forceSource
-        self.number: int|None = number
+        self.number: int | None = number
         self.keywords: dict[str, t.Any] = keywords
         # environLocal.printDebug(['creating pickle filter'])
 
     def getPickleFp(self,
-                    directory: pathlib.Path|str|None = None,
-                    zipType: str|None = None) -> pathlib.Path:
+                    directory: pathlib.Path | str | None = None,
+                    zipType: str | None = None) -> pathlib.Path:
         '''
         Returns the file path of the pickle file for this file.
 
@@ -326,7 +326,7 @@ class PickleFilter:
         if pickleFp.exists():
             os.remove(pickleFp)
 
-    def status(self) -> tuple[pathlib.Path, bool, pathlib.Path|None]:
+    def status(self) -> tuple[pathlib.Path, bool, pathlib.Path | None]:
         '''
         Given a file path specified with __init__, look for an up-to-date pickled
         version of this file path. If it exists, return its fp, otherwise return the
@@ -490,13 +490,13 @@ class Converter:
     }
 
     def __init__(self):
-        self.subConverter: subConverters.SubConverter|None = None
+        self.subConverter: subConverters.SubConverter | None = None
         # a stream object unthawed
-        self._thawedStream: stream.Score|stream.Part|stream.Opus|None = None
+        self._thawedStream: stream.Score | stream.Part | stream.Opus | None = None
 
     def _getDownloadFp(
         self,
-        directory: pathlib.Path|str,
+        directory: pathlib.Path | str,
         ext: str,
         url: str,
     ):
@@ -513,9 +513,9 @@ class Converter:
     # noinspection PyShadowingBuiltins
     def parseFileNoPickle(
         self,
-        fp: pathlib.Path|str,
-        number: int|None = None,
-        format: str|None = None,
+        fp: pathlib.Path | str,
+        number: int | None = None,
+        format: str | None = None,
         forceSource: bool = False,
         **keywords
     ):
@@ -640,7 +640,7 @@ class Converter:
 
     def parseData(
         self,
-        dataStr: str|bytes,
+        dataStr: str | bytes,
         number=None,
         format=None,
         forceSource=False,
@@ -703,8 +703,8 @@ class Converter:
         self,
         url: str,
         *,
-        format: str|None = None,
-        number: int|None = None,
+        format: str | None = None,
+        number: int | None = None,
         forceSource: bool = False,
         **keywords,
     ) -> None:
@@ -980,7 +980,7 @@ class Converter:
     def formatFromHeader(
         self,
         dataStr: _StrOrBytes
-    ) -> tuple[str|None, _StrOrBytes]:
+    ) -> tuple[str | None, _StrOrBytes]:
         '''
         if dataStr begins with a text header such as  "tinyNotation:" then
         return that format plus the dataStr with the head removed.
@@ -1049,7 +1049,7 @@ class Converter:
                     break
         return (foundFormat, dataStr)
 
-    def regularizeFormat(self, fmt: str) -> str|None:
+    def regularizeFormat(self, fmt: str) -> str | None:
         '''
         Take in a string representing a format, a file extension (w/ or without leading dot)
         etc. and find the format string that best represents the format that should be used.
@@ -1121,7 +1121,7 @@ class Converter:
     # --------------------------------------------------------------------------
     # properties
     @property
-    def stream(self) -> stream.Score|stream.Part|stream.Opus|None:
+    def stream(self) -> stream.Score | stream.Part | stream.Opus | None:
         '''
         Returns the .subConverter.stream object.
         '''
@@ -1144,7 +1144,7 @@ def parseFile(fp,
               number=None,
               format=None,
               forceSource=False,
-              **keywords) -> stream.Score|stream.Part|stream.Opus:
+              **keywords) -> stream.Score | stream.Part | stream.Opus:
     '''
     Given a file path, attempt to parse the file into a Stream.
     '''
@@ -1160,7 +1160,7 @@ def parseFile(fp,
 def parseData(dataStr,
               number=None,
               format=None,
-              **keywords) -> stream.Score|stream.Part|stream.Opus:
+              **keywords) -> stream.Score | stream.Part | stream.Opus:
     '''
     Given musical data represented within a Python string, attempt to parse the
     data into a Stream.
@@ -1178,7 +1178,7 @@ def parseURL(url,
              format=None,
              number=None,
              forceSource=False,
-             **keywords) -> stream.Score|stream.Part|stream.Opus:
+             **keywords) -> stream.Score | stream.Part | stream.Opus:
     '''
     Given a URL, attempt to download and parse the file into a Stream. Note:
     URL downloading will not happen automatically unless the user has set their
@@ -1193,12 +1193,12 @@ def parseURL(url,
     return v.stream
 
 
-def parse(value: bundles.MetadataEntry|bytes|str|pathlib.Path,
+def parse(value: bundles.MetadataEntry | bytes | str | pathlib.Path,
           *,
           forceSource: bool = False,
-          number: int|None = None,
-          format: str|None = None,  # pylint: disable=redefined-builtin
-          **keywords) -> stream.Score|stream.Part|stream.Opus:
+          number: int | None = None,
+          format: str | None = None,  # pylint: disable=redefined-builtin
+          **keywords) -> stream.Score | stream.Part | stream.Opus:
     r'''
     Given a file path, encoded data in a Python string, or a URL, attempt to
     parse the item into a Stream.  Note: URL downloading will not happen

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -264,19 +264,19 @@ class PickleFilter:
     def __init__(self,
                  fp: t.Union[str, pathlib.Path],
                  forceSource: bool = False,
-                 number: t.Optional[int] = None,
+                 number: int|None = None,
                  # quantizePost: bool = False,
                  # quarterLengthDivisors: t.Optional[Iterable[int]] = None,
                  **keywords):
         self.fp: pathlib.Path = common.cleanpath(fp, returnPathlib=True)
         self.forceSource: bool = forceSource
-        self.number: t.Optional[int] = number
+        self.number: int|None = number
         self.keywords: dict[str, t.Any] = keywords
         # environLocal.printDebug(['creating pickle filter'])
 
     def getPickleFp(self,
                     directory: t.Union[pathlib.Path, str, None] = None,
-                    zipType: t.Optional[str] = None) -> pathlib.Path:
+                    zipType: str|None = None) -> pathlib.Path:
         '''
         Returns the file path of the pickle file for this file.
 
@@ -490,7 +490,7 @@ class Converter:
     }
 
     def __init__(self):
-        self.subConverter: t.Optional[subConverters.SubConverter] = None
+        self.subConverter: subConverters.SubConverter|None = None
         # a stream object unthawed
         self._thawedStream: t.Union[stream.Score, stream.Part, stream.Opus, None] = None
 
@@ -514,8 +514,8 @@ class Converter:
     def parseFileNoPickle(
         self,
         fp: t.Union[pathlib.Path, str],
-        number: t.Optional[int] = None,
-        format: t.Optional[str] = None,
+        number: int|None = None,
+        format: str|None = None,
         forceSource: bool = False,
         **keywords
     ):
@@ -703,8 +703,8 @@ class Converter:
         self,
         url: str,
         *,
-        format: t.Optional[str] = None,
-        number: t.Optional[int] = None,
+        format: str|None = None,
+        number: int|None = None,
         forceSource: bool = False,
         **keywords,
     ) -> None:
@@ -1196,8 +1196,8 @@ def parseURL(url,
 def parse(value: t.Union[bundles.MetadataEntry, bytes, str, pathlib.Path],
           *,
           forceSource: bool = False,
-          number: t.Optional[int] = None,
-          format: t.Optional[str] = None,  # pylint: disable=redefined-builtin
+          number: int|None = None,
+          format: str|None = None,  # pylint: disable=redefined-builtin
           **keywords) -> t.Union[stream.Score, stream.Part, stream.Opus]:
     r'''
     Given a file path, encoded data in a Python string, or a URL, attempt to

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -75,7 +75,7 @@ __all__ = [
 
 environLocal = environment.Environment('converter')
 
-_StrOrBytes = t.TypeVar('_StrOrBytes', bound=t.Union[str, bytes])
+_StrOrBytes = t.TypeVar('_StrOrBytes', bound=str|bytes)
 
 # ------------------------------------------------------------------------------
 class ArchiveManagerException(exceptions21.Music21Exception):
@@ -123,7 +123,7 @@ class ArchiveManager:
     # for info on mxl files, see
     # http://www.recordare.com/xml/compressed-mxl.html
 
-    def __init__(self, fp: t.Union[str, pathlib.Path], archiveType='zip'):
+    def __init__(self, fp: str|pathlib.Path, archiveType='zip'):
         self.fp: pathlib.Path = common.cleanpath(fp, returnPathlib=True)
         self.archiveType: str = archiveType
 
@@ -262,11 +262,11 @@ class PickleFilter:
     '''
 
     def __init__(self,
-                 fp: t.Union[str, pathlib.Path],
+                 fp: str|pathlib.Path,
                  forceSource: bool = False,
                  number: int|None = None,
                  # quantizePost: bool = False,
-                 # quarterLengthDivisors: t.Optional[Iterable[int]] = None,
+                 # quarterLengthDivisors: Iterable[int]|None = None,
                  **keywords):
         self.fp: pathlib.Path = common.cleanpath(fp, returnPathlib=True)
         self.forceSource: bool = forceSource
@@ -326,7 +326,7 @@ class PickleFilter:
         if pickleFp.exists():
             os.remove(pickleFp)
 
-    def status(self) -> tuple[pathlib.Path, bool, t.Optional[pathlib.Path]]:
+    def status(self) -> tuple[pathlib.Path, bool, pathlib.Path|None]:
         '''
         Given a file path specified with __init__, look for an up-to-date pickled
         version of this file path. If it exists, return its fp, otherwise return the
@@ -377,7 +377,7 @@ class PickleFilter:
 _registeredSubconverters: list[type[subConverters.SubConverter]] = []
 # default subconverters to skip
 _deregisteredSubconverters: list[
-    t.Union[type[subConverters.SubConverter], t.Literal['all']]
+    type[subConverters.SubConverter] | t.Literal['all']
 ] = []
 
 
@@ -419,7 +419,7 @@ def registerSubconverter(newSubConverter) -> None:
 
 
 def unregisterSubconverter(
-    removeSubconverter: t.Union[t.Literal['all'], type[subConverters.SubConverter]]
+    removeSubconverter: t.Literal['all'] | type[subConverters.SubConverter]
 ) -> None:
     # noinspection PyShadowingNames
     '''
@@ -496,7 +496,7 @@ class Converter:
 
     def _getDownloadFp(
         self,
-        directory: t.Union[pathlib.Path, str],
+        directory: pathlib.Path|str,
         ext: str,
         url: str,
     ):
@@ -513,7 +513,7 @@ class Converter:
     # noinspection PyShadowingBuiltins
     def parseFileNoPickle(
         self,
-        fp: t.Union[pathlib.Path, str],
+        fp: pathlib.Path|str,
         number: int|None = None,
         format: str|None = None,
         forceSource: bool = False,
@@ -640,7 +640,7 @@ class Converter:
 
     def parseData(
         self,
-        dataStr: t.Union[str, bytes],
+        dataStr: str|bytes,
         number=None,
         format=None,
         forceSource=False,
@@ -980,7 +980,7 @@ class Converter:
     def formatFromHeader(
         self,
         dataStr: _StrOrBytes
-    ) -> tuple[t.Optional[str], _StrOrBytes]:
+    ) -> tuple[str|None, _StrOrBytes]:
         '''
         if dataStr begins with a text header such as  "tinyNotation:" then
         return that format plus the dataStr with the head removed.
@@ -1049,7 +1049,7 @@ class Converter:
                     break
         return (foundFormat, dataStr)
 
-    def regularizeFormat(self, fmt: str) -> t.Optional[str]:
+    def regularizeFormat(self, fmt: str) -> str|None:
         '''
         Take in a string representing a format, a file extension (w/ or without leading dot)
         etc. and find the format string that best represents the format that should be used.
@@ -1121,7 +1121,7 @@ class Converter:
     # --------------------------------------------------------------------------
     # properties
     @property
-    def stream(self) -> t.Union[stream.Score, stream.Part, stream.Opus, None]:
+    def stream(self) -> stream.Score|stream.Part|stream.Opus|None:
         '''
         Returns the .subConverter.stream object.
         '''
@@ -1144,7 +1144,7 @@ def parseFile(fp,
               number=None,
               format=None,
               forceSource=False,
-              **keywords) -> t.Union[stream.Score, stream.Part, stream.Opus]:
+              **keywords) -> stream.Score|stream.Part|stream.Opus:
     '''
     Given a file path, attempt to parse the file into a Stream.
     '''
@@ -1160,7 +1160,7 @@ def parseFile(fp,
 def parseData(dataStr,
               number=None,
               format=None,
-              **keywords) -> t.Union[stream.Score, stream.Part, stream.Opus]:
+              **keywords) -> stream.Score|stream.Part|stream.Opus:
     '''
     Given musical data represented within a Python string, attempt to parse the
     data into a Stream.
@@ -1178,7 +1178,7 @@ def parseURL(url,
              format=None,
              number=None,
              forceSource=False,
-             **keywords) -> t.Union[stream.Score, stream.Part, stream.Opus]:
+             **keywords) -> stream.Score|stream.Part|stream.Opus:
     '''
     Given a URL, attempt to download and parse the file into a Stream. Note:
     URL downloading will not happen automatically unless the user has set their
@@ -1193,12 +1193,12 @@ def parseURL(url,
     return v.stream
 
 
-def parse(value: t.Union[bundles.MetadataEntry, bytes, str, pathlib.Path],
+def parse(value: bundles.MetadataEntry|bytes|str|pathlib.Path,
           *,
           forceSource: bool = False,
           number: int|None = None,
           format: str|None = None,  # pylint: disable=redefined-builtin
-          **keywords) -> t.Union[stream.Score, stream.Part, stream.Opus]:
+          **keywords) -> stream.Score|stream.Part|stream.Opus:
     r'''
     Given a file path, encoded data in a Python string, or a URL, attempt to
     parse the item into a Stream.  Note: URL downloading will not happen

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -98,7 +98,7 @@ class SubConverter:
         # return self.stream
 
     def parseFile(self,
-                  filePath: t.Union[str, pathlib.Path],
+                  filePath: str|pathlib.Path,
                   number: int|None = None,
                   **keywords):
         '''
@@ -273,7 +273,7 @@ class SubConverter:
 
     def writeDataStream(self,
                         fp,
-                        dataStr: t.Union[str, bytes],
+                        dataStr: str|bytes,
                         **keywords) -> pathlib.Path:  # pragma: no cover
         '''
         Writes the data stream to `fp` or to a temporary file and returns the
@@ -713,7 +713,7 @@ class ConverterHumdrum(SubConverter):
         return self.data
 
     def parseFile(self,
-                  filePath: t.Union[pathlib.Path, str],
+                  filePath: pathlib.Path|str,
                   number: int|None = None,
                   **keywords):
         '''
@@ -826,7 +826,7 @@ class ConverterNoteworthy(SubConverter):
         self.stream = noteworthyTranslate.NoteworthyTranslator().parseString(nwcData)
 
     def parseFile(self,
-                  filePath: t.Union[pathlib.Path, str],
+                  filePath: pathlib.Path|str,
                   number: int|None = None,
                   **keywords):
         # noinspection SpellCheckingInspection,PyShadowingNames
@@ -863,7 +863,7 @@ class ConverterNoteworthyBinary(SubConverter):
         self.stream = noteworthyBinary.NWCConverter().parseString(nwcData)
 
     def parseFile(self,
-                  filePath: t.Union[pathlib.Path, str],
+                  filePath: pathlib.Path|str,
                   number: int|None = None,
                   **keywords):
         from music21.noteworthy import binaryTranslate as noteworthyBinary
@@ -885,7 +885,7 @@ class ConverterMusicXML(SubConverter):
                                          }
 
     @staticmethod
-    def findNumberedPNGPath(inputFp: t.Union[str, pathlib.Path]) -> pathlib.Path:
+    def findNumberedPNGPath(inputFp: str|pathlib.Path) -> pathlib.Path:
         '''
         Find the first numbered file path corresponding to the provided unnumbered file path
         ending in ".png". Raises an exception if no file can be found.
@@ -920,7 +920,7 @@ class ConverterMusicXML(SubConverter):
         self.stream = c.stream
 
     def parseFile(self,
-                  filePath: t.Union[str, pathlib.Path],
+                  filePath: str|pathlib.Path,
                   number: int|None = None,
                   **keywords):
         '''
@@ -1027,7 +1027,7 @@ class ConverterMusicXML(SubConverter):
 
     def writeDataStream(self,
                         fp,
-                        dataStr: t.Union[str, bytes],
+                        dataStr: str|bytes,
                         **keywords) -> pathlib.Path:  # pragma: no cover
         # noinspection PyShadowingNames
         '''
@@ -1185,7 +1185,7 @@ class ConverterMidi(SubConverter):
         self.stream = midiTranslate.midiStringToStream(strData, **self.keywords)
 
     def parseFile(self,
-                  filePath: t.Union[pathlib.Path, str],
+                  filePath: pathlib.Path|str,
                   number: int|None = None,
                   **keywords):
         '''
@@ -1250,7 +1250,7 @@ class ConverterABC(SubConverter):
             abcFormat.translate.abcToStreamScore(abcHandler, self.stream)
 
     def parseFile(self,
-                  filePath: t.Union[pathlib.Path, str],
+                  filePath: pathlib.Path|str,
                   number: int|None = None,
                   **keywords):
         '''
@@ -1301,7 +1301,7 @@ class ConverterRomanText(SubConverter):
             romanTextTranslate.romanTextToStreamScore(rtHandler, self.stream)
 
     def parseFile(self,
-                  filePath: t.Union[pathlib.Path, str],
+                  filePath: pathlib.Path|str,
                   number: int|None = None,
                   **keywords):
         from music21.romanText import rtObjects
@@ -1348,7 +1348,7 @@ class ConverterClercqTemperley(SubConverter):
         self.stream = ctSong.toScore()
 
     def parseFile(self,
-                  filePath: t.Union[pathlib.Path, str],
+                  filePath: pathlib.Path|str,
                   number=None,
                   **keywords):
         self.parseData(filePath)
@@ -1375,7 +1375,7 @@ class ConverterCapella(SubConverter):
         self.stream = partScore
 
     def parseFile(self,
-                  filePath: t.Union[str, pathlib.Path],
+                  filePath: str|pathlib.Path,
                   number: int|None = None,
                   **keywords):
         '''
@@ -1413,7 +1413,7 @@ class ConverterMuseData(SubConverter):
         musedataTranslate.museDataWorkToStreamScore(mdw, self.stream)
 
     def parseFile(self,
-                  filePath: t.Union[str, pathlib.Path],
+                  filePath: str|pathlib.Path,
                   number: int|None = None,
                   **keywords):
         '''
@@ -1489,7 +1489,7 @@ class ConverterMEI(SubConverter):
 
     def parseFile(
         self,
-        filePath: t.Union[str, pathlib.Path],
+        filePath: str|pathlib.Path,
         number: int|None = None,
         **keywords,
     ) -> stream.Stream:

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -77,13 +77,13 @@ class SubConverter:
     registerInputExtensions: tuple[str, ...] = ()  # if converter supports input
     registerOutputExtensions: tuple[str, ...] = ()  # if converter supports output
     registerOutputSubformatExtensions: dict[str, str] = {}
-    launchKey: t.Union[str, pathlib.Path, None] = None
+    launchKey: str|pathlib.Path|None = None
 
     codecWrite = False
     stringEncoding = 'utf-8'
 
     def __init__(self, **keywords):
-        self._stream: t.Union[stream.Score, stream.Part, stream.Opus] = stream.Score()
+        self._stream: stream.Score|stream.Part|stream.Opus = stream.Score()
         self.keywords = keywords
 
     def parseData(self, dataString, number=None):

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -77,13 +77,13 @@ class SubConverter:
     registerInputExtensions: tuple[str, ...] = ()  # if converter supports input
     registerOutputExtensions: tuple[str, ...] = ()  # if converter supports output
     registerOutputSubformatExtensions: dict[str, str] = {}
-    launchKey: str|pathlib.Path|None = None
+    launchKey: str | pathlib.Path | None = None
 
     codecWrite = False
     stringEncoding = 'utf-8'
 
     def __init__(self, **keywords):
-        self._stream: stream.Score|stream.Part|stream.Opus = stream.Score()
+        self._stream: stream.Score | stream.Part | stream.Opus = stream.Score()
         self.keywords = keywords
 
     def parseData(self, dataString, number=None):
@@ -98,13 +98,13 @@ class SubConverter:
         # return self.stream
 
     def parseFile(self,
-                  filePath: str|pathlib.Path,
-                  number: int|None = None,
+                  filePath: str | pathlib.Path,
+                  number: int | None = None,
                   **keywords):
         '''
         Called when a file is encountered. If all that needs to be done is
         loading the file and putting the data into parseData then there is no need
-        to implement this method.  Just set self.readBinary to True|False.
+        to implement this method.  Just set self.readBinary to True | False.
         '''
         if self.readBinary is False:
             import locale
@@ -273,7 +273,7 @@ class SubConverter:
 
     def writeDataStream(self,
                         fp,
-                        dataStr: str|bytes,
+                        dataStr: str | bytes,
                         **keywords) -> pathlib.Path:  # pragma: no cover
         '''
         Writes the data stream to `fp` or to a temporary file and returns the
@@ -713,8 +713,8 @@ class ConverterHumdrum(SubConverter):
         return self.data
 
     def parseFile(self,
-                  filePath: pathlib.Path|str,
-                  number: int|None = None,
+                  filePath: pathlib.Path | str,
+                  number: int | None = None,
                   **keywords):
         '''
         Open Humdrum data from a file path.
@@ -826,8 +826,8 @@ class ConverterNoteworthy(SubConverter):
         self.stream = noteworthyTranslate.NoteworthyTranslator().parseString(nwcData)
 
     def parseFile(self,
-                  filePath: pathlib.Path|str,
-                  number: int|None = None,
+                  filePath: pathlib.Path | str,
+                  number: int | None = None,
                   **keywords):
         # noinspection SpellCheckingInspection,PyShadowingNames
         '''
@@ -863,8 +863,8 @@ class ConverterNoteworthyBinary(SubConverter):
         self.stream = noteworthyBinary.NWCConverter().parseString(nwcData)
 
     def parseFile(self,
-                  filePath: pathlib.Path|str,
-                  number: int|None = None,
+                  filePath: pathlib.Path | str,
+                  number: int | None = None,
                   **keywords):
         from music21.noteworthy import binaryTranslate as noteworthyBinary
         self.stream = noteworthyBinary.NWCConverter().parseFile(filePath)
@@ -885,7 +885,7 @@ class ConverterMusicXML(SubConverter):
                                          }
 
     @staticmethod
-    def findNumberedPNGPath(inputFp: str|pathlib.Path) -> pathlib.Path:
+    def findNumberedPNGPath(inputFp: str | pathlib.Path) -> pathlib.Path:
         '''
         Find the first numbered file path corresponding to the provided unnumbered file path
         ending in ".png". Raises an exception if no file can be found.
@@ -920,8 +920,8 @@ class ConverterMusicXML(SubConverter):
         self.stream = c.stream
 
     def parseFile(self,
-                  filePath: str|pathlib.Path,
-                  number: int|None = None,
+                  filePath: str | pathlib.Path,
+                  number: int | None = None,
                   **keywords):
         '''
         Open from a file path; check to see if there is a pickled
@@ -956,7 +956,7 @@ class ConverterMusicXML(SubConverter):
                             fp,
                             subformats=None,
                             *,
-                            dpi: int|None = None,
+                            dpi: int | None = None,
                             **keywords) -> pathlib.Path:  # pragma: no cover
         '''
         Take the output of the conversion process and run it through musescore to convert it
@@ -1027,7 +1027,7 @@ class ConverterMusicXML(SubConverter):
 
     def writeDataStream(self,
                         fp,
-                        dataStr: str|bytes,
+                        dataStr: str | bytes,
                         **keywords) -> pathlib.Path:  # pragma: no cover
         # noinspection PyShadowingNames
         '''
@@ -1080,7 +1080,7 @@ class ConverterMusicXML(SubConverter):
               subformats=None,
               *,
               makeNotation=True,
-              compress: bool|None = None,
+              compress: bool | None = None,
               **keywords):
         '''
         Write to a .musicxml file.
@@ -1185,8 +1185,8 @@ class ConverterMidi(SubConverter):
         self.stream = midiTranslate.midiStringToStream(strData, **self.keywords)
 
     def parseFile(self,
-                  filePath: pathlib.Path|str,
-                  number: int|None = None,
+                  filePath: pathlib.Path | str,
+                  number: int | None = None,
                   **keywords):
         '''
         Get MIDI data from a file path.
@@ -1250,8 +1250,8 @@ class ConverterABC(SubConverter):
             abcFormat.translate.abcToStreamScore(abcHandler, self.stream)
 
     def parseFile(self,
-                  filePath: pathlib.Path|str,
-                  number: int|None = None,
+                  filePath: pathlib.Path | str,
+                  number: int | None = None,
                   **keywords):
         '''
         Get ABC data from a file path. If more than one work is defined in the ABC
@@ -1301,8 +1301,8 @@ class ConverterRomanText(SubConverter):
             romanTextTranslate.romanTextToStreamScore(rtHandler, self.stream)
 
     def parseFile(self,
-                  filePath: pathlib.Path|str,
-                  number: int|None = None,
+                  filePath: pathlib.Path | str,
+                  number: int | None = None,
                   **keywords):
         from music21.romanText import rtObjects
         from music21.romanText import translate as romanTextTranslate
@@ -1348,7 +1348,7 @@ class ConverterClercqTemperley(SubConverter):
         self.stream = ctSong.toScore()
 
     def parseFile(self,
-                  filePath: pathlib.Path|str,
+                  filePath: pathlib.Path | str,
                   number=None,
                   **keywords):
         self.parseData(filePath)
@@ -1375,8 +1375,8 @@ class ConverterCapella(SubConverter):
         self.stream = partScore
 
     def parseFile(self,
-                  filePath: str|pathlib.Path,
-                  number: int|None = None,
+                  filePath: str | pathlib.Path,
+                  number: int | None = None,
                   **keywords):
         '''
         Parse a Capella file
@@ -1413,8 +1413,8 @@ class ConverterMuseData(SubConverter):
         musedataTranslate.museDataWorkToStreamScore(mdw, self.stream)
 
     def parseFile(self,
-                  filePath: str|pathlib.Path,
-                  number: int|None = None,
+                  filePath: str | pathlib.Path,
+                  number: int | None = None,
                   **keywords):
         '''
         parse fp (a pathlib.Path()) and number
@@ -1489,8 +1489,8 @@ class ConverterMEI(SubConverter):
 
     def parseFile(
         self,
-        filePath: str|pathlib.Path,
-        number: int|None = None,
+        filePath: str | pathlib.Path,
+        number: int | None = None,
         **keywords,
     ) -> stream.Stream:
         '''

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -25,7 +25,6 @@ import base64
 import os
 import pathlib
 import subprocess
-import typing as t
 import unittest
 
 from music21 import common

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -99,7 +99,7 @@ class SubConverter:
 
     def parseFile(self,
                   filePath: t.Union[str, pathlib.Path],
-                  number: t.Optional[int] = None,
+                  number: int|None = None,
                   **keywords):
         '''
         Called when a file is encountered. If all that needs to be done is
@@ -714,7 +714,7 @@ class ConverterHumdrum(SubConverter):
 
     def parseFile(self,
                   filePath: t.Union[pathlib.Path, str],
-                  number: t.Optional[int] = None,
+                  number: int|None = None,
                   **keywords):
         '''
         Open Humdrum data from a file path.
@@ -827,7 +827,7 @@ class ConverterNoteworthy(SubConverter):
 
     def parseFile(self,
                   filePath: t.Union[pathlib.Path, str],
-                  number: t.Optional[int] = None,
+                  number: int|None = None,
                   **keywords):
         # noinspection SpellCheckingInspection,PyShadowingNames
         '''
@@ -864,7 +864,7 @@ class ConverterNoteworthyBinary(SubConverter):
 
     def parseFile(self,
                   filePath: t.Union[pathlib.Path, str],
-                  number: t.Optional[int] = None,
+                  number: int|None = None,
                   **keywords):
         from music21.noteworthy import binaryTranslate as noteworthyBinary
         self.stream = noteworthyBinary.NWCConverter().parseFile(filePath)
@@ -921,7 +921,7 @@ class ConverterMusicXML(SubConverter):
 
     def parseFile(self,
                   filePath: t.Union[str, pathlib.Path],
-                  number: t.Optional[int] = None,
+                  number: int|None = None,
                   **keywords):
         '''
         Open from a file path; check to see if there is a pickled
@@ -956,7 +956,7 @@ class ConverterMusicXML(SubConverter):
                             fp,
                             subformats=None,
                             *,
-                            dpi: t.Optional[int] = None,
+                            dpi: int|None = None,
                             **keywords) -> pathlib.Path:  # pragma: no cover
         '''
         Take the output of the conversion process and run it through musescore to convert it
@@ -1080,7 +1080,7 @@ class ConverterMusicXML(SubConverter):
               subformats=None,
               *,
               makeNotation=True,
-              compress: t.Optional[bool] = None,
+              compress: bool|None = None,
               **keywords):
         '''
         Write to a .musicxml file.
@@ -1186,7 +1186,7 @@ class ConverterMidi(SubConverter):
 
     def parseFile(self,
                   filePath: t.Union[pathlib.Path, str],
-                  number: t.Optional[int] = None,
+                  number: int|None = None,
                   **keywords):
         '''
         Get MIDI data from a file path.
@@ -1251,7 +1251,7 @@ class ConverterABC(SubConverter):
 
     def parseFile(self,
                   filePath: t.Union[pathlib.Path, str],
-                  number: t.Optional[int] = None,
+                  number: int|None = None,
                   **keywords):
         '''
         Get ABC data from a file path. If more than one work is defined in the ABC
@@ -1302,7 +1302,7 @@ class ConverterRomanText(SubConverter):
 
     def parseFile(self,
                   filePath: t.Union[pathlib.Path, str],
-                  number: t.Optional[int] = None,
+                  number: int|None = None,
                   **keywords):
         from music21.romanText import rtObjects
         from music21.romanText import translate as romanTextTranslate
@@ -1376,7 +1376,7 @@ class ConverterCapella(SubConverter):
 
     def parseFile(self,
                   filePath: t.Union[str, pathlib.Path],
-                  number: t.Optional[int] = None,
+                  number: int|None = None,
                   **keywords):
         '''
         Parse a Capella file
@@ -1414,7 +1414,7 @@ class ConverterMuseData(SubConverter):
 
     def parseFile(self,
                   filePath: t.Union[str, pathlib.Path],
-                  number: t.Optional[int] = None,
+                  number: int|None = None,
                   **keywords):
         '''
         parse fp (a pathlib.Path()) and number
@@ -1490,7 +1490,7 @@ class ConverterMEI(SubConverter):
     def parseFile(
         self,
         filePath: t.Union[str, pathlib.Path],
-        number: t.Optional[int] = None,
+        number: int|None = None,
         **keywords,
     ) -> stream.Stream:
         '''

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -1068,15 +1068,15 @@ class Iterator:
                   'titleList', 'numberList', 'returnType', 'iterationType']
 
     def __init__(self,
-                 currentNumber: int|None = None,
-                 highestNumber: int|None = None,
+                 currentNumber: int | None = None,
+                 highestNumber: int | None = None,
                  *,
                  numberingSystem: str = 'riemenschneider',
                  returnType: str = 'stream',
                  iterationType: str = 'number',
                  analysis: bool = False,
-                 numberList: list[int]|None = None,
-                 titleList: list[str]|None = None,
+                 numberList: list[int] | None = None,
+                 titleList: list[str] | None = None,
                  ):
         '''
         By default: numberingSystem = 'riemenschneider', currentNumber = 1,

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -1068,8 +1068,8 @@ class Iterator:
                   'titleList', 'numberList', 'returnType', 'iterationType']
 
     def __init__(self,
-                 currentNumber: t.Optional[int] = None,
-                 highestNumber: t.Optional[int] = None,
+                 currentNumber: int|None = None,
+                 highestNumber: int|None = None,
                  *,
                  numberingSystem: str = 'riemenschneider',
                  returnType: str = 'stream',

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -17,7 +17,6 @@ class for easily iterating through the chorale collection.
 from __future__ import annotations
 
 import copy
-import typing as t
 import unittest
 
 from music21 import environment

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -1075,8 +1075,8 @@ class Iterator:
                  returnType: str = 'stream',
                  iterationType: str = 'number',
                  analysis: bool = False,
-                 numberList: t.Optional[list[int]] = None,
-                 titleList: t.Optional[list[str]] = None,
+                 numberList: list[int]|None = None,
+                 titleList: list[str]|None = None,
                  ):
         '''
         By default: numberingSystem = 'riemenschneider', currentNumber = 1,

--- a/music21/corpus/manager.py
+++ b/music21/corpus/manager.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import pathlib
 import os
-import typing as t
 from typing import TYPE_CHECKING
 
 from music21 import common

--- a/music21/corpus/manager.py
+++ b/music21/corpus/manager.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from music21.metadata import bundles
 
 
-_metadataBundles: dict[str, bundles.MetadataBundle|None] = {
+_metadataBundles: dict[str, bundles.MetadataBundle | None] = {
     'core': None,
     'local': None,
     # 'virtual': None,

--- a/music21/corpus/manager.py
+++ b/music21/corpus/manager.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from music21.metadata import bundles
 
 
-_metadataBundles: dict[str, t.Optional[bundles.MetadataBundle]] = {
+_metadataBundles: dict[str, bundles.MetadataBundle|None] = {
     'core': None,
     'local': None,
     # 'virtual': None,

--- a/music21/derivation.py
+++ b/music21/derivation.py
@@ -196,7 +196,7 @@ class Derivation(SlottedObjectMixin):
     # PUBLIC PROPERTIES #
 
     @property
-    def client(self) -> t.Optional[base.Music21Object]:
+    def client(self) -> base.Music21Object|None:
         c = common.unwrapWeakref(self._client)
         if c is None and self._clientId is not None:
             self._clientId = None
@@ -206,7 +206,7 @@ class Derivation(SlottedObjectMixin):
         return c
 
     @client.setter
-    def client(self, client: t.Optional[base.Music21Object]):
+    def client(self, client: base.Music21Object|None):
         # client is the Stream that this derivation lives on
         if client is None:
             self._clientId = None
@@ -247,7 +247,7 @@ class Derivation(SlottedObjectMixin):
             origin = origin.derivation.origin
 
     @property
-    def method(self) -> t.Optional[str]:
+    def method(self) -> str|None:
         '''
         Returns or sets the string of the method that was used to generate this
         Stream.
@@ -287,15 +287,15 @@ class Derivation(SlottedObjectMixin):
         return self._method
 
     @method.setter
-    def method(self, method: t.Optional[str]):
+    def method(self, method: str|None):
         self._method = method
 
     @property
-    def origin(self) -> t.Optional[base.Music21Object]:
+    def origin(self) -> base.Music21Object|None:
         return self._origin
 
     @origin.setter
-    def origin(self, origin: t.Optional[base.Music21Object]):
+    def origin(self, origin: base.Music21Object|None):
         # for now, origin is not a weak ref
         if origin is None:
             self._originId = None
@@ -306,7 +306,7 @@ class Derivation(SlottedObjectMixin):
             # self._origin = common.wrapWeakref(origin)
 
     @property
-    def rootDerivation(self) -> t.Optional[base.Music21Object]:
+    def rootDerivation(self) -> base.Music21Object|None:
         r'''
         Return a reference to the oldest source of this Stream; that is, chain
         calls to :attr:`~music21.stream.Stream.derivesFrom` until we get to a

--- a/music21/derivation.py
+++ b/music21/derivation.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 from collections.abc import Generator
 import functools
-import typing as t
 from typing import TYPE_CHECKING  # Pylint bug
 import unittest
 

--- a/music21/derivation.py
+++ b/music21/derivation.py
@@ -153,11 +153,11 @@ class Derivation(SlottedObjectMixin):
     def __init__(self, client=None):
         # store a reference to the Music21Object that has this Derivation object as a property
         self._client = None
-        self._clientId: int|None = None  # store python-id to optimize w/o unwrapping
-        self._method: str|None = None
+        self._clientId: int | None = None  # store python-id to optimize w/o unwrapping
+        self._method: str | None = None
         # origin should be stored as a weak ref -- the place where the client was derived from.
         self._origin = None
-        self._originId: int|None = None  # store id to optimize w/o unwrapping
+        self._originId: int | None = None  # store id to optimize w/o unwrapping
 
         # set client; can handle None
         self.client = client
@@ -196,7 +196,7 @@ class Derivation(SlottedObjectMixin):
     # PUBLIC PROPERTIES #
 
     @property
-    def client(self) -> base.Music21Object|None:
+    def client(self) -> base.Music21Object | None:
         c = common.unwrapWeakref(self._client)
         if c is None and self._clientId is not None:
             self._clientId = None
@@ -206,7 +206,7 @@ class Derivation(SlottedObjectMixin):
         return c
 
     @client.setter
-    def client(self, client: base.Music21Object|None):
+    def client(self, client: base.Music21Object | None):
         # client is the Stream that this derivation lives on
         if client is None:
             self._clientId = None
@@ -247,7 +247,7 @@ class Derivation(SlottedObjectMixin):
             origin = origin.derivation.origin
 
     @property
-    def method(self) -> str|None:
+    def method(self) -> str | None:
         '''
         Returns or sets the string of the method that was used to generate this
         Stream.
@@ -287,15 +287,15 @@ class Derivation(SlottedObjectMixin):
         return self._method
 
     @method.setter
-    def method(self, method: str|None):
+    def method(self, method: str | None):
         self._method = method
 
     @property
-    def origin(self) -> base.Music21Object|None:
+    def origin(self) -> base.Music21Object | None:
         return self._origin
 
     @origin.setter
-    def origin(self, origin: base.Music21Object|None):
+    def origin(self, origin: base.Music21Object | None):
         # for now, origin is not a weak ref
         if origin is None:
             self._originId = None
@@ -306,7 +306,7 @@ class Derivation(SlottedObjectMixin):
             # self._origin = common.wrapWeakref(origin)
 
     @property
-    def rootDerivation(self) -> base.Music21Object|None:
+    def rootDerivation(self) -> base.Music21Object | None:
         r'''
         Return a reference to the oldest source of this Stream; that is, chain
         calls to :attr:`~music21.stream.Stream.derivesFrom` until we get to a

--- a/music21/derivation.py
+++ b/music21/derivation.py
@@ -153,11 +153,11 @@ class Derivation(SlottedObjectMixin):
     def __init__(self, client=None):
         # store a reference to the Music21Object that has this Derivation object as a property
         self._client = None
-        self._clientId: t.Optional[int] = None  # store python-id to optimize w/o unwrapping
-        self._method: t.Optional[str] = None
+        self._clientId: int|None = None  # store python-id to optimize w/o unwrapping
+        self._method: str|None = None
         # origin should be stored as a weak ref -- the place where the client was derived from.
         self._origin = None
-        self._originId: t.Optional[int] = None  # store id to optimize w/o unwrapping
+        self._originId: int|None = None  # store id to optimize w/o unwrapping
 
         # set client; can handle None
         self.client = client

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -1068,8 +1068,8 @@ class Tuplet(prebase.ProtoM21Object):
         self.frozen = False
         # environLocal.printDebug(['creating Tuplet instance'])
 
-        self._durationNormal: t.Optional[DurationTuple] = None
-        self._durationActual: t.Optional[DurationTuple] = None
+        self._durationNormal: DurationTuple|None = None
+        self._durationActual: DurationTuple|None = None
 
         # necessary for some complex tuplets, interrupted, for instance
         self.tupletId = tupletId
@@ -1613,12 +1613,12 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
     def __init__(self,
                  typeOrDuration: t.Union[str, OffsetQLIn, DurationTuple, None] = None,
                  *,
-                 type: t.Optional[str] = None,  # pylint: disable=redefined-builtin
-                 dots: t.Optional[int] = None,
-                 quarterLength: t.Optional[OffsetQLIn] = None,
-                 durationTuple: t.Optional[DurationTuple] = None,
+                 type: str|None = None,  # pylint: disable=redefined-builtin
+                 dots: int|None = None,
+                 quarterLength: OffsetQLIn|None = None,
+                 durationTuple: DurationTuple|None = None,
                  components: t.Optional[Iterable[DurationTuple]] = None,
-                 client: t.Optional[base.Music21Object] = None,
+                 client: base.Music21Object|None = None,
                  **keywords):
         # First positional argument is assumed to be type string or a quarterLength.
         # no need for super() on ProtoM21 or SlottedObjectMixin
@@ -1630,7 +1630,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         self._quarterLengthNeedsUpdating = False
         self._typeNeedsUpdating = False
 
-        self._unlinkedType: t.Optional[str] = None
+        self._unlinkedType: str|None = None
         self._dotGroups: tuple[int, ...] = (0,)
         self._tuplets: tuple['Tuplet', ...] = ()  # an empty tuple
         self._qtrLength: OffsetQL = 0.0

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -164,7 +164,7 @@ extendedTupletNumerators: tuple[int, ...] = (
 
 class QuarterLengthConversion(t.NamedTuple):
     components: tuple[DurationTuple]
-    tuplet: t.Optional[Tuplet]
+    tuplet: Tuplet|None
 
 
 def unitSpec(durationObjectOrObjects):
@@ -345,7 +345,7 @@ def convertQuarterLengthToType(qLen: OffsetQLIn) -> str:
 
 def dottedMatch(qLen: OffsetQLIn,
                 maxDots=4
-                ) -> t.Union[tuple[int, str], tuple[t.Literal[False], t.Literal[False]]]:
+                ) -> tuple[int, str]|tuple[t.Literal[False], t.Literal[False]]:
     '''
     Given a quarterLength, determine if there is a dotted
     (or non-dotted) type that exactly matches. Returns a pair of
@@ -724,7 +724,7 @@ def quarterConversion(qLen: OffsetQLIn) -> QuarterLengthConversion:
 def convertTypeToQuarterLength(
     dType: str,
     dots=0,
-    tuplets: t.Optional[list[Tuplet]] = None,
+    tuplets: list[Tuplet]|None = None,
     dotGroups=None
 ) -> OffsetQL:
     # noinspection PyShadowingNames
@@ -1049,22 +1049,22 @@ class Tuplet(prebase.ProtoM21Object):
     # TODO: use __setattr__ to freeze all properties, and make a metaclass
     # exceptions: tuplet type, tuplet id: things that don't affect length
     '''
-    def __init__(self,
-                 numberNotesActual: int = 3,
-                 numberNotesNormal: int = 2,
-                 durationActual: t.Union[DurationTuple, Duration,
-                                         str, tuple[str, int], None] = None,
-                 durationNormal: t.Union[DurationTuple, Duration,
-                                         str, tuple[str, int], None] = None,
-                 *,
-                 tupletId: int = 0,
-                 nestedLevel: int = 1,
-                 type: TupletType = None,  # pylint: disable=redefined-builtin
-                 bracket: t.Literal[True, False, 'slur'] = True,
-                 placement: t.Literal['above', 'below'] = 'above',
-                 tupletActualShow: TupletShowOptions = 'number',
-                 tupletNormalShow: TupletShowOptions = None,
-                 **keywords):
+    def __init__(
+        self,
+        numberNotesActual: int = 3,
+        numberNotesNormal: int = 2,
+        durationActual: DurationTuple | Duration | str | tuple[str, int] | None = None,
+        durationNormal: DurationTuple | Duration | str | tuple[str, int] | None = None,
+        *,
+        tupletId: int = 0,
+        nestedLevel: int = 1,
+        type: TupletType = None,  # pylint: disable=redefined-builtin
+        bracket: t.Literal[True, False, 'slur'] = True,
+        placement: t.Literal['above', 'below'] = 'above',
+        tupletActualShow: TupletShowOptions = 'number',
+        tupletNormalShow: TupletShowOptions = None,
+        **keywords
+    ):
         self.frozen = False
         # environLocal.printDebug(['creating Tuplet instance'])
 
@@ -1171,7 +1171,7 @@ class Tuplet(prebase.ProtoM21Object):
                 'A frozen tuplet (or one attached to a duration) has immutable length.')
 
     # PUBLIC METHODS #
-    def augmentOrDiminish(self, amountToScale: t.Union[int, float]):
+    def augmentOrDiminish(self, amountToScale: int|float):
         '''
         Given a number greater than zero,
         multiplies the current quarterLength of the
@@ -1229,7 +1229,7 @@ class Tuplet(prebase.ProtoM21Object):
 
     def setDurationType(
         self,
-        durType: t.Union[str, int, float, fractions.Fraction],
+        durType: str|int|float|fractions.Fraction,
         dots=0
     ):
         '''
@@ -1373,7 +1373,7 @@ class Tuplet(prebase.ProtoM21Object):
 
     # PUBLIC PROPERTIES #
     @property
-    def durationActual(self) -> t.Optional[DurationTuple]:
+    def durationActual(self) -> DurationTuple|None:
         '''
         durationActual is a DurationTuple that represents the notes that are
         actually present and counted in a tuplet.  For instance, in a 7
@@ -1397,7 +1397,7 @@ class Tuplet(prebase.ProtoM21Object):
         return self._durationActual
 
     @durationActual.setter
-    def durationActual(self, dA: t.Union[DurationTuple, Duration, str, None]):
+    def durationActual(self, dA: DurationTuple|Duration|str|None):
         self._checkFrozen()
 
         if isinstance(dA, DurationTuple) or dA is None:
@@ -1411,7 +1411,7 @@ class Tuplet(prebase.ProtoM21Object):
             self._durationActual = durationTupleFromTypeDots(dA, dots=0)
 
     @property
-    def durationNormal(self) -> t.Optional[DurationTuple]:
+    def durationNormal(self) -> DurationTuple|None:
         '''
         durationNormal is a DurationTuple that represents the notes that
         would be present in the space normally (if there were no tuplets).  For instance, in a 7
@@ -1435,7 +1435,7 @@ class Tuplet(prebase.ProtoM21Object):
         return self._durationNormal
 
     @durationNormal.setter
-    def durationNormal(self, dN: t.Union[DurationTuple, Duration, str, None]):
+    def durationNormal(self, dN: DurationTuple|Duration|str|None):
         self._checkFrozen()
         if isinstance(dN, DurationTuple) or dN is None:
             self._durationNormal = dN
@@ -1617,7 +1617,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
                  dots: int|None = None,
                  quarterLength: OffsetQLIn|None = None,
                  durationTuple: DurationTuple|None = None,
-                 components: t.Optional[Iterable[DurationTuple]] = None,
+                 components: Iterable[DurationTuple]|None = None,
                  client: base.Music21Object|None = None,
                  **keywords):
         # First positional argument is assumed to be type string or a quarterLength.
@@ -1848,7 +1848,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
     linked = property(_getLinked, _setLinked)
 
-    def addDurationTuple(self, dur: t.Union[DurationTuple, Duration, str, OffsetQLIn]):
+    def addDurationTuple(self, dur: DurationTuple|Duration|str|OffsetQLIn):
         '''
         Add a DurationTuple or a Duration's components to this Duration.
         Does not simplify the Duration.  For instance, adding two
@@ -2227,7 +2227,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
     def getGraceDuration(
         self,
         appoggiatura=False
-    ) -> t.Union['GraceDuration', 'AppoggiaturaDuration']:
+    ) -> GraceDuration | AppoggiaturaDuration:
         # noinspection PyShadowingNames
         '''
         Return a deepcopy of this Duration as a GraceDuration instance with the same types.
@@ -2807,7 +2807,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             return False
 
     @property
-    def ordinal(self) -> t.Union[int, str, None]:
+    def ordinal(self) -> int|str|None:
         '''
         Get the ordinal value of the Duration, where whole is 4,
         half is 5, etc.

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -164,7 +164,7 @@ extendedTupletNumerators: tuple[int, ...] = (
 
 class QuarterLengthConversion(t.NamedTuple):
     components: tuple[DurationTuple]
-    tuplet: Tuplet|None
+    tuplet: Tuplet | None
 
 
 def unitSpec(durationObjectOrObjects):
@@ -345,7 +345,7 @@ def convertQuarterLengthToType(qLen: OffsetQLIn) -> str:
 
 def dottedMatch(qLen: OffsetQLIn,
                 maxDots=4
-                ) -> tuple[int, str]|tuple[t.Literal[False], t.Literal[False]]:
+                ) -> tuple[int, str] | tuple[t.Literal[False], t.Literal[False]]:
     '''
     Given a quarterLength, determine if there is a dotted
     (or non-dotted) type that exactly matches. Returns a pair of
@@ -724,7 +724,7 @@ def quarterConversion(qLen: OffsetQLIn) -> QuarterLengthConversion:
 def convertTypeToQuarterLength(
     dType: str,
     dots=0,
-    tuplets: list[Tuplet]|None = None,
+    tuplets: list[Tuplet] | None = None,
     dotGroups=None
 ) -> OffsetQL:
     # noinspection PyShadowingNames
@@ -1068,8 +1068,8 @@ class Tuplet(prebase.ProtoM21Object):
         self.frozen = False
         # environLocal.printDebug(['creating Tuplet instance'])
 
-        self._durationNormal: DurationTuple|None = None
-        self._durationActual: DurationTuple|None = None
+        self._durationNormal: DurationTuple | None = None
+        self._durationActual: DurationTuple | None = None
 
         # necessary for some complex tuplets, interrupted, for instance
         self.tupletId = tupletId
@@ -1171,7 +1171,7 @@ class Tuplet(prebase.ProtoM21Object):
                 'A frozen tuplet (or one attached to a duration) has immutable length.')
 
     # PUBLIC METHODS #
-    def augmentOrDiminish(self, amountToScale: int|float):
+    def augmentOrDiminish(self, amountToScale: int | float):
         '''
         Given a number greater than zero,
         multiplies the current quarterLength of the
@@ -1229,7 +1229,7 @@ class Tuplet(prebase.ProtoM21Object):
 
     def setDurationType(
         self,
-        durType: str|int|float|fractions.Fraction,
+        durType: str | int | float | fractions.Fraction,
         dots=0
     ):
         '''
@@ -1373,7 +1373,7 @@ class Tuplet(prebase.ProtoM21Object):
 
     # PUBLIC PROPERTIES #
     @property
-    def durationActual(self) -> DurationTuple|None:
+    def durationActual(self) -> DurationTuple | None:
         '''
         durationActual is a DurationTuple that represents the notes that are
         actually present and counted in a tuplet.  For instance, in a 7
@@ -1397,7 +1397,7 @@ class Tuplet(prebase.ProtoM21Object):
         return self._durationActual
 
     @durationActual.setter
-    def durationActual(self, dA: DurationTuple|Duration|str|None):
+    def durationActual(self, dA: DurationTuple | Duration | str | None):
         self._checkFrozen()
 
         if isinstance(dA, DurationTuple) or dA is None:
@@ -1411,7 +1411,7 @@ class Tuplet(prebase.ProtoM21Object):
             self._durationActual = durationTupleFromTypeDots(dA, dots=0)
 
     @property
-    def durationNormal(self) -> DurationTuple|None:
+    def durationNormal(self) -> DurationTuple | None:
         '''
         durationNormal is a DurationTuple that represents the notes that
         would be present in the space normally (if there were no tuplets).  For instance, in a 7
@@ -1435,7 +1435,7 @@ class Tuplet(prebase.ProtoM21Object):
         return self._durationNormal
 
     @durationNormal.setter
-    def durationNormal(self, dN: DurationTuple|Duration|str|None):
+    def durationNormal(self, dN: DurationTuple | Duration | str | None):
         self._checkFrozen()
         if isinstance(dN, DurationTuple) or dN is None:
             self._durationNormal = dN
@@ -1611,14 +1611,14 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
     # INITIALIZER #
 
     def __init__(self,
-                 typeOrDuration: str|OffsetQLIn|DurationTuple|None = None,
+                 typeOrDuration: str | OffsetQLIn | DurationTuple | None = None,
                  *,
-                 type: str|None = None,  # pylint: disable=redefined-builtin
-                 dots: int|None = None,
-                 quarterLength: OffsetQLIn|None = None,
-                 durationTuple: DurationTuple|None = None,
-                 components: Iterable[DurationTuple]|None = None,
-                 client: base.Music21Object|None = None,
+                 type: str | None = None,  # pylint: disable=redefined-builtin
+                 dots: int | None = None,
+                 quarterLength: OffsetQLIn | None = None,
+                 durationTuple: DurationTuple | None = None,
+                 components: Iterable[DurationTuple] | None = None,
+                 client: base.Music21Object | None = None,
                  **keywords):
         # First positional argument is assumed to be type string or a quarterLength.
         # no need for super() on ProtoM21 or SlottedObjectMixin
@@ -1630,7 +1630,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         self._quarterLengthNeedsUpdating = False
         self._typeNeedsUpdating = False
 
-        self._unlinkedType: str|None = None
+        self._unlinkedType: str | None = None
         self._dotGroups: tuple[int, ...] = (0,)
         self._tuplets: tuple['Tuplet', ...] = ()  # an empty tuple
         self._qtrLength: OffsetQL = 0.0
@@ -1848,7 +1848,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
     linked = property(_getLinked, _setLinked)
 
-    def addDurationTuple(self, dur: DurationTuple|Duration|str|OffsetQLIn):
+    def addDurationTuple(self, dur: DurationTuple | Duration | str | OffsetQLIn):
         '''
         Add a DurationTuple or a Duration's components to this Duration.
         Does not simplify the Duration.  For instance, adding two
@@ -2807,7 +2807,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
             return False
 
     @property
-    def ordinal(self) -> int|str|None:
+    def ordinal(self) -> int | str | None:
         '''
         Get the ordinal value of the Duration, where whole is 4,
         half is 5, etc.
@@ -3092,7 +3092,7 @@ class GraceDuration(Duration):
     # INITIALIZER #
 
     def __init__(self,
-                 typeOrDuration: str|OffsetQLIn|DurationTuple|None = None,
+                 typeOrDuration: str | OffsetQLIn | DurationTuple | None = None,
                  **keywords):
         super().__init__(typeOrDuration, **keywords)
         # update components to derive types; this sets ql, but this
@@ -3112,8 +3112,8 @@ class GraceDuration(Duration):
         self._slash = None
         self.slash = True  # can be True, False, or None; make None go to True?
         # values are unit interval percentages
-        self.stealTimePrevious: float|None = None
-        self.stealTimeFollowing: float|None = None
+        self.stealTimePrevious: float | None = None
+        self.stealTimeFollowing: float | None = None
 
 
     # PUBLIC PROPERTIES #
@@ -3159,7 +3159,7 @@ class AppoggiaturaDuration(GraceDuration):
     # INITIALIZER #
 
     def __init__(self,
-                 typeOrDuration: str|OffsetQLIn|DurationTuple|None = None,
+                 typeOrDuration: str | OffsetQLIn | DurationTuple | None = None,
                  **keywords):
         super().__init__(typeOrDuration, **keywords)
         self.slash = False  # can be True, False, or None; make None go to True?

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -1611,7 +1611,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
     # INITIALIZER #
 
     def __init__(self,
-                 typeOrDuration: t.Union[str, OffsetQLIn, DurationTuple, None] = None,
+                 typeOrDuration: str|OffsetQLIn|DurationTuple|None = None,
                  *,
                  type: str|None = None,  # pylint: disable=redefined-builtin
                  dots: int|None = None,
@@ -3092,7 +3092,7 @@ class GraceDuration(Duration):
     # INITIALIZER #
 
     def __init__(self,
-                 typeOrDuration: t.Union[str, OffsetQLIn, DurationTuple, None] = None,
+                 typeOrDuration: str|OffsetQLIn|DurationTuple|None = None,
                  **keywords):
         super().__init__(typeOrDuration, **keywords)
         # update components to derive types; this sets ql, but this
@@ -3112,8 +3112,8 @@ class GraceDuration(Duration):
         self._slash = None
         self.slash = True  # can be True, False, or None; make None go to True?
         # values are unit interval percentages
-        self.stealTimePrevious: t.Union[float, None] = None
-        self.stealTimeFollowing: t.Union[float, None] = None
+        self.stealTimePrevious: float|None = None
+        self.stealTimeFollowing: float|None = None
 
 
     # PUBLIC PROPERTIES #
@@ -3159,7 +3159,7 @@ class AppoggiaturaDuration(GraceDuration):
     # INITIALIZER #
 
     def __init__(self,
-                 typeOrDuration: t.Union[str, OffsetQLIn, DurationTuple, None] = None,
+                 typeOrDuration: str|OffsetQLIn|DurationTuple|None = None,
                  **keywords):
         super().__init__(typeOrDuration, **keywords)
         self.slash = False  # can be True, False, or None; make None go to True?

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -437,7 +437,7 @@ class _EnvironmentCore:
             ]:
                 self[name] = value  # use for key checking
 
-    def _checkAccessibility(self, path: str|pathlib.Path|None) -> bool:
+    def _checkAccessibility(self, path: str | pathlib.Path | None) -> bool:
         '''
         Return True if the path exists, is readable and writable.
         '''
@@ -650,7 +650,7 @@ class _EnvironmentCore:
         # darwin specific option
         # os.path.join(os.environ['HOME'], 'Library',)
 
-    def getTempFile(self, suffix='', returnPathlib=True) -> str|pathlib.Path:
+    def getTempFile(self, suffix='', returnPathlib=True) -> str | pathlib.Path:
         '''
         Gets a temporary file with a suffix that will work for a bit.
 
@@ -1010,7 +1010,7 @@ class Environment:
     def getTempFile(self, suffix: str = '', returnPathlib: t.Literal[True] = True) -> pathlib.Path:
         return pathlib.Path('/')  # astroid #1015
 
-    def getTempFile(self, suffix: str = '', returnPathlib=True) -> str|pathlib.Path:
+    def getTempFile(self, suffix: str = '', returnPathlib=True) -> str | pathlib.Path:
         '''
         Return a file path to a temporary file with the specified suffix (file
         extension).

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -437,7 +437,7 @@ class _EnvironmentCore:
             ]:
                 self[name] = value  # use for key checking
 
-    def _checkAccessibility(self, path: t.Optional[t.Union[str, pathlib.Path]]) -> bool:
+    def _checkAccessibility(self, path: str|pathlib.Path|None) -> bool:
         '''
         Return True if the path exists, is readable and writable.
         '''
@@ -650,7 +650,7 @@ class _EnvironmentCore:
         # darwin specific option
         # os.path.join(os.environ['HOME'], 'Library',)
 
-    def getTempFile(self, suffix='', returnPathlib=True) -> t.Union[str, pathlib.Path]:
+    def getTempFile(self, suffix='', returnPathlib=True) -> str|pathlib.Path:
         '''
         Gets a temporary file with a suffix that will work for a bit.
 
@@ -1010,7 +1010,7 @@ class Environment:
     def getTempFile(self, suffix: str = '', returnPathlib: t.Literal[True] = True) -> pathlib.Path:
         return pathlib.Path('/')  # astroid #1015
 
-    def getTempFile(self, suffix: str = '', returnPathlib=True) -> t.Union[str, pathlib.Path]:
+    def getTempFile(self, suffix: str = '', returnPathlib=True) -> str|pathlib.Path:
         '''
         Return a file path to a temporary file with the specified suffix (file
         extension).

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -173,7 +173,7 @@ class RehearsalMark(Expression):
         return repr(self.content)
 
     @staticmethod
-    def _getNumberingFromContent(c) -> str|None:
+    def _getNumberingFromContent(c) -> str | None:
         '''
         if numbering was not set, get it from the content
 
@@ -368,7 +368,7 @@ class TextExpression(Expression):
             return ''
 
     @property
-    def enclosure(self) -> style.Enclosure|None:
+    def enclosure(self) -> style.Enclosure | None:
         '''
         Returns or sets the enclosure on the Style object
         stored on .style.
@@ -394,7 +394,7 @@ class TextExpression(Expression):
         return self.style.enclosure
 
     @enclosure.setter
-    def enclosure(self, value: style.Enclosure|None):
+    def enclosure(self, value: style.Enclosure | None):
         if not self.hasStyleInformation and value is None:
             return
         self.style.enclosure = value
@@ -466,7 +466,7 @@ class Ornament(Expression):
                 *,
                 inPlace: bool = False
                 ) -> tuple[list[note.Note],
-                           note.Note|None,
+                           note.Note | None,
                            list[note.Note]]:
         '''
         subclassable method call that takes a sourceObject
@@ -490,7 +490,7 @@ class Ornament(Expression):
         fillObjects: list[note.Note],
         transposeInterval: interval.IntervalBase,
         *,
-        useQL: OffsetQL|None = None
+        useQL: OffsetQL | None = None
     ) -> None:
         '''
         Used by trills and mordents to fill out their realization.
@@ -1534,7 +1534,7 @@ class ArpeggioMark(Expression):
     >>> am.type
     'down'
     '''
-    def __init__(self, arpeggioType: str|None = None):
+    def __init__(self, arpeggioType: str | None = None):
         super().__init__()
         if arpeggioType is None:
             arpeggioType = 'normal'
@@ -1581,8 +1581,8 @@ class ArpeggioMarkSpanner(spanner.Spanner):
             )
         self.type = arpeggioType
 
-    def noteExtremes(self) -> tuple[note.Note|None,
-                                    note.Note|None]:
+    def noteExtremes(self) -> tuple[note.Note | None,
+                                    note.Note | None]:
         '''
         Return the lowest and highest note spanned by the element,
         extracting them from Chords if need be.

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -173,7 +173,7 @@ class RehearsalMark(Expression):
         return repr(self.content)
 
     @staticmethod
-    def _getNumberingFromContent(c) -> t.Optional[str]:
+    def _getNumberingFromContent(c) -> str|None:
         '''
         if numbering was not set, get it from the content
 
@@ -368,7 +368,7 @@ class TextExpression(Expression):
             return ''
 
     @property
-    def enclosure(self) -> t.Optional[style.Enclosure]:
+    def enclosure(self) -> style.Enclosure|None:
         '''
         Returns or sets the enclosure on the Style object
         stored on .style.
@@ -394,7 +394,7 @@ class TextExpression(Expression):
         return self.style.enclosure
 
     @enclosure.setter
-    def enclosure(self, value: t.Optional[style.Enclosure]):
+    def enclosure(self, value: style.Enclosure|None):
         if not self.hasStyleInformation and value is None:
             return
         self.style.enclosure = value
@@ -466,7 +466,7 @@ class Ornament(Expression):
                 *,
                 inPlace: bool = False
                 ) -> tuple[list[note.Note],
-                           t.Optional[note.Note],
+                           note.Note|None,
                            list[note.Note]]:
         '''
         subclassable method call that takes a sourceObject
@@ -1581,8 +1581,8 @@ class ArpeggioMarkSpanner(spanner.Spanner):
             )
         self.type = arpeggioType
 
-    def noteExtremes(self) -> tuple[t.Optional[note.Note],
-                                    t.Optional[note.Note]]:
+    def noteExtremes(self) -> tuple[note.Note|None,
+                                    note.Note|None]:
         '''
         Return the lowest and highest note spanned by the element,
         extracting them from Chords if need be.

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import copy
 import string
-import typing as t
 from typing import TYPE_CHECKING  # pylint needs no alias
 
 from music21 import base

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -490,7 +490,7 @@ class Ornament(Expression):
         fillObjects: list[note.Note],
         transposeInterval: interval.IntervalBase,
         *,
-        useQL: t.Optional[OffsetQL] = None
+        useQL: OffsetQL|None = None
     ) -> None:
         '''
         Used by trills and mordents to fill out their realization.
@@ -1534,7 +1534,7 @@ class ArpeggioMark(Expression):
     >>> am.type
     'down'
     '''
-    def __init__(self, arpeggioType: t.Optional[str] = None):
+    def __init__(self, arpeggioType: str|None = None):
         super().__init__()
         if arpeggioType is None:
             arpeggioType = 'normal'

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -142,7 +142,7 @@ class FeatureExtractor:
     '''
     def __init__(self, dataOrStream=None, **keywords):
         self.stream = None  # the original Stream, or None
-        self.data: t.Optional[DataInstance] = None  # a DataInstance object: use to get data
+        self.data: DataInstance|None = None  # a DataInstance object: use to get data
         self.setData(dataOrStream)
 
         self.feature = None  # Feature object that results from processing

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -16,7 +16,6 @@ from collections.abc import KeysView
 import os
 import pathlib
 import pickle
-import typing as t
 import unittest
 
 from music21 import common

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -141,7 +141,7 @@ class FeatureExtractor:
     '''
     def __init__(self, dataOrStream=None, **keywords):
         self.stream = None  # the original Stream, or None
-        self.data: DataInstance|None = None  # a DataInstance object: use to get data
+        self.data: DataInstance | None = None  # a DataInstance object: use to get data
         self.setData(dataOrStream)
 
         self.feature = None  # Feature object that results from processing

--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -112,7 +112,7 @@ class QualityFeature(featuresModule.FeatureExtractor):
         Do processing necessary, storing result in feature.
         '''
         allKeys = self.data['flat.getElementsByClass(Key)']
-        keyFeature: t.Optional[int] = None
+        keyFeature: int|None = None
         if len(allKeys) == 1:
             k0 = allKeys[0]
             if k0.mode == 'major':

--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -111,7 +111,7 @@ class QualityFeature(featuresModule.FeatureExtractor):
         Do processing necessary, storing result in feature.
         '''
         allKeys = self.data['flat.getElementsByClass(Key)']
-        keyFeature: int|None = None
+        keyFeature: int | None = None
         if len(allKeys) == 1:
             k0 = allKeys[0]
             if k0.mode == 'major':

--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -13,7 +13,6 @@ Original music21 feature extractors.
 '''
 from __future__ import annotations
 
-import typing as t
 import unittest
 
 from music21 import environment

--- a/music21/figuredBass/resolution.py
+++ b/music21/figuredBass/resolution.py
@@ -747,7 +747,7 @@ def _resolvePitches(possibToResolve, howToResolve):
 
 def _unpackSeventhChord(
     seventhChord: chord.Chord
-) -> list[t.Optional[pitch.Pitch]]:
+) -> list[pitch.Pitch|None]:
     '''
     Takes in a Chord and returns a list of Pitches (or Nones) corresponding
     to the bass, root, fifth, seventh.

--- a/music21/figuredBass/resolution.py
+++ b/music21/figuredBass/resolution.py
@@ -747,7 +747,7 @@ def _resolvePitches(possibToResolve, howToResolve):
 
 def _unpackSeventhChord(
     seventhChord: chord.Chord
-) -> list[pitch.Pitch|None]:
+) -> list[pitch.Pitch | None]:
     '''
     Takes in a Chord and returns a list of Pitches (or Nones) corresponding
     to the bass, root, fifth, seventh.

--- a/music21/figuredBass/resolution.py
+++ b/music21/figuredBass/resolution.py
@@ -27,7 +27,6 @@ arguments, the methods only :meth:`~music21.pitch.Pitch.transpose` each
 from __future__ import annotations
 
 import unittest
-import typing as t
 
 from music21 import exceptions21
 from music21 import chord

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -67,12 +67,12 @@ class Segment:
     }
 
     def __init__(self,
-                 bassNote: t.Union[str, note.Note] = 'C3',
+                 bassNote: str|note.Note = 'C3',
                  notationString: str|None = None,
                  fbScale: realizerScale.FiguredBassScale|None = None,
                  fbRules: rules.Rules|None = None,
                  numParts=4,
-                 maxPitch: t.Union[str, pitch.Pitch] = 'B5',
+                 maxPitch: str|pitch.Pitch = 'B5',
                  listOfPitches=None):
         '''
         A Segment corresponds to a 1:1 realization of a bassNote and notationString
@@ -864,8 +864,8 @@ class OverlaidSegment(Segment):
 # HELPER METHODS
 # --------------
 def getPitches(pitchNames=('C', 'E', 'G'),
-               bassPitch: t.Union[str, pitch.Pitch] = 'C3',
-               maxPitch: t.Union[str, pitch.Pitch] = 'C8'):
+               bassPitch: str|pitch.Pitch = 'C3',
+               maxPitch: str|pitch.Pitch = 'C8'):
     '''
     Given a list of pitchNames, a bassPitch, and a maxPitch, returns a sorted list of
     pitches between the two limits (inclusive) which correspond to items in pitchNames.

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -14,8 +14,6 @@ import copy
 import itertools
 import unittest
 
-import typing as t
-
 from music21 import chord
 from music21 import environment
 from music21 import exceptions21
@@ -30,7 +28,7 @@ from music21.figuredBass import rules
 # used below
 _MOD = 'figuredBass.segment'
 
-_defaultRealizerScale: dict[str, realizerScale.FiguredBassScale|None] = {
+_defaultRealizerScale: dict[str, realizerScale.FiguredBassScale | None] = {
     'scale': None,  # singleton
 }
 
@@ -69,7 +67,7 @@ class Segment:
     def __init__(self,
                  bassNote: str | note.Note = 'C3',
                  notationString: str | None = None,
-                 fbScale: realizerScale.FiguredBassScale|None = None,
+                 fbScale: realizerScale.FiguredBassScale | None = None,
                  fbRules: rules.Rules | None = None,
                  numParts=4,
                  maxPitch: str | pitch.Pitch = 'B5',

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -67,12 +67,12 @@ class Segment:
     }
 
     def __init__(self,
-                 bassNote: str|note.Note = 'C3',
-                 notationString: str|None = None,
+                 bassNote: str | note.Note = 'C3',
+                 notationString: str | None = None,
                  fbScale: realizerScale.FiguredBassScale|None = None,
-                 fbRules: rules.Rules|None = None,
+                 fbRules: rules.Rules | None = None,
                  numParts=4,
-                 maxPitch: str|pitch.Pitch = 'B5',
+                 maxPitch: str | pitch.Pitch = 'B5',
                  listOfPitches=None):
         '''
         A Segment corresponds to a 1:1 realization of a bassNote and notationString
@@ -864,8 +864,8 @@ class OverlaidSegment(Segment):
 # HELPER METHODS
 # --------------
 def getPitches(pitchNames=('C', 'E', 'G'),
-               bassPitch: str|pitch.Pitch = 'C3',
-               maxPitch: str|pitch.Pitch = 'C8'):
+               bassPitch: str | pitch.Pitch = 'C3',
+               maxPitch: str | pitch.Pitch = 'C8'):
     '''
     Given a list of pitchNames, a bassPitch, and a maxPitch, returns a sorted list of
     pitches between the two limits (inclusive) which correspond to items in pitchNames.

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -30,7 +30,7 @@ from music21.figuredBass import rules
 # used below
 _MOD = 'figuredBass.segment'
 
-_defaultRealizerScale: dict[str, t.Optional[realizerScale.FiguredBassScale]] = {
+_defaultRealizerScale: dict[str, realizerScale.FiguredBassScale|None] = {
     'scale': None,  # singleton
 }
 

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -68,9 +68,9 @@ class Segment:
 
     def __init__(self,
                  bassNote: t.Union[str, note.Note] = 'C3',
-                 notationString: t.Optional[str] = None,
-                 fbScale: t.Optional[realizerScale.FiguredBassScale] = None,
-                 fbRules: t.Optional[rules.Rules] = None,
+                 notationString: str|None = None,
+                 fbScale: realizerScale.FiguredBassScale|None = None,
+                 fbRules: rules.Rules|None = None,
                  numParts=4,
                  maxPitch: t.Union[str, pitch.Pitch] = 'B5',
                  listOfPitches=None):

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -107,7 +107,7 @@ class StreamFreezeThawBase:
     def __init__(self):
         self.stream = None
 
-    def getPickleFp(self, directory: t.Union[str, pathlib.Path]) -> pathlib.Path:
+    def getPickleFp(self, directory: str|pathlib.Path) -> pathlib.Path:
         if not isinstance(directory, pathlib.Path):
             directory = pathlib.Path(directory)
 
@@ -115,7 +115,7 @@ class StreamFreezeThawBase:
         streamStr = str(time.time())
         return directory / ('m21-' + common.getMd5(streamStr) + '.p')
 
-    def getJsonFp(self, directory: t.Union[str, pathlib.Path]) -> pathlib.Path:
+    def getJsonFp(self, directory: str|pathlib.Path) -> pathlib.Path:
         return self.getPickleFp(directory).with_suffix('.p.json')
 
 

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -107,7 +107,7 @@ class StreamFreezeThawBase:
     def __init__(self):
         self.stream = None
 
-    def getPickleFp(self, directory: str|pathlib.Path) -> pathlib.Path:
+    def getPickleFp(self, directory: str | pathlib.Path) -> pathlib.Path:
         if not isinstance(directory, pathlib.Path):
             directory = pathlib.Path(directory)
 
@@ -115,7 +115,7 @@ class StreamFreezeThawBase:
         streamStr = str(time.time())
         return directory / ('m21-' + common.getMd5(streamStr) + '.p')
 
-    def getJsonFp(self, directory: str|pathlib.Path) -> pathlib.Path:
+    def getJsonFp(self, directory: str | pathlib.Path) -> pathlib.Path:
         return self.getPickleFp(directory).with_suffix('.p.json')
 
 

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -74,7 +74,6 @@ import os
 import pathlib
 import pickle
 import time
-import typing as t
 import unittest
 import weakref
 import zlib

--- a/music21/graph/__init__.py
+++ b/music21/graph/__init__.py
@@ -68,7 +68,7 @@ environLocal = environment.Environment('graph')
 
 def plotStream(
     streamObj: stream.Stream,
-    graphFormat: t.Optional[str] = None,
+    graphFormat: str|None = None,
     xValue=None,
     yValue=None,
     zValue=None,

--- a/music21/graph/__init__.py
+++ b/music21/graph/__init__.py
@@ -68,7 +68,7 @@ environLocal = environment.Environment('graph')
 
 def plotStream(
     streamObj: stream.Stream,
-    graphFormat: str|None = None,
+    graphFormat: str | None = None,
     xValue=None,
     yValue=None,
     zValue=None,

--- a/music21/graph/findPlot.py
+++ b/music21/graph/findPlot.py
@@ -182,7 +182,7 @@ def getPlotClassesFromFormat(graphFormat, checkPlotClasses=None):
     return filteredPlots
 
 
-def getAxisClassFromValue(axisValue: str) -> t.Optional[type[axis.Axis]]:
+def getAxisClassFromValue(axisValue: str) -> type[axis.Axis] | None:
     '''
     given an axis value return the single best axis for the value, or None
 
@@ -205,7 +205,8 @@ def getAxisClassFromValue(axisValue: str) -> t.Optional[type[axis.Axis]]:
     return None
 
 
-def axisMatchesValue(axisClass: t.Union[type[axis.Axis], axis.Axis], axisValue: str) -> bool:
+def axisMatchesValue(axisClass: type[axis.Axis] | axis.Axis,
+                     axisValue: str) -> bool:
     '''
     Returns Bool about whether axisValue.lower() is anywhere in axisClass.quantities
 

--- a/music21/graph/findPlot.py
+++ b/music21/graph/findPlot.py
@@ -236,7 +236,7 @@ def axisMatchesValue(axisClass: t.Union[type[axis.Axis], axis.Axis], axisValue: 
     return False
 
 
-def getPlotsToMake(graphFormat: t.Optional[str] = None,
+def getPlotsToMake(graphFormat: str|None = None,
                    xValue=None,
                    yValue=None,
                    zValue=None):

--- a/music21/graph/findPlot.py
+++ b/music21/graph/findPlot.py
@@ -237,7 +237,7 @@ def axisMatchesValue(axisClass: type[axis.Axis] | axis.Axis,
     return False
 
 
-def getPlotsToMake(graphFormat: str|None = None,
+def getPlotsToMake(graphFormat: str | None = None,
                    xValue=None,
                    yValue=None,
                    zValue=None):

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import math
 import random
-import typing as t
 import unittest
 
 from music21 import common

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -99,7 +99,7 @@ class Graph(prebase.ProtoM21Object):
     '''
     graphType = 'genericGraph'
     axisKeys: tuple[str, ...] = ('x', 'y')
-    figureSizeDefault: tuple[int|float, ...] = (6, 6)
+    figureSizeDefault: tuple[int | float, ...] = (6, 6)
 
     keywordConfigurables: tuple[str, ...] = (
         'alpha',

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -99,7 +99,7 @@ class Graph(prebase.ProtoM21Object):
     '''
     graphType = 'genericGraph'
     axisKeys: tuple[str, ...] = ('x', 'y')
-    figureSizeDefault: tuple[t.Union[int, float], ...] = (6, 6)
+    figureSizeDefault: tuple[int|float, ...] = (6, 6)
 
     keywordConfigurables: tuple[str, ...] = (
         'alpha',
@@ -1005,7 +1005,7 @@ class GraphHorizontalBar(Graph):
 
             if points:
                 uniformFormatPerRow = (len(points[0]) == 2)
-                rowFaceColors: t.Union[str, list[str]]
+                rowFaceColors: str | list[str]
                 if uniformFormatPerRow:
                     rowFaceColors = faceColor
                     positionPoints = points

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -209,8 +209,8 @@ class Harmony(chord.Chord):
 
     def __init__(self,
                  figure: str|None = None,
-                 root: t.Union[str, pitch.Pitch, None] = None,
-                 bass: t.Union[str, pitch.Pitch, None] = None,
+                 root: str|pitch.Pitch|None = None,
+                 bass: str|pitch.Pitch|None = None,
                  inversion: int|None = None,
                  updatePitches: bool = True,
                  **keywords
@@ -1577,8 +1577,8 @@ class ChordSymbol(Harmony):
 
     def __init__(self,
                  figure=None,
-                 root: t.Union[pitch.Pitch, str, None] = None,
-                 bass: t.Union[pitch.Pitch, str, None] = None,
+                 root: pitch.Pitch|str|None = None,
+                 bass: pitch.Pitch|str|None = None,
                  inversion: int|None = None,
                  kind='',
                  kindStr='',

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -208,10 +208,10 @@ class Harmony(chord.Chord):
     # INITIALIZER #
 
     def __init__(self,
-                 figure: t.Optional[str] = None,
+                 figure: str|None = None,
                  root: t.Union[str, pitch.Pitch, None] = None,
                  bass: t.Union[str, pitch.Pitch, None] = None,
-                 inversion: t.Optional[int] = None,
+                 inversion: int|None = None,
                  updatePitches: bool = True,
                  **keywords
                  ):
@@ -273,7 +273,7 @@ class Harmony(chord.Chord):
         '''
         return
 
-    def _updateFromParameters(self, root, bass, inversion: t.Optional[int] = None):
+    def _updateFromParameters(self, root, bass, inversion: int|None = None):
         '''
         This method must be called twice, once before the pitches
         are rendered, and once after. This is because after the pitches
@@ -1579,7 +1579,7 @@ class ChordSymbol(Harmony):
                  figure=None,
                  root: t.Union[pitch.Pitch, str, None] = None,
                  bass: t.Union[pitch.Pitch, str, None] = None,
-                 inversion: t.Optional[int] = None,
+                 inversion: int|None = None,
                  kind='',
                  kindStr='',
                  **keywords

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -2335,7 +2335,7 @@ class ChordSymbol(Harmony):
         else:
             return False
 
-    def transpose(self: T, value, *, inPlace=False) -> t.Optional[T]:
+    def transpose(self: T, value, *, inPlace=False) -> T|None:
         '''
         Overrides :meth:`~music21.chord.Chord.transpose` so that this ChordSymbol's
         `figure` is appropriately cleared afterward.
@@ -2441,7 +2441,7 @@ class NoChord(ChordSymbol):
         # do nothing, everything is already set.
         return
 
-    def transpose(self: NCT, _value, *, inPlace=False) -> t.Optional[NCT]:
+    def transpose(self: NCT, _value, *, inPlace=False) -> NCT|None:
         '''
         Overrides :meth:`~music21.chord.Chord.transpose` to do nothing.
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -208,10 +208,10 @@ class Harmony(chord.Chord):
     # INITIALIZER #
 
     def __init__(self,
-                 figure: str|None = None,
-                 root: str|pitch.Pitch|None = None,
-                 bass: str|pitch.Pitch|None = None,
-                 inversion: int|None = None,
+                 figure: str | None = None,
+                 root: str | pitch.Pitch | None = None,
+                 bass: str | pitch.Pitch | None = None,
+                 inversion: int | None = None,
                  updatePitches: bool = True,
                  **keywords
                  ):
@@ -273,7 +273,7 @@ class Harmony(chord.Chord):
         '''
         return
 
-    def _updateFromParameters(self, root, bass, inversion: int|None = None):
+    def _updateFromParameters(self, root, bass, inversion: int | None = None):
         '''
         This method must be called twice, once before the pitches
         are rendered, and once after. This is because after the pitches
@@ -1577,9 +1577,9 @@ class ChordSymbol(Harmony):
 
     def __init__(self,
                  figure=None,
-                 root: pitch.Pitch|str|None = None,
-                 bass: pitch.Pitch|str|None = None,
-                 inversion: int|None = None,
+                 root: pitch.Pitch | str | None = None,
+                 bass: pitch.Pitch | str | None = None,
+                 inversion: int | None = None,
                  kind='',
                  kindStr='',
                  **keywords
@@ -2335,7 +2335,7 @@ class ChordSymbol(Harmony):
         else:
             return False
 
-    def transpose(self: T, value, *, inPlace=False) -> T|None:
+    def transpose(self: T, value, *, inPlace=False) -> T | None:
         '''
         Overrides :meth:`~music21.chord.Chord.transpose` so that this ChordSymbol's
         `figure` is appropriately cleared afterward.
@@ -2441,7 +2441,7 @@ class NoChord(ChordSymbol):
         # do nothing, everything is already set.
         return
 
-    def transpose(self: NCT, _value, *, inPlace=False) -> NCT|None:
+    def transpose(self: NCT, _value, *, inPlace=False) -> NCT | None:
         '''
         Overrides :meth:`~music21.chord.Chord.transpose` to do nothing.
 

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1064,7 +1064,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
         self._spineCollection = None
         self._spineType = None
 
-        self.isFirstVoice: t.Union[bool, None] = None
+        self.isFirstVoice: bool|None = None
         self.iterIndex = None
 
     def _reprInternal(self):

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -48,7 +48,6 @@ from __future__ import annotations
 import copy
 import math
 import re
-import typing as t
 import unittest
 
 from music21 import articulations

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -2005,7 +2005,7 @@ class SpineCollection(prebase.ProtoM21Object):
                 if not hasVoices:
                     continue
 
-                voices: list[t.Optional[stream.Voice]] = [None for i in range(10)]
+                voices: list[stream.Voice|None] = [None for i in range(10)]
                 measureElements = el.elements
                 for mEl in measureElements:
                     mElGroups = mEl.groups

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1571,7 +1571,7 @@ class SpineEvent(prebase.ProtoM21Object):
         self.contents = contents
         self.position = position
         self.protoSpineId: int = 0
-        self.spineId: t.Optional[int] = None
+        self.spineId: int|None = None
 
     def _reprInternal(self):
         return str(self.contents)

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1064,7 +1064,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
         self._spineCollection = None
         self._spineType = None
 
-        self.isFirstVoice: bool|None = None
+        self.isFirstVoice: bool | None = None
         self.iterIndex = None
 
     def _reprInternal(self):
@@ -1571,7 +1571,7 @@ class SpineEvent(prebase.ProtoM21Object):
         self.contents = contents
         self.position = position
         self.protoSpineId: int = 0
-        self.spineId: int|None = None
+        self.spineId: int | None = None
 
     def _reprInternal(self):
         return str(self.contents)
@@ -2005,7 +2005,7 @@ class SpineCollection(prebase.ProtoM21Object):
                 if not hasVoices:
                     continue
 
-                voices: list[stream.Voice|None] = [None for i in range(10)]
+                voices: list[stream.Voice | None] = [None for i in range(10)]
                 measureElements = el.elements
                 for mEl in measureElements:
                     mElGroups = mEl.groups

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -163,20 +163,20 @@ class Instrument(base.Music21Object):
         self.printPartName = None  # True = yes, False = no, None = let others decide
         self.printPartAbbreviation = None
 
-        self.instrumentId: t.Optional[str] = None  # apply to midi and instrument
+        self.instrumentId: str|None = None  # apply to midi and instrument
         self._instrumentIdIsRandom = False
 
         self.instrumentName: str = instrumentName
-        self.instrumentAbbreviation: t.Optional[str] = None
-        self.midiProgram: t.Optional[int] = None  # 0-indexed
-        self.midiChannel: t.Optional[int] = None  # 0-indexed
-        self.instrumentSound: t.Optional[str] = None
+        self.instrumentAbbreviation: str|None = None
+        self.midiProgram: int|None = None  # 0-indexed
+        self.midiChannel: int|None = None  # 0-indexed
+        self.instrumentSound: str|None = None
 
         self.lowestNote = None
         self.highestNote = None
 
         # define interval to go from written to sounding
-        self.transposition: t.Optional[interval.Interval] = None
+        self.transposition: interval.Interval|None = None
 
         self.inGMPercMap = False
         self.soundfontFn = None  # if defined...

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -47,7 +47,7 @@ environLocal = environment.Environment('instrument')
 
 def unbundleInstruments(streamIn: stream.Stream,
                         *,
-                        inPlace=False) -> stream.Stream|None:
+                        inPlace=False) -> stream.Stream | None:
     # noinspection PyShadowingNames
     '''
     takes a :class:`~music21.stream.Stream` that has :class:`~music21.note.NotRest` objects
@@ -86,7 +86,7 @@ def unbundleInstruments(streamIn: stream.Stream,
 
 def bundleInstruments(streamIn: stream.Stream,
                       *,
-                      inPlace=False) -> stream.Stream|None:
+                      inPlace=False) -> stream.Stream | None:
     # noinspection PyShadowingNames
     '''
     >>> up1 = note.Unpitched()
@@ -163,20 +163,20 @@ class Instrument(base.Music21Object):
         self.printPartName = None  # True = yes, False = no, None = let others decide
         self.printPartAbbreviation = None
 
-        self.instrumentId: str|None = None  # apply to midi and instrument
+        self.instrumentId: str | None = None  # apply to midi and instrument
         self._instrumentIdIsRandom = False
 
         self.instrumentName: str = instrumentName
-        self.instrumentAbbreviation: str|None = None
-        self.midiProgram: int|None = None  # 0-indexed
-        self.midiChannel: int|None = None  # 0-indexed
-        self.instrumentSound: str|None = None
+        self.instrumentAbbreviation: str | None = None
+        self.midiProgram: int | None = None  # 0-indexed
+        self.midiChannel: int | None = None  # 0-indexed
+        self.instrumentSound: str | None = None
 
         self.lowestNote = None
         self.highestNote = None
 
         # define interval to go from written to sounding
-        self.transposition: interval.Interval|None = None
+        self.transposition: interval.Interval | None = None
 
         self.inGMPercMap = False
         self.soundfontFn = None  # if defined...

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -47,7 +47,7 @@ environLocal = environment.Environment('instrument')
 
 def unbundleInstruments(streamIn: stream.Stream,
                         *,
-                        inPlace=False) -> t.Optional[stream.Stream]:
+                        inPlace=False) -> stream.Stream|None:
     # noinspection PyShadowingNames
     '''
     takes a :class:`~music21.stream.Stream` that has :class:`~music21.note.NotRest` objects
@@ -86,7 +86,7 @@ def unbundleInstruments(streamIn: stream.Stream,
 
 def bundleInstruments(streamIn: stream.Stream,
                       *,
-                      inPlace=False) -> t.Optional[stream.Stream]:
+                      inPlace=False) -> stream.Stream|None:
     # noinspection PyShadowingNames
     '''
     >>> up1 = note.Unpitched()

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -314,7 +314,7 @@ class IntervalException(exceptions21.Music21Exception):
 # some utility functions
 
 def _extractPitch(
-    nOrP: note.Note|pitch.Pitch
+    nOrP: note.Note | pitch.Pitch
 ) -> pitch.Pitch:
     '''
     utility function to return either the object itself
@@ -413,7 +413,7 @@ def convertDiatonicNumberToStep(dn: int) -> tuple[StepName, int]:
         stepNumber = (dn - 1) - (octave * 7)
         return STEPNAMES[stepNumber], (octave - 1)
 
-def parseSpecifier(value: str|int|Specifier) -> Specifier:
+def parseSpecifier(value: str | int | Specifier) -> Specifier:
     '''
     Given an integer or a string representing a "specifier" (major, minor,
     perfect, diminished, etc.), return the Specifier.
@@ -486,7 +486,7 @@ def parseSpecifier(value: str|int|Specifier) -> Specifier:
 
     raise IntervalException(f'Cannot find a match for value: {value!r}')
 
-def convertGeneric(value: int|str) -> int:
+def convertGeneric(value: int | str) -> int:
     '''
     Convert an interval specified in terms of its name (second, third)
     into an integer. If integers are passed, assume the are correct.
@@ -551,7 +551,7 @@ def convertGeneric(value: int|str) -> int:
 
 
 def convertSemitoneToSpecifierGenericMicrotone(
-    count: int|float
+    count: int | float
 ) -> tuple[Specifier, int, float]:
     '''
     Given a number of semitones (positive or negative),
@@ -603,7 +603,7 @@ def convertSemitoneToSpecifierGenericMicrotone(
     return (spec, (generic + (octave * 7)) * dirScale, cents)
 
 
-def convertSemitoneToSpecifierGeneric(count: int|float) -> tuple[Specifier, int]:
+def convertSemitoneToSpecifierGeneric(count: int | float) -> tuple[Specifier, int]:
     '''
     Given a number of semitones, return a default diatonic specifier, and
     a number that can be used as a GenericInterval
@@ -886,7 +886,7 @@ class GenericInterval(IntervalBase):
     Changed in v.6 -- large intervals get abbreviations
     '''
     def __init__(self,
-                 value: int|str = 'Unison',
+                 value: int | str = 'Unison',
                  **keywords):
         super().__init__(**keywords)
         self._value: int = 1
@@ -1423,7 +1423,7 @@ class GenericInterval(IntervalBase):
     def transposePitchKeyAware(
         self,
         p: pitch.Pitch,
-        k: key.KeySignature|None = None,
+        k: key.KeySignature | None = None,
         *,
         inPlace: bool = False
     ):
@@ -1520,7 +1520,7 @@ class GenericInterval(IntervalBase):
         if inPlace is False:
             return newPitch
 
-    def getDiatonic(self, specifier: Specifier|str) -> DiatonicInterval:
+    def getDiatonic(self, specifier: Specifier | str) -> DiatonicInterval:
         '''
         Given a specifier, return a :class:`~music21.interval.DiatonicInterval` object.
 
@@ -1666,8 +1666,8 @@ class DiatonicInterval(IntervalBase):
     }
 
     def __init__(self,
-                 specifier: str|int = 'P',
-                 generic: int|GenericInterval|str = 1,
+                 specifier: str | int = 'P',
+                 generic: int | GenericInterval | str = 1,
                  **keywords):
         super().__init__(**keywords)
 
@@ -2219,13 +2219,13 @@ class ChromaticInterval(IntervalBase):
     True
     '''
 
-    def __init__(self, semitones: int|float = 0, **keywords):
+    def __init__(self, semitones: int | float = 0, **keywords):
         super().__init__(**keywords)
 
         if semitones == int(semitones):
             semitones = int(semitones)
 
-        self.semitones: int|float = semitones
+        self.semitones: int | float = semitones
 
     def _reprInternal(self) -> str:
         return str(self.directed)
@@ -2277,7 +2277,7 @@ class ChromaticInterval(IntervalBase):
         return round(self.semitones * 100.0, 5)
 
     @property
-    def directed(self) -> int|float:
+    def directed(self) -> int | float:
         '''
         A synonym for `.semitones`
 
@@ -2288,7 +2288,7 @@ class ChromaticInterval(IntervalBase):
         return self.semitones
 
     @property
-    def undirected(self) -> int|float:
+    def undirected(self) -> int | float:
         '''
         The absolute value of the number of semitones:
 
@@ -2319,7 +2319,7 @@ class ChromaticInterval(IntervalBase):
         return Direction.OBLIQUE
 
     @property
-    def mod12(self) -> int|float:
+    def mod12(self) -> int | float:
         '''
         The number of semitones within an octave using modulo arithmatic.
 
@@ -2337,7 +2337,7 @@ class ChromaticInterval(IntervalBase):
         return self.semitones % 12
 
     @property
-    def simpleUndirected(self) -> int|float:
+    def simpleUndirected(self) -> int | float:
         '''
         The number of semitones within an octave while ignoring direction.
 
@@ -2355,7 +2355,7 @@ class ChromaticInterval(IntervalBase):
         return self.undirected % 12
 
     @property
-    def simpleDirected(self) -> int|float:
+    def simpleDirected(self) -> int | float:
         '''
         The number of semitones within an octave while preserving direction.
 
@@ -2593,8 +2593,8 @@ def _stringToDiatonicChromatic(
 
 
 def notesToGeneric(
-    n1: pitch.Pitch|note.Note,
-    n2: pitch.Pitch|note.Note
+    n1: pitch.Pitch | note.Note,
+    n2: pitch.Pitch | note.Note
 ) -> GenericInterval:
     '''
     Given two :class:`~music21.note.Note` objects,
@@ -2621,8 +2621,8 @@ def notesToGeneric(
     return GenericInterval(genDist)
 
 def notesToChromatic(
-    n1: pitch.Pitch|note.Note,
-    n2: pitch.Pitch|note.Note
+    n1: pitch.Pitch | note.Note,
+    n2: pitch.Pitch | note.Note
 ) -> ChromaticInterval:
     '''
     Given two :class:`~music21.note.Note` objects,
@@ -2731,8 +2731,8 @@ def intervalsToDiatonic(
 
 
 def intervalFromGenericAndChromatic(
-    gInt: GenericInterval|int,
-    cInt: ChromaticInterval|int|float,
+    gInt: GenericInterval | int,
+    cInt: ChromaticInterval | int | float,
 ) -> Interval:
     '''
     Given a :class:`~music21.interval.GenericInterval` and a
@@ -2991,16 +2991,16 @@ class Interval(IntervalBase):
                                pitch.Pitch,
                                note.Note,
                                None] = None,
-                 arg1: pitch.Pitch|note.Note|None = None,
+                 arg1: pitch.Pitch | note.Note | None = None,
                  /,
                  *,
-                 diatonic: DiatonicInterval|None = None,
-                 chromatic: ChromaticInterval|None = None,
-                 pitchStart: pitch.Pitch|None = None,
-                 pitchEnd: pitch.Pitch|None = None,
-                 noteStart: note.Note|pitch.Pitch|None = None,
-                 noteEnd: note.Note|pitch.Pitch|None = None,
-                 name: str|None = None,
+                 diatonic: DiatonicInterval | None = None,
+                 chromatic: ChromaticInterval | None = None,
+                 pitchStart: pitch.Pitch | None = None,
+                 pitchEnd: pitch.Pitch | None = None,
+                 noteStart: note.Note | pitch.Pitch | None = None,
+                 noteEnd: note.Note | pitch.Pitch | None = None,
+                 name: str | None = None,
                  **keywords):
         super().__init__(**keywords)
 
@@ -3076,8 +3076,8 @@ class Interval(IntervalBase):
         self.chromatic: ChromaticInterval = chromatic
 
         # these can be accessed through pitchStart and pitchEnd properties
-        self._pitchStart: pitch.Pitch|None = pitchStart
-        self._pitchEnd: pitch.Pitch|None = pitchEnd
+        self._pitchStart: pitch.Pitch | None = pitchStart
+        self._pitchEnd: pitch.Pitch | None = pitchEnd
 
         self.intervalType: t.Literal['harmonic', 'melodic', ''] = ''
 
@@ -3200,15 +3200,15 @@ class Interval(IntervalBase):
         return self.diatonic.directedSimpleNiceName
 
     @property
-    def semitones(self) -> int|float:
+    def semitones(self) -> int | float:
         return self.chromatic.semitones
 
     @property
-    def direction(self) -> Direction|None:
+    def direction(self) -> Direction | None:
         return self.chromatic.direction
 
     @property
-    def specifier(self) -> Specifier|None:
+    def specifier(self) -> Specifier | None:
         return self.diatonic.specifier
 
     @property
@@ -3333,7 +3333,7 @@ class Interval(IntervalBase):
                        p: pitch.Pitch,
                        *,
                        reverse=False,
-                       maxAccidental: int|None = 4,
+                       maxAccidental: int | None = 4,
                        inPlace=False):
         '''
         Given a :class:`~music21.pitch.Pitch` object, return a new,
@@ -3637,7 +3637,7 @@ class Interval(IntervalBase):
         self._pitchStart = pitch1
 
     @property
-    def noteStart(self) -> music21.note.Note|None:
+    def noteStart(self) -> music21.note.Note | None:
         '''
         Return or set the Note that pitchStart is attached to.  For
         backwards compatibility
@@ -3650,14 +3650,14 @@ class Interval(IntervalBase):
             return note.Note(pitch=p)
 
     @noteStart.setter
-    def noteStart(self, n: music21.note.Note|None):
+    def noteStart(self, n: music21.note.Note | None):
         if n:
             self.pitchStart = n.pitch
         else:
             self.pitchStart = None
 
     @property
-    def noteEnd(self) -> music21.note.Note|None:
+    def noteEnd(self) -> music21.note.Note | None:
         '''
         Return or set the Note that pitchEnd is attached to.  For
         backwards compatibility
@@ -3670,7 +3670,7 @@ class Interval(IntervalBase):
             return note.Note(pitch=p)
 
     @noteEnd.setter
-    def noteEnd(self, n: music21.note.Note|None):
+    def noteEnd(self, n: music21.note.Note | None):
         if n:
             self.pitchEnd = n.pitch
         else:
@@ -3678,9 +3678,9 @@ class Interval(IntervalBase):
 
 
 # ------------------------------------------------------------------------------
-def getWrittenHigherNote(note1: note.Note|pitch.Pitch,
-                         note2: note.Note|pitch.Pitch
-                         ) -> note.Note|pitch.Pitch:
+def getWrittenHigherNote(note1: note.Note | pitch.Pitch,
+                         note2: note.Note | pitch.Pitch
+                         ) -> note.Note | pitch.Pitch:
     '''
     Given two :class:`~music21.pitch.Pitch` or :class:`~music21.note.Note` objects,
     this function returns the higher element based on diatonic note
@@ -3716,9 +3716,9 @@ def getWrittenHigherNote(note1: note.Note|pitch.Pitch,
         return getAbsoluteHigherNote(note1, note2)
 
 
-def getAbsoluteHigherNote(note1: note.Note|pitch.Pitch,
-                          note2: note.Note|pitch.Pitch
-                          ) -> note.Note|pitch.Pitch:
+def getAbsoluteHigherNote(note1: note.Note | pitch.Pitch,
+                          note2: note.Note | pitch.Pitch
+                          ) -> note.Note | pitch.Pitch:
     '''
     Given two :class:`~music21.pitch.Pitch` or :class:`~music21.note.Note` objects,
     returns the higher element based on sounding pitch.
@@ -3739,9 +3739,9 @@ def getAbsoluteHigherNote(note1: note.Note|pitch.Pitch,
         return note1
 
 
-def getWrittenLowerNote(note1: note.Note|pitch.Pitch,
-                        note2: note.Note|pitch.Pitch
-                        ) -> note.Note|pitch.Pitch:
+def getWrittenLowerNote(note1: note.Note | pitch.Pitch,
+                        note2: note.Note | pitch.Pitch
+                        ) -> note.Note | pitch.Pitch:
     '''
     Given two :class:`~music21.pitch.Pitch` or :class:`~music21.note.Note` objects,
     returns the lower element based on diatonic note
@@ -3771,9 +3771,9 @@ def getWrittenLowerNote(note1: note.Note|pitch.Pitch,
         return getAbsoluteLowerNote(note1, note2)
 
 
-def getAbsoluteLowerNote(note1: note.Note|pitch.Pitch,
-                         note2: note.Note|pitch.Pitch
-                         ) -> note.Note|pitch.Pitch:
+def getAbsoluteLowerNote(note1: note.Note | pitch.Pitch,
+                         note2: note.Note | pitch.Pitch
+                         ) -> note.Note | pitch.Pitch:
     '''
     Given two :class:`~music21.note.Note` or :class:`~music21.pitch.Pitch` objects, returns
     the lower element based on actual pitch.
@@ -3796,7 +3796,7 @@ def getAbsoluteLowerNote(note1: note.Note|pitch.Pitch,
 
 def transposePitch(
     pitch1: pitch.Pitch,
-    interval1: str|Interval,
+    interval1: str | Interval,
     *,
     inPlace=False
 ) -> pitch.Pitch:
@@ -3849,7 +3849,7 @@ def transposePitch(
 
 def transposeNote(
         note1: note.Note,
-        intervalString: str|Interval) -> note.Note:
+        intervalString: str | Interval) -> note.Note:
     '''
     To be deprecated: call `n.transpose(intervalString)` directly.
 

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -1423,7 +1423,7 @@ class GenericInterval(IntervalBase):
     def transposePitchKeyAware(
         self,
         p: pitch.Pitch,
-        k: t.Optional[key.KeySignature] = None,
+        k: key.KeySignature|None = None,
         *,
         inPlace: bool = False
     ):
@@ -2994,13 +2994,13 @@ class Interval(IntervalBase):
                  arg1: t.Union[pitch.Pitch, note.Note, None] = None,
                  /,
                  *,
-                 diatonic: t.Optional[DiatonicInterval] = None,
-                 chromatic: t.Optional[ChromaticInterval] = None,
-                 pitchStart: t.Optional[pitch.Pitch] = None,
-                 pitchEnd: t.Optional[pitch.Pitch] = None,
+                 diatonic: DiatonicInterval|None = None,
+                 chromatic: ChromaticInterval|None = None,
+                 pitchStart: pitch.Pitch|None = None,
+                 pitchEnd: pitch.Pitch|None = None,
                  noteStart: t.Union[note.Note, pitch.Pitch, None] = None,
                  noteEnd: t.Union[note.Note, pitch.Pitch, None] = None,
-                 name: t.Optional[str] = None,
+                 name: str|None = None,
                  **keywords):
         super().__init__(**keywords)
 
@@ -3076,8 +3076,8 @@ class Interval(IntervalBase):
         self.chromatic: ChromaticInterval = chromatic
 
         # these can be accessed through pitchStart and pitchEnd properties
-        self._pitchStart: t.Optional[pitch.Pitch] = pitchStart
-        self._pitchEnd: t.Optional[pitch.Pitch] = pitchEnd
+        self._pitchStart: pitch.Pitch|None = pitchStart
+        self._pitchEnd: pitch.Pitch|None = pitchEnd
 
         self.intervalType: t.Literal['harmonic', 'melodic', ''] = ''
 
@@ -3333,7 +3333,7 @@ class Interval(IntervalBase):
                        p: pitch.Pitch,
                        *,
                        reverse=False,
-                       maxAccidental: t.Optional[int] = 4,
+                       maxAccidental: int|None = 4,
                        inPlace=False):
         '''
         Given a :class:`~music21.pitch.Pitch` object, return a new,

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -886,7 +886,7 @@ class GenericInterval(IntervalBase):
     Changed in v.6 -- large intervals get abbreviations
     '''
     def __init__(self,
-                 value: t.Union[int, str] = 'Unison',
+                 value: int|str = 'Unison',
                  **keywords):
         super().__init__(**keywords)
         self._value: int = 1
@@ -1666,8 +1666,8 @@ class DiatonicInterval(IntervalBase):
     }
 
     def __init__(self,
-                 specifier: t.Union[str, int] = 'P',
-                 generic: t.Union[int, GenericInterval, str] = 1,
+                 specifier: str|int = 'P',
+                 generic: int|GenericInterval|str = 1,
                  **keywords):
         super().__init__(**keywords)
 
@@ -2219,13 +2219,13 @@ class ChromaticInterval(IntervalBase):
     True
     '''
 
-    def __init__(self, semitones: t.Union[int, float] = 0, **keywords):
+    def __init__(self, semitones: int|float = 0, **keywords):
         super().__init__(**keywords)
 
         if semitones == int(semitones):
             semitones = int(semitones)
 
-        self.semitones: t.Union[int, float] = semitones
+        self.semitones: int|float = semitones
 
     def _reprInternal(self) -> str:
         return str(self.directed)
@@ -2991,15 +2991,15 @@ class Interval(IntervalBase):
                                pitch.Pitch,
                                note.Note,
                                None] = None,
-                 arg1: t.Union[pitch.Pitch, note.Note, None] = None,
+                 arg1: pitch.Pitch|note.Note|None = None,
                  /,
                  *,
                  diatonic: DiatonicInterval|None = None,
                  chromatic: ChromaticInterval|None = None,
                  pitchStart: pitch.Pitch|None = None,
                  pitchEnd: pitch.Pitch|None = None,
-                 noteStart: t.Union[note.Note, pitch.Pitch, None] = None,
-                 noteEnd: t.Union[note.Note, pitch.Pitch, None] = None,
+                 noteStart: note.Note|pitch.Pitch|None = None,
+                 noteEnd: note.Note|pitch.Pitch|None = None,
                  name: str|None = None,
                  **keywords):
         super().__init__(**keywords)

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -314,7 +314,7 @@ class IntervalException(exceptions21.Music21Exception):
 # some utility functions
 
 def _extractPitch(
-    nOrP: t.Union[note.Note, pitch.Pitch]
+    nOrP: note.Note|pitch.Pitch
 ) -> pitch.Pitch:
     '''
     utility function to return either the object itself
@@ -413,7 +413,7 @@ def convertDiatonicNumberToStep(dn: int) -> tuple[StepName, int]:
         stepNumber = (dn - 1) - (octave * 7)
         return STEPNAMES[stepNumber], (octave - 1)
 
-def parseSpecifier(value: t.Union[str, int, Specifier]) -> Specifier:
+def parseSpecifier(value: str|int|Specifier) -> Specifier:
     '''
     Given an integer or a string representing a "specifier" (major, minor,
     perfect, diminished, etc.), return the Specifier.
@@ -486,7 +486,7 @@ def parseSpecifier(value: t.Union[str, int, Specifier]) -> Specifier:
 
     raise IntervalException(f'Cannot find a match for value: {value!r}')
 
-def convertGeneric(value: t.Union[int, str]) -> int:
+def convertGeneric(value: int|str) -> int:
     '''
     Convert an interval specified in terms of its name (second, third)
     into an integer. If integers are passed, assume the are correct.
@@ -551,7 +551,7 @@ def convertGeneric(value: t.Union[int, str]) -> int:
 
 
 def convertSemitoneToSpecifierGenericMicrotone(
-    count: t.Union[int, float]
+    count: int|float
 ) -> tuple[Specifier, int, float]:
     '''
     Given a number of semitones (positive or negative),
@@ -603,7 +603,7 @@ def convertSemitoneToSpecifierGenericMicrotone(
     return (spec, (generic + (octave * 7)) * dirScale, cents)
 
 
-def convertSemitoneToSpecifierGeneric(count: t.Union[int, float]) -> tuple[Specifier, int]:
+def convertSemitoneToSpecifierGeneric(count: int|float) -> tuple[Specifier, int]:
     '''
     Given a number of semitones, return a default diatonic specifier, and
     a number that can be used as a GenericInterval
@@ -1520,7 +1520,7 @@ class GenericInterval(IntervalBase):
         if inPlace is False:
             return newPitch
 
-    def getDiatonic(self, specifier: t.Union[Specifier, str]) -> DiatonicInterval:
+    def getDiatonic(self, specifier: Specifier|str) -> DiatonicInterval:
         '''
         Given a specifier, return a :class:`~music21.interval.DiatonicInterval` object.
 
@@ -2277,7 +2277,7 @@ class ChromaticInterval(IntervalBase):
         return round(self.semitones * 100.0, 5)
 
     @property
-    def directed(self) -> t.Union[int, float]:
+    def directed(self) -> int|float:
         '''
         A synonym for `.semitones`
 
@@ -2288,7 +2288,7 @@ class ChromaticInterval(IntervalBase):
         return self.semitones
 
     @property
-    def undirected(self) -> t.Union[int, float]:
+    def undirected(self) -> int|float:
         '''
         The absolute value of the number of semitones:
 
@@ -2319,7 +2319,7 @@ class ChromaticInterval(IntervalBase):
         return Direction.OBLIQUE
 
     @property
-    def mod12(self) -> t.Union[int, float]:
+    def mod12(self) -> int|float:
         '''
         The number of semitones within an octave using modulo arithmatic.
 
@@ -2337,7 +2337,7 @@ class ChromaticInterval(IntervalBase):
         return self.semitones % 12
 
     @property
-    def simpleUndirected(self) -> t.Union[int, float]:
+    def simpleUndirected(self) -> int|float:
         '''
         The number of semitones within an octave while ignoring direction.
 
@@ -2355,7 +2355,7 @@ class ChromaticInterval(IntervalBase):
         return self.undirected % 12
 
     @property
-    def simpleDirected(self) -> t.Union[int, float]:
+    def simpleDirected(self) -> int|float:
         '''
         The number of semitones within an octave while preserving direction.
 
@@ -2593,8 +2593,8 @@ def _stringToDiatonicChromatic(
 
 
 def notesToGeneric(
-    n1: t.Union[pitch.Pitch, note.Note],
-    n2: t.Union[pitch.Pitch, note.Note]
+    n1: pitch.Pitch|note.Note,
+    n2: pitch.Pitch|note.Note
 ) -> GenericInterval:
     '''
     Given two :class:`~music21.note.Note` objects,
@@ -2621,8 +2621,8 @@ def notesToGeneric(
     return GenericInterval(genDist)
 
 def notesToChromatic(
-    n1: t.Union[pitch.Pitch, note.Note],
-    n2: t.Union[pitch.Pitch, note.Note]
+    n1: pitch.Pitch|note.Note,
+    n2: pitch.Pitch|note.Note
 ) -> ChromaticInterval:
     '''
     Given two :class:`~music21.note.Note` objects,
@@ -2731,8 +2731,8 @@ def intervalsToDiatonic(
 
 
 def intervalFromGenericAndChromatic(
-    gInt: t.Union[GenericInterval, int],
-    cInt: t.Union[ChromaticInterval, int, float],
+    gInt: GenericInterval|int,
+    cInt: ChromaticInterval|int|float,
 ) -> Interval:
     '''
     Given a :class:`~music21.interval.GenericInterval` and a
@@ -3200,15 +3200,15 @@ class Interval(IntervalBase):
         return self.diatonic.directedSimpleNiceName
 
     @property
-    def semitones(self) -> t.Union[int, float]:
+    def semitones(self) -> int|float:
         return self.chromatic.semitones
 
     @property
-    def direction(self) -> t.Optional[Direction]:
+    def direction(self) -> Direction|None:
         return self.chromatic.direction
 
     @property
-    def specifier(self) -> t.Optional[Specifier]:
+    def specifier(self) -> Specifier|None:
         return self.diatonic.specifier
 
     @property
@@ -3637,7 +3637,7 @@ class Interval(IntervalBase):
         self._pitchStart = pitch1
 
     @property
-    def noteStart(self) -> t.Optional[music21.note.Note]:
+    def noteStart(self) -> music21.note.Note|None:
         '''
         Return or set the Note that pitchStart is attached to.  For
         backwards compatibility
@@ -3650,14 +3650,14 @@ class Interval(IntervalBase):
             return note.Note(pitch=p)
 
     @noteStart.setter
-    def noteStart(self, n: t.Optional[music21.note.Note]):
+    def noteStart(self, n: music21.note.Note|None):
         if n:
             self.pitchStart = n.pitch
         else:
             self.pitchStart = None
 
     @property
-    def noteEnd(self) -> t.Optional[music21.note.Note]:
+    def noteEnd(self) -> music21.note.Note|None:
         '''
         Return or set the Note that pitchEnd is attached to.  For
         backwards compatibility
@@ -3670,7 +3670,7 @@ class Interval(IntervalBase):
             return note.Note(pitch=p)
 
     @noteEnd.setter
-    def noteEnd(self, n: t.Optional[music21.note.Note]):
+    def noteEnd(self, n: music21.note.Note|None):
         if n:
             self.pitchEnd = n.pitch
         else:
@@ -3678,9 +3678,9 @@ class Interval(IntervalBase):
 
 
 # ------------------------------------------------------------------------------
-def getWrittenHigherNote(note1: t.Union[note.Note, pitch.Pitch],
-                         note2: t.Union[note.Note, pitch.Pitch]
-                         ) -> t.Union[note.Note, pitch.Pitch]:
+def getWrittenHigherNote(note1: note.Note|pitch.Pitch,
+                         note2: note.Note|pitch.Pitch
+                         ) -> note.Note|pitch.Pitch:
     '''
     Given two :class:`~music21.pitch.Pitch` or :class:`~music21.note.Note` objects,
     this function returns the higher element based on diatonic note
@@ -3716,9 +3716,9 @@ def getWrittenHigherNote(note1: t.Union[note.Note, pitch.Pitch],
         return getAbsoluteHigherNote(note1, note2)
 
 
-def getAbsoluteHigherNote(note1: t.Union[note.Note, pitch.Pitch],
-                          note2: t.Union[note.Note, pitch.Pitch]
-                          ) -> t.Union[note.Note, pitch.Pitch]:
+def getAbsoluteHigherNote(note1: note.Note|pitch.Pitch,
+                          note2: note.Note|pitch.Pitch
+                          ) -> note.Note|pitch.Pitch:
     '''
     Given two :class:`~music21.pitch.Pitch` or :class:`~music21.note.Note` objects,
     returns the higher element based on sounding pitch.
@@ -3739,9 +3739,9 @@ def getAbsoluteHigherNote(note1: t.Union[note.Note, pitch.Pitch],
         return note1
 
 
-def getWrittenLowerNote(note1: t.Union[note.Note, pitch.Pitch],
-                        note2: t.Union[note.Note, pitch.Pitch]
-                        ) -> t.Union[note.Note, pitch.Pitch]:
+def getWrittenLowerNote(note1: note.Note|pitch.Pitch,
+                        note2: note.Note|pitch.Pitch
+                        ) -> note.Note|pitch.Pitch:
     '''
     Given two :class:`~music21.pitch.Pitch` or :class:`~music21.note.Note` objects,
     returns the lower element based on diatonic note
@@ -3771,9 +3771,9 @@ def getWrittenLowerNote(note1: t.Union[note.Note, pitch.Pitch],
         return getAbsoluteLowerNote(note1, note2)
 
 
-def getAbsoluteLowerNote(note1: t.Union[note.Note, pitch.Pitch],
-                         note2: t.Union[note.Note, pitch.Pitch]
-                         ) -> t.Union[note.Note, pitch.Pitch]:
+def getAbsoluteLowerNote(note1: note.Note|pitch.Pitch,
+                         note2: note.Note|pitch.Pitch
+                         ) -> note.Note|pitch.Pitch:
     '''
     Given two :class:`~music21.note.Note` or :class:`~music21.pitch.Pitch` objects, returns
     the lower element based on actual pitch.
@@ -3796,7 +3796,7 @@ def getAbsoluteLowerNote(note1: t.Union[note.Note, pitch.Pitch],
 
 def transposePitch(
     pitch1: pitch.Pitch,
-    interval1: t.Union[str, Interval],
+    interval1: str|Interval,
     *,
     inPlace=False
 ) -> pitch.Pitch:
@@ -3849,7 +3849,7 @@ def transposePitch(
 
 def transposeNote(
         note1: note.Note,
-        intervalString: t.Union[str, Interval]) -> note.Note:
+        intervalString: str|Interval) -> note.Note:
     '''
     To be deprecated: call `n.transpose(intervalString)` directly.
 

--- a/music21/key.py
+++ b/music21/key.py
@@ -342,7 +342,7 @@ class KeySignature(base.Music21Object):
 
     classSortOrder = 2
 
-    def __init__(self, sharps: t.Optional[int] = 0):
+    def __init__(self, sharps: int|None = 0):
         super().__init__()
         # position on the circle of fifths, where 1 is one sharp, -1 is one flat
 
@@ -401,7 +401,7 @@ class KeySignature(base.Music21Object):
     def _reprInternal(self):
         return 'of ' + self._strDescription()
 
-    def asKey(self, mode: t.Optional[str] = None, tonic: t.Optional[str] = None):
+    def asKey(self, mode: str|None = None, tonic: str|None = None):
         '''
         Return a `key.Key` object representing this KeySignature object as a key in the
         given mode or in the given tonic. If `mode` is None, and `tonic` is not provided,
@@ -938,7 +938,7 @@ class Key(KeySignature, scale.DiatonicScale):
     <music21.key.Key of f# minor>
     '''
     _sharps = 0
-    _mode: t.Optional[str] = None
+    _mode: str|None = None
     tonic: pitch.Pitch
 
     def __init__(self,

--- a/music21/key.py
+++ b/music21/key.py
@@ -41,7 +41,7 @@ environLocal = environment.Environment('key')
 
 KeySignatureType = t.TypeVar('KeySignatureType', bound='KeySignature')
 KeyType = t.TypeVar('KeyType', bound='Key')
-TransposeTypes = int|str|interval.Interval|interval.GenericInterval
+TransposeTypes = int | str | interval.Interval | interval.GenericInterval
 
 
 # ------------------------------------------------------------------------------
@@ -167,7 +167,7 @@ modeSharpsAlter = {'major': 0,
                    }
 
 
-def pitchToSharps(value: str|pitch.Pitch|note.Note,
+def pitchToSharps(value: str | pitch.Pitch | note.Note,
                   mode: str = None) -> int:
     '''
     Given a pitch string or :class:`music21.pitch.Pitch` or
@@ -342,7 +342,7 @@ class KeySignature(base.Music21Object):
 
     classSortOrder = 2
 
-    def __init__(self, sharps: int|None = 0):
+    def __init__(self, sharps: int | None = 0):
         super().__init__()
         # position on the circle of fifths, where 1 is one sharp, -1 is one flat
 
@@ -360,7 +360,7 @@ class KeySignature(base.Music21Object):
         self._sharps = sharps
         # need to store a list of pitch objects, used for creating a
         # non-traditional key
-        self._alteredPitches: list[pitch.Pitch]|None = None
+        self._alteredPitches: list[pitch.Pitch] | None = None
         self.accidentalsApplyOnlyToOctave = False
 
     def __hash__(self):
@@ -401,7 +401,7 @@ class KeySignature(base.Music21Object):
     def _reprInternal(self):
         return 'of ' + self._strDescription()
 
-    def asKey(self, mode: str|None = None, tonic: str|None = None):
+    def asKey(self, mode: str | None = None, tonic: str | None = None):
         '''
         Return a `key.Key` object representing this KeySignature object as a key in the
         given mode or in the given tonic. If `mode` is None, and `tonic` is not provided,
@@ -542,7 +542,7 @@ class KeySignature(base.Music21Object):
         return post
 
     @alteredPitches.setter
-    def alteredPitches(self, newAlteredPitches: list[str|pitch.Pitch|note.Note]
+    def alteredPitches(self, newAlteredPitches: list[str | pitch.Pitch | note.Note]
                        ) -> None:
         self.clearCache()
         newList: list[pitch.Pitch] = []
@@ -580,7 +580,7 @@ class KeySignature(base.Music21Object):
         else:
             return False
 
-    def accidentalByStep(self, step: StepName) -> pitch.Accidental|None:
+    def accidentalByStep(self, step: StepName) -> pitch.Accidental | None:
         '''
         Given a step (C, D, E, F, etc.) return the accidental
         for that note in this key (using the natural minor for minor)
@@ -679,7 +679,7 @@ class KeySignature(base.Music21Object):
     def transpose(self: KeySignatureType,
                   value: TransposeTypes,
                   *,
-                  inPlace: bool = False) -> KeySignatureType|None:
+                  inPlace: bool = False) -> KeySignatureType | None:
         '''
         Transpose the KeySignature by the user-provided value.
         If the value is an integer, the transposition is treated
@@ -726,7 +726,7 @@ class KeySignature(base.Music21Object):
         >>> eFlat
         <music21.key.KeySignature of 3 flats>
         '''
-        intervalObj: interval.Interval|interval.GenericInterval
+        intervalObj: interval.Interval | interval.GenericInterval
         if isinstance(value, interval.Interval):  # it is an Interval class
             intervalObj = value
         elif isinstance(value, interval.GenericInterval):
@@ -754,7 +754,7 @@ class KeySignature(base.Music21Object):
         else:
             return None
 
-    def transposePitchFromC(self, p: pitch.Pitch, *, inPlace=False) -> pitch.Pitch|None:
+    def transposePitchFromC(self, p: pitch.Pitch, *, inPlace=False) -> pitch.Pitch | None:
         '''
         Takes a pitch in C major and transposes it so that it has
         the same step position in the current key signature.
@@ -850,10 +850,10 @@ class KeySignature(base.Music21Object):
     # --------------------------------------------------------------------------
     # properties
 
-    def _getSharps(self) -> int|None:
+    def _getSharps(self) -> int | None:
         return self._sharps
 
-    def _setSharps(self, value: int|None):
+    def _setSharps(self, value: int | None):
         if value != self._sharps:
             self._sharps = value
             self.clearCache()
@@ -938,11 +938,11 @@ class Key(KeySignature, scale.DiatonicScale):
     <music21.key.Key of f# minor>
     '''
     _sharps = 0
-    _mode: str|None = None
+    _mode: str | None = None
     tonic: pitch.Pitch
 
     def __init__(self,
-                 tonic: str|pitch.Pitch|note.Note = 'C',
+                 tonic: str | pitch.Pitch | note.Note = 'C',
                  mode=None):
         if isinstance(tonic, (note.Note, pitch.Pitch)):
             tonicStr = tonic.name
@@ -1247,7 +1247,7 @@ class Key(KeySignature, scale.DiatonicScale):
                   value: TransposeTypes,
                   *,
                   inPlace: bool = False
-                  ) -> KeyType|None:
+                  ) -> KeyType | None:
         '''
         Transpose the Key by the user-provided value.
         If the value is an integer, the transposition is treated

--- a/music21/key.py
+++ b/music21/key.py
@@ -41,7 +41,7 @@ environLocal = environment.Environment('key')
 
 KeySignatureType = t.TypeVar('KeySignatureType', bound='KeySignature')
 KeyType = t.TypeVar('KeyType', bound='Key')
-TransposeTypes = t.Union[int, str, interval.Interval, interval.GenericInterval]
+TransposeTypes = int|str|interval.Interval|interval.GenericInterval
 
 
 # ------------------------------------------------------------------------------
@@ -167,7 +167,7 @@ modeSharpsAlter = {'major': 0,
                    }
 
 
-def pitchToSharps(value: t.Union[str, pitch.Pitch, note.Note],
+def pitchToSharps(value: str|pitch.Pitch|note.Note,
                   mode: str = None) -> int:
     '''
     Given a pitch string or :class:`music21.pitch.Pitch` or
@@ -360,7 +360,7 @@ class KeySignature(base.Music21Object):
         self._sharps = sharps
         # need to store a list of pitch objects, used for creating a
         # non-traditional key
-        self._alteredPitches: t.Optional[list[pitch.Pitch]] = None
+        self._alteredPitches: list[pitch.Pitch]|None = None
         self.accidentalsApplyOnlyToOctave = False
 
     def __hash__(self):
@@ -542,7 +542,7 @@ class KeySignature(base.Music21Object):
         return post
 
     @alteredPitches.setter
-    def alteredPitches(self, newAlteredPitches: list[t.Union[str, pitch.Pitch, note.Note]]
+    def alteredPitches(self, newAlteredPitches: list[str|pitch.Pitch|note.Note]
                        ) -> None:
         self.clearCache()
         newList: list[pitch.Pitch] = []
@@ -580,7 +580,7 @@ class KeySignature(base.Music21Object):
         else:
             return False
 
-    def accidentalByStep(self, step: StepName) -> t.Optional[pitch.Accidental]:
+    def accidentalByStep(self, step: StepName) -> pitch.Accidental|None:
         '''
         Given a step (C, D, E, F, etc.) return the accidental
         for that note in this key (using the natural minor for minor)
@@ -679,7 +679,7 @@ class KeySignature(base.Music21Object):
     def transpose(self: KeySignatureType,
                   value: TransposeTypes,
                   *,
-                  inPlace: bool = False) -> t.Optional[KeySignatureType]:
+                  inPlace: bool = False) -> KeySignatureType|None:
         '''
         Transpose the KeySignature by the user-provided value.
         If the value is an integer, the transposition is treated
@@ -726,7 +726,7 @@ class KeySignature(base.Music21Object):
         >>> eFlat
         <music21.key.KeySignature of 3 flats>
         '''
-        intervalObj: t.Union[interval.Interval, interval.GenericInterval]
+        intervalObj: interval.Interval|interval.GenericInterval
         if isinstance(value, interval.Interval):  # it is an Interval class
             intervalObj = value
         elif isinstance(value, interval.GenericInterval):
@@ -754,7 +754,7 @@ class KeySignature(base.Music21Object):
         else:
             return None
 
-    def transposePitchFromC(self, p: pitch.Pitch, *, inPlace=False) -> t.Optional[pitch.Pitch]:
+    def transposePitchFromC(self, p: pitch.Pitch, *, inPlace=False) -> pitch.Pitch|None:
         '''
         Takes a pitch in C major and transposes it so that it has
         the same step position in the current key signature.
@@ -850,10 +850,10 @@ class KeySignature(base.Music21Object):
     # --------------------------------------------------------------------------
     # properties
 
-    def _getSharps(self) -> t.Optional[int]:
+    def _getSharps(self) -> int|None:
         return self._sharps
 
-    def _setSharps(self, value: t.Optional[int]):
+    def _setSharps(self, value: int|None):
         if value != self._sharps:
             self._sharps = value
             self.clearCache()
@@ -1247,7 +1247,7 @@ class Key(KeySignature, scale.DiatonicScale):
                   value: TransposeTypes,
                   *,
                   inPlace: bool = False
-                  ) -> t.Optional[KeyType]:
+                  ) -> KeyType|None:
         '''
         Transpose the Key by the user-provided value.
         If the value is an integer, the transposition is treated

--- a/music21/key.py
+++ b/music21/key.py
@@ -942,7 +942,7 @@ class Key(KeySignature, scale.DiatonicScale):
     tonic: pitch.Pitch
 
     def __init__(self,
-                 tonic: t.Union[str, pitch.Pitch, note.Note] = 'C',
+                 tonic: str|pitch.Pitch|note.Note = 'C',
                  mode=None):
         if isinstance(tonic, (note.Note, pitch.Pitch)):
             tonicStr = tonic.name

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -156,18 +156,18 @@ class ScoreLayout(LayoutBase):
                  *,
                  scalingMillimeters: t.Union[int, float, None] = None,
                  scalingTenths: t.Union[int, float, None] = None,
-                 musicFont: t.Optional[str] = None,
-                 wordFont: t.Optional[str] = None,
-                 pageLayout: t.Optional[PageLayout] = None,
-                 systemLayout: t.Optional[SystemLayout] = None,
+                 musicFont: str|None = None,
+                 wordFont: str|None = None,
+                 pageLayout: PageLayout|None = None,
+                 systemLayout: SystemLayout|None = None,
                  staffLayoutList: t.Optional[list[StaffLayout]] = None,
                  **keywords):
         super().__init__(**keywords)
 
         self.scalingMillimeters = scalingMillimeters
         self.scalingTenths = scalingTenths
-        self.pageLayout: t.Optional[PageLayout] = pageLayout
-        self.systemLayout: t.Optional[SystemLayout] = systemLayout
+        self.pageLayout: PageLayout|None = pageLayout
+        self.systemLayout: SystemLayout|None = systemLayout
         self.staffLayoutList: list[StaffLayout] = []
         self.musicFont = musicFont
         self.wordFont = wordFont
@@ -225,7 +225,7 @@ class PageLayout(LayoutBase):
 
     def __init__(self,
                  *,
-                 pageNumber: t.Optional[int] = None,
+                 pageNumber: int|None = None,
                  leftMargin: t.Union[int, float, None] = None,
                  rightMargin: t.Union[int, float, None] = None,
                  topMargin: t.Union[int, float, None] = None,
@@ -362,7 +362,7 @@ class StaffLayout(LayoutBase):
                  distance: t.Union[int, float, None] = None,
                  staffNumber: t.Union[int, float, None] = None,
                  staffSize: t.Union[int, float, None] = None,
-                 staffLines: t.Optional[int] = None,
+                 staffLines: int|None = None,
                  hidden: t.Union[bool, None] = None,
                  staffType: StaffType = StaffType.REGULAR,
                  **keywords):
@@ -371,7 +371,7 @@ class StaffLayout(LayoutBase):
         # this is the distance between adjacent staves
         self.distance = distance
         self.staffNumber = staffNumber
-        self.staffSize: t.Optional[float] = None if staffSize is None else float(staffSize)
+        self.staffSize: float|None = None if staffSize is None else float(staffSize)
         self.staffLines = staffLines
         self.hidden = hidden  # True = hidden; False = shown; None = inherit
         self.staffType: StaffType = staffType
@@ -426,9 +426,9 @@ class StaffGroup(spanner.Spanner):
     '''
     def __init__(self,
                  *spannedElements,
-                 name: t.Optional[str] = None,
+                 name: str|None = None,
                  barTogether: t.Literal[True, False, None, 'Mensurstrich'] = True,
-                 abbreviation: t.Optional[str] = None,
+                 abbreviation: str|None = None,
                  symbol: t.Literal['bracket', 'line', 'grace', 'square'] = None,
                  **keywords):
         super().__init__(*spannedElements, **keywords)

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -154,20 +154,20 @@ class ScoreLayout(LayoutBase):
 
     def __init__(self,
                  *,
-                 scalingMillimeters: int|float|None = None,
-                 scalingTenths: int|float|None = None,
-                 musicFont: str|None = None,
-                 wordFont: str|None = None,
-                 pageLayout: PageLayout|None = None,
-                 systemLayout: SystemLayout|None = None,
-                 staffLayoutList: list[StaffLayout]|None = None,
+                 scalingMillimeters: int | float | None = None,
+                 scalingTenths: int | float | None = None,
+                 musicFont: str | None = None,
+                 wordFont: str | None = None,
+                 pageLayout: PageLayout | None = None,
+                 systemLayout: SystemLayout | None = None,
+                 staffLayoutList: list[StaffLayout] | None = None,
                  **keywords):
         super().__init__(**keywords)
 
         self.scalingMillimeters = scalingMillimeters
         self.scalingTenths = scalingTenths
-        self.pageLayout: PageLayout|None = pageLayout
-        self.systemLayout: SystemLayout|None = systemLayout
+        self.pageLayout: PageLayout | None = pageLayout
+        self.systemLayout: SystemLayout | None = systemLayout
         self.staffLayoutList: list[StaffLayout] = []
         self.musicFont = musicFont
         self.wordFont = wordFont
@@ -225,14 +225,14 @@ class PageLayout(LayoutBase):
 
     def __init__(self,
                  *,
-                 pageNumber: int|None = None,
-                 leftMargin: int|float|None = None,
-                 rightMargin: int|float|None = None,
-                 topMargin: int|float|None = None,
-                 bottomMargin: int|float|None = None,
-                 pageHeight: int|float|None = None,
-                 pageWidth: int|float|None = None,
-                 isNew: bool|None = None,
+                 pageNumber: int | None = None,
+                 leftMargin: int | float | None = None,
+                 rightMargin: int | float | None = None,
+                 topMargin: int | float | None = None,
+                 bottomMargin: int | float | None = None,
+                 pageHeight: int | float | None = None,
+                 pageWidth: int | float | None = None,
+                 isNew: bool | None = None,
                  **keywords):
         super().__init__(**keywords)
 
@@ -274,11 +274,11 @@ class SystemLayout(LayoutBase):
     '''
     def __init__(self,
                  *,
-                 leftMargin: int|float|None = None,
-                 rightMargin: int|float|None = None,
-                 distance: int|float|None = None,
-                 topDistance: int|float|None = None,
-                 isNew: bool|None = None,
+                 leftMargin: int | float | None = None,
+                 rightMargin: int | float | None = None,
+                 distance: int | float | None = None,
+                 topDistance: int | float | None = None,
+                 isNew: bool | None = None,
                  **keywords):
         super().__init__(**keywords)
 
@@ -359,11 +359,11 @@ class StaffLayout(LayoutBase):
     }
     def __init__(self,
                  *,
-                 distance: int|float|None = None,
-                 staffNumber: int|float|None = None,
-                 staffSize: int|float|None = None,
-                 staffLines: int|None = None,
-                 hidden: bool|None = None,
+                 distance: int | float | None = None,
+                 staffNumber: int | float | None = None,
+                 staffSize: int | float | None = None,
+                 staffLines: int | None = None,
+                 hidden: bool | None = None,
                  staffType: StaffType = StaffType.REGULAR,
                  **keywords):
         super().__init__(**keywords)
@@ -371,7 +371,7 @@ class StaffLayout(LayoutBase):
         # this is the distance between adjacent staves
         self.distance = distance
         self.staffNumber = staffNumber
-        self.staffSize: float|None = None if staffSize is None else float(staffSize)
+        self.staffSize: float | None = None if staffSize is None else float(staffSize)
         self.staffLines = staffLines
         self.hidden = hidden  # True = hidden; False = shown; None = inherit
         self.staffType: StaffType = staffType
@@ -426,9 +426,9 @@ class StaffGroup(spanner.Spanner):
     '''
     def __init__(self,
                  *spannedElements,
-                 name: str|None = None,
+                 name: str | None = None,
                  barTogether: t.Literal[True, False, None, 'Mensurstrich'] = True,
-                 abbreviation: str|None = None,
+                 abbreviation: str | None = None,
                  symbol: t.Literal['bracket', 'line', 'grace', 'square'] = None,
                  **keywords):
         super().__init__(*spannedElements, **keywords)
@@ -1288,7 +1288,7 @@ class LayoutScore(stream.Opus):
         self,
         pageId: int,
         systemId: int
-    ) -> tuple[int|None, int]:
+    ) -> tuple[int | None, int]:
         # noinspection PyShadowingNames
         '''
         given a pageId and systemId, get the (pageId, systemId) for the previous system.

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -154,8 +154,8 @@ class ScoreLayout(LayoutBase):
 
     def __init__(self,
                  *,
-                 scalingMillimeters: t.Union[int, float, None] = None,
-                 scalingTenths: t.Union[int, float, None] = None,
+                 scalingMillimeters: int|float|None = None,
+                 scalingTenths: int|float|None = None,
                  musicFont: str|None = None,
                  wordFont: str|None = None,
                  pageLayout: PageLayout|None = None,
@@ -226,13 +226,13 @@ class PageLayout(LayoutBase):
     def __init__(self,
                  *,
                  pageNumber: int|None = None,
-                 leftMargin: t.Union[int, float, None] = None,
-                 rightMargin: t.Union[int, float, None] = None,
-                 topMargin: t.Union[int, float, None] = None,
-                 bottomMargin: t.Union[int, float, None] = None,
-                 pageHeight: t.Union[int, float, None] = None,
-                 pageWidth: t.Union[int, float, None] = None,
-                 isNew: t.Union[bool, None] = None,
+                 leftMargin: int|float|None = None,
+                 rightMargin: int|float|None = None,
+                 topMargin: int|float|None = None,
+                 bottomMargin: int|float|None = None,
+                 pageHeight: int|float|None = None,
+                 pageWidth: int|float|None = None,
+                 isNew: bool|None = None,
                  **keywords):
         super().__init__(**keywords)
 
@@ -274,11 +274,11 @@ class SystemLayout(LayoutBase):
     '''
     def __init__(self,
                  *,
-                 leftMargin: t.Union[int, float, None] = None,
-                 rightMargin: t.Union[int, float, None] = None,
-                 distance: t.Union[int, float, None] = None,
-                 topDistance: t.Union[int, float, None] = None,
-                 isNew: t.Union[bool, None] = None,
+                 leftMargin: int|float|None = None,
+                 rightMargin: int|float|None = None,
+                 distance: int|float|None = None,
+                 topDistance: int|float|None = None,
+                 isNew: bool|None = None,
                  **keywords):
         super().__init__(**keywords)
 
@@ -359,11 +359,11 @@ class StaffLayout(LayoutBase):
     }
     def __init__(self,
                  *,
-                 distance: t.Union[int, float, None] = None,
-                 staffNumber: t.Union[int, float, None] = None,
-                 staffSize: t.Union[int, float, None] = None,
+                 distance: int|float|None = None,
+                 staffNumber: int|float|None = None,
+                 staffSize: int|float|None = None,
                  staffLines: int|None = None,
-                 hidden: t.Union[bool, None] = None,
+                 hidden: bool|None = None,
                  staffType: StaffType = StaffType.REGULAR,
                  **keywords):
         super().__init__(**keywords)

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -160,7 +160,7 @@ class ScoreLayout(LayoutBase):
                  wordFont: str|None = None,
                  pageLayout: PageLayout|None = None,
                  systemLayout: SystemLayout|None = None,
-                 staffLayoutList: t.Optional[list[StaffLayout]] = None,
+                 staffLayoutList: list[StaffLayout]|None = None,
                  **keywords):
         super().__init__(**keywords)
 
@@ -1288,7 +1288,7 @@ class LayoutScore(stream.Opus):
         self,
         pageId: int,
         systemId: int
-    ) -> tuple[t.Optional[int], int]:
+    ) -> tuple[int|None, int]:
         # noinspection PyShadowingNames
         '''
         given a pageId and systemId, get the (pageId, systemId) for the previous system.

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -1528,7 +1528,7 @@ class LilypondConverter:
 
     def lyMultipliedDurationFromDuration(
         self,
-        durationObj: t.Union[duration.Duration, duration.DurationTuple],
+        durationObj: duration.Duration|duration.DurationTuple,
     ):
         r'''
         take a simple Duration (that is, one with one DurationTuple)
@@ -1568,7 +1568,7 @@ class LilypondConverter:
         >>> [str(lpc.lyMultipliedDurationFromDuration(c)) for c in components]
         ['1 ', '4 ']
         '''
-        number_type: t.Union[float, int, str]
+        number_type: float|int|str
         try:
             number_type = duration.convertTypeToNumber(durationObj.type)  # module call
         except duration.DurationException as de:

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -1528,7 +1528,7 @@ class LilypondConverter:
 
     def lyMultipliedDurationFromDuration(
         self,
-        durationObj: duration.Duration|duration.DurationTuple,
+        durationObj: duration.Duration | duration.DurationTuple,
     ):
         r'''
         take a simple Duration (that is, one with one DurationTuple)
@@ -1568,7 +1568,7 @@ class LilypondConverter:
         >>> [str(lpc.lyMultipliedDurationFromDuration(c)) for c in components]
         ['1 ', '4 ']
         '''
-        number_type: float|int|str
+        number_type: float | int | str
         try:
             number_type = duration.convertTypeToNumber(durationObj.type)  # module call
         except duration.DurationException as de:

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -22,7 +22,6 @@ import pathlib
 import re
 import subprocess
 import sys
-import typing as t
 import unittest
 
 from music21 import clef

--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -342,7 +342,7 @@ class MeiToM21Converter:
 # -----------------------------------------------------------------------------
 def safePitch(
     name: str,
-    accidental: t.Optional[str] = None,
+    accidental: str|None = None,
     octave: t.Union[str, int] = ''
 ) -> pitch.Pitch:
     '''

--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -343,7 +343,7 @@ class MeiToM21Converter:
 def safePitch(
     name: str,
     accidental: str|None = None,
-    octave: t.Union[str, int] = ''
+    octave: str|int = ''
 ) -> pitch.Pitch:
     '''
     Safely build a :class:`~music21.pitch.Pitch` from a string.
@@ -381,7 +381,7 @@ def safePitch(
 
 
 def makeDuration(
-    base: t.Union[float, int, Fraction] = 0.0,
+    base: float|int|Fraction = 0.0,
     dots: int = 0
 ) -> duration.Duration:
     '''

--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -342,8 +342,8 @@ class MeiToM21Converter:
 # -----------------------------------------------------------------------------
 def safePitch(
     name: str,
-    accidental: str|None = None,
-    octave: str|int = ''
+    accidental: str | None = None,
+    octave: str | int = ''
 ) -> pitch.Pitch:
     '''
     Safely build a :class:`~music21.pitch.Pitch` from a string.
@@ -381,7 +381,7 @@ def safePitch(
 
 
 def makeDuration(
-    base: float|int|Fraction = 0.0,
+    base: float | int | Fraction = 0.0,
     dots: int = 0
 ) -> duration.Duration:
     '''
@@ -1027,7 +1027,7 @@ def _timeSigFromAttrs(elem):
     return meter.TimeSignature(f"{elem.get('meter.count')!s}/{elem.get('meter.unit')!s}")
 
 
-def _keySigFromAttrs(elem: Element) -> key.Key|key.KeySignature:
+def _keySigFromAttrs(elem: Element) -> key.Key | key.KeySignature:
     '''
     From any tag with (at minimum) either @key.pname or @key.sig attributes, make a
     :class:`KeySignature` or :class:`Key`, as possible.

--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -617,7 +617,8 @@ def _makeArticList(attr):
     return articList
 
 
-def _getOctaveShift(dis: t.Union[t.Literal['8', '15', '22'], None], disPlace: str) -> int:
+def _getOctaveShift(dis: t.Literal['8', '15', '22'] | None,
+                    disPlace: str) -> int:
     '''
     Use :func:`_getOctaveShift` to calculate the :attr:`octaveShift` attribute for a
     :class:`~music21.clef.Clef` subclass. Any of the arguments may be ``None``.
@@ -1026,7 +1027,7 @@ def _timeSigFromAttrs(elem):
     return meter.TimeSignature(f"{elem.get('meter.count')!s}/{elem.get('meter.unit')!s}")
 
 
-def _keySigFromAttrs(elem: Element) -> t.Union[key.Key, key.KeySignature]:
+def _keySigFromAttrs(elem: Element) -> key.Key|key.KeySignature:
     '''
     From any tag with (at minimum) either @key.pname or @key.sig attributes, make a
     :class:`KeySignature` or :class:`Key`, as possible.

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -263,7 +263,8 @@ class Metadata(base.Music21Object):
 
     def add(self,
             name: str,
-            value: t.Union[t.Any, Iterable[t.Any]]):
+            value: t.Any | Iterable[t.Any],
+            ) -> None:
         '''
         Adds a single item or multiple items with this name, leaving any existing
         items with this name in place.
@@ -328,7 +329,7 @@ class Metadata(base.Music21Object):
         '''
         return self._get(name, isCustom=True)
 
-    def addCustom(self, name: str, value: t.Union[t.Any, Iterable[t.Any]]):
+    def addCustom(self, name: str, value: t.Any | Iterable[t.Any]):
         '''
         Adds any custom-named metadata items. The name can be free-form,
         or it can be a custom 'namespace:name'.
@@ -357,7 +358,7 @@ class Metadata(base.Music21Object):
         '''
         self._add(name, value, isCustom=True)
 
-    def setCustom(self, name: str, value: t.Union[t.Any, Iterable[t.Any]]):
+    def setCustom(self, name: str, value: t.Any | Iterable[t.Any]):
         '''
         Sets any custom-named metadata items (deleting any existing such items).
         The name can be free-form, or it can be a custom 'namespace:name'.
@@ -389,7 +390,7 @@ class Metadata(base.Music21Object):
 #   A few utility routines for clients calling public APIs
 
     @staticmethod
-    def uniqueNameToNamespaceName(uniqueName: str) -> t.Optional[str]:
+    def uniqueNameToNamespaceName(uniqueName: str) -> str|None:
         '''
         Translates a unique name to the associated standard property's
         namespace name (i.e. the property's name in the form 'namespace:name').
@@ -415,7 +416,7 @@ class Metadata(base.Music21Object):
         return properties.UNIQUE_NAME_TO_NAMESPACE_NAME.get(uniqueName, None)
 
     @staticmethod
-    def namespaceNameToUniqueName(namespaceName: str) -> t.Optional[str]:
+    def namespaceNameToUniqueName(namespaceName: str) -> str|None:
         '''
         Translates a standard property namespace name ('namespace:name') to that
         standard property's uniqueName.
@@ -440,7 +441,7 @@ class Metadata(base.Music21Object):
         return properties.NAMESPACE_NAME_TO_UNIQUE_NAME.get(namespaceName, None)
 
     @staticmethod
-    def isContributorUniqueName(uniqueName: t.Optional[str]) -> bool:
+    def isContributorUniqueName(uniqueName: str|None) -> bool:
         '''
         Determines if a unique name is associated with a standard contributor
         property.  Returns False if no such associated standard contributor
@@ -898,7 +899,7 @@ class Metadata(base.Music21Object):
 
         return self._get(key, isCustom=False)
 
-    def __setitem__(self, key: str, value: t.Union[t.Any, Iterable[t.Any]]):
+    def __setitem__(self, key: str, value: t.Any | Iterable[t.Any]):
         '''
         "Dictionary key" access for all standard uniqueNames and
         standard keys of the form 'namespace:name'.
@@ -969,7 +970,7 @@ class Metadata(base.Music21Object):
         uniqueName: str = self._contributorRoleToUniqueName(c.role)
         self._add(uniqueName, c, isCustom=False)
 
-    def getContributorsByRole(self, role: t.Optional[str]) -> tuple[Contributor, ...]:
+    def getContributorsByRole(self, role: str|None) -> tuple[Contributor, ...]:
         r'''
         Return a :class:`~music21.metadata.Contributor` if defined for a
         provided role.
@@ -1340,7 +1341,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'dateCreated', value)
 
     @property
-    def fileFormat(self) -> t.Optional[str]:
+    def fileFormat(self) -> str|None:
         '''
         Get or set the file format that was parsed.
         '''
@@ -1352,7 +1353,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'fileFormat', value)
 
     @property
-    def filePath(self) -> t.Optional[str]:
+    def filePath(self) -> str|None:
         '''
         Get or set the file path that was parsed.
         '''
@@ -1364,7 +1365,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'filePath', value)
 
     @property
-    def fileNumber(self) -> t.Optional[str]:
+    def fileNumber(self) -> str|None:
         '''
         Get or set the file number that was parsed.
         '''
@@ -1497,7 +1498,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'movementName', value)
 
     @property
-    def movementNumber(self) -> t.Optional[str]:
+    def movementNumber(self) -> str|None:
         r'''
         Get or set the movement number as a string (or None)
 
@@ -1518,7 +1519,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'movementNumber', value)
 
     @property
-    def number(self) -> t.Optional[str]:
+    def number(self) -> str|None:
         r'''
         Get or set the number of the work within a collection of pieces,
         as a string. (for instance, the number within a collection of ABC files)
@@ -1546,7 +1547,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'number', value)
 
     @property
-    def opusNumber(self) -> t.Optional[str]:
+    def opusNumber(self) -> str|None:
         r'''
         Get or set the opus number.
 
@@ -1647,7 +1648,7 @@ class Metadata(base.Music21Object):
 # -----------------------------------------------------------------------------
 # Internal support routines (many of them static).
 
-    def _getStringValueByNamespaceName(self, namespaceName: str) -> t.Optional[str]:
+    def _getStringValueByNamespaceName(self, namespaceName: str) -> str|None:
         '''
         Gets a single str value (a summary if necessary) for a supported
         'namespace:name'.
@@ -1801,7 +1802,7 @@ class Metadata(base.Music21Object):
 
         raise AttributeError(f'invalid attributeName: {attributeName}')
 
-    def _getSingularAttribute(self, attributeName: str) -> t.Optional[str]:
+    def _getSingularAttribute(self, attributeName: str) -> str|None:
         '''
         This returns a single string (perhaps a summary) for supported uniqueNames,
         grandfathered workIds, and grandfathered workId abbrevations.
@@ -2064,7 +2065,7 @@ class Metadata(base.Music21Object):
         return prop.needsArticleNormalization
 
     @staticmethod
-    def _contributorRoleToUniqueName(role: t.Optional[str]) -> str:
+    def _contributorRoleToUniqueName(role: str|None) -> str:
         '''
         Translates a contributor role to a standard uniqueName that
         should be used to store that contributor.  For standard contributor
@@ -2130,7 +2131,7 @@ class Metadata(base.Music21Object):
                     ' Call addCustom/setCustom/getCustom for custom names.')
             name = uniqueName
 
-        valueList: t.Optional[list[ValueType]] = self._contents.get(name, None)
+        valueList: list[ValueType]|None = self._contents.get(name, None)
 
         if not valueList:
             # return empty tuple
@@ -2139,7 +2140,7 @@ class Metadata(base.Music21Object):
         # return a tuple containing contents of list
         return tuple(valueList)
 
-    def _add(self, name: str, value: t.Union[t.Any, Iterable[t.Any]], isCustom: bool):
+    def _add(self, name: str, value: t.Any | Iterable[t.Any], isCustom: bool):
         '''
         Adds a single item or multiple items with this name, leaving any existing
         items with this name in place.
@@ -2170,7 +2171,7 @@ class Metadata(base.Music21Object):
         for v in value:
             convertedValues.append(self._convertValue(name, v))
 
-        prevValues: t.Optional[list[ValueType]] = self._contents.get(name, None)
+        prevValues: list[ValueType]|None = self._contents.get(name, None)
         if not prevValues:  # None or []
             # set the convertedValues list in there
             # it's always a list, even if there's only one value
@@ -2179,7 +2180,7 @@ class Metadata(base.Music21Object):
             # add the convertedValues list to the existing list
             self._contents[name] = prevValues + convertedValues
 
-    def _set(self, name: str, value: t.Union[t.Any, Iterable[t.Any]], isCustom: bool):
+    def _set(self, name: str, value: t.Any | Iterable[t.Any], isCustom: bool):
         '''
         Sets a single item or multiple items with this name, replacing any
         existing items with this name.  If isCustom is False, the name must
@@ -2272,7 +2273,7 @@ class Metadata(base.Music21Object):
         ...     metadata.DateBetween(['1938','1939']))
         <music21.metadata.primitives.DateBetween 1938/--/-- to 1939/--/-->
         '''
-        valueType: t.Optional[type[ValueType]] = properties.UNIQUE_NAME_TO_VALUE_TYPE.get(
+        valueType: type[ValueType]|None = properties.UNIQUE_NAME_TO_VALUE_TYPE.get(
             uniqueName, None
         )
         originalValue: t.Any = value

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -469,7 +469,7 @@ class Metadata(base.Music21Object):
         '''
         if not uniqueName:
             return False
-        prop: t.Optional[PropertyDescription] = (
+        prop: PropertyDescription|None = (
             properties.UNIQUE_NAME_TO_PROPERTY_DESCRIPTION.get(uniqueName, None)
         )
         if prop is None:
@@ -1113,7 +1113,7 @@ class Metadata(base.Music21Object):
 
                     # see if there is an associated grandfathered workId, and if so,
                     # search for that, too.
-                    workId: t.Optional[str] = properties.UNIQUE_NAME_TO_MUSIC21_WORK_ID.get(
+                    workId: str|None = properties.UNIQUE_NAME_TO_MUSIC21_WORK_ID.get(
                         uniqueName, None
                     )
 
@@ -1636,7 +1636,7 @@ class Metadata(base.Music21Object):
             'movementName',
         )
         for uniqueName in searchId:
-            titleSummary: t.Optional[str] = self._getStringValueByNamespaceName(
+            titleSummary: str|None = self._getStringValueByNamespaceName(
                 properties.UNIQUE_NAME_TO_NAMESPACE_NAME[uniqueName]
             )
             if titleSummary:
@@ -1886,7 +1886,7 @@ class Metadata(base.Music21Object):
         False
 
         '''
-        prop: t.Optional[PropertyDescription] = (
+        prop: PropertyDescription|None = (
             properties.UNIQUE_NAME_TO_PROPERTY_DESCRIPTION.get(uniqueName, None)
         )
         if prop is None:
@@ -1928,7 +1928,7 @@ class Metadata(base.Music21Object):
         >>> metadata.Metadata._isStandardNamespaceName('average duration')
         False
         '''
-        prop: t.Optional[PropertyDescription] = (
+        prop: PropertyDescription|None = (
             properties.NAMESPACE_NAME_TO_PROPERTY_DESCRIPTION.get(namespaceName, None)
         )
         if prop is None:
@@ -1967,7 +1967,7 @@ class Metadata(base.Music21Object):
         >>> metadata.Metadata._isContributorUniqueName('average duration')
         False
         '''
-        prop: t.Optional[PropertyDescription] = (
+        prop: PropertyDescription|None = (
             properties.UNIQUE_NAME_TO_PROPERTY_DESCRIPTION.get(uniqueName, None)
         )
         if prop is None:
@@ -2017,7 +2017,7 @@ class Metadata(base.Music21Object):
         >>> metadata.Metadata._isContributorNamespaceName('average duration')
         False
         '''
-        prop: t.Optional[PropertyDescription] = (
+        prop: PropertyDescription|None = (
             properties.NAMESPACE_NAME_TO_PROPERTY_DESCRIPTION.get(namespaceName, None)
         )
         if prop is None:
@@ -2055,7 +2055,7 @@ class Metadata(base.Music21Object):
         >>> metadata.Metadata._namespaceNameNeedsArticleNormalization('average duration')
         False
         '''
-        prop: t.Optional[PropertyDescription] = (
+        prop: PropertyDescription|None = (
             properties.NAMESPACE_NAME_TO_PROPERTY_DESCRIPTION.get(namespaceName, None)
         )
         if prop is None:
@@ -2095,7 +2095,7 @@ class Metadata(base.Music21Object):
         if role is None:
             return 'otherContributor'
 
-        prop: t.Optional[PropertyDescription] = (
+        prop: PropertyDescription|None = (
             properties.UNIQUE_NAME_TO_PROPERTY_DESCRIPTION.get(role, None)
         )
 

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -390,7 +390,7 @@ class Metadata(base.Music21Object):
 #   A few utility routines for clients calling public APIs
 
     @staticmethod
-    def uniqueNameToNamespaceName(uniqueName: str) -> str|None:
+    def uniqueNameToNamespaceName(uniqueName: str) -> str | None:
         '''
         Translates a unique name to the associated standard property's
         namespace name (i.e. the property's name in the form 'namespace:name').
@@ -416,7 +416,7 @@ class Metadata(base.Music21Object):
         return properties.UNIQUE_NAME_TO_NAMESPACE_NAME.get(uniqueName, None)
 
     @staticmethod
-    def namespaceNameToUniqueName(namespaceName: str) -> str|None:
+    def namespaceNameToUniqueName(namespaceName: str) -> str | None:
         '''
         Translates a standard property namespace name ('namespace:name') to that
         standard property's uniqueName.
@@ -441,7 +441,7 @@ class Metadata(base.Music21Object):
         return properties.NAMESPACE_NAME_TO_UNIQUE_NAME.get(namespaceName, None)
 
     @staticmethod
-    def isContributorUniqueName(uniqueName: str|None) -> bool:
+    def isContributorUniqueName(uniqueName: str | None) -> bool:
         '''
         Determines if a unique name is associated with a standard contributor
         property.  Returns False if no such associated standard contributor
@@ -470,7 +470,7 @@ class Metadata(base.Music21Object):
         '''
         if not uniqueName:
             return False
-        prop: PropertyDescription|None = (
+        prop: PropertyDescription | None = (
             properties.UNIQUE_NAME_TO_PROPERTY_DESCRIPTION.get(uniqueName, None)
         )
         if prop is None:
@@ -970,7 +970,7 @@ class Metadata(base.Music21Object):
         uniqueName: str = self._contributorRoleToUniqueName(c.role)
         self._add(uniqueName, c, isCustom=False)
 
-    def getContributorsByRole(self, role: str|None) -> tuple[Contributor, ...]:
+    def getContributorsByRole(self, role: str | None) -> tuple[Contributor, ...]:
         r'''
         Return a :class:`~music21.metadata.Contributor` if defined for a
         provided role.
@@ -1114,7 +1114,7 @@ class Metadata(base.Music21Object):
 
                     # see if there is an associated grandfathered workId, and if so,
                     # search for that, too.
-                    workId: str|None = properties.UNIQUE_NAME_TO_MUSIC21_WORK_ID.get(
+                    workId: str | None = properties.UNIQUE_NAME_TO_MUSIC21_WORK_ID.get(
                         uniqueName, None
                     )
 
@@ -1341,7 +1341,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'dateCreated', value)
 
     @property
-    def fileFormat(self) -> str|None:
+    def fileFormat(self) -> str | None:
         '''
         Get or set the file format that was parsed.
         '''
@@ -1353,7 +1353,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'fileFormat', value)
 
     @property
-    def filePath(self) -> str|None:
+    def filePath(self) -> str | None:
         '''
         Get or set the file path that was parsed.
         '''
@@ -1365,7 +1365,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'filePath', value)
 
     @property
-    def fileNumber(self) -> str|None:
+    def fileNumber(self) -> str | None:
         '''
         Get or set the file number that was parsed.
         '''
@@ -1498,7 +1498,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'movementName', value)
 
     @property
-    def movementNumber(self) -> str|None:
+    def movementNumber(self) -> str | None:
         r'''
         Get or set the movement number as a string (or None)
 
@@ -1519,7 +1519,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'movementNumber', value)
 
     @property
-    def number(self) -> str|None:
+    def number(self) -> str | None:
         r'''
         Get or set the number of the work within a collection of pieces,
         as a string. (for instance, the number within a collection of ABC files)
@@ -1547,7 +1547,7 @@ class Metadata(base.Music21Object):
         setattr(self, 'number', value)
 
     @property
-    def opusNumber(self) -> str|None:
+    def opusNumber(self) -> str | None:
         r'''
         Get or set the opus number.
 
@@ -1637,7 +1637,7 @@ class Metadata(base.Music21Object):
             'movementName',
         )
         for uniqueName in searchId:
-            titleSummary: str|None = self._getStringValueByNamespaceName(
+            titleSummary: str | None = self._getStringValueByNamespaceName(
                 properties.UNIQUE_NAME_TO_NAMESPACE_NAME[uniqueName]
             )
             if titleSummary:
@@ -1648,7 +1648,7 @@ class Metadata(base.Music21Object):
 # -----------------------------------------------------------------------------
 # Internal support routines (many of them static).
 
-    def _getStringValueByNamespaceName(self, namespaceName: str) -> str|None:
+    def _getStringValueByNamespaceName(self, namespaceName: str) -> str | None:
         '''
         Gets a single str value (a summary if necessary) for a supported
         'namespace:name'.
@@ -1802,7 +1802,7 @@ class Metadata(base.Music21Object):
 
         raise AttributeError(f'invalid attributeName: {attributeName}')
 
-    def _getSingularAttribute(self, attributeName: str) -> str|None:
+    def _getSingularAttribute(self, attributeName: str) -> str | None:
         '''
         This returns a single string (perhaps a summary) for supported uniqueNames,
         grandfathered workIds, and grandfathered workId abbrevations.
@@ -1887,7 +1887,7 @@ class Metadata(base.Music21Object):
         False
 
         '''
-        prop: PropertyDescription|None = (
+        prop: PropertyDescription | None = (
             properties.UNIQUE_NAME_TO_PROPERTY_DESCRIPTION.get(uniqueName, None)
         )
         if prop is None:
@@ -1929,7 +1929,7 @@ class Metadata(base.Music21Object):
         >>> metadata.Metadata._isStandardNamespaceName('average duration')
         False
         '''
-        prop: PropertyDescription|None = (
+        prop: PropertyDescription | None = (
             properties.NAMESPACE_NAME_TO_PROPERTY_DESCRIPTION.get(namespaceName, None)
         )
         if prop is None:
@@ -1968,7 +1968,7 @@ class Metadata(base.Music21Object):
         >>> metadata.Metadata._isContributorUniqueName('average duration')
         False
         '''
-        prop: PropertyDescription|None = (
+        prop: PropertyDescription | None = (
             properties.UNIQUE_NAME_TO_PROPERTY_DESCRIPTION.get(uniqueName, None)
         )
         if prop is None:
@@ -2018,7 +2018,7 @@ class Metadata(base.Music21Object):
         >>> metadata.Metadata._isContributorNamespaceName('average duration')
         False
         '''
-        prop: PropertyDescription|None = (
+        prop: PropertyDescription | None = (
             properties.NAMESPACE_NAME_TO_PROPERTY_DESCRIPTION.get(namespaceName, None)
         )
         if prop is None:
@@ -2056,7 +2056,7 @@ class Metadata(base.Music21Object):
         >>> metadata.Metadata._namespaceNameNeedsArticleNormalization('average duration')
         False
         '''
-        prop: PropertyDescription|None = (
+        prop: PropertyDescription | None = (
             properties.NAMESPACE_NAME_TO_PROPERTY_DESCRIPTION.get(namespaceName, None)
         )
         if prop is None:
@@ -2065,7 +2065,7 @@ class Metadata(base.Music21Object):
         return prop.needsArticleNormalization
 
     @staticmethod
-    def _contributorRoleToUniqueName(role: str|None) -> str:
+    def _contributorRoleToUniqueName(role: str | None) -> str:
         '''
         Translates a contributor role to a standard uniqueName that
         should be used to store that contributor.  For standard contributor
@@ -2096,7 +2096,7 @@ class Metadata(base.Music21Object):
         if role is None:
             return 'otherContributor'
 
-        prop: PropertyDescription|None = (
+        prop: PropertyDescription | None = (
             properties.UNIQUE_NAME_TO_PROPERTY_DESCRIPTION.get(role, None)
         )
 
@@ -2131,7 +2131,7 @@ class Metadata(base.Music21Object):
                     ' Call addCustom/setCustom/getCustom for custom names.')
             name = uniqueName
 
-        valueList: list[ValueType]|None = self._contents.get(name, None)
+        valueList: list[ValueType] | None = self._contents.get(name, None)
 
         if not valueList:
             # return empty tuple
@@ -2171,7 +2171,7 @@ class Metadata(base.Music21Object):
         for v in value:
             convertedValues.append(self._convertValue(name, v))
 
-        prevValues: list[ValueType]|None = self._contents.get(name, None)
+        prevValues: list[ValueType] | None = self._contents.get(name, None)
         if not prevValues:  # None or []
             # set the convertedValues list in there
             # it's always a list, even if there's only one value
@@ -2273,7 +2273,7 @@ class Metadata(base.Music21Object):
         ...     metadata.DateBetween(['1938','1939']))
         <music21.metadata.primitives.DateBetween 1938/--/-- to 1939/--/-->
         '''
-        valueType: type[ValueType]|None = properties.UNIQUE_NAME_TO_VALUE_TYPE.get(
+        valueType: type[ValueType] | None = properties.UNIQUE_NAME_TO_VALUE_TYPE.get(
             uniqueName, None
         )
         originalValue: t.Any = value

--- a/music21/metadata/primitives.py
+++ b/music21/metadata/primitives.py
@@ -89,18 +89,18 @@ class Date(prebase.ProtoM21Object):
 
     def __init__(self,
                  *,
-                 year: t.Union[int, str, None] = None,
-                 month: t.Union[int, str, None] = None,
-                 day: t.Union[int, str, None] = None,
-                 hour: t.Union[int, str, None] = None,
-                 minute: t.Union[int, str, None] = None,
-                 second: t.Union[int, float, str, None] = None,
-                 yearError: t.Union[str, None] = None,
-                 monthError: t.Union[str, None] = None,
-                 dayError: t.Union[str, None] = None,
-                 hourError: t.Union[str, None] = None,
-                 minuteError: t.Union[str, None] = None,
-                 secondError: t.Union[str, None] = None):
+                 year: int|str|None = None,
+                 month: int|str|None = None,
+                 day: int|str|None = None,
+                 hour: int|str|None = None,
+                 minute: int|str|None = None,
+                 second: int|float|str|None = None,
+                 yearError: str|None = None,
+                 monthError: str|None = None,
+                 dayError: str|None = None,
+                 hourError: str|None = None,
+                 minuteError: str|None = None,
+                 secondError: str|None = None):
         if year is not None and yearError is None:
             year, yearError = self._stripError(year)
         if month is not None and monthError is None:
@@ -849,7 +849,7 @@ class Text(prebase.ProtoM21Object):
                  encodingScheme: str|None = None):
         if isinstance(data, Text):
             # accessing private attributes here; not desirable
-            self._data: t.Union[str, Text] = data._data
+            self._data: str|Text = data._data
             self._language: str|None = data._language
             self.isTranslated: bool|None = data.isTranslated
             self.encodingScheme: str|None = data.encodingScheme
@@ -1083,11 +1083,11 @@ class Contributor(prebase.ProtoM21Object):
 
     def __init__(self,
                  *,
-                 name: t.Union[str, Text, None] = None,
+                 name: str|Text|None = None,
                  names: Iterable[t.Union[str, Text]] = (),
-                 role: t.Union[str, Text, None] = None,
-                 birth: t.Union[None, DateSingle, str] = None,
-                 death: t.Union[None, DateSingle, str] = None,
+                 role: str|Text|None = None,
+                 birth: None|DateSingle|str = None,
+                 death: None|DateSingle|str = None,
                  **keywords):
         self._role = None
         if role:

--- a/music21/metadata/primitives.py
+++ b/music21/metadata/primitives.py
@@ -89,18 +89,18 @@ class Date(prebase.ProtoM21Object):
 
     def __init__(self,
                  *,
-                 year: int|str|None = None,
-                 month: int|str|None = None,
-                 day: int|str|None = None,
-                 hour: int|str|None = None,
-                 minute: int|str|None = None,
-                 second: int|float|str|None = None,
-                 yearError: str|None = None,
-                 monthError: str|None = None,
-                 dayError: str|None = None,
-                 hourError: str|None = None,
-                 minuteError: str|None = None,
-                 secondError: str|None = None):
+                 year: int | str | None = None,
+                 month: int | str | None = None,
+                 day: int | str | None = None,
+                 hour: int | str | None = None,
+                 minute: int | str | None = None,
+                 second: int | float | str | None = None,
+                 yearError: str | None = None,
+                 monthError: str | None = None,
+                 dayError: str | None = None,
+                 hourError: str | None = None,
+                 minuteError: str | None = None,
+                 secondError: str | None = None):
         if year is not None and yearError is None:
             year, yearError = self._stripError(year)
         if month is not None and monthError is None:
@@ -116,21 +116,21 @@ class Date(prebase.ProtoM21Object):
 
         self._sanityCheck(year=year, month=month, day=day, hour=hour, minute=minute, second=second)
 
-        self.year = t.cast(int|None, year)
-        self.month = t.cast(int|None, month)
-        self.day = t.cast(int|None, day)
-        self.hour = t.cast(int|None, hour)
-        self.minute = t.cast(int|None, minute)
-        self.second = t.cast(int|None, second)
+        self.year = t.cast(int | None, year)
+        self.month = t.cast(int | None, month)
+        self.day = t.cast(int | None, day)
+        self.hour = t.cast(int | None, hour)
+        self.minute = t.cast(int | None, minute)
+        self.second = t.cast(int | None, second)
 
         # error: can be 'approximate', 'uncertain' or None.
         # None is assumed to be certain
-        self.yearError: str|None = yearError
-        self.monthError: str|None = monthError
-        self.dayError: str|None = dayError
-        self.hourError: str|None = hourError
-        self.minuteError: str|None = minuteError
-        self.secondError: str|None = secondError
+        self.yearError: str | None = yearError
+        self.monthError: str | None = monthError
+        self.dayError: str | None = dayError
+        self.hourError: str | None = hourError
+        self.minuteError: str | None = minuteError
+        self.secondError: str | None = secondError
         self.attrNames = ('year', 'month', 'day', 'hour', 'minute', 'second')
 
     # SPECIAL METHODS #
@@ -178,8 +178,8 @@ class Date(prebase.ProtoM21Object):
 
     # PRIVATE METHODS #
     def _stripError(self,
-                    value: int|float|str,
-                    ) -> tuple[int, str|None]:
+                    value: int | float | str,
+                    ) -> tuple[int, str | None]:
         r'''
         Strip error symbols from a numerical value. Return cleaned source and
         sym. Only one error symbol is expected per string.
@@ -196,7 +196,7 @@ class Date(prebase.ProtoM21Object):
         >>> d._stripError('4.43')
         (4, None)
         '''
-        uncertainty: str|None = None
+        uncertainty: str | None = None
         if isinstance(value, str):  # if a number, let pass
             sym = self.approximateSymbols + self.uncertainSymbols + self.priorTimeSymbols
             found = None
@@ -358,8 +358,8 @@ class Date(prebase.ProtoM21Object):
         >>> d.minute, d.second
         (50, 32)
         '''
-        post: list[int|None] = []
-        postError: list[str|None] = []
+        post: list[int | None] = []
+        postError: list[str | None] = []
         dateStr = dateStr.replace(':', '/')
         dateStr = dateStr.replace(' ', '')
         for chunk in dateStr.split('/'):
@@ -481,7 +481,7 @@ class DatePrimitive(prebase.ProtoM21Object):
         # store an array of values marking if date data itself
         # is certain, approximate, or uncertain
         # here, dataError is relevance
-        self._dataUncertainty: list[str|None] = []
+        self._dataUncertainty: list[str | None] = []
         self.relevance = relevance  # will use property
 
     # SPECIAL METHODS #
@@ -843,16 +843,16 @@ class Text(prebase.ProtoM21Object):
     # INITIALIZER #
 
     def __init__(self,
-                 data: str|Text = '',
-                 language: str|None = None,
-                 isTranslated: bool|None = None,   # True, False, or None (unknown)
-                 encodingScheme: str|None = None):
+                 data: str | Text = '',
+                 language: str | None = None,
+                 isTranslated: bool | None = None,   # True, False, or None (unknown)
+                 encodingScheme: str | None = None):
         if isinstance(data, Text):
             # accessing private attributes here; not desirable
-            self._data: str|Text = data._data
-            self._language: str|None = data._language
-            self.isTranslated: bool|None = data.isTranslated
-            self.encodingScheme: str|None = data.encodingScheme
+            self._data: str | Text = data._data
+            self._language: str | None = data._language
+            self.isTranslated: bool | None = data.isTranslated
+            self.encodingScheme: str | None = data.encodingScheme
         else:
             self._data = data
             self._language = language
@@ -1002,9 +1002,9 @@ class Copyright(Text):
     '''
 
     def __init__(self,
-                 data: str|Text = '',
-                 language: str|None = None,
-                 isTranslated: bool|None = None,   # True, False, or None (unknown)
+                 data: str | Text = '',
+                 language: str | None = None,
+                 isTranslated: bool | None = None,   # True, False, or None (unknown)
                  *, role=None):
         super().__init__(data, language, isTranslated)
         self.role = role
@@ -1083,11 +1083,11 @@ class Contributor(prebase.ProtoM21Object):
 
     def __init__(self,
                  *,
-                 name: str|Text|None = None,
-                 names: Iterable[str|Text] = (),
-                 role: str|Text|None = None,
-                 birth: None|DateSingle|str = None,
-                 death: None|DateSingle|str = None,
+                 name: str | Text | None = None,
+                 names: Iterable[str | Text] = (),
+                 role: str | Text | None = None,
+                 birth: None | DateSingle | str = None,
+                 death: None | DateSingle | str = None,
                  **keywords):
         self._role = None
         if role:
@@ -1112,8 +1112,8 @@ class Contributor(prebase.ProtoM21Object):
         # store the nationality, if known (not currently used)
         self._nationality: list[Text] = []
 
-        self.birth: DateSingle|None = None
-        self.death: DateSingle|None = None
+        self.birth: DateSingle | None = None
+        self.death: DateSingle | None = None
 
         if birth is not None:
             if not isinstance(birth, DateSingle):
@@ -1213,7 +1213,7 @@ class Contributor(prebase.ProtoM21Object):
 
     # PUBLIC METHODS #
 
-    def age(self) -> datetime.timedelta|None:
+    def age(self) -> datetime.timedelta | None:
         r'''
         Calculate the age at death of the Contributor, returning a
         datetime.timedelta object.
@@ -1608,8 +1608,8 @@ _DOC_ORDER = (
     Copyright,
 )
 
-DateParseType = Date|datetime.datetime|str
-ValueType = DatePrimitive|Text|Contributor|Copyright|int
+DateParseType = Date | datetime.datetime | str
+ValueType = DatePrimitive | Text | Contributor | Copyright | int
 
 
 if __name__ == '__main__':

--- a/music21/metadata/primitives.py
+++ b/music21/metadata/primitives.py
@@ -125,12 +125,12 @@ class Date(prebase.ProtoM21Object):
 
         # error: can be 'approximate', 'uncertain' or None.
         # None is assumed to be certain
-        self.yearError: t.Optional[str] = yearError
-        self.monthError: t.Optional[str] = monthError
-        self.dayError: t.Optional[str] = dayError
-        self.hourError: t.Optional[str] = hourError
-        self.minuteError: t.Optional[str] = minuteError
-        self.secondError: t.Optional[str] = secondError
+        self.yearError: str|None = yearError
+        self.monthError: str|None = monthError
+        self.dayError: str|None = dayError
+        self.hourError: str|None = hourError
+        self.minuteError: str|None = minuteError
+        self.secondError: str|None = secondError
         self.attrNames = ('year', 'month', 'day', 'hour', 'minute', 'second')
 
     # SPECIAL METHODS #
@@ -196,7 +196,7 @@ class Date(prebase.ProtoM21Object):
         >>> d._stripError('4.43')
         (4, None)
         '''
-        uncertainty: t.Optional[str] = None
+        uncertainty: str|None = None
         if isinstance(value, str):  # if a number, let pass
             sym = self.approximateSymbols + self.uncertainSymbols + self.priorTimeSymbols
             found = None
@@ -844,15 +844,15 @@ class Text(prebase.ProtoM21Object):
 
     def __init__(self,
                  data: t.Union[str, 'Text'] = '',
-                 language: t.Optional[str] = None,
-                 isTranslated: t.Optional[bool] = None,   # True, False, or None (unknown)
-                 encodingScheme: t.Optional[str] = None):
+                 language: str|None = None,
+                 isTranslated: bool|None = None,   # True, False, or None (unknown)
+                 encodingScheme: str|None = None):
         if isinstance(data, Text):
             # accessing private attributes here; not desirable
             self._data: t.Union[str, Text] = data._data
-            self._language: t.Optional[str] = data._language
-            self.isTranslated: t.Optional[bool] = data.isTranslated
-            self.encodingScheme: t.Optional[str] = data.encodingScheme
+            self._language: str|None = data._language
+            self.isTranslated: bool|None = data.isTranslated
+            self.encodingScheme: str|None = data.encodingScheme
         else:
             self._data = data
             self._language = language
@@ -1003,8 +1003,8 @@ class Copyright(Text):
 
     def __init__(self,
                  data: t.Union[str, 'Text'] = '',
-                 language: t.Optional[str] = None,
-                 isTranslated: t.Optional[bool] = None,   # True, False, or None (unknown)
+                 language: str|None = None,
+                 isTranslated: bool|None = None,   # True, False, or None (unknown)
                  *, role=None):
         super().__init__(data, language, isTranslated)
         self.role = role
@@ -1112,8 +1112,8 @@ class Contributor(prebase.ProtoM21Object):
         # store the nationality, if known (not currently used)
         self._nationality: list[Text] = []
 
-        self.birth: t.Optional[DateSingle] = None
-        self.death: t.Optional[DateSingle] = None
+        self.birth: DateSingle|None = None
+        self.death: DateSingle|None = None
 
         if birth is not None:
             if not isinstance(birth, DateSingle):

--- a/music21/metadata/primitives.py
+++ b/music21/metadata/primitives.py
@@ -116,12 +116,12 @@ class Date(prebase.ProtoM21Object):
 
         self._sanityCheck(year=year, month=month, day=day, hour=hour, minute=minute, second=second)
 
-        self.year = t.cast(t.Optional[int], year)
-        self.month = t.cast(t.Optional[int], month)
-        self.day = t.cast(t.Optional[int], day)
-        self.hour = t.cast(t.Optional[int], hour)
-        self.minute = t.cast(t.Optional[int], minute)
-        self.second = t.cast(t.Optional[int], second)
+        self.year = t.cast(int|None, year)
+        self.month = t.cast(int|None, month)
+        self.day = t.cast(int|None, day)
+        self.hour = t.cast(int|None, hour)
+        self.minute = t.cast(int|None, minute)
+        self.second = t.cast(int|None, second)
 
         # error: can be 'approximate', 'uncertain' or None.
         # None is assumed to be certain
@@ -178,8 +178,8 @@ class Date(prebase.ProtoM21Object):
 
     # PRIVATE METHODS #
     def _stripError(self,
-                    value: t.Union[int, float, str],
-                    ) -> tuple[int, t.Optional[str]]:
+                    value: int|float|str,
+                    ) -> tuple[int, str|None]:
         r'''
         Strip error symbols from a numerical value. Return cleaned source and
         sym. Only one error symbol is expected per string.
@@ -358,8 +358,8 @@ class Date(prebase.ProtoM21Object):
         >>> d.minute, d.second
         (50, 32)
         '''
-        post: list[t.Optional[int]] = []
-        postError: list[t.Optional[str]] = []
+        post: list[int|None] = []
+        postError: list[str|None] = []
         dateStr = dateStr.replace(':', '/')
         dateStr = dateStr.replace(' ', '')
         for chunk in dateStr.split('/'):
@@ -481,7 +481,7 @@ class DatePrimitive(prebase.ProtoM21Object):
         # store an array of values marking if date data itself
         # is certain, approximate, or uncertain
         # here, dataError is relevance
-        self._dataUncertainty: list[t.Union[str, None]] = []
+        self._dataUncertainty: list[str|None] = []
         self.relevance = relevance  # will use property
 
     # SPECIAL METHODS #
@@ -843,7 +843,7 @@ class Text(prebase.ProtoM21Object):
     # INITIALIZER #
 
     def __init__(self,
-                 data: t.Union[str, 'Text'] = '',
+                 data: str|Text = '',
                  language: str|None = None,
                  isTranslated: bool|None = None,   # True, False, or None (unknown)
                  encodingScheme: str|None = None):
@@ -1002,7 +1002,7 @@ class Copyright(Text):
     '''
 
     def __init__(self,
-                 data: t.Union[str, 'Text'] = '',
+                 data: str|Text = '',
                  language: str|None = None,
                  isTranslated: bool|None = None,   # True, False, or None (unknown)
                  *, role=None):
@@ -1084,7 +1084,7 @@ class Contributor(prebase.ProtoM21Object):
     def __init__(self,
                  *,
                  name: str|Text|None = None,
-                 names: Iterable[t.Union[str, Text]] = (),
+                 names: Iterable[str|Text] = (),
                  role: str|Text|None = None,
                  birth: None|DateSingle|str = None,
                  death: None|DateSingle|str = None,
@@ -1213,7 +1213,7 @@ class Contributor(prebase.ProtoM21Object):
 
     # PUBLIC METHODS #
 
-    def age(self) -> t.Optional[datetime.timedelta]:
+    def age(self) -> datetime.timedelta|None:
         r'''
         Calculate the age at death of the Contributor, returning a
         datetime.timedelta object.
@@ -1608,8 +1608,8 @@ _DOC_ORDER = (
     Copyright,
 )
 
-DateParseType = t.Union[Date, datetime.datetime, str]
-ValueType = t.Union[DatePrimitive, Text, Contributor, Copyright, int]
+DateParseType = Date|datetime.datetime|str
+ValueType = DatePrimitive|Text|Contributor|Copyright|int
 
 
 if __name__ == '__main__':

--- a/music21/metadata/properties.py
+++ b/music21/metadata/properties.py
@@ -12,7 +12,6 @@
 # -----------------------------------------------------------------------------
 from __future__ import annotations
 
-import typing as t
 from dataclasses import dataclass
 
 from music21.metadata.primitives import (DatePrimitive, Text, Contributor, Copyright, ValueType)

--- a/music21/metadata/properties.py
+++ b/music21/metadata/properties.py
@@ -47,11 +47,11 @@ class PropertyDescription:
         metadata, and is the tuple element type clients will always receive from
         md['uniqueName'] or md['namespace:name'].
     '''
-    uniqueName: str|None = None
+    uniqueName: str | None = None
     name: str = ''
     namespace: str = ''
-    oldMusic21Abbrev: str|None = None
-    oldMusic21WorkId: str|None = None
+    oldMusic21Abbrev: str | None = None
+    oldMusic21WorkId: str | None = None
     valueType: type[ValueType] = Text
     needsArticleNormalization: bool = False
     isContributor: bool = False

--- a/music21/metadata/properties.py
+++ b/music21/metadata/properties.py
@@ -48,11 +48,11 @@ class PropertyDescription:
         metadata, and is the tuple element type clients will always receive from
         md['uniqueName'] or md['namespace:name'].
     '''
-    uniqueName: t.Optional[str] = None
+    uniqueName: str|None = None
     name: str = ''
     namespace: str = ''
-    oldMusic21Abbrev: t.Optional[str] = None
-    oldMusic21WorkId: t.Optional[str] = None
+    oldMusic21Abbrev: str|None = None
+    oldMusic21WorkId: str|None = None
     valueType: type[ValueType] = Text
     needsArticleNormalization: bool = False
     isContributor: bool = False

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -476,7 +476,7 @@ class TimeSignature(TimeSignatureBase):
         if value is None:
             value = f'{defaults.meterNumerator}/{defaults.meterDenominatorBeatType}'
 
-        self._overriddenBarDuration: t.Optional[duration.Duration] = None
+        self._overriddenBarDuration: duration.Duration|None = None
         self.symbol: str = ''
         self.displaySequence: MeterSequence = _SENTINEL_METER_SEQUENCE
         self.beatSequence: MeterSequence = _SENTINEL_METER_SEQUENCE

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -1189,7 +1189,7 @@ class TimeSignature(TimeSignatureBase):
 
         '''
         # NOTE: this is a performance critical method
-        firstPartitionForm: t.Union[MeterSequence, int, None]
+        firstPartitionForm: MeterSequence|int|None
 
         # create a scratch MeterSequence for structure
         tsStr = f'{self.numerator}/{self.denominator}'
@@ -1248,7 +1248,7 @@ class TimeSignature(TimeSignatureBase):
 
     # --------------------------------------------------------------------------
     # access data for other processing
-    def getBeams(self, srcList, measureStartOffset=0.0) -> list[t.Optional[beam.Beams]]:
+    def getBeams(self, srcList, measureStartOffset=0.0) -> list[beam.Beams|None]:
         '''
         Given a qLen position and an iterable of Music21Objects, return a list of Beams objects.
 
@@ -1563,7 +1563,9 @@ class TimeSignature(TimeSignatureBase):
             pos += self.accentSequence[i].duration.quarterLength
         return False
 
-    def setAccentWeight(self, weights: t.Union[Sequence[float], float], level: int = 0) -> None:
+    def setAccentWeight(self,
+                        weights: Sequence[float] | float,
+                        level: int = 0) -> None:
         '''
         Set accent weight, or floating point scalars, for the accent MeterSequence.
         Provide a list of float values; if this list is shorter than the length

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -476,7 +476,7 @@ class TimeSignature(TimeSignatureBase):
         if value is None:
             value = f'{defaults.meterNumerator}/{defaults.meterDenominatorBeatType}'
 
-        self._overriddenBarDuration: duration.Duration|None = None
+        self._overriddenBarDuration: duration.Duration | None = None
         self.symbol: str = ''
         self.displaySequence: MeterSequence = _SENTINEL_METER_SEQUENCE
         self.beatSequence: MeterSequence = _SENTINEL_METER_SEQUENCE
@@ -1189,7 +1189,7 @@ class TimeSignature(TimeSignatureBase):
 
         '''
         # NOTE: this is a performance critical method
-        firstPartitionForm: MeterSequence|int|None
+        firstPartitionForm: MeterSequence | int | None
 
         # create a scratch MeterSequence for structure
         tsStr = f'{self.numerator}/{self.denominator}'
@@ -1248,7 +1248,7 @@ class TimeSignature(TimeSignatureBase):
 
     # --------------------------------------------------------------------------
     # access data for other processing
-    def getBeams(self, srcList, measureStartOffset=0.0) -> list[beam.Beams|None]:
+    def getBeams(self, srcList, measureStartOffset=0.0) -> list[beam.Beams | None]:
         '''
         Given a qLen position and an iterable of Music21Objects, return a list of Beams objects.
 

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -56,7 +56,7 @@ class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
     )
 
     # INITIALIZER #
-    def __init__(self, slashNotation: str|None = None, weight=1):
+    def __init__(self, slashNotation: str | None = None, weight=1):
         # because of how they are copied, MeterTerminals must not have any
         # initialization parameters without defaults
         self._duration = None
@@ -1775,7 +1775,7 @@ class MeterSequence(MeterTerminal):
         iMatch = self.offsetToIndex(qLenPos)
         return opFrac(self[iMatch].weight)
 
-    def offsetToDepth(self, qLenPos, align='quantize', index: int|None = None):
+    def offsetToDepth(self, qLenPos, align='quantize', index: int | None = None):
         '''
         Given a qLenPos, return the maximum available depth at this position.
 

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -16,7 +16,6 @@ This module defines two component objects for defining nested metrical structure
 from __future__ import annotations
 
 import copy
-import typing as t
 
 from music21 import prebase
 from music21.common.numberTools import opFrac

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -57,7 +57,7 @@ class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
     )
 
     # INITIALIZER #
-    def __init__(self, slashNotation: t.Optional[str] = None, weight=1):
+    def __init__(self, slashNotation: str|None = None, weight=1):
         # because of how they are copied, MeterTerminals must not have any
         # initialization parameters without defaults
         self._duration = None
@@ -1776,7 +1776,7 @@ class MeterSequence(MeterTerminal):
         iMatch = self.offsetToIndex(qLenPos)
         return opFrac(self[iMatch].weight)
 
-    def offsetToDepth(self, qLenPos, align='quantize', index: t.Optional[int] = None):
+    def offsetToDepth(self, qLenPos, align='quantize', index: int|None = None):
         '''
         Given a qLenPos, return the maximum available depth at this position.
 

--- a/music21/meter/tools.py
+++ b/music21/meter/tools.py
@@ -168,7 +168,7 @@ def slashMixedToFraction(valueSrc: str) -> tuple[NumDenomTuple, bool]:
             post.append((intNum, intDenom))
         else:  # search ahead for next defined denominator
             summedNumerator = True
-            match: int|None = None
+            match: int | None = None
             for j in range(i, len(pre)):  # this O(n^2) operation is easily simplified to O(n)
                 if pre[j][1] is not None:
                     match = pre[j][1]

--- a/music21/meter/tools.py
+++ b/music21/meter/tools.py
@@ -168,7 +168,7 @@ def slashMixedToFraction(valueSrc: str) -> tuple[NumDenomTuple, bool]:
             post.append((intNum, intDenom))
         else:  # search ahead for next defined denominator
             summedNumerator = True
-            match: t.Optional[int] = None
+            match: int|None = None
             for j in range(i, len(pre)):  # this O(n^2) operation is easily simplified to O(n)
                 if pre[j][1] is not None:
                     match = pre[j][1]

--- a/music21/meter/tools.py
+++ b/music21/meter/tools.py
@@ -133,7 +133,7 @@ def slashMixedToFraction(valueSrc: str) -> tuple[NumDenomTuple, bool]:
 
     Changed in v7 -- new location and returns a tuple as first value.
     '''
-    pre: list[t.Union[NumDenom, tuple[int, None]]] = []
+    pre: list[NumDenom | tuple[int, None]] = []
     post: list[NumDenom] = []
     summedNumerator = False
     value = valueSrc.strip()  # rem whitespace
@@ -641,7 +641,7 @@ def divisionOptionsPreset(n, d) -> MeterOptions:
     Provide fixed set of meter divisions that will not be easily
     obtained algorithmically.
 
-    Currently does nothing except to allow partitioning 5/8 as 2/8, 2/8, 1/8 as a possibility
+    Currently, does nothing except to allow partitioning 5/8 as 2/8, 2/8, 1/8 as a possibility
     (sim for 5/16, etc.)
 
     >>> meter.tools.divisionOptionsPreset(5, 8)

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -475,8 +475,8 @@ class MidiEvent(prebase.ProtoM21Object):
         self.time: int = time
         self.channel: int|None = channel
 
-        self.parameter1: t.Union[int, bytes, None] = None  # pitch or first data value
-        self.parameter2: t.Union[int, bytes, None] = None  # velocity or second data value
+        self.parameter1: int|bytes|None = None  # pitch or first data value
+        self.parameter2: int|bytes|None = None  # velocity or second data value
 
         # data is a property...
 

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -466,14 +466,14 @@ class MidiEvent(prebase.ProtoM21Object):
     '''
     # pylint: disable=redefined-builtin
     def __init__(self,
-                 track: t.Optional[MidiTrack] = None,
+                 track: MidiTrack|None = None,
                  type=None,
                  time: int = 0,
-                 channel: t.Optional[int] = None):
-        self.track: t.Optional[MidiTrack] = track  # a MidiTrack object
+                 channel: int|None = None):
+        self.track: MidiTrack|None = track  # a MidiTrack object
         self.type = type
         self.time: int = time
-        self.channel: t.Optional[int] = channel
+        self.channel: int|None = channel
 
         self.parameter1: t.Union[int, bytes, None] = None  # pitch or first data value
         self.parameter2: t.Union[int, bytes, None] = None  # velocity or second data value
@@ -482,15 +482,15 @@ class MidiEvent(prebase.ProtoM21Object):
 
         # if this is a Note on/off, need to store original
         # pitch space value in order to determine if this has a microtone
-        self.centShift: t.Optional[int] = None
+        self.centShift: int|None = None
 
         # store a reference to a corresponding event
         # if a noteOn, store the note off, and vice versa
         # circular ref -- but modern Python will garbage collect it.
-        self.correspondingEvent: t.Optional[MidiEvent] = None
+        self.correspondingEvent: MidiEvent|None = None
 
         # store and pass on a running status if found
-        self.lastStatusByte: t.Optional[int] = None
+        self.lastStatusByte: int|None = None
 
     @property
     def sortOrder(self) -> int:

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -466,31 +466,31 @@ class MidiEvent(prebase.ProtoM21Object):
     '''
     # pylint: disable=redefined-builtin
     def __init__(self,
-                 track: MidiTrack|None = None,
+                 track: MidiTrack | None = None,
                  type=None,
                  time: int = 0,
-                 channel: int|None = None):
-        self.track: MidiTrack|None = track  # a MidiTrack object
+                 channel: int | None = None):
+        self.track: MidiTrack | None = track  # a MidiTrack object
         self.type = type
         self.time: int = time
-        self.channel: int|None = channel
+        self.channel: int | None = channel
 
-        self.parameter1: int|bytes|None = None  # pitch or first data value
-        self.parameter2: int|bytes|None = None  # velocity or second data value
+        self.parameter1: int | bytes | None = None  # pitch or first data value
+        self.parameter2: int | bytes | None = None  # velocity or second data value
 
         # data is a property...
 
         # if this is a Note on/off, need to store original
         # pitch space value in order to determine if this has a microtone
-        self.centShift: int|None = None
+        self.centShift: int | None = None
 
         # store a reference to a corresponding event
         # if a noteOn, store the note off, and vice versa
         # circular ref -- but modern Python will garbage collect it.
-        self.correspondingEvent: MidiEvent|None = None
+        self.correspondingEvent: MidiEvent | None = None
 
         # store and pass on a running status if found
-        self.lastStatusByte: int|None = None
+        self.lastStatusByte: int | None = None
 
     @property
     def sortOrder(self) -> int:

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -322,7 +322,7 @@ def midiEventsToNote(
     eventTuple: tuple[tuple[int, midi.MidiEvent],
                       tuple[int, midi.MidiEvent]],
     ticksPerQuarter: int = defaults.ticksPerQuarter,
-) -> t.Union[note.Note, note.Unpitched]:
+) -> note.Note|note.Unpitched:
     # noinspection PyShadowingNames
     '''
     Convert from a tuple of two tuples of an int and a midi.MidiEvent objects
@@ -426,12 +426,12 @@ def midiEventsToNote(
     nr.volume.velocityIsRelative = False  # not relative coming from MIDI
     # n._midiVelocity = eOn.velocity
 
-    return t.cast(t.Union[note.Note, note.Unpitched], nr)
+    return t.cast(note.Note|note.Unpitched, nr)
 
 
 def noteToMidiEvents(
-    inputM21: t.Union[note.Note, note.Unpitched], *, includeDeltaTime=True, channel=1
-) -> list[t.Union[midi.DeltaTime, midi.MidiEvent]]:
+    inputM21: note.Note|note.Unpitched, *, includeDeltaTime=True, channel=1
+) -> list[midi.DeltaTime|midi.MidiEvent]:
     # noinspection PyShadowingNames
     '''
     Translate a music21 Note to a list of four MIDI events --
@@ -477,7 +477,7 @@ def noteToMidiEvents(
     n = inputM21
 
     mt = None  # use a midi track set to None
-    eventList: list[t.Union[midi.DeltaTime, midi.MidiEvent]] = []
+    eventList: list[midi.DeltaTime|midi.MidiEvent] = []
 
     if includeDeltaTime:
         dt = midiModule.DeltaTime(mt, channel=channel)
@@ -664,7 +664,7 @@ def midiEventsToChord(
 
 def chordToMidiEvents(
     inputM21: chord.ChordBase, *, includeDeltaTime=True, channel=1
-) -> list[t.Union[midi.DeltaTime, midi.MidiEvent]]:
+) -> list[midi.DeltaTime|midi.MidiEvent]:
     # noinspection PyShadowingNames
     '''
     Translates a :class:`~music21.chord.Chord` object to a
@@ -697,7 +697,7 @@ def chordToMidiEvents(
     '''
     from music21 import midi as midiModule
     mt = None  # midi track
-    eventList: list[t.Union[midi.DeltaTime, midi.MidiEvent]] = []
+    eventList: list[midi.DeltaTime|midi.MidiEvent] = []
     c = inputM21
 
     # temporary storage for setting correspondence
@@ -1060,7 +1060,7 @@ def midiEventsToKey(eventList) -> key.Key:
 def keySignatureToMidiEvents(
     ks: key.KeySignature,
     includeDeltaTime=True
-) -> list[t.Union[midi.DeltaTime, midi.MidiEvent]]:
+) -> list[midi.DeltaTime|midi.MidiEvent]:
     # noinspection PyShadowingNames
     r'''
     Convert a single :class:`~music21.key.Key` or
@@ -1086,7 +1086,7 @@ def keySignatureToMidiEvents(
     '''
     from music21 import midi as midiModule
     mt = None  # use a midi track set to None
-    eventList: list[t.Union[midi.DeltaTime, midi.MidiEvent]] = []
+    eventList: list[midi.DeltaTime|midi.MidiEvent] = []
     if includeDeltaTime:
         dt = midiModule.DeltaTime(track=mt)
         # leave dt.time set to zero; will be shifted later as necessary
@@ -1129,7 +1129,7 @@ def midiEventsToTempo(eventList):
 def tempoToMidiEvents(
     tempoIndication: tempo.MetronomeMark,
     includeDeltaTime=True,
-) -> t.Optional[list[t.Union[midi.DeltaTime, midi.MidiEvent]]]:
+) -> list[midi.DeltaTime|midi.MidiEvent] | None:
     # noinspection PyShadowingNames
     r'''
     Given any TempoIndication, convert it to list of :class:`~music21.midi.MidiEvent`
@@ -1179,7 +1179,7 @@ def tempoToMidiEvents(
     if not hasattr(tempoIndication, 'number') or tempoIndication.number is None:
         return None
     mt = None  # use a midi track set to None
-    eventList: list[t.Union[midi.DeltaTime, midi.MidiEvent]] = []
+    eventList: list[midi.DeltaTime|midi.MidiEvent] = []
     if includeDeltaTime:
         dt = midiModule.DeltaTime(track=mt)
         eventList.append(dt)
@@ -1263,7 +1263,7 @@ def getPacketFromMidiEvent(
 
 def elementToMidiEventList(
     el: base.Music21Object
-) -> t.Optional[list[midi.MidiEvent]]:
+) -> list[midi.MidiEvent]|None:
     '''
     Return a list of MidiEvents (or None) from a Music21Object,
     assuming that dynamics have already been applied, etc.
@@ -1280,7 +1280,7 @@ def elementToMidiEventList(
     '''
     # TODO: this is the best use of the switch statement when minimum Python
     #    version is 3.10
-    sub: t.Optional[list[t.Union[midi.DeltaTime, midi.MidiEvent]]]
+    sub: list[midi.DeltaTime|midi.MidiEvent] | None
     if isinstance(el, note.Rest):
         return None
     elif isinstance(el, note.Note):
@@ -1663,7 +1663,7 @@ def filterPacketsByTrackId(
 def packetsToDeltaSeparatedEvents(
         packets: list[dict[str, t.Any]],
         midiTrack: midi.MidiTrack,
-) -> list[t.Union[midi.MidiEvent, midi.DeltaTime]]:
+) -> list[midi.MidiEvent|midi.DeltaTime]:
     '''
     Given a list of packets (which already contain MidiEvent objects)
     return a list of those Events with proper delta times between them.
@@ -1676,7 +1676,7 @@ def packetsToDeltaSeparatedEvents(
     '''
     from music21.midi import DeltaTime
 
-    events: list[t.Union[midi.MidiEvent, DeltaTime]] = []
+    events: list[midi.MidiEvent|DeltaTime] = []
     lastOffset = 0
     for packet in packets:
         midiEvent = packet['midiEvent']
@@ -2238,8 +2238,8 @@ def conductorStream(s: stream.Stream) -> stream.Part:
 
 def channelInstrumentData(
     s: stream.Stream,
-    acceptableChannelList: t.Optional[list[int]] = None,
-) -> tuple[dict[t.Union[int, None], int], list[int]]:
+    acceptableChannelList: list[int]|None = None,
+) -> tuple[dict[int|None, int], list[int]]:
     '''
     Read through Stream `s` and finding instruments in it, return a 2-tuple,
     the first a dictionary mapping MIDI program numbers to channel numbers,
@@ -2468,7 +2468,7 @@ def packetStorageFromSubstreamList(
 
 def updatePacketStorageWithChannelInfo(
         packetStorage: dict[int, dict[str, t.Any]],
-        channelByInstrument: dict[t.Union[int, None], t.Union[int, None]],
+        channelByInstrument: dict[int|None, int|None],
 ) -> None:
     '''
     Take the packetStorage dictionary and using information
@@ -2635,7 +2635,7 @@ def streamToMidiFile(
     inputM21: stream.Stream,
     *,
     addStartDelay: bool = False,
-    acceptableChannelList: t.Optional[list[int]] = None,
+    acceptableChannelList: list[int]|None = None,
 ) -> midi.MidiFile:
     # noinspection PyShadowingNames
     '''

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -322,7 +322,7 @@ def midiEventsToNote(
     eventTuple: tuple[tuple[int, midi.MidiEvent],
                       tuple[int, midi.MidiEvent]],
     ticksPerQuarter: int = defaults.ticksPerQuarter,
-) -> note.Note|note.Unpitched:
+) -> note.Note | note.Unpitched:
     # noinspection PyShadowingNames
     '''
     Convert from a tuple of two tuples of an int and a midi.MidiEvent objects
@@ -426,12 +426,12 @@ def midiEventsToNote(
     nr.volume.velocityIsRelative = False  # not relative coming from MIDI
     # n._midiVelocity = eOn.velocity
 
-    return t.cast(note.Note|note.Unpitched, nr)
+    return t.cast(note.Note | note.Unpitched, nr)
 
 
 def noteToMidiEvents(
-    inputM21: note.Note|note.Unpitched, *, includeDeltaTime=True, channel=1
-) -> list[midi.DeltaTime|midi.MidiEvent]:
+    inputM21: note.Note | note.Unpitched, *, includeDeltaTime=True, channel=1
+) -> list[midi.DeltaTime | midi.MidiEvent]:
     # noinspection PyShadowingNames
     '''
     Translate a music21 Note to a list of four MIDI events --
@@ -477,7 +477,7 @@ def noteToMidiEvents(
     n = inputM21
 
     mt = None  # use a midi track set to None
-    eventList: list[midi.DeltaTime|midi.MidiEvent] = []
+    eventList: list[midi.DeltaTime | midi.MidiEvent] = []
 
     if includeDeltaTime:
         dt = midiModule.DeltaTime(mt, channel=channel)
@@ -664,7 +664,7 @@ def midiEventsToChord(
 
 def chordToMidiEvents(
     inputM21: chord.ChordBase, *, includeDeltaTime=True, channel=1
-) -> list[midi.DeltaTime|midi.MidiEvent]:
+) -> list[midi.DeltaTime | midi.MidiEvent]:
     # noinspection PyShadowingNames
     '''
     Translates a :class:`~music21.chord.Chord` object to a
@@ -697,7 +697,7 @@ def chordToMidiEvents(
     '''
     from music21 import midi as midiModule
     mt = None  # midi track
-    eventList: list[midi.DeltaTime|midi.MidiEvent] = []
+    eventList: list[midi.DeltaTime | midi.MidiEvent] = []
     c = inputM21
 
     # temporary storage for setting correspondence
@@ -1060,7 +1060,7 @@ def midiEventsToKey(eventList) -> key.Key:
 def keySignatureToMidiEvents(
     ks: key.KeySignature,
     includeDeltaTime=True
-) -> list[midi.DeltaTime|midi.MidiEvent]:
+) -> list[midi.DeltaTime | midi.MidiEvent]:
     # noinspection PyShadowingNames
     r'''
     Convert a single :class:`~music21.key.Key` or
@@ -1086,7 +1086,7 @@ def keySignatureToMidiEvents(
     '''
     from music21 import midi as midiModule
     mt = None  # use a midi track set to None
-    eventList: list[midi.DeltaTime|midi.MidiEvent] = []
+    eventList: list[midi.DeltaTime | midi.MidiEvent] = []
     if includeDeltaTime:
         dt = midiModule.DeltaTime(track=mt)
         # leave dt.time set to zero; will be shifted later as necessary
@@ -1129,7 +1129,7 @@ def midiEventsToTempo(eventList):
 def tempoToMidiEvents(
     tempoIndication: tempo.MetronomeMark,
     includeDeltaTime=True,
-) -> list[midi.DeltaTime|midi.MidiEvent] | None:
+) -> list[midi.DeltaTime | midi.MidiEvent] | None:
     # noinspection PyShadowingNames
     r'''
     Given any TempoIndication, convert it to list of :class:`~music21.midi.MidiEvent`
@@ -1179,7 +1179,7 @@ def tempoToMidiEvents(
     if not hasattr(tempoIndication, 'number') or tempoIndication.number is None:
         return None
     mt = None  # use a midi track set to None
-    eventList: list[midi.DeltaTime|midi.MidiEvent] = []
+    eventList: list[midi.DeltaTime | midi.MidiEvent] = []
     if includeDeltaTime:
         dt = midiModule.DeltaTime(track=mt)
         eventList.append(dt)
@@ -1206,8 +1206,8 @@ def getPacketFromMidiEvent(
         trackId: int,
         offset: int,
         midiEvent: midi.MidiEvent,
-        obj: base.Music21Object|None = None,
-        lastInstrument: instrument.Instrument|None = None
+        obj: base.Music21Object | None = None,
+        lastInstrument: instrument.Instrument | None = None
 ) -> dict[str, t.Any]:
     '''
     Pack a dictionary of parameters for each event.
@@ -1263,7 +1263,7 @@ def getPacketFromMidiEvent(
 
 def elementToMidiEventList(
     el: base.Music21Object
-) -> list[midi.MidiEvent]|None:
+) -> list[midi.MidiEvent] | None:
     '''
     Return a list of MidiEvents (or None) from a Music21Object,
     assuming that dynamics have already been applied, etc.
@@ -1280,7 +1280,7 @@ def elementToMidiEventList(
     '''
     # TODO: this is the best use of the switch statement when minimum Python
     #    version is 3.10
-    sub: list[midi.DeltaTime|midi.MidiEvent] | None
+    sub: list[midi.DeltaTime | midi.MidiEvent] | None
     if isinstance(el, note.Rest):
         return None
     elif isinstance(el, note.Note):
@@ -1628,7 +1628,7 @@ def assignPacketsToChannels(
 
 def filterPacketsByTrackId(
     packetsSrc: list[dict[str, t.Any]],
-    trackIdFilter: int|None = None,
+    trackIdFilter: int | None = None,
 ) -> list[dict[str, t.Any]]:
     '''
     Given a list of Packet dictionaries, return a list of
@@ -1663,7 +1663,7 @@ def filterPacketsByTrackId(
 def packetsToDeltaSeparatedEvents(
         packets: list[dict[str, t.Any]],
         midiTrack: midi.MidiTrack,
-) -> list[midi.MidiEvent|midi.DeltaTime]:
+) -> list[midi.MidiEvent | midi.DeltaTime]:
     '''
     Given a list of packets (which already contain MidiEvent objects)
     return a list of those Events with proper delta times between them.
@@ -1676,7 +1676,7 @@ def packetsToDeltaSeparatedEvents(
     '''
     from music21.midi import DeltaTime
 
-    events: list[midi.MidiEvent|DeltaTime] = []
+    events: list[midi.MidiEvent | DeltaTime] = []
     lastOffset = 0
     for packet in packets:
         midiEvent = packet['midiEvent']
@@ -1880,7 +1880,7 @@ def midiTrackToStream(
     ticksPerQuarter: int = defaults.ticksPerQuarter,
     quantizePost=True,
     inputM21=None,
-    conductorPart: stream.Part|None = None,
+    conductorPart: stream.Part | None = None,
     isFirst: bool = False,
     quarterLengthDivisors: Sequence[int] = (),
     **keywords
@@ -2080,7 +2080,7 @@ def midiTrackToStream(
     if conductorPart is not None:
         insertConductorEvents(conductorPart, s, isFirst=isFirst)
 
-    meterStream: stream.Stream|None = None
+    meterStream: stream.Stream | None = None
     if conductorPart is not None:
         ts_iter = conductorPart['TimeSignature']
         if ts_iter:
@@ -2238,8 +2238,8 @@ def conductorStream(s: stream.Stream) -> stream.Part:
 
 def channelInstrumentData(
     s: stream.Stream,
-    acceptableChannelList: list[int]|None = None,
-) -> tuple[dict[int|None, int], list[int]]:
+    acceptableChannelList: list[int] | None = None,
+) -> tuple[dict[int | None, int], list[int]]:
     '''
     Read through Stream `s` and finding instruments in it, return a 2-tuple,
     the first a dictionary mapping MIDI program numbers to channel numbers,
@@ -2468,7 +2468,7 @@ def packetStorageFromSubstreamList(
 
 def updatePacketStorageWithChannelInfo(
         packetStorage: dict[int, dict[str, t.Any]],
-        channelByInstrument: dict[int|None, int|None],
+        channelByInstrument: dict[int | None, int | None],
 ) -> None:
     '''
     Take the packetStorage dictionary and using information
@@ -2590,7 +2590,7 @@ def midiTracksToStreams(
     midiTracks: list[midi.MidiTrack],
     ticksPerQuarter: int = defaults.ticksPerQuarter,
     quantizePost=True,
-    inputM21: stream.Score|None = None,
+    inputM21: stream.Score | None = None,
     **keywords
 ) -> stream.Score:
     '''
@@ -2635,7 +2635,7 @@ def streamToMidiFile(
     inputM21: stream.Stream,
     *,
     addStartDelay: bool = False,
-    acceptableChannelList: list[int]|None = None,
+    acceptableChannelList: list[int] | None = None,
 ) -> midi.MidiFile:
     # noinspection PyShadowingNames
     '''

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -393,7 +393,7 @@ def midiEventsToNote(
     tOn, eOn = eventTuple[0]
     tOff, unused_eOff = eventTuple[1]
 
-    returnClass: t.Union[type[note.Unpitched], type[note.Note]]
+    returnClass: type[note.Unpitched] | type[note.Note]
     if eOn.channel == 10:
         returnClass = note.Unpitched
     else:
@@ -631,7 +631,7 @@ def midiEventsToChord(
         v.velocityIsRelative = False  # velocity is absolute coming from
         volumes.append(v)
 
-    returnClass: t.Union[type[percussion.PercussionChord], type[chord.Chord]]
+    returnClass: type[percussion.PercussionChord] | type[chord.Chord]
     if any_channel_10:
         returnClass = percussion.PercussionChord
     else:

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1206,8 +1206,8 @@ def getPacketFromMidiEvent(
         trackId: int,
         offset: int,
         midiEvent: midi.MidiEvent,
-        obj: t.Optional[base.Music21Object] = None,
-        lastInstrument: t.Optional[instrument.Instrument] = None
+        obj: base.Music21Object|None = None,
+        lastInstrument: instrument.Instrument|None = None
 ) -> dict[str, t.Any]:
     '''
     Pack a dictionary of parameters for each event.
@@ -1628,7 +1628,7 @@ def assignPacketsToChannels(
 
 def filterPacketsByTrackId(
     packetsSrc: list[dict[str, t.Any]],
-    trackIdFilter: t.Optional[int] = None,
+    trackIdFilter: int|None = None,
 ) -> list[dict[str, t.Any]]:
     '''
     Given a list of Packet dictionaries, return a list of
@@ -1880,7 +1880,7 @@ def midiTrackToStream(
     ticksPerQuarter: int = defaults.ticksPerQuarter,
     quantizePost=True,
     inputM21=None,
-    conductorPart: t.Optional[stream.Part] = None,
+    conductorPart: stream.Part|None = None,
     isFirst: bool = False,
     quarterLengthDivisors: Sequence[int] = (),
     **keywords
@@ -2080,7 +2080,7 @@ def midiTrackToStream(
     if conductorPart is not None:
         insertConductorEvents(conductorPart, s, isFirst=isFirst)
 
-    meterStream: t.Optional[stream.Stream] = None
+    meterStream: stream.Stream|None = None
     if conductorPart is not None:
         ts_iter = conductorPart['TimeSignature']
         if ts_iter:
@@ -2590,7 +2590,7 @@ def midiTracksToStreams(
     midiTracks: list[midi.MidiTrack],
     ticksPerQuarter: int = defaults.ticksPerQuarter,
     quantizePost=True,
-    inputM21: t.Optional[stream.Score] = None,
+    inputM21: stream.Score|None = None,
     **keywords
 ) -> stream.Score:
     '''

--- a/music21/musicxml/archiveTools.py
+++ b/music21/musicxml/archiveTools.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import os
 import pathlib
-import typing as t
 import zipfile
 
 from music21 import common

--- a/music21/musicxml/archiveTools.py
+++ b/music21/musicxml/archiveTools.py
@@ -48,7 +48,7 @@ def compressAllXMLFiles(*, deleteOriginal=False):
     )
 
 
-def compressXML(filename: str|pathlib.Path,
+def compressXML(filename: str | pathlib.Path,
                 *,
                 deleteOriginal=False,
                 silent=False,
@@ -100,7 +100,7 @@ def compressXML(filename: str|pathlib.Path,
     return True
 
 
-def uncompressMXL(filename: str|pathlib.Path,
+def uncompressMXL(filename: str | pathlib.Path,
                   *,
                   deleteOriginal=False,
                   strictMxlCheck=True) -> bool:

--- a/music21/musicxml/archiveTools.py
+++ b/music21/musicxml/archiveTools.py
@@ -48,7 +48,7 @@ def compressAllXMLFiles(*, deleteOriginal=False):
     )
 
 
-def compressXML(filename: t.Union[str, pathlib.Path],
+def compressXML(filename: str|pathlib.Path,
                 *,
                 deleteOriginal=False,
                 silent=False,
@@ -100,7 +100,7 @@ def compressXML(filename: t.Union[str, pathlib.Path],
     return True
 
 
-def uncompressMXL(filename: t.Union[str, pathlib.Path],
+def uncompressMXL(filename: str|pathlib.Path,
                   *,
                   deleteOriginal=False,
                   strictMxlCheck=True) -> bool:

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5340,7 +5340,7 @@ class MeasureExporter(XMLExporterBase):
         self.xmlRoot.append(mxHarmony)
         return mxHarmony
 
-    def romanNumeralToXml(self, rn: roman.RomanNumeral) -> t.Union[Element, list[Element]]:
+    def romanNumeralToXml(self, rn: roman.RomanNumeral) -> Element | list[Element]:
         '''
         Convert a RomanNumeral object to either a chord (if .writeAsChord is True)
         or a Harmony XML Element.

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -2632,7 +2632,7 @@ class PartExporter(XMLExporterBase):
     }
 
     def __init__(self,
-                 partObj: t.Union[stream.Part, stream.Score, None] = None,
+                 partObj: stream.Part|stream.Score|None = None,
                  parent: ScoreExporter|None = None):
         super().__init__()
         # partObj can be a Score IF it has no parts within it.  But better to
@@ -2640,7 +2640,7 @@ class PartExporter(XMLExporterBase):
 
         if partObj is None:
             partObj = stream.Part()
-        self.stream: t.Union[stream.Part, stream.Score] = partObj
+        self.stream: stream.Part|stream.Score = partObj
         self.parent = parent  # ScoreExporter
         self.xmlRoot = Element('part')
 
@@ -4002,7 +4002,7 @@ class MeasureExporter(XMLExporterBase):
         if n.isRest:
             return
 
-        searchingObject: t.Union[note.NotRest, chord.Chord] = chordParent if chordParent else n
+        searchingObject: note.NotRest|chord.Chord = chordParent if chordParent else n
         closest_inst = searchingObject.getInstrument(returnDefault=True)
 
         instance_to_use = None

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -164,7 +164,7 @@ def _setTagTextFromAttribute(
     m21El,
     xmlEl: Element,
     tag: str,
-    attributeName: str|None = None,
+    attributeName: str | None = None,
     *,
     transform=None,
     forceEmpty=False
@@ -279,7 +279,7 @@ def _setAttributeFromAttribute(m21El, xmlEl, xmlAttributeName, attributeName=Non
 
 
 def _synchronizeIds(element: Element,
-                    m21Object: prebase.ProtoM21Object|None) -> None:
+                    m21Object: prebase.ProtoM21Object | None) -> None:
     # noinspection PyTypeChecker
     '''
     MusicXML 3.1 defines the id attribute (entity: %optional-unique-id)
@@ -803,7 +803,7 @@ class XMLExporterBase:
     '''
     def __init__(self):
         self.xmlRoot = None
-        self.stream: stream.Stream|None = None
+        self.stream: stream.Stream | None = None
 
     def asBytes(self, noCopy=True) -> bytes:
         '''
@@ -1445,7 +1445,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
     a musicxml Element.
     '''
 
-    def __init__(self, score: stream.Score|None = None, makeNotation: bool = True):
+    def __init__(self, score: stream.Score | None = None, makeNotation: bool = True):
         super().__init__()
         if score is None:
             # should not be done this way.
@@ -1458,8 +1458,8 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
 
         self.scoreMetadata = None
 
-        self.spannerBundle: spanner.SpannerBundle|None = None
-        self.meterStream: stream.Stream[meter.TimeSignatureBase]|None = None
+        self.spannerBundle: spanner.SpannerBundle | None = None
+        self.meterStream: stream.Stream[meter.TimeSignatureBase] | None = None
         self.scoreLayouts = None
         self.firstScoreLayout = None
         self.textBoxes = None
@@ -1474,8 +1474,8 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         self.instrumentsByStream: dict[int, stream.Stream] = {}
 
         self.instrumentList: list[instrument.Instrument] = []
-        self.instrumentIdList: list[str|None] = []
-        self.midiChannelList: list[int|None] = []
+        self.instrumentIdList: list[str | None] = []
+        self.midiChannelList: list[int | None] = []
 
         self.parts: list[stream.Part] = []
 
@@ -2436,7 +2436,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
                 # We have already emitted all the copyrights.
                 continue
 
-            namespaceName: str|None = md.uniqueNameToNamespaceName(uniqueName)
+            namespaceName: str | None = md.uniqueNameToNamespaceName(uniqueName)
             if namespaceName is None:
                 namespaceName = uniqueName
 
@@ -2558,7 +2558,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         mxScoreHeader = self.xmlRoot
         mxWork = Element('work')
         # TODO: work-number
-        firstTitleFound: metadata.Text|None = None
+        firstTitleFound: metadata.Text | None = None
         titles: tuple[metadata.Text, ...] = mdObj['title']
         if titles:
             if firstTitleFound is None:
@@ -2632,15 +2632,15 @@ class PartExporter(XMLExporterBase):
     }
 
     def __init__(self,
-                 partObj: stream.Part|stream.Score|None = None,
-                 parent: ScoreExporter|None = None):
+                 partObj: stream.Part | stream.Score | None = None,
+                 parent: ScoreExporter | None = None):
         super().__init__()
         # partObj can be a Score IF it has no parts within it.  But better to
         # always have it be a Part
 
         if partObj is None:
             partObj = stream.Part()
-        self.stream: stream.Part|stream.Score = partObj
+        self.stream: stream.Part | stream.Score = partObj
         self.parent = parent  # ScoreExporter
         self.xmlRoot = Element('part')
 
@@ -2657,7 +2657,7 @@ class PartExporter(XMLExporterBase):
             self.midiChannelList = parent.midiChannelList  # shared list
             self.makeNotation = parent.makeNotation
 
-        self.previousPartStaffInGroup: stream.PartStaff|None = None
+        self.previousPartStaffInGroup: stream.PartStaff | None = None
 
         self.instrumentStream: stream.Stream[instrument.Instrument] | None = None
         self.firstInstrumentObject = None
@@ -2667,7 +2667,7 @@ class PartExporter(XMLExporterBase):
         self.lastDivisions = None
 
         # The staffGroup to which this part belongs (if it belongs to one)
-        self.staffGroup: layout.StaffGroup|None = None
+        self.staffGroup: layout.StaffGroup | None = None
 
         self.spannerBundle = partObj.spannerBundle
 
@@ -3125,8 +3125,8 @@ class MeasureExporter(XMLExporterBase):
     ignoreOnParseClasses = {'LayoutBase', 'Barline'}
 
     def __init__(self,
-                 measureObj: stream.Measure|None = None,
-                 parent: PartExporter|None = None):
+                 measureObj: stream.Measure | None = None,
+                 parent: PartExporter | None = None):
         super().__init__()
         if measureObj is None:  # no point, but...
             self.stream = stream.Measure()
@@ -3142,7 +3142,7 @@ class MeasureExporter(XMLExporterBase):
         self.mxTranspose = None
         self.measureOffsetStart = 0.0
         self.offsetInMeasure = 0.0
-        self.currentVoiceId: int|None = None
+        self.currentVoiceId: int | None = None
         self.nextFreeVoiceNumber: int = 1
         self.nextArpeggioNumber: int = 1
         self.arpeggioNumbers: dict[expressions.ArpeggioMarkSpanner, int] = {}
@@ -3506,7 +3506,7 @@ class MeasureExporter(XMLExporterBase):
         self,
         obj: base.Music21Object,
         noteIndexInChord: int = 0,
-        objectSpannerBundle: spanner.SpannerBundle|None = None
+        objectSpannerBundle: spanner.SpannerBundle | None = None
     ) -> list[Element]:
         '''
         return a list of <notations> from spanners related to the object that should appear
@@ -3673,7 +3673,7 @@ class MeasureExporter(XMLExporterBase):
             if isinstance(obj, chord.Chord):
                 sub_obj = obj[noteIndexInChord]
 
-            mxArpeggio: Element|None = None
+            mxArpeggio: Element | None = None
             if ams.type == 'non-arpeggio':
                 min_note, max_note = ams.noteExtremes()
                 # <non-arpeggiate> goes only on top and bottom note in chord
@@ -3988,7 +3988,7 @@ class MeasureExporter(XMLExporterBase):
     def setNoteInstrument(self,
                           n: note.NotRest,
                           mxNote: Element,
-                          chordParent: chord.Chord|None):
+                          chordParent: chord.Chord | None):
         '''
         Insert <instrument> tags if necessary, that is, when there is more than one
         instrument anywhere in the same musicxml <part>.
@@ -4002,7 +4002,7 @@ class MeasureExporter(XMLExporterBase):
         if n.isRest:
             return
 
-        searchingObject: note.NotRest|chord.Chord = chordParent if chordParent else n
+        searchingObject: note.NotRest | chord.Chord = chordParent if chordParent else n
         closest_inst = searchingObject.getInstrument(returnDefault=True)
 
         instance_to_use = None
@@ -4126,7 +4126,7 @@ class MeasureExporter(XMLExporterBase):
         if r.stepShift != 0:
             mxDisplayStep = SubElement(mxRestTag, 'display-step')
             mxDisplayOctave = SubElement(mxRestTag, 'display-octave')
-            currentClef: clef.PitchClef|None = r.getContextByClass(clef.PitchClef)
+            currentClef: clef.PitchClef | None = r.getContextByClass(clef.PitchClef)
             if currentClef is None or not hasattr(currentClef, 'lowestLine'):
                 currentClef = clef.TrebleClef()
                 # this should not be common enough to
@@ -4414,7 +4414,7 @@ class MeasureExporter(XMLExporterBase):
 
         return mxFrameNote
 
-    def fretBoardToXml(self, fretBoard) -> Element|None:
+    def fretBoardToXml(self, fretBoard) -> Element | None:
         '''
         The ChordWithFretBoard Object combines chord symbols with FretNote objects.
 
@@ -4519,7 +4519,7 @@ class MeasureExporter(XMLExporterBase):
         self,
         mxNote: Element,
         n: note.GeneralNote,
-        chordParent: chord.Chord|None = None
+        chordParent: chord.Chord | None = None
     ) -> None:
         '''
         Determine if an <notehead> element needs to be added to this <note>
@@ -6468,7 +6468,7 @@ class MeasureExporter(XMLExporterBase):
         # TODO: staff-size
         return mxStaffDetails
 
-    def timeSignatureToXml(self, ts: meter.TimeSignature|meter.SenzaMisuraTimeSignature):
+    def timeSignatureToXml(self, ts: meter.TimeSignature | meter.SenzaMisuraTimeSignature):
         '''
         Returns a single <time> tag from a meter.TimeSignature object.
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -164,7 +164,7 @@ def _setTagTextFromAttribute(
     m21El,
     xmlEl: Element,
     tag: str,
-    attributeName: t.Optional[str] = None,
+    attributeName: str|None = None,
     *,
     transform=None,
     forceEmpty=False
@@ -803,7 +803,7 @@ class XMLExporterBase:
     '''
     def __init__(self):
         self.xmlRoot = None
-        self.stream: t.Optional[stream.Stream] = None
+        self.stream: stream.Stream|None = None
 
     def asBytes(self, noCopy=True) -> bytes:
         '''
@@ -1445,7 +1445,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
     a musicxml Element.
     '''
 
-    def __init__(self, score: t.Optional[stream.Score] = None, makeNotation: bool = True):
+    def __init__(self, score: stream.Score|None = None, makeNotation: bool = True):
         super().__init__()
         if score is None:
             # should not be done this way.
@@ -1458,7 +1458,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
 
         self.scoreMetadata = None
 
-        self.spannerBundle: t.Optional[spanner.SpannerBundle] = None
+        self.spannerBundle: spanner.SpannerBundle|None = None
         self.meterStream: t.Optional[stream.Stream[meter.TimeSignatureBase]] = None
         self.scoreLayouts = None
         self.firstScoreLayout = None
@@ -2436,7 +2436,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
                 # We have already emitted all the copyrights.
                 continue
 
-            namespaceName: t.Optional[str] = md.uniqueNameToNamespaceName(uniqueName)
+            namespaceName: str|None = md.uniqueNameToNamespaceName(uniqueName)
             if namespaceName is None:
                 namespaceName = uniqueName
 
@@ -2558,7 +2558,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         mxScoreHeader = self.xmlRoot
         mxWork = Element('work')
         # TODO: work-number
-        firstTitleFound: t.Optional[metadata.Text] = None
+        firstTitleFound: metadata.Text|None = None
         titles: tuple[metadata.Text, ...] = mdObj['title']
         if titles:
             if firstTitleFound is None:
@@ -2633,7 +2633,7 @@ class PartExporter(XMLExporterBase):
 
     def __init__(self,
                  partObj: t.Union[stream.Part, stream.Score, None] = None,
-                 parent: t.Optional[ScoreExporter] = None):
+                 parent: ScoreExporter|None = None):
         super().__init__()
         # partObj can be a Score IF it has no parts within it.  But better to
         # always have it be a Part
@@ -2657,7 +2657,7 @@ class PartExporter(XMLExporterBase):
             self.midiChannelList = parent.midiChannelList  # shared list
             self.makeNotation = parent.makeNotation
 
-        self.previousPartStaffInGroup: t.Optional[stream.PartStaff] = None
+        self.previousPartStaffInGroup: stream.PartStaff|None = None
 
         self.instrumentStream: t.Optional[stream.Stream[instrument.Instrument]] = None
         self.firstInstrumentObject = None
@@ -2667,7 +2667,7 @@ class PartExporter(XMLExporterBase):
         self.lastDivisions = None
 
         # The staffGroup to which this part belongs (if it belongs to one)
-        self.staffGroup: t.Optional[layout.StaffGroup] = None
+        self.staffGroup: layout.StaffGroup|None = None
 
         self.spannerBundle = partObj.spannerBundle
 
@@ -3125,8 +3125,8 @@ class MeasureExporter(XMLExporterBase):
     ignoreOnParseClasses = {'LayoutBase', 'Barline'}
 
     def __init__(self,
-                 measureObj: t.Optional[stream.Measure] = None,
-                 parent: t.Optional[PartExporter] = None):
+                 measureObj: stream.Measure|None = None,
+                 parent: PartExporter|None = None):
         super().__init__()
         if measureObj is None:  # no point, but...
             self.stream = stream.Measure()
@@ -3142,7 +3142,7 @@ class MeasureExporter(XMLExporterBase):
         self.mxTranspose = None
         self.measureOffsetStart = 0.0
         self.offsetInMeasure = 0.0
-        self.currentVoiceId: t.Optional[int] = None
+        self.currentVoiceId: int|None = None
         self.nextFreeVoiceNumber: int = 1
         self.nextArpeggioNumber: int = 1
         self.arpeggioNumbers: dict[expressions.ArpeggioMarkSpanner, int] = {}
@@ -3506,7 +3506,7 @@ class MeasureExporter(XMLExporterBase):
         self,
         obj: base.Music21Object,
         noteIndexInChord: int = 0,
-        objectSpannerBundle: t.Optional[spanner.SpannerBundle] = None
+        objectSpannerBundle: spanner.SpannerBundle|None = None
     ) -> list[Element]:
         '''
         return a list of <notations> from spanners related to the object that should appear
@@ -3673,7 +3673,7 @@ class MeasureExporter(XMLExporterBase):
             if isinstance(obj, chord.Chord):
                 sub_obj = obj[noteIndexInChord]
 
-            mxArpeggio: t.Optional[Element] = None
+            mxArpeggio: Element|None = None
             if ams.type == 'non-arpeggio':
                 min_note, max_note = ams.noteExtremes()
                 # <non-arpeggiate> goes only on top and bottom note in chord
@@ -4126,7 +4126,7 @@ class MeasureExporter(XMLExporterBase):
         if r.stepShift != 0:
             mxDisplayStep = SubElement(mxRestTag, 'display-step')
             mxDisplayOctave = SubElement(mxRestTag, 'display-octave')
-            currentClef: t.Optional[clef.PitchClef] = r.getContextByClass(clef.PitchClef)
+            currentClef: clef.PitchClef|None = r.getContextByClass(clef.PitchClef)
             if currentClef is None or not hasattr(currentClef, 'lowestLine'):
                 currentClef = clef.TrebleClef()
                 # this should not be common enough to
@@ -4519,7 +4519,7 @@ class MeasureExporter(XMLExporterBase):
         self,
         mxNote: Element,
         n: note.GeneralNote,
-        chordParent: t.Optional[chord.Chord] = None
+        chordParent: chord.Chord|None = None
     ) -> None:
         '''
         Determine if an <notehead> element needs to be added to this <note>

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -279,7 +279,7 @@ def _setAttributeFromAttribute(m21El, xmlEl, xmlAttributeName, attributeName=Non
 
 
 def _synchronizeIds(element: Element,
-                    m21Object: t.Optional[prebase.ProtoM21Object]) -> None:
+                    m21Object: prebase.ProtoM21Object|None) -> None:
     # noinspection PyTypeChecker
     '''
     MusicXML 3.1 defines the id attribute (entity: %optional-unique-id)
@@ -1459,7 +1459,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         self.scoreMetadata = None
 
         self.spannerBundle: spanner.SpannerBundle|None = None
-        self.meterStream: t.Optional[stream.Stream[meter.TimeSignatureBase]] = None
+        self.meterStream: stream.Stream[meter.TimeSignatureBase]|None = None
         self.scoreLayouts = None
         self.firstScoreLayout = None
         self.textBoxes = None
@@ -1474,8 +1474,8 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         self.instrumentsByStream: dict[int, stream.Stream] = {}
 
         self.instrumentList: list[instrument.Instrument] = []
-        self.instrumentIdList: list[t.Optional[str]] = []
-        self.midiChannelList: list[t.Optional[int]] = []
+        self.instrumentIdList: list[str|None] = []
+        self.midiChannelList: list[int|None] = []
 
         self.parts: list[stream.Part] = []
 
@@ -2659,7 +2659,7 @@ class PartExporter(XMLExporterBase):
 
         self.previousPartStaffInGroup: stream.PartStaff|None = None
 
-        self.instrumentStream: t.Optional[stream.Stream[instrument.Instrument]] = None
+        self.instrumentStream: stream.Stream[instrument.Instrument] | None = None
         self.firstInstrumentObject = None
 
         # keep track of this so that we only put out new attributes when something
@@ -3988,7 +3988,7 @@ class MeasureExporter(XMLExporterBase):
     def setNoteInstrument(self,
                           n: note.NotRest,
                           mxNote: Element,
-                          chordParent: t.Optional[chord.Chord]):
+                          chordParent: chord.Chord|None):
         '''
         Insert <instrument> tags if necessary, that is, when there is more than one
         instrument anywhere in the same musicxml <part>.
@@ -4414,7 +4414,7 @@ class MeasureExporter(XMLExporterBase):
 
         return mxFrameNote
 
-    def fretBoardToXml(self, fretBoard) -> t.Optional[Element]:
+    def fretBoardToXml(self, fretBoard) -> Element|None:
         '''
         The ChordWithFretBoard Object combines chord symbols with FretNote objects.
 
@@ -6468,7 +6468,7 @@ class MeasureExporter(XMLExporterBase):
         # TODO: staff-size
         return mxStaffDetails
 
-    def timeSignatureToXml(self, ts: t.Union[meter.TimeSignature, meter.SenzaMisuraTimeSignature]):
+    def timeSignatureToXml(self, ts: meter.TimeSignature|meter.SenzaMisuraTimeSignature):
         '''
         Returns a single <time> tag from a meter.TimeSignature object.
 

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -322,7 +322,7 @@ class PartStaffExporterMixin:
           </note>
         </measure>
         '''
-        initialPartStaffRoot: t.Optional[Element] = None
+        initialPartStaffRoot: Element|None = None
         for i, ps in enumerate(group):
             staffNumber: int = i + 1  # 1-indexed
             thisPartStaffRoot: Element = self.getRootForPartStaff(ps)
@@ -547,7 +547,7 @@ class PartStaffExporterMixin:
             in this StaffGroup does not compare to the first instance of that class
             in the earliest staff where found (not necessarily the first) using `comparison`.
             '''
-            initialM21Instance: t.Optional[M21ObjType] = None
+            initialM21Instance: M21ObjType|None = None
             # noinspection PyShadowingNames
             for ps in group:  # ps okay to reuse.
                 if initialM21Instance is None:
@@ -565,8 +565,8 @@ class PartStaffExporterMixin:
         multiKey: bool = isMultiAttribute(KeySignature)
         multiMeter: bool = isMultiAttribute(TimeSignature, comparison='ratioEqual')
 
-        initialPartStaffRoot: t.Optional[Element] = None
-        mxAttributes: t.Optional[Element] = None
+        initialPartStaffRoot: Element|None = None
+        mxAttributes: Element|None = None
         for i, ps in enumerate(group):
             staffNumber: int = i + 1  # 1-indexed
 
@@ -574,7 +574,7 @@ class PartStaffExporterMixin:
             if initialPartStaffRoot is None:
                 initialPartStaffRoot = self.getRootForPartStaff(ps)
                 mxAttributes = initialPartStaffRoot.find('measure/attributes')
-                clef1: t.Optional[Element] = mxAttributes.find('clef') if mxAttributes else None
+                clef1: Element|None = mxAttributes.find('clef') if mxAttributes else None
                 if clef1 is not None:
                     clef1.set('number', '1')
 
@@ -599,7 +599,7 @@ class PartStaffExporterMixin:
             # Subsequent PartStaffs in group: set additional clefs on mxAttributes
             else:
                 thisPartStaffRoot: Element = self.getRootForPartStaff(ps)
-                oldClef: t.Optional[Element] = thisPartStaffRoot.find('measure/attributes/clef')
+                oldClef: Element|None = thisPartStaffRoot.find('measure/attributes/clef')
                 if oldClef is not None and mxAttributes is not None:
                     clefsInMxAttributesAlready = mxAttributes.findall('clef')
                     if len(clefsInMxAttributesAlready) >= staffNumber:
@@ -629,7 +629,7 @@ class PartStaffExporterMixin:
                     )
 
                 if multiMeter:
-                    oldMeter: t.Optional[Element] = thisPartStaffRoot.find(
+                    oldMeter: Element|None = thisPartStaffRoot.find(
                         'measure/attributes/time'
                     )
                     if oldMeter:
@@ -640,7 +640,7 @@ class PartStaffExporterMixin:
                             tagList=['staves']
                         )
                 if multiKey:
-                    oldKey: t.Optional[Element] = thisPartStaffRoot.find('measure/attributes/key')
+                    oldKey: Element|None = thisPartStaffRoot.find('measure/attributes/key')
                     if oldKey:
                         oldKey.set('number', str(staffNumber))
                         helpers.insertBeforeElements(

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -322,7 +322,7 @@ class PartStaffExporterMixin:
           </note>
         </measure>
         '''
-        initialPartStaffRoot: Element|None = None
+        initialPartStaffRoot: Element | None = None
         for i, ps in enumerate(group):
             staffNumber: int = i + 1  # 1-indexed
             thisPartStaffRoot: Element = self.getRootForPartStaff(ps)
@@ -387,7 +387,7 @@ class PartStaffExporterMixin:
         DIVIDER_COMMENT = '========================= Measure [NNN] =========================='
         PLACEHOLDER = '[NNN]'
 
-        def makeDivider(inner_sourceNumber: int|str) -> Element:
+        def makeDivider(inner_sourceNumber: int | str) -> Element:
             return Comment(DIVIDER_COMMENT.replace(PLACEHOLDER, str(inner_sourceNumber)))
 
         sourceMeasures = iter(source.findall('measure'))
@@ -547,7 +547,7 @@ class PartStaffExporterMixin:
             in this StaffGroup does not compare to the first instance of that class
             in the earliest staff where found (not necessarily the first) using `comparison`.
             '''
-            initialM21Instance: M21ObjType|None = None
+            initialM21Instance: M21ObjType | None = None
             # noinspection PyShadowingNames
             for ps in group:  # ps okay to reuse.
                 if initialM21Instance is None:
@@ -565,8 +565,8 @@ class PartStaffExporterMixin:
         multiKey: bool = isMultiAttribute(KeySignature)
         multiMeter: bool = isMultiAttribute(TimeSignature, comparison='ratioEqual')
 
-        initialPartStaffRoot: Element|None = None
-        mxAttributes: Element|None = None
+        initialPartStaffRoot: Element | None = None
+        mxAttributes: Element | None = None
         for i, ps in enumerate(group):
             staffNumber: int = i + 1  # 1-indexed
 
@@ -574,7 +574,7 @@ class PartStaffExporterMixin:
             if initialPartStaffRoot is None:
                 initialPartStaffRoot = self.getRootForPartStaff(ps)
                 mxAttributes = initialPartStaffRoot.find('measure/attributes')
-                clef1: Element|None = mxAttributes.find('clef') if mxAttributes else None
+                clef1: Element | None = mxAttributes.find('clef') if mxAttributes else None
                 if clef1 is not None:
                     clef1.set('number', '1')
 
@@ -599,7 +599,7 @@ class PartStaffExporterMixin:
             # Subsequent PartStaffs in group: set additional clefs on mxAttributes
             else:
                 thisPartStaffRoot: Element = self.getRootForPartStaff(ps)
-                oldClef: Element|None = thisPartStaffRoot.find('measure/attributes/clef')
+                oldClef: Element | None = thisPartStaffRoot.find('measure/attributes/clef')
                 if oldClef is not None and mxAttributes is not None:
                     clefsInMxAttributesAlready = mxAttributes.findall('clef')
                     if len(clefsInMxAttributesAlready) >= staffNumber:
@@ -629,7 +629,7 @@ class PartStaffExporterMixin:
                     )
 
                 if multiMeter:
-                    oldMeter: Element|None = thisPartStaffRoot.find(
+                    oldMeter: Element | None = thisPartStaffRoot.find(
                         'measure/attributes/time'
                     )
                     if oldMeter:
@@ -640,7 +640,7 @@ class PartStaffExporterMixin:
                             tagList=['staves']
                         )
                 if multiKey:
-                    oldKey: Element|None = thisPartStaffRoot.find('measure/attributes/key')
+                    oldKey: Element | None = thisPartStaffRoot.find('measure/attributes/key')
                     if oldKey:
                         oldKey.set('number', str(staffNumber))
                         helpers.insertBeforeElements(

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -387,7 +387,7 @@ class PartStaffExporterMixin:
         DIVIDER_COMMENT = '========================= Measure [NNN] =========================='
         PLACEHOLDER = '[NNN]'
 
-        def makeDivider(inner_sourceNumber: t.Union[int, str]) -> Element:
+        def makeDivider(inner_sourceNumber: int|str) -> Element:
             return Comment(DIVIDER_COMMENT.replace(PLACEHOLDER, str(inner_sourceNumber)))
 
         sourceMeasures = iter(source.findall('measure'))

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -80,7 +80,7 @@ _recognizableKeys: list[str] = list(
 
 # ------------------------------------------------------------------------------
 # Helpers...
-def _clean(badStr: str|None) -> str|None:
+def _clean(badStr: str | None) -> str | None:
     # need to remove badly-formed strings
     if badStr is None:
         return None
@@ -1319,7 +1319,7 @@ class MusicXMLImporter(XMLParserBase):
 
     def identificationToMetadata(self,
                                  identification: ET.Element,
-                                 inputM21: metadata.Metadata|None = None):
+                                 inputM21: metadata.Metadata | None = None):
         '''
         Convert an <identification> tag, containing <creator> tags, <rights> tags, and
         <miscellaneous> tag.
@@ -1435,7 +1435,7 @@ class MusicXMLImporter(XMLParserBase):
 
     def creatorToContributor(self,
                              creator: ET.Element,
-                             inputM21: metadata.primitives.Contributor|None = None):
+                             inputM21: metadata.primitives.Contributor | None = None):
         # noinspection PyShadowingNames
         '''
         Given a <creator> tag, fill the necessary parameters of a Contributor.
@@ -1550,8 +1550,8 @@ class PartParser(XMLParserBase):
         self.lastMeasureOffset = 0.0
 
         # a dict of clefs per staff number
-        self.lastClefs: dict[int, clef.Clef|None] = {NO_STAFF_ASSIGNED: clef.TrebleClef()}
-        self.activeTuplets: list[duration.Tuplet|None] = [None] * 7
+        self.lastClefs: dict[int, clef.Clef | None] = {NO_STAFF_ASSIGNED: clef.TrebleClef()}
+        self.activeTuplets: list[duration.Tuplet | None] = [None] * 7
 
         self.maxStaves = 1  # will be changed in measure parsing...
 
@@ -1716,7 +1716,7 @@ class PartParser(XMLParserBase):
         # TODO: elevation
         # TODO: store id attribute somewhere
         mxMIDIInstrument = mxScorePart.find('midi-instrument')
-        i: instrument.Instrument|None = None
+        i: instrument.Instrument | None = None
         if mxMIDIInstrument is not None:
             mxMidiProgram = mxMIDIInstrument.find('midi-program')
             mxMidiUnpitched = mxMIDIInstrument.find('midi-unpitched')
@@ -2356,9 +2356,9 @@ class MeasureParser(XMLParserBase):
         self.staffReference: StaffReferenceType = {}
         if parent is not None:
             # list of current tuplets or Nones
-            self.activeTuplets: list[duration.Tuplet|None] = parent.activeTuplets
+            self.activeTuplets: list[duration.Tuplet | None] = parent.activeTuplets
         else:
-            self.activeTuplets: list[duration.Tuplet|None] = [None] * 7
+            self.activeTuplets: list[duration.Tuplet | None] = [None] * 7
 
         self.useVoices = False
         self.voicesById = {}
@@ -2379,7 +2379,7 @@ class MeasureParser(XMLParserBase):
         # key is a tuple of the
         #     staff number (or None) and offsetMeasureNote, and the value is a
         #     StaffLayout object.
-        self.staffLayoutObjects: dict[tuple[int|None, float], layout.StaffLayout] = {}
+        self.staffLayoutObjects: dict[tuple[int | None, float], layout.StaffLayout] = {}
         self.stream = stream.Measure()
 
         self.mxNoteList = []  # for accumulating notes in chords
@@ -2399,11 +2399,11 @@ class MeasureParser(XMLParserBase):
         self.restAndNoteCount = {'rest': 0, 'note': 0}
         if parent is not None:
             # share dict
-            self.lastClefs: dict[int, clef.Clef|None] = self.parent.lastClefs
+            self.lastClefs: dict[int, clef.Clef | None] = self.parent.lastClefs
 
         else:
             # a dict of clefs for staffIndexes:
-            self.lastClefs: dict[int, clef.Clef|None] = {NO_STAFF_ASSIGNED: None}
+            self.lastClefs: dict[int, clef.Clef | None] = {NO_STAFF_ASSIGNED: None}
         self.parseIndex = 0
 
         # what is the offset in the measure of the current note position?
@@ -2414,7 +2414,7 @@ class MeasureParser(XMLParserBase):
         # older versions of Finale put a forward tag at the end, but this
         # disguises the incomplete last measure.  The PartParser will
         # pick this up from the last measure.
-        self.endedWithForwardTag: note.Rest|None = None
+        self.endedWithForwardTag: note.Rest | None = None
 
     @staticmethod
     def getStaffNumber(mxObjectOrNumber) -> int:
@@ -2741,7 +2741,7 @@ class MeasureParser(XMLParserBase):
         isRest = False
         # TODO: Unpitched
 
-        offsetIncrement: float|fractions.Fraction = 0.0
+        offsetIncrement: float | fractions.Fraction = 0.0
 
         if mxNote.find('rest') is not None:  # it is a Rest
             isRest = True
@@ -2754,7 +2754,7 @@ class MeasureParser(XMLParserBase):
             isChord = True  # first note of chord is not identified.
             voiceOfChord = mxNote.find('voice')
             if voiceOfChord is not None:
-                vIndex: str|int|None = voiceOfChord.text
+                vIndex: str | int | None = voiceOfChord.text
                 if isinstance(vIndex, str):
                     try:
                         vIndex = int(vIndex)
@@ -2898,7 +2898,7 @@ class MeasureParser(XMLParserBase):
         self.spannerBundle.freePendingSpannedElementAssignment(c)
         return c
 
-    def xmlToSimpleNote(self, mxNote, freeSpanners=True) -> note.Note|note.Unpitched:
+    def xmlToSimpleNote(self, mxNote, freeSpanners=True) -> note.Note | note.Unpitched:
         # noinspection PyShadowingNames
         '''
         Translate a MusicXML <note> (without <chord/>)
@@ -2946,7 +2946,7 @@ class MeasureParser(XMLParserBase):
         '''
         d = self.xmlToDuration(mxNote)
 
-        n: note.Note|note.Unpitched
+        n: note.Note | note.Unpitched
 
         mxUnpitched = mxNote.find('unpitched')
         if mxUnpitched is None:
@@ -3722,7 +3722,7 @@ class MeasureParser(XMLParserBase):
                     arpeggioType = 'non-arpeggio'
                 else:
                     arpeggioType = mxObj.get('direction')
-                idFound: str|None = mxObj.get('number')
+                idFound: str | None = mxObj.get('number')
                 if idFound is None:
                     arpeggio = expressions.ArpeggioMark(arpeggioType)
                     n.expressions.append(arpeggio)
@@ -4369,7 +4369,7 @@ class MeasureParser(XMLParserBase):
         remainingTupletAmountToAccountFor = tup.tupletMultiplier()
         timeModTup = tup
 
-        returnTuplets: list[duration.Tuplet|None] = [None] * 8
+        returnTuplets: list[duration.Tuplet | None] = [None] * 8
         removeFromActiveTuplets = set()
 
         # a set of tuplets to set to stop...
@@ -4510,7 +4510,7 @@ class MeasureParser(XMLParserBase):
             n.lyrics.append(lyricObj)
             currentLyricNumber += 1
 
-    def xmlToLyric(self, mxLyric, inputM21=None) -> note.Lyric|None:
+    def xmlToLyric(self, mxLyric, inputM21=None) -> note.Lyric | None:
         # noinspection PyShadowingNames
         '''
         Translate a MusicXML <lyric> tag to a
@@ -4952,9 +4952,9 @@ class MeasureParser(XMLParserBase):
         # TODO: musicxml 4: attr: arrangement -- C/E or C over E etc.
         # TODO: offset
         # Element staff is covered by insertCoreAndReference in xmlHarmony()
-        b: pitch.Pitch|None = None
-        r: pitch.Pitch|None = None
-        inversion: int|None = None
+        b: pitch.Pitch | None = None
+        r: pitch.Pitch | None = None
+        inversion: int | None = None
         chordKind: str = ''
         chordKindStr: str = ''
 
@@ -5883,8 +5883,8 @@ class MeasureParser(XMLParserBase):
     def xmlStaffLayoutFromStaffDetails(
         self,
         mxDetails,
-        m21staffLayout: layout.StaffLayout|None = None
-    ) -> layout.StaffLayout|None:
+        m21staffLayout: layout.StaffLayout | None = None
+    ) -> layout.StaffLayout | None:
         # noinspection PyShadowingNames
         '''
         Returns a new StaffLayout object from staff-details or sets attributes on an existing one

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -80,7 +80,7 @@ _recognizableKeys: list[str] = list(
 
 # ------------------------------------------------------------------------------
 # Helpers...
-def _clean(badStr: t.Optional[str]) -> t.Optional[str]:
+def _clean(badStr: str|None) -> str|None:
     # need to remove badly-formed strings
     if badStr is None:
         return None
@@ -1550,8 +1550,8 @@ class PartParser(XMLParserBase):
         self.lastMeasureOffset = 0.0
 
         # a dict of clefs per staff number
-        self.lastClefs: dict[int, t.Optional[clef.Clef]] = {NO_STAFF_ASSIGNED: clef.TrebleClef()}
-        self.activeTuplets: list[t.Optional[duration.Tuplet]] = [None] * 7
+        self.lastClefs: dict[int, clef.Clef|None] = {NO_STAFF_ASSIGNED: clef.TrebleClef()}
+        self.activeTuplets: list[duration.Tuplet|None] = [None] * 7
 
         self.maxStaves = 1  # will be changed in measure parsing...
 
@@ -2356,9 +2356,9 @@ class MeasureParser(XMLParserBase):
         self.staffReference: StaffReferenceType = {}
         if parent is not None:
             # list of current tuplets or Nones
-            self.activeTuplets: list[t.Optional[duration.Tuplet]] = parent.activeTuplets
+            self.activeTuplets: list[duration.Tuplet|None] = parent.activeTuplets
         else:
-            self.activeTuplets: list[t.Optional[duration.Tuplet]] = [None] * 7
+            self.activeTuplets: list[duration.Tuplet|None] = [None] * 7
 
         self.useVoices = False
         self.voicesById = {}
@@ -2379,7 +2379,7 @@ class MeasureParser(XMLParserBase):
         # key is a tuple of the
         #     staff number (or None) and offsetMeasureNote, and the value is a
         #     StaffLayout object.
-        self.staffLayoutObjects: dict[tuple[t.Optional[int], float], layout.StaffLayout] = {}
+        self.staffLayoutObjects: dict[tuple[int|None, float], layout.StaffLayout] = {}
         self.stream = stream.Measure()
 
         self.mxNoteList = []  # for accumulating notes in chords
@@ -2399,11 +2399,11 @@ class MeasureParser(XMLParserBase):
         self.restAndNoteCount = {'rest': 0, 'note': 0}
         if parent is not None:
             # share dict
-            self.lastClefs: dict[int, t.Optional[clef.Clef]] = self.parent.lastClefs
+            self.lastClefs: dict[int, clef.Clef|None] = self.parent.lastClefs
 
         else:
             # a dict of clefs for staffIndexes:
-            self.lastClefs: dict[int, t.Optional[clef.Clef]] = {NO_STAFF_ASSIGNED: None}
+            self.lastClefs: dict[int, clef.Clef|None] = {NO_STAFF_ASSIGNED: None}
         self.parseIndex = 0
 
         # what is the offset in the measure of the current note position?
@@ -2898,7 +2898,7 @@ class MeasureParser(XMLParserBase):
         self.spannerBundle.freePendingSpannedElementAssignment(c)
         return c
 
-    def xmlToSimpleNote(self, mxNote, freeSpanners=True) -> t.Union[note.Note, note.Unpitched]:
+    def xmlToSimpleNote(self, mxNote, freeSpanners=True) -> note.Note|note.Unpitched:
         # noinspection PyShadowingNames
         '''
         Translate a MusicXML <note> (without <chord/>)
@@ -2946,7 +2946,7 @@ class MeasureParser(XMLParserBase):
         '''
         d = self.xmlToDuration(mxNote)
 
-        n: t.Union[note.Note, note.Unpitched]
+        n: note.Note|note.Unpitched
 
         mxUnpitched = mxNote.find('unpitched')
         if mxUnpitched is None:
@@ -4369,7 +4369,7 @@ class MeasureParser(XMLParserBase):
         remainingTupletAmountToAccountFor = tup.tupletMultiplier()
         timeModTup = tup
 
-        returnTuplets: list[t.Optional[duration.Tuplet]] = [None] * 8
+        returnTuplets: list[duration.Tuplet|None] = [None] * 8
         removeFromActiveTuplets = set()
 
         # a set of tuplets to set to stop...
@@ -4510,7 +4510,7 @@ class MeasureParser(XMLParserBase):
             n.lyrics.append(lyricObj)
             currentLyricNumber += 1
 
-    def xmlToLyric(self, mxLyric, inputM21=None) -> t.Optional[note.Lyric]:
+    def xmlToLyric(self, mxLyric, inputM21=None) -> note.Lyric|None:
         # noinspection PyShadowingNames
         '''
         Translate a MusicXML <lyric> tag to a
@@ -5884,7 +5884,7 @@ class MeasureParser(XMLParserBase):
         self,
         mxDetails,
         m21staffLayout: layout.StaffLayout|None = None
-    ) -> t.Optional[layout.StaffLayout]:
+    ) -> layout.StaffLayout|None:
         # noinspection PyShadowingNames
         '''
         Returns a new StaffLayout object from staff-details or sets attributes on an existing one

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2741,7 +2741,7 @@ class MeasureParser(XMLParserBase):
         isRest = False
         # TODO: Unpitched
 
-        offsetIncrement: t.Union[float, fractions.Fraction] = 0.0
+        offsetIncrement: float|fractions.Fraction = 0.0
 
         if mxNote.find('rest') is not None:  # it is a Rest
             isRest = True
@@ -2754,7 +2754,7 @@ class MeasureParser(XMLParserBase):
             isChord = True  # first note of chord is not identified.
             voiceOfChord = mxNote.find('voice')
             if voiceOfChord is not None:
-                vIndex: t.Union[str, int, None] = voiceOfChord.text
+                vIndex: str|int|None = voiceOfChord.text
                 if isinstance(vIndex, str):
                     try:
                         vIndex = int(vIndex)

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1319,7 +1319,7 @@ class MusicXMLImporter(XMLParserBase):
 
     def identificationToMetadata(self,
                                  identification: ET.Element,
-                                 inputM21: t.Optional[metadata.Metadata] = None):
+                                 inputM21: metadata.Metadata|None = None):
         '''
         Convert an <identification> tag, containing <creator> tags, <rights> tags, and
         <miscellaneous> tag.
@@ -1435,7 +1435,7 @@ class MusicXMLImporter(XMLParserBase):
 
     def creatorToContributor(self,
                              creator: ET.Element,
-                             inputM21: t.Optional[metadata.primitives.Contributor] = None):
+                             inputM21: metadata.primitives.Contributor|None = None):
         # noinspection PyShadowingNames
         '''
         Given a <creator> tag, fill the necessary parameters of a Contributor.
@@ -1716,7 +1716,7 @@ class PartParser(XMLParserBase):
         # TODO: elevation
         # TODO: store id attribute somewhere
         mxMIDIInstrument = mxScorePart.find('midi-instrument')
-        i: t.Optional[instrument.Instrument] = None
+        i: instrument.Instrument|None = None
         if mxMIDIInstrument is not None:
             mxMidiProgram = mxMIDIInstrument.find('midi-program')
             mxMidiUnpitched = mxMIDIInstrument.find('midi-unpitched')
@@ -2414,7 +2414,7 @@ class MeasureParser(XMLParserBase):
         # older versions of Finale put a forward tag at the end, but this
         # disguises the incomplete last measure.  The PartParser will
         # pick this up from the last measure.
-        self.endedWithForwardTag: t.Optional[note.Rest] = None
+        self.endedWithForwardTag: note.Rest|None = None
 
     @staticmethod
     def getStaffNumber(mxObjectOrNumber) -> int:
@@ -3722,7 +3722,7 @@ class MeasureParser(XMLParserBase):
                     arpeggioType = 'non-arpeggio'
                 else:
                     arpeggioType = mxObj.get('direction')
-                idFound: t.Optional[str] = mxObj.get('number')
+                idFound: str|None = mxObj.get('number')
                 if idFound is None:
                     arpeggio = expressions.ArpeggioMark(arpeggioType)
                     n.expressions.append(arpeggio)
@@ -4952,9 +4952,9 @@ class MeasureParser(XMLParserBase):
         # TODO: musicxml 4: attr: arrangement -- C/E or C over E etc.
         # TODO: offset
         # Element staff is covered by insertCoreAndReference in xmlHarmony()
-        b: t.Optional[pitch.Pitch] = None
-        r: t.Optional[pitch.Pitch] = None
-        inversion: t.Optional[int] = None
+        b: pitch.Pitch|None = None
+        r: pitch.Pitch|None = None
+        inversion: int|None = None
         chordKind: str = ''
         chordKindStr: str = ''
 
@@ -5883,7 +5883,7 @@ class MeasureParser(XMLParserBase):
     def xmlStaffLayoutFromStaffDetails(
         self,
         mxDetails,
-        m21staffLayout: t.Optional[layout.StaffLayout] = None
+        m21staffLayout: layout.StaffLayout|None = None
     ) -> t.Optional[layout.StaffLayout]:
         # noinspection PyShadowingNames
         '''

--- a/music21/note.py
+++ b/music21/note.py
@@ -335,7 +335,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         self._syllabic = newSyllabic
 
     @property
-    def identifier(self) -> t.Union[str, int]:
+    def identifier(self) -> str|int:
         '''
         By default, this is the same as self.number. However, if there is a
         descriptive identifier like 'part2verse1', it is stored here and
@@ -363,7 +363,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
             return self._identifier
 
     @identifier.setter
-    def identifier(self, value: t.Union[str, None]):
+    def identifier(self, value: str|None):
         self._identifier = value
 
     @property
@@ -656,7 +656,7 @@ class GeneralNote(base.Music21Object):
         allText = [ly.text for ly in self.lyrics]
         return '\n'.join([textStr for textStr in allText if textStr is not None])
 
-    def _setLyric(self, value: t.Union[str, Lyric, None]) -> None:
+    def _setLyric(self, value: str|Lyric|None) -> None:
         self.lyrics = []
         if value is None:
             return
@@ -1131,7 +1131,7 @@ class NotRest(GeneralNote):
         self._notehead = value
 
     @property
-    def noteheadFill(self) -> t.Union[bool, None]:
+    def noteheadFill(self) -> bool|None:
         '''
         Get or set the note head fill status of this NotRest. Valid note head fill values are
         True, False, or None (meaning default).  "yes" and "no" are converted to True
@@ -1152,7 +1152,7 @@ class NotRest(GeneralNote):
         return self._noteheadFill
 
     @noteheadFill.setter
-    def noteheadFill(self, value: t.Union[bool, None, str]):
+    def noteheadFill(self, value: bool|None|str):
         boolValue: bool|None
         if value in ('none', None, 'default'):
             boolValue = None  # allow setting to none or None
@@ -1191,7 +1191,7 @@ class NotRest(GeneralNote):
         return self._noteheadParenthesis
 
     @noteheadParenthesis.setter
-    def noteheadParenthesis(self, value: t.Union[bool, str, int]):
+    def noteheadParenthesis(self, value: bool|str|int):
         boolValue: bool
         if value in (True, 'yes', 1):
             boolValue = True
@@ -1239,7 +1239,7 @@ class NotRest(GeneralNote):
 
         return volume_out
 
-    def _setVolume(self, value: t.Union[None, volume.Volume, int, float], setClient=True):
+    def _setVolume(self, value: None|volume.Volume|int|float, setClient=True):
         # DO NOT CHANGE TO @property because of optional attributes
         # setClient is only False when Chords are bundling Notes.
         if value is None:
@@ -1280,7 +1280,7 @@ class NotRest(GeneralNote):
         return self._getVolume()
 
     @volume.setter
-    def volume(self, value: t.Union[None, volume.Volume, int, float]):
+    def volume(self, value: None|volume.Volume|int|float):
         self._setVolume(value)
 
     def _getStoredInstrument(self):

--- a/music21/note.py
+++ b/music21/note.py
@@ -206,14 +206,14 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
                  *,
                  applyRaw: bool = False,
                  syllabic: SyllabicChoices = None,
-                 identifier: str|None = None,
+                 identifier: str | None = None,
                  **keywords):
         super().__init__()
-        self._identifier: str|None = None
+        self._identifier: str | None = None
         self._number: int = 1
         self._text: str = ''
         self._syllabic: SyllabicChoices = None
-        self.components: list[Lyric|None] = None
+        self.components: list[Lyric | None] = None
         self.elisionBefore = ' '
 
         # these are set by setTextAndSyllabic
@@ -335,7 +335,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         self._syllabic = newSyllabic
 
     @property
-    def identifier(self) -> str|int:
+    def identifier(self) -> str | int:
         '''
         By default, this is the same as self.number. However, if there is a
         descriptive identifier like 'part2verse1', it is stored here and
@@ -363,7 +363,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
             return self._identifier
 
     @identifier.setter
-    def identifier(self, value: str|None):
+    def identifier(self, value: str | None):
         self._identifier = value
 
     @property
@@ -573,8 +573,8 @@ class GeneralNote(base.Music21Object):
 
     def __init__(self,
                  *,
-                 duration: Duration|None = None,
-                 lyric: None|str|Lyric = None,
+                 duration: Duration | None = None,
+                 lyric: None | str | Lyric = None,
                  **keywords
                  ):
         if duration is None:
@@ -602,7 +602,7 @@ class GeneralNote(base.Music21Object):
             self.addLyric(lyric)
 
         # note: Chords handle ties differently
-        self._tie: tie.Tie|None = None  # store a Tie object
+        self._tie: tie.Tie | None = None  # store a Tie object
 
     def __eq__(self, other):
         '''
@@ -634,7 +634,7 @@ class GeneralNote(base.Music21Object):
 
     # --------------------------------------------------------------------------
     @property
-    def tie(self) -> tie.Tie|None:
+    def tie(self) -> tie.Tie | None:
         '''
         Return and set a :class:`~music21.note.Tie` object, or None.
 
@@ -646,17 +646,17 @@ class GeneralNote(base.Music21Object):
         return self._tie
 
     @tie.setter
-    def tie(self, value: tie.Tie|None):
+    def tie(self, value: tie.Tie | None):
         self._tie = value
 
-    def _getLyric(self) -> str|None:
+    def _getLyric(self) -> str | None:
         if not self.lyrics:
             return None
 
         allText = [ly.text for ly in self.lyrics]
         return '\n'.join([textStr for textStr in allText if textStr is not None])
 
-    def _setLyric(self, value: str|Lyric|None) -> None:
+    def _setLyric(self, value: str | Lyric | None) -> None:
         self.lyrics = []
         if value is None:
             return
@@ -979,20 +979,20 @@ class NotRest(GeneralNote):
     }
 
     def __init__(self,
-                 beams: beam.Beams|None = None,
+                 beams: beam.Beams | None = None,
                  **keywords):
         super().__init__(**keywords)
         self._notehead: str = 'normal'
-        self._noteheadFill: bool|None = None
+        self._noteheadFill: bool | None = None
         self._noteheadParenthesis: bool = False
         self._stemDirection: str = 'unspecified'
-        self._volume: volume.Volume|None = None  # created on demand
+        self._volume: volume.Volume | None = None  # created on demand
         if beams is not None:
             self.beams = beams
         else:
             self.beams = beam.Beams()
-        self._storedInstrument: instrument.Instrument|None = None
-        self._chordAttached: chord.ChordBase|None = None
+        self._storedInstrument: instrument.Instrument | None = None
+        self._chordAttached: chord.ChordBase | None = None
 
     # ==============================================================================================
     # Special functions
@@ -1131,7 +1131,7 @@ class NotRest(GeneralNote):
         self._notehead = value
 
     @property
-    def noteheadFill(self) -> bool|None:
+    def noteheadFill(self) -> bool | None:
         '''
         Get or set the note head fill status of this NotRest. Valid note head fill values are
         True, False, or None (meaning default).  "yes" and "no" are converted to True
@@ -1152,8 +1152,8 @@ class NotRest(GeneralNote):
         return self._noteheadFill
 
     @noteheadFill.setter
-    def noteheadFill(self, value: bool|None|str):
-        boolValue: bool|None
+    def noteheadFill(self, value: bool | None | str):
+        boolValue: bool | None
         if value in ('none', None, 'default'):
             boolValue = None  # allow setting to none or None
         elif value in (True, 'filled', 'yes'):
@@ -1191,7 +1191,7 @@ class NotRest(GeneralNote):
         return self._noteheadParenthesis
 
     @noteheadParenthesis.setter
-    def noteheadParenthesis(self, value: bool|str|int):
+    def noteheadParenthesis(self, value: bool | str | int):
         boolValue: bool
         if value in (True, 'yes', 1):
             boolValue = True
@@ -1222,7 +1222,7 @@ class NotRest(GeneralNote):
             return True
 
     def _getVolume(self,
-                   forceClient: base.Music21Object|None = None
+                   forceClient: base.Music21Object | None = None
                    ) -> volume.Volume:
         # DO NOT CHANGE TO @property because of optional attributes
         # lazy volume creation.  property is set below.
@@ -1239,7 +1239,7 @@ class NotRest(GeneralNote):
 
         return volume_out
 
-    def _setVolume(self, value: None|volume.Volume|int|float, setClient=True):
+    def _setVolume(self, value: None | volume.Volume | int | float, setClient=True):
         # DO NOT CHANGE TO @property because of optional attributes
         # setClient is only False when Chords are bundling Notes.
         if value is None:
@@ -1280,7 +1280,7 @@ class NotRest(GeneralNote):
         return self._getVolume()
 
     @volume.setter
-    def volume(self, value: None|volume.Volume|int|float):
+    def volume(self, value: None | volume.Volume | int | float):
         self._setVolume(value)
 
     def _getStoredInstrument(self):
@@ -1314,13 +1314,13 @@ class NotRest(GeneralNote):
     def getInstrument(self,
                       *,
                       returnDefault: t.Literal[False]
-                      ) -> instrument.Instrument|None:
+                      ) -> instrument.Instrument | None:
         return None  # astroid #1015
 
     def getInstrument(self,
                       *,
                       returnDefault: bool = True
-                      ) -> instrument.Instrument|None:
+                      ) -> instrument.Instrument | None:
         '''
         Retrieves the `.storedInstrument` on this `NotRest` instance, if any.
         If one is not found, executes a context search (without following
@@ -1464,13 +1464,13 @@ class Note(NotRest):
 
     # Accepts an argument for pitch
     def __init__(self,
-                 pitch: str|int|Pitch|None = None,
+                 pitch: str | int | Pitch | None = None,
                  *,
-                 name: str|None = None,
-                 nameWithOctave: str|None = None,
+                 name: str | None = None,
+                 nameWithOctave: str | None = None,
                  **keywords):
         super().__init__(**keywords)
-        self._chordAttached: chord.Chord|None
+        self._chordAttached: chord.Chord | None
 
         if pitch is not None:
             if isinstance(pitch, Pitch):
@@ -1634,10 +1634,10 @@ class Note(NotRest):
     def step(self, value: StepName):
         self.pitch.step = value
 
-    def _getOctave(self) -> int|None:
+    def _getOctave(self) -> int | None:
         return self.pitch.octave
 
-    def _setOctave(self, value: int|None):
+    def _setOctave(self, value: int | None):
         self.pitch.octave = value
 
     octave = property(_getOctave,
@@ -1837,7 +1837,7 @@ class Unpitched(NotRest):
                  displayName=None,
                  **keywords):
         super().__init__(**keywords)
-        self._chordAttached: percussion.PercussionChord|None = None
+        self._chordAttached: percussion.PercussionChord | None = None
 
         self.displayStep: StepName = 'B'
         self.displayOctave: int = 4
@@ -1966,7 +1966,7 @@ class Rest(GeneralNote):
     }
 
     def __init__(self,
-                 length: str|OffsetQLIn|None = None,
+                 length: str | OffsetQLIn | None = None,
                  *,
                  stepShift: int = 0,
                  fullMeasure: t.Literal[True, False, 'auto', 'always'] = 'auto',

--- a/music21/note.py
+++ b/music21/note.py
@@ -206,14 +206,14 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
                  *,
                  applyRaw: bool = False,
                  syllabic: SyllabicChoices = None,
-                 identifier: t.Optional[str] = None,
+                 identifier: str|None = None,
                  **keywords):
         super().__init__()
-        self._identifier: t.Optional[str] = None
+        self._identifier: str|None = None
         self._number: int = 1
         self._text: str = ''
         self._syllabic: SyllabicChoices = None
-        self.components: t.Optional[list[Lyric]] = None
+        self.components: list[Lyric|None] = None
         self.elisionBefore = ' '
 
         # these are set by setTextAndSyllabic
@@ -573,7 +573,7 @@ class GeneralNote(base.Music21Object):
 
     def __init__(self,
                  *,
-                 duration: t.Optional[Duration] = None,
+                 duration: Duration|None = None,
                  lyric: t.Union[None, str, Lyric] = None,
                  **keywords
                  ):
@@ -602,7 +602,7 @@ class GeneralNote(base.Music21Object):
             self.addLyric(lyric)
 
         # note: Chords handle ties differently
-        self._tie: t.Optional[tie.Tie] = None  # store a Tie object
+        self._tie: tie.Tie|None = None  # store a Tie object
 
     def __eq__(self, other):
         '''
@@ -634,7 +634,7 @@ class GeneralNote(base.Music21Object):
 
     # --------------------------------------------------------------------------
     @property
-    def tie(self) -> t.Optional[tie.Tie]:
+    def tie(self) -> tie.Tie|None:
         '''
         Return and set a :class:`~music21.note.Tie` object, or None.
 
@@ -646,10 +646,10 @@ class GeneralNote(base.Music21Object):
         return self._tie
 
     @tie.setter
-    def tie(self, value: t.Optional[tie.Tie]):
+    def tie(self, value: tie.Tie|None):
         self._tie = value
 
-    def _getLyric(self) -> t.Optional[str]:
+    def _getLyric(self) -> str|None:
         if not self.lyrics:
             return None
 
@@ -979,20 +979,20 @@ class NotRest(GeneralNote):
     }
 
     def __init__(self,
-                 beams: t.Optional[beam.Beams] = None,
+                 beams: beam.Beams|None = None,
                  **keywords):
         super().__init__(**keywords)
         self._notehead: str = 'normal'
-        self._noteheadFill: t.Optional[bool] = None
+        self._noteheadFill: bool|None = None
         self._noteheadParenthesis: bool = False
         self._stemDirection: str = 'unspecified'
-        self._volume: t.Optional[volume.Volume] = None  # created on demand
+        self._volume: volume.Volume|None = None  # created on demand
         if beams is not None:
             self.beams = beams
         else:
             self.beams = beam.Beams()
-        self._storedInstrument: t.Optional[instrument.Instrument] = None
-        self._chordAttached: t.Optional[chord.ChordBase] = None
+        self._storedInstrument: instrument.Instrument|None = None
+        self._chordAttached: chord.ChordBase|None = None
 
     # ==============================================================================================
     # Special functions
@@ -1153,7 +1153,7 @@ class NotRest(GeneralNote):
 
     @noteheadFill.setter
     def noteheadFill(self, value: t.Union[bool, None, str]):
-        boolValue: t.Optional[bool]
+        boolValue: bool|None
         if value in ('none', None, 'default'):
             boolValue = None  # allow setting to none or None
         elif value in (True, 'filled', 'yes'):
@@ -1222,7 +1222,7 @@ class NotRest(GeneralNote):
             return True
 
     def _getVolume(self,
-                   forceClient: t.Optional[base.Music21Object] = None
+                   forceClient: base.Music21Object|None = None
                    ) -> volume.Volume:
         # DO NOT CHANGE TO @property because of optional attributes
         # lazy volume creation.  property is set below.
@@ -1314,13 +1314,13 @@ class NotRest(GeneralNote):
     def getInstrument(self,
                       *,
                       returnDefault: t.Literal[False]
-                      ) -> t.Optional[instrument.Instrument]:
+                      ) -> instrument.Instrument|None:
         return None  # astroid #1015
 
     def getInstrument(self,
                       *,
                       returnDefault: bool = True
-                      ) -> t.Optional[instrument.Instrument]:
+                      ) -> instrument.Instrument|None:
         '''
         Retrieves the `.storedInstrument` on this `NotRest` instance, if any.
         If one is not found, executes a context search (without following
@@ -1466,11 +1466,11 @@ class Note(NotRest):
     def __init__(self,
                  pitch: t.Union[str, int, Pitch, None] = None,
                  *,
-                 name: t.Optional[str] = None,
-                 nameWithOctave: t.Optional[str] = None,
+                 name: str|None = None,
+                 nameWithOctave: str|None = None,
                  **keywords):
         super().__init__(**keywords)
-        self._chordAttached: t.Optional[chord.Chord]
+        self._chordAttached: chord.Chord|None
 
         if pitch is not None:
             if isinstance(pitch, Pitch):
@@ -1634,10 +1634,10 @@ class Note(NotRest):
     def step(self, value: StepName):
         self.pitch.step = value
 
-    def _getOctave(self) -> t.Optional[int]:
+    def _getOctave(self) -> int|None:
         return self.pitch.octave
 
-    def _setOctave(self, value: t.Optional[int]):
+    def _setOctave(self, value: int|None):
         self.pitch.octave = value
 
     octave = property(_getOctave,
@@ -1837,7 +1837,7 @@ class Unpitched(NotRest):
                  displayName=None,
                  **keywords):
         super().__init__(**keywords)
-        self._chordAttached: t.Optional[percussion.PercussionChord] = None
+        self._chordAttached: percussion.PercussionChord|None = None
 
         self.displayStep: StepName = 'B'
         self.displayOctave: int = 4

--- a/music21/note.py
+++ b/music21/note.py
@@ -213,7 +213,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
         self._number: int = 1
         self._text: str = ''
         self._syllabic: SyllabicChoices = None
-        self.components: list[Lyric | None] = None
+        self.components: list[Lyric] | None = None
         self.elisionBefore = ' '
 
         # these are set by setTextAndSyllabic

--- a/music21/note.py
+++ b/music21/note.py
@@ -574,7 +574,7 @@ class GeneralNote(base.Music21Object):
     def __init__(self,
                  *,
                  duration: Duration|None = None,
-                 lyric: t.Union[None, str, Lyric] = None,
+                 lyric: None|str|Lyric = None,
                  **keywords
                  ):
         if duration is None:
@@ -1464,7 +1464,7 @@ class Note(NotRest):
 
     # Accepts an argument for pitch
     def __init__(self,
-                 pitch: t.Union[str, int, Pitch, None] = None,
+                 pitch: str|int|Pitch|None = None,
                  *,
                  name: str|None = None,
                  nameWithOctave: str|None = None,
@@ -1966,7 +1966,7 @@ class Rest(GeneralNote):
     }
 
     def __init__(self,
-                 length: t.Union[str, OffsetQLIn, None] = None,
+                 length: str|OffsetQLIn|None = None,
                  *,
                  stepShift: int = 0,
                  fullMeasure: t.Literal[True, False, 'auto', 'always'] = 'auto',

--- a/music21/noteworthy/binaryTranslate.py
+++ b/music21/noteworthy/binaryTranslate.py
@@ -78,7 +78,6 @@ from __future__ import annotations
 
 import pathlib
 import struct
-import typing as t
 
 from music21 import environment
 from music21 import exceptions21

--- a/music21/noteworthy/binaryTranslate.py
+++ b/music21/noteworthy/binaryTranslate.py
@@ -138,7 +138,7 @@ class NWCConverter:
         self.staffHeight = 0
 
     # noinspection SpellCheckingInspection
-    def parseFile(self, fp: pathlib.Path|str):
+    def parseFile(self, fp: pathlib.Path | str):
         # noinspection PyShadowingNames
         r'''
         Parse a file (calls .toStream)

--- a/music21/noteworthy/binaryTranslate.py
+++ b/music21/noteworthy/binaryTranslate.py
@@ -138,7 +138,7 @@ class NWCConverter:
         self.staffHeight = 0
 
     # noinspection SpellCheckingInspection
-    def parseFile(self, fp: t.Union[pathlib.Path, str]):
+    def parseFile(self, fp: pathlib.Path|str):
         # noinspection PyShadowingNames
         r'''
         Parse a file (calls .toStream)

--- a/music21/percussion.py
+++ b/music21/percussion.py
@@ -13,7 +13,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-import typing as t
 import unittest
 
 from music21 import common
@@ -70,7 +69,7 @@ class PercussionChord(chord.ChordBase):
         return tuple(self._notes)
 
     @notes.setter
-    def notes(self, newNotes: Iterable[note.Unpitched|note.Note]) -> None:
+    def notes(self, newNotes: Iterable[note.Unpitched | note.Note]) -> None:
         '''
         Sets notes to an iterable of Note or Unpitched objects
         '''

--- a/music21/percussion.py
+++ b/music21/percussion.py
@@ -70,7 +70,7 @@ class PercussionChord(chord.ChordBase):
         return tuple(self._notes)
 
     @notes.setter
-    def notes(self, newNotes: Iterable[t.Union[note.Unpitched, note.Note]]) -> None:
+    def notes(self, newNotes: Iterable[note.Unpitched|note.Note]) -> None:
         '''
         Sets notes to an iterable of Note or Unpitched objects
         '''

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -685,9 +685,9 @@ class Microtone(prebase.ProtoM21Object, SlottedObjectMixin):
     # INITIALIZER #
 
     def __init__(self,
-                 centsOrString: t.Union[str, int, float] = 0,
+                 centsOrString: str|int|float = 0,
                  harmonicShift=1):
-        self._centShift: t.Union[int, float] = 0
+        self._centShift: int|float = 0
         self._harmonicShift: int = harmonicShift  # the first harmonic is the start
 
         if isinstance(centsOrString, (int, float)):
@@ -885,7 +885,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
 
     # INITIALIZER #
 
-    def __init__(self, specifier: t.Union[int, str, float] = 'natural'):
+    def __init__(self, specifier: int|str|float = 'natural'):
         super().__init__()
         # managed by properties
         self._displayType = 'normal'
@@ -1804,7 +1804,7 @@ class Pitch(prebase.ProtoM21Object):
                  step: StepName|None = None,
                  octave: int|None = None,
                  accidental: t.Union[Accidental, str, int, float, None] = None,
-                 microtone: t.Union[Microtone, int, float, None] = None,
+                 microtone: Microtone|int|float|None = None,
                  pitchClass: t.Optional[t.Union[int, PitchClassString]] = None,
                  midi: int|None = None,
                  ps: float|None = None,
@@ -2987,7 +2987,7 @@ class Pitch(prebase.ProtoM21Object):
     @pitchClass.setter
     def pitchClass(self, value: t.Union[int, PitchClassString]):
         # permit the submission of strings, like "A" and "B"
-        valueOut: t.Union[int, float] = _convertPitchClassToNumber(value)
+        valueOut: int|float = _convertPitchClassToNumber(value)
         # get step and accidental w/o octave
         self.step, self._accidental = _convertPsToStep(valueOut)[0:2]
 

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -140,8 +140,8 @@ accidentalModifiersSorted = _sortModifiers()
 # utility functions
 
 def _convertPitchClassToNumber(
-    ps: t.Union[int, float, PitchClassString]
-) -> t.Union[int, float]:
+    ps: int|float|PitchClassString
+) -> int|float:
     '''
     Given a pitch class string
     return the pitch class representation.
@@ -183,7 +183,7 @@ def convertPitchClassToStr(pc: int) -> str:
     return f'{pc:X}'  # using hex conversion, good up to 15
 
 
-def _convertPsToOct(ps: t.Union[int, float]) -> int:
+def _convertPsToOct(ps: int|float) -> int:
     '''
     Utility conversion; does not process internals.
     Converts a midiNote number to an octave number.
@@ -212,7 +212,7 @@ def _convertPsToOct(ps: t.Union[int, float]) -> int:
 
 
 def _convertPsToStep(
-    ps: t.Union[int, float]
+    ps: int|float
 ) -> tuple[StepName,
              Accidental,
              Microtone,
@@ -412,7 +412,7 @@ def _convertCentsToAlterAndCents(shift) -> tuple[float, float]:
     return alterShift + alterAdd, float(cents)
 
 
-def _convertHarmonicToCents(value: t.Union[int, float]) -> int:
+def _convertHarmonicToCents(value: int|float) -> int:
     r'''
     Given a harmonic number, return the total number shift in cents
     assuming 12 tone equal temperament.
@@ -1207,7 +1207,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
     def setAttributeIndependently(self, attribute, value):
         '''
         Set an attribute of 'name', 'alter', and 'modifier', independently
-        from other attributes.
+        of the other attributes.
 
         >>> a = pitch.Accidental('natural')
         >>> a.setAttributeIndependently('alter', 1.0)
@@ -1799,13 +1799,13 @@ class Pitch(prebase.ProtoM21Object):
     }
 
     def __init__(self,
-                 name: t.Optional[t.Union[str, int, float]] = None,
+                 name: str|int|float|None = None,
                  *,
                  step: StepName|None = None,
                  octave: int|None = None,
-                 accidental: t.Union[Accidental, str, int, float, None] = None,
+                 accidental: Accidental|str|int|float|None = None,
                  microtone: Microtone|int|float|None = None,
-                 pitchClass: t.Optional[t.Union[int, PitchClassString]] = None,
+                 pitchClass: int|PitchClassString|None = None,
                  midi: int|None = None,
                  ps: float|None = None,
                  fundamental: Pitch|None = None,
@@ -2068,7 +2068,7 @@ class Pitch(prebase.ProtoM21Object):
         self._groups = new
 
     @property
-    def accidental(self) -> t.Optional[Accidental]:
+    def accidental(self) -> Accidental|None:
         '''
         Stores an optional accidental object contained within the
         Pitch object.  This might return None, which is different
@@ -2092,7 +2092,7 @@ class Pitch(prebase.ProtoM21Object):
         return self._accidental
 
     @accidental.setter
-    def accidental(self, value: t.Union[str, Accidental, None, int, float]):
+    def accidental(self, value: str|Accidental|None|int|float):
         if isinstance(value, Accidental):
             self._accidental = value
         elif value is None:
@@ -2145,7 +2145,7 @@ class Pitch(prebase.ProtoM21Object):
             return self._microtone
 
     @microtone.setter
-    def microtone(self, value: t.Union[float, int, str, None, Microtone]):
+    def microtone(self, value: float|int|str|None|Microtone):
         if isinstance(value, (str, float, int)):
             self._microtone = Microtone(value)
         elif value is None:  # set to zero
@@ -2985,7 +2985,7 @@ class Pitch(prebase.ProtoM21Object):
         return round(self.ps) % 12
 
     @pitchClass.setter
-    def pitchClass(self, value: t.Union[int, PitchClassString]):
+    def pitchClass(self, value: int|PitchClassString):
         # permit the submission of strings, like "A" and "B"
         valueOut: int|float = _convertPitchClassToNumber(value)
         # get step and accidental w/o octave
@@ -3024,7 +3024,7 @@ class Pitch(prebase.ProtoM21Object):
 
 
     @property
-    def octave(self) -> t.Optional[int]:
+    def octave(self) -> int|None:
         '''
         Returns or sets the octave of the note.
         Setting the octave updates the pitchSpace attribute.
@@ -3052,7 +3052,7 @@ class Pitch(prebase.ProtoM21Object):
         return self._octave
 
     @octave.setter
-    def octave(self, value: t.Optional[t.Union[int, float]]):
+    def octave(self, value: int|float|None):
         if value is not None:
             self._octave = int(value)
         else:
@@ -3380,7 +3380,7 @@ class Pitch(prebase.ProtoM21Object):
         return self.freq440
 
     @frequency.setter
-    def frequency(self, value: t.Union[int, float]):
+    def frequency(self, value: int|float):
         self.freq440 = value
 
     # these methods may belong in a temperament object
@@ -3408,7 +3408,7 @@ class Pitch(prebase.ProtoM21Object):
             return 440.0 * (self._twelfth_root_of_two ** A4offset)
 
     @freq440.setter
-    def freq440(self, value: t.Union[int, float]):
+    def freq440(self, value: int|float):
         post = 12 * (math.log(value / 440.0) / math.log(2)) + 69
         # environLocal.printDebug(['convertFqToPs():', 'input', fq, 'output', repr(post)])
         # rounding here is essential
@@ -3417,7 +3417,7 @@ class Pitch(prebase.ProtoM21Object):
         self.ps = p2
 
     # --------------------------------------------------------------------------
-    def getHarmonic(self, number: int) -> 'Pitch':
+    def getHarmonic(self, number: int) -> Pitch:
         '''
         Return a Pitch object representing the harmonic found above this Pitch.
 
@@ -3517,7 +3517,7 @@ class Pitch(prebase.ProtoM21Object):
         return final
 
     def harmonicFromFundamental(self,
-                                fundamental: t.Union[str, 'Pitch']
+                                fundamental: str | Pitch,
                                 ) -> tuple[int, float]:
         # noinspection PyShadowingNames
         '''
@@ -3635,7 +3635,7 @@ class Pitch(prebase.ProtoM21Object):
         # return harmonicMatch, fundamental
 
     def harmonicString(self,
-                       fundamental: t.Union[str, 'music21.pitch.Pitch', None] = None
+                       fundamental: str | Pitch | None = None
                        ) -> str:
         '''
         Return a string representation of a harmonic equivalence.
@@ -3697,8 +3697,8 @@ class Pitch(prebase.ProtoM21Object):
 
     def harmonicAndFundamentalFromPitch(
             self,
-            target: t.Union[str, 'Pitch']
-    ) -> tuple[int, 'Pitch']:
+            target: str | Pitch
+    ) -> tuple[int, Pitch]:
         '''
         Given a Pitch that is a plausible target for a fundamental,
         return the harmonic number and a potentially shifted fundamental
@@ -3730,7 +3730,7 @@ class Pitch(prebase.ProtoM21Object):
 
     def harmonicAndFundamentalStringFromPitch(
             self,
-            fundamental: t.Union[str, 'Pitch']
+            fundamental: str | Pitch
     ) -> str:
         '''
         Given a Pitch that is a plausible target for a fundamental,
@@ -3776,7 +3776,7 @@ class Pitch(prebase.ProtoM21Object):
 
     # --------------------------------------------------------------------------
 
-    def isEnharmonic(self, other: 'Pitch') -> bool:
+    def isEnharmonic(self, other: Pitch) -> bool:
         '''
         Return True if other is an enharmonic equivalent of self.
 
@@ -3871,7 +3871,7 @@ class Pitch(prebase.ProtoM21Object):
 
     def _getEnharmonicHelper(self: PitchType,
                              inPlace: bool,
-                             up: bool) -> t.Optional[PitchType]:
+                             up: bool) -> PitchType|None:
         '''
         abstracts the code from `getHigherEnharmonic` and `getLowerEnharmonic`
         '''
@@ -3907,7 +3907,7 @@ class Pitch(prebase.ProtoM21Object):
     def getHigherEnharmonic(self: PitchType, *, inPlace: t.Literal[True]) -> None:
         return None
 
-    def getHigherEnharmonic(self: PitchType, *, inPlace: bool = False) -> t.Optional[PitchType]:
+    def getHigherEnharmonic(self: PitchType, *, inPlace: bool = False) -> PitchType|None:
         '''
         Returns an enharmonic `Pitch` object that is a higher
         enharmonic.  That is, the `Pitch` a diminished-second above
@@ -3971,7 +3971,7 @@ class Pitch(prebase.ProtoM21Object):
     def getLowerEnharmonic(self: PitchType, *, inPlace: t.Literal[True]) -> None:
         return None
 
-    def getLowerEnharmonic(self: PitchType, *, inPlace: bool = False) -> t.Optional[PitchType]:
+    def getLowerEnharmonic(self: PitchType, *, inPlace: bool = False) -> PitchType|None:
         '''
         returns a Pitch enharmonic that is a diminished second
         below the current note
@@ -4009,7 +4009,7 @@ class Pitch(prebase.ProtoM21Object):
         *,
         inPlace=False,
         mostCommon=False
-    ) -> t.Optional[PitchType]:
+    ) -> PitchType|None:
         '''
         Returns a new Pitch (or sets the current one if inPlace is True)
         that is either the same as the current pitch or has fewer
@@ -4098,7 +4098,7 @@ class Pitch(prebase.ProtoM21Object):
         else:
             return returnObj
 
-    def getEnharmonic(self: PitchType, *, inPlace=False) -> t.Optional[PitchType]:
+    def getEnharmonic(self: PitchType, *, inPlace=False) -> PitchType|None:
         '''
         Returns a new Pitch that is the(/an) enharmonic equivalent of this Pitch.
         Can be thought of as flipEnharmonic or something like that.
@@ -4356,7 +4356,7 @@ class Pitch(prebase.ProtoM21Object):
     @overload
     def transpose(
         self: PitchType,
-        value: t.Union[interval.IntervalBase, str, int],
+        value: interval.IntervalBase|str|int,
         *,
         inPlace: t.Literal[True]
     ) -> None:
@@ -4365,7 +4365,7 @@ class Pitch(prebase.ProtoM21Object):
     @overload
     def transpose(
         self: PitchType,
-        value: t.Union[interval.IntervalBase, str, int],
+        value: interval.IntervalBase|str|int,
         *,
         inPlace: t.Literal[False] = False
     ) -> PitchType:
@@ -4373,10 +4373,10 @@ class Pitch(prebase.ProtoM21Object):
 
     def transpose(
         self: PitchType,
-        value: t.Union[interval.IntervalBase, str, int],
+        value: interval.IntervalBase|str|int,
         *,
         inPlace: bool = False
-    ) -> t.Optional[PitchType]:
+    ) -> PitchType|None:
         '''
         Transpose the pitch by the user-provided value.  If the value is an
         integer, the transposition is treated in half steps. If the value is a
@@ -4496,7 +4496,7 @@ class Pitch(prebase.ProtoM21Object):
         *,
         minimize=False,
         inPlace=False
-    ) -> t.Optional[PitchType]:
+    ) -> PitchType|None:
         # noinspection PyShadowingNames
         '''
         Given a source Pitch, shift it down some number of octaves until it is below the
@@ -4594,7 +4594,7 @@ class Pitch(prebase.ProtoM21Object):
                              target,
                              *,
                              minimize=False,
-                             inPlace=False) -> t.Optional[PitchType]:
+                             inPlace=False) -> PitchType|None:
         '''
         Given a source Pitch, shift it up octaves until it is above the target.
 
@@ -4748,10 +4748,10 @@ class Pitch(prebase.ProtoM21Object):
     def updateAccidentalDisplay(
         self,
         *,
-        pitchPast: t.Optional[list[Pitch]] = None,
-        pitchPastMeasure: t.Optional[list[Pitch]] = None,
-        otherSimultaneousPitches: t.Optional[list[Pitch]] = None,
-        alteredPitches: t.Optional[list[Pitch]] = None,
+        pitchPast: list[Pitch]|None = None,
+        pitchPastMeasure: list[Pitch]|None = None,
+        otherSimultaneousPitches: list[Pitch]|None = None,
+        alteredPitches: list[Pitch]|None = None,
         cautionaryPitchClass: bool = True,
         cautionaryAll: bool = False,
         overrideStatus: bool = False,

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -901,7 +901,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         self.displayLocation = 'normal'
 
         # store a reference to the Pitch that has this Accidental object as a property
-        self._client: t.Optional[Pitch] = None
+        self._client: Pitch|None = None
         self._name = ''
         self._modifier = ''
         self._alter = 0.0     # semitones to alter step
@@ -1801,17 +1801,17 @@ class Pitch(prebase.ProtoM21Object):
     def __init__(self,
                  name: t.Optional[t.Union[str, int, float]] = None,
                  *,
-                 step: t.Optional[StepName] = None,
-                 octave: t.Optional[int] = None,
+                 step: StepName|None = None,
+                 octave: int|None = None,
                  accidental: t.Union[Accidental, str, int, float, None] = None,
                  microtone: t.Union[Microtone, int, float, None] = None,
                  pitchClass: t.Optional[t.Union[int, PitchClassString]] = None,
-                 midi: t.Optional[int] = None,
-                 ps: t.Optional[float] = None,
-                 fundamental: t.Optional[Pitch] = None,
+                 midi: int|None = None,
+                 ps: float|None = None,
+                 fundamental: Pitch|None = None,
                  **keywords):
         # No need for super().__init__() on protoM21Object
-        self._groups: t.Optional[base.Groups] = None
+        self._groups: base.Groups|None = None
 
         if isinstance(name, type(self)):
             name = name.nameWithOctave
@@ -1819,31 +1819,31 @@ class Pitch(prebase.ProtoM21Object):
         # this should not be set, as will be updated when needed
         self._step: StepName = defaults.pitchStep  # this is only the pitch step
 
-        self._overridden_freq440: t.Optional[float] = None
+        self._overridden_freq440: float|None = None
 
         # store an Accidental and Microtone objects
         # note that creating an Accidental object is much more time-consuming
         # than a microtone
-        self._accidental: t.Optional[Accidental] = None
+        self._accidental: Accidental|None = None
         # 5% of pitch creation time; it'll be created in a sec anyhow
-        self._microtone: t.Optional[Microtone] = None
+        self._microtone: Microtone|None = None
 
         # CA, Q: should this remain an attribute or only refer to value in defaults?
         # MSC A: no, it's a useful attribute for cases such as scales where if there are
         #        no octaves we give a defaultOctave higher than the previous
         #        (MSC 12 years later: maybe Chris was right...)
         self.defaultOctave: int = defaults.pitchOctave
-        self._octave: t.Optional[int] = None
+        self._octave: int|None = None
 
         # if True, accidental is not known; is determined algorithmically
         # likely due to pitch data from midi or pitch space/class numbers
         self.spellingIsInferred = False
         # the fundamental attribute stores an optional pitch
         # that defines the fundamental used to create this Pitch
-        self.fundamental: t.Optional[Pitch] = None
+        self.fundamental: Pitch|None = None
 
         # so that we can tell clients about changes in pitches.
-        self._client: t.Optional[note.Note] = None
+        self._client: note.Note|None = None
 
         # name combines step, octave, and accidental
         if name is not None:

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -140,8 +140,8 @@ accidentalModifiersSorted = _sortModifiers()
 # utility functions
 
 def _convertPitchClassToNumber(
-    ps: int|float|PitchClassString
-) -> int|float:
+    ps: int | float | PitchClassString
+) -> int | float:
     '''
     Given a pitch class string
     return the pitch class representation.
@@ -183,7 +183,7 @@ def convertPitchClassToStr(pc: int) -> str:
     return f'{pc:X}'  # using hex conversion, good up to 15
 
 
-def _convertPsToOct(ps: int|float) -> int:
+def _convertPsToOct(ps: int | float) -> int:
     '''
     Utility conversion; does not process internals.
     Converts a midiNote number to an octave number.
@@ -212,7 +212,7 @@ def _convertPsToOct(ps: int|float) -> int:
 
 
 def _convertPsToStep(
-    ps: int|float
+    ps: int | float
 ) -> tuple[StepName,
              Accidental,
              Microtone,
@@ -412,7 +412,7 @@ def _convertCentsToAlterAndCents(shift) -> tuple[float, float]:
     return alterShift + alterAdd, float(cents)
 
 
-def _convertHarmonicToCents(value: int|float) -> int:
+def _convertHarmonicToCents(value: int | float) -> int:
     r'''
     Given a harmonic number, return the total number shift in cents
     assuming 12 tone equal temperament.
@@ -685,9 +685,9 @@ class Microtone(prebase.ProtoM21Object, SlottedObjectMixin):
     # INITIALIZER #
 
     def __init__(self,
-                 centsOrString: str|int|float = 0,
+                 centsOrString: str | int | float = 0,
                  harmonicShift=1):
-        self._centShift: int|float = 0
+        self._centShift: int | float = 0
         self._harmonicShift: int = harmonicShift  # the first harmonic is the start
 
         if isinstance(centsOrString, (int, float)):
@@ -885,7 +885,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
 
     # INITIALIZER #
 
-    def __init__(self, specifier: int|str|float = 'natural'):
+    def __init__(self, specifier: int | str | float = 'natural'):
         super().__init__()
         # managed by properties
         self._displayType = 'normal'
@@ -901,7 +901,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         self.displayLocation = 'normal'
 
         # store a reference to the Pitch that has this Accidental object as a property
-        self._client: Pitch|None = None
+        self._client: Pitch | None = None
         self._name = ''
         self._modifier = ''
         self._alter = 0.0     # semitones to alter step
@@ -1799,19 +1799,19 @@ class Pitch(prebase.ProtoM21Object):
     }
 
     def __init__(self,
-                 name: str|int|float|None = None,
+                 name: str | int | float | None = None,
                  *,
-                 step: StepName|None = None,
-                 octave: int|None = None,
-                 accidental: Accidental|str|int|float|None = None,
-                 microtone: Microtone|int|float|None = None,
-                 pitchClass: int|PitchClassString|None = None,
-                 midi: int|None = None,
-                 ps: float|None = None,
-                 fundamental: Pitch|None = None,
+                 step: StepName | None = None,
+                 octave: int | None = None,
+                 accidental: Accidental | str | int | float | None = None,
+                 microtone: Microtone | int | float | None = None,
+                 pitchClass: int | PitchClassString | None = None,
+                 midi: int | None = None,
+                 ps: float | None = None,
+                 fundamental: Pitch | None = None,
                  **keywords):
         # No need for super().__init__() on protoM21Object
-        self._groups: base.Groups|None = None
+        self._groups: base.Groups | None = None
 
         if isinstance(name, type(self)):
             name = name.nameWithOctave
@@ -1819,31 +1819,31 @@ class Pitch(prebase.ProtoM21Object):
         # this should not be set, as will be updated when needed
         self._step: StepName = defaults.pitchStep  # this is only the pitch step
 
-        self._overridden_freq440: float|None = None
+        self._overridden_freq440: float | None = None
 
         # store an Accidental and Microtone objects
         # note that creating an Accidental object is much more time-consuming
         # than a microtone
-        self._accidental: Accidental|None = None
+        self._accidental: Accidental | None = None
         # 5% of pitch creation time; it'll be created in a sec anyhow
-        self._microtone: Microtone|None = None
+        self._microtone: Microtone | None = None
 
         # CA, Q: should this remain an attribute or only refer to value in defaults?
         # MSC A: no, it's a useful attribute for cases such as scales where if there are
         #        no octaves we give a defaultOctave higher than the previous
         #        (MSC 12 years later: maybe Chris was right...)
         self.defaultOctave: int = defaults.pitchOctave
-        self._octave: int|None = None
+        self._octave: int | None = None
 
         # if True, accidental is not known; is determined algorithmically
         # likely due to pitch data from midi or pitch space/class numbers
         self.spellingIsInferred = False
         # the fundamental attribute stores an optional pitch
         # that defines the fundamental used to create this Pitch
-        self.fundamental: Pitch|None = None
+        self.fundamental: Pitch | None = None
 
         # so that we can tell clients about changes in pitches.
-        self._client: note.Note|None = None
+        self._client: note.Note | None = None
 
         # name combines step, octave, and accidental
         if name is not None:
@@ -2068,7 +2068,7 @@ class Pitch(prebase.ProtoM21Object):
         self._groups = new
 
     @property
-    def accidental(self) -> Accidental|None:
+    def accidental(self) -> Accidental | None:
         '''
         Stores an optional accidental object contained within the
         Pitch object.  This might return None, which is different
@@ -2092,7 +2092,7 @@ class Pitch(prebase.ProtoM21Object):
         return self._accidental
 
     @accidental.setter
-    def accidental(self, value: str|Accidental|None|int|float):
+    def accidental(self, value: str | Accidental | None | int | float):
         if isinstance(value, Accidental):
             self._accidental = value
         elif value is None:
@@ -2145,7 +2145,7 @@ class Pitch(prebase.ProtoM21Object):
             return self._microtone
 
     @microtone.setter
-    def microtone(self, value: float|int|str|None|Microtone):
+    def microtone(self, value: float | int | str | None | Microtone):
         if isinstance(value, (str, float, int)):
             self._microtone = Microtone(value)
         elif value is None:  # set to zero
@@ -2985,9 +2985,9 @@ class Pitch(prebase.ProtoM21Object):
         return round(self.ps) % 12
 
     @pitchClass.setter
-    def pitchClass(self, value: int|PitchClassString):
+    def pitchClass(self, value: int | PitchClassString):
         # permit the submission of strings, like "A" and "B"
-        valueOut: int|float = _convertPitchClassToNumber(value)
+        valueOut: int | float = _convertPitchClassToNumber(value)
         # get step and accidental w/o octave
         self.step, self._accidental = _convertPsToStep(valueOut)[0:2]
 
@@ -3024,7 +3024,7 @@ class Pitch(prebase.ProtoM21Object):
 
 
     @property
-    def octave(self) -> int|None:
+    def octave(self) -> int | None:
         '''
         Returns or sets the octave of the note.
         Setting the octave updates the pitchSpace attribute.
@@ -3052,7 +3052,7 @@ class Pitch(prebase.ProtoM21Object):
         return self._octave
 
     @octave.setter
-    def octave(self, value: int|float|None):
+    def octave(self, value: int | float | None):
         if value is not None:
             self._octave = int(value)
         else:
@@ -3380,7 +3380,7 @@ class Pitch(prebase.ProtoM21Object):
         return self.freq440
 
     @frequency.setter
-    def frequency(self, value: int|float):
+    def frequency(self, value: int | float):
         self.freq440 = value
 
     # these methods may belong in a temperament object
@@ -3408,7 +3408,7 @@ class Pitch(prebase.ProtoM21Object):
             return 440.0 * (self._twelfth_root_of_two ** A4offset)
 
     @freq440.setter
-    def freq440(self, value: int|float):
+    def freq440(self, value: int | float):
         post = 12 * (math.log(value / 440.0) / math.log(2)) + 69
         # environLocal.printDebug(['convertFqToPs():', 'input', fq, 'output', repr(post)])
         # rounding here is essential
@@ -3871,7 +3871,7 @@ class Pitch(prebase.ProtoM21Object):
 
     def _getEnharmonicHelper(self: PitchType,
                              inPlace: bool,
-                             up: bool) -> PitchType|None:
+                             up: bool) -> PitchType | None:
         '''
         abstracts the code from `getHigherEnharmonic` and `getLowerEnharmonic`
         '''
@@ -3907,7 +3907,7 @@ class Pitch(prebase.ProtoM21Object):
     def getHigherEnharmonic(self: PitchType, *, inPlace: t.Literal[True]) -> None:
         return None
 
-    def getHigherEnharmonic(self: PitchType, *, inPlace: bool = False) -> PitchType|None:
+    def getHigherEnharmonic(self: PitchType, *, inPlace: bool = False) -> PitchType | None:
         '''
         Returns an enharmonic `Pitch` object that is a higher
         enharmonic.  That is, the `Pitch` a diminished-second above
@@ -3971,7 +3971,7 @@ class Pitch(prebase.ProtoM21Object):
     def getLowerEnharmonic(self: PitchType, *, inPlace: t.Literal[True]) -> None:
         return None
 
-    def getLowerEnharmonic(self: PitchType, *, inPlace: bool = False) -> PitchType|None:
+    def getLowerEnharmonic(self: PitchType, *, inPlace: bool = False) -> PitchType | None:
         '''
         returns a Pitch enharmonic that is a diminished second
         below the current note
@@ -4009,7 +4009,7 @@ class Pitch(prebase.ProtoM21Object):
         *,
         inPlace=False,
         mostCommon=False
-    ) -> PitchType|None:
+    ) -> PitchType | None:
         '''
         Returns a new Pitch (or sets the current one if inPlace is True)
         that is either the same as the current pitch or has fewer
@@ -4098,7 +4098,7 @@ class Pitch(prebase.ProtoM21Object):
         else:
             return returnObj
 
-    def getEnharmonic(self: PitchType, *, inPlace=False) -> PitchType|None:
+    def getEnharmonic(self: PitchType, *, inPlace=False) -> PitchType | None:
         '''
         Returns a new Pitch that is the(/an) enharmonic equivalent of this Pitch.
         Can be thought of as flipEnharmonic or something like that.
@@ -4356,7 +4356,7 @@ class Pitch(prebase.ProtoM21Object):
     @overload
     def transpose(
         self: PitchType,
-        value: interval.IntervalBase|str|int,
+        value: interval.IntervalBase | str | int,
         *,
         inPlace: t.Literal[True]
     ) -> None:
@@ -4365,7 +4365,7 @@ class Pitch(prebase.ProtoM21Object):
     @overload
     def transpose(
         self: PitchType,
-        value: interval.IntervalBase|str|int,
+        value: interval.IntervalBase | str | int,
         *,
         inPlace: t.Literal[False] = False
     ) -> PitchType:
@@ -4373,10 +4373,10 @@ class Pitch(prebase.ProtoM21Object):
 
     def transpose(
         self: PitchType,
-        value: interval.IntervalBase|str|int,
+        value: interval.IntervalBase | str | int,
         *,
         inPlace: bool = False
-    ) -> PitchType|None:
+    ) -> PitchType | None:
         '''
         Transpose the pitch by the user-provided value.  If the value is an
         integer, the transposition is treated in half steps. If the value is a
@@ -4496,7 +4496,7 @@ class Pitch(prebase.ProtoM21Object):
         *,
         minimize=False,
         inPlace=False
-    ) -> PitchType|None:
+    ) -> PitchType | None:
         # noinspection PyShadowingNames
         '''
         Given a source Pitch, shift it down some number of octaves until it is below the
@@ -4594,7 +4594,7 @@ class Pitch(prebase.ProtoM21Object):
                              target,
                              *,
                              minimize=False,
-                             inPlace=False) -> PitchType|None:
+                             inPlace=False) -> PitchType | None:
         '''
         Given a source Pitch, shift it up octaves until it is above the target.
 
@@ -4748,10 +4748,10 @@ class Pitch(prebase.ProtoM21Object):
     def updateAccidentalDisplay(
         self,
         *,
-        pitchPast: list[Pitch]|None = None,
-        pitchPastMeasure: list[Pitch]|None = None,
-        otherSimultaneousPitches: list[Pitch]|None = None,
-        alteredPitches: list[Pitch]|None = None,
+        pitchPast: list[Pitch] | None = None,
+        pitchPastMeasure: list[Pitch] | None = None,
+        otherSimultaneousPitches: list[Pitch] | None = None,
+        alteredPitches: list[Pitch] | None = None,
         cautionaryPitchClass: bool = True,
         cautionaryAll: bool = False,
         overrideStatus: bool = False,

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -78,7 +78,7 @@ class ProtoM21Object:
     # it only needs to be made once (11 microseconds per call, can be
     # a big part of iteration; from cache just 1 microsecond)
     _classTupleCacheDict: dict[type, tuple[str, ...]] = {}
-    _classSetCacheDict: dict[type, frozenset[t.Union[str, type]]] = {}
+    _classSetCacheDict: dict[type, frozenset[str|type]] = {}
 
     __slots__: tuple[str, ...] = ()
 
@@ -160,7 +160,7 @@ class ProtoM21Object:
             return classTuple
 
     @property
-    def classSet(self) -> frozenset[t.Union[str, type]]:
+    def classSet(self) -> frozenset[str|type]:
         '''
         Returns a set (that is, unordered, but indexed) of all classes that
         this class belongs to, including
@@ -223,7 +223,7 @@ class ProtoM21Object:
         try:
             return self._classSetCacheDict[self.__class__]
         except KeyError:
-            classList: list[t.Union[str, type]] = list(self.classes)
+            classList: list[str|type] = list(self.classes)
             classList.extend(self.__class__.mro())
             fullyQualifiedStrings = [x.__module__ + '.' + x.__name__ for x in self.__class__.mro()]
             classList.extend(fullyQualifiedStrings)

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -78,7 +78,7 @@ class ProtoM21Object:
     # it only needs to be made once (11 microseconds per call, can be
     # a big part of iteration; from cache just 1 microsecond)
     _classTupleCacheDict: dict[type, tuple[str, ...]] = {}
-    _classSetCacheDict: dict[type, frozenset[str|type]] = {}
+    _classSetCacheDict: dict[type, frozenset[str | type]] = {}
 
     __slots__: tuple[str, ...] = ()
 
@@ -160,7 +160,7 @@ class ProtoM21Object:
             return classTuple
 
     @property
-    def classSet(self) -> frozenset[str|type]:
+    def classSet(self) -> frozenset[str | type]:
         '''
         Returns a set (that is, unordered, but indexed) of all classes that
         this class belongs to, including
@@ -223,7 +223,7 @@ class ProtoM21Object:
         try:
             return self._classSetCacheDict[self.__class__]
         except KeyError:
-            classList: list[str|type] = list(self.classes)
+            classList: list[str | type] = list(self.classes)
             classList.extend(self.__class__.mro())
             fullyQualifiedStrings = [x.__module__ + '.' + x.__name__ for x in self.__class__.mro()]
             classList.extend(fullyQualifiedStrings)

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import copy
 import string
-import typing as t
 from typing import TYPE_CHECKING  # pylint needs no alias
 
 from music21 import environment

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -1738,7 +1738,7 @@ class Expander:
             return post
         return None
 
-    def isExpandable(self) -> t.Union[bool, None]:
+    def isExpandable(self) -> bool|None:
         '''
         Return True or False if this Stream is expandable, that is,
         if it has balanced repeats or sensible Da Capo or Dal Segno

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -1738,7 +1738,7 @@ class Expander:
             return post
         return None
 
-    def isExpandable(self) -> bool|None:
+    def isExpandable(self) -> bool | None:
         '''
         Return True or False if this Stream is expandable, that is,
         if it has balanced repeats or sensible Da Capo or Dal Segno

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -737,7 +737,7 @@ def correctRNAlterationForMinor(
 
 def romanNumeralFromChord(
     chordObj: chord.Chord,
-    keyObj: key.Key | str = None,
+    keyObj: key.Key | str | None = None,
     preferSecondaryDominants: bool = False,
 ) -> RomanNumeral:
     # noinspection PyShadowingNames

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -525,7 +525,7 @@ def figureTupleSolo(
 
 
 def identifyAsTonicOrDominant(
-    inChord: list|tuple|chord.Chord,
+    inChord: list | tuple | chord.Chord,
     inKey: key.Key
 ) -> t.Union[str, t.Literal[False]]:
     '''
@@ -606,7 +606,7 @@ def identifyAsTonicOrDominant(
     return rootScaleDeg + romanInversionName(inChord)
 
 
-def romanInversionName(inChord: chord.Chord, inv: int|None = None) -> str:
+def romanInversionName(inChord: chord.Chord, inv: int | None = None) -> str:
     '''
     Extremely similar to Chord's inversionName() method, but returns string
     values and allows incomplete triads.
@@ -737,7 +737,7 @@ def correctRNAlterationForMinor(
 
 def romanNumeralFromChord(
     chordObj: chord.Chord,
-    keyObj: key.Key|str = None,
+    keyObj: key.Key | str = None,
     preferSecondaryDominants: bool = False,
 ) -> RomanNumeral:
     # noinspection PyShadowingNames
@@ -2237,8 +2237,8 @@ class RomanNumeral(harmony.Harmony):
 
     def __init__(
         self,
-        figure: str|int = '',
-        keyOrScale: key.Key|scale.ConcreteScale|str|None = None,
+        figure: str | int = '',
+        keyOrScale: key.Key | scale.ConcreteScale | str | None = None,
         *,
         caseMatters=True,
         updatePitches=True,
@@ -2246,10 +2246,10 @@ class RomanNumeral(harmony.Harmony):
         seventhMinor=Minor67Default.QUALITY,
     ):
         self.primaryFigure: str = ''
-        self.secondaryRomanNumeral: RomanNumeral|None = None
-        self.secondaryRomanNumeralKey: key.Key|None = None
+        self.secondaryRomanNumeral: RomanNumeral | None = None
+        self.secondaryRomanNumeralKey: key.Key | None = None
 
-        self.pivotChord: RomanNumeral|None = None
+        self.pivotChord: RomanNumeral | None = None
         self.caseMatters: bool = caseMatters
         self.scaleCardinality: int = 7
 
@@ -2278,8 +2278,8 @@ class RomanNumeral(harmony.Harmony):
         self._scale = None
         self.scaleDegree: int = 0
         self.frontAlterationString: str = ''
-        self.frontAlterationTransposeInterval: interval.Interval|None = None
-        self.frontAlterationAccidental: pitch.Accidental|None = None
+        self.frontAlterationTransposeInterval: interval.Interval | None = None
+        self.frontAlterationAccidental: pitch.Accidental | None = None
         self.romanNumeralAlone: str = ''
         self.figuresWritten: str = ''
         self.figuresNotationObj: fbNotation.Notation = _NOTATION_SINGLETON
@@ -2288,7 +2288,7 @@ class RomanNumeral(harmony.Harmony):
 
         self.impliedQuality: str = ''
 
-        self.impliedScale: scale.ConcreteScale|None = None
+        self.impliedScale: scale.ConcreteScale | None = None
         self.useImpliedScale: bool = False
         self.bracketedAlterations: list[tuple[str, int]] = []
         self.omittedSteps: list[int] = []
@@ -2301,7 +2301,7 @@ class RomanNumeral(harmony.Harmony):
 
         super().__init__(figure, updatePitches=updatePitches)
         self._parsingComplete = True
-        self._functionalityScore: int|None = None
+        self._functionalityScore: int | None = None
         self.editorial.followsKeyChange = False
 
     # SPECIAL METHODS #
@@ -2579,9 +2579,9 @@ class RomanNumeral(harmony.Harmony):
 
     def _correctForSecondaryRomanNumeral(
         self,
-        useScale: key.Key|scale.ConcreteScale,
-        figure: str|None = None
-    ) -> tuple[str, key.Key|scale.ConcreteScale]:
+        useScale: key.Key | scale.ConcreteScale,
+        figure: str | None = None
+    ) -> tuple[str, key.Key | scale.ConcreteScale]:
         '''
         Creates .secondaryRomanNumeral object and .secondaryRomanNumeralKey Key object
         inside the RomanNumeral object (recursively in case of V/V/V/V etc.) and returns
@@ -2793,8 +2793,8 @@ class RomanNumeral(harmony.Harmony):
     def _parseRNAloneAmidstAug6(
         self,
         workingFigure: str,
-        useScale: key.Key|scale.ConcreteScale,
-    ) -> tuple[str, key.Key|scale.ConcreteScale]:
+        useScale: key.Key | scale.ConcreteScale,
+    ) -> tuple[str, key.Key | scale.ConcreteScale]:
         # noinspection PyShadowingNames
         '''
         Sets and removes from workingFigure the roman numeral alone, possibly
@@ -2901,7 +2901,7 @@ class RomanNumeral(harmony.Harmony):
 
     def adjustMinorVIandVIIByQuality(
         self,
-        useScale: key.Key|scale.ConcreteScale
+        useScale: key.Key | scale.ConcreteScale
     ) -> None:
         '''
         Fix minor vi and vii to always be #vi and #vii if `.caseMatters`.
@@ -2933,7 +2933,7 @@ class RomanNumeral(harmony.Harmony):
     def _adjustMinorVIandVIIByQuality(
         self,
         workingFigure: str,
-        useScale: key.Key|scale.ConcreteScale
+        useScale: key.Key | scale.ConcreteScale
     ) -> str:
         '''
         Fix minor vi and vii to always be #vi and #vii if `.caseMatters`.
@@ -3045,7 +3045,7 @@ class RomanNumeral(harmony.Harmony):
         '''
         Utility function to update the pitches to the new figure etc.
         '''
-        useScale: key.Key|scale.ConcreteScale
+        useScale: key.Key | scale.ConcreteScale
         if self.secondaryRomanNumeralKey is not None:
             useScale = self.secondaryRomanNumeralKey
         elif self.useImpliedScale and self.impliedScale is not None:
@@ -3352,7 +3352,7 @@ class RomanNumeral(harmony.Harmony):
             #     ])
 
     @property
-    def scaleDegreeWithAlteration(self) -> tuple[int, pitch.Accidental|None]:
+    def scaleDegreeWithAlteration(self) -> tuple[int, pitch.Accidental | None]:
         '''
         Returns a two element tuple of the scale degree and the
         accidental that alters the scale degree for things such as #ii or
@@ -3376,7 +3376,7 @@ class RomanNumeral(harmony.Harmony):
 
     def bassScaleDegreeFromNotation(
         self,
-        notationObject: fbNotation.Notation|None = None
+        notationObject: fbNotation.Notation | None = None
     ) -> int:
         '''
         Given a notationObject from

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -525,7 +525,7 @@ def figureTupleSolo(
 
 
 def identifyAsTonicOrDominant(
-    inChord: t.Union[list, tuple, chord.Chord],
+    inChord: list|tuple|chord.Chord,
     inKey: key.Key
 ) -> t.Union[str, t.Literal[False]]:
     '''
@@ -2238,7 +2238,7 @@ class RomanNumeral(harmony.Harmony):
     def __init__(
         self,
         figure: str|int = '',
-        keyOrScale: t.Optional[t.Union[key.Key, scale.ConcreteScale, str]] = None,
+        keyOrScale: key.Key|scale.ConcreteScale|str|None = None,
         *,
         caseMatters=True,
         updatePitches=True,
@@ -2247,7 +2247,7 @@ class RomanNumeral(harmony.Harmony):
     ):
         self.primaryFigure: str = ''
         self.secondaryRomanNumeral: RomanNumeral|None = None
-        self.secondaryRomanNumeralKey: 'key.Key'|None = None
+        self.secondaryRomanNumeralKey: key.Key|None = None
 
         self.pivotChord: RomanNumeral|None = None
         self.caseMatters: bool = caseMatters
@@ -2579,9 +2579,9 @@ class RomanNumeral(harmony.Harmony):
 
     def _correctForSecondaryRomanNumeral(
         self,
-        useScale: t.Union[key.Key, scale.ConcreteScale],
+        useScale: key.Key|scale.ConcreteScale,
         figure: str|None = None
-    ) -> tuple[str, t.Union[key.Key, scale.ConcreteScale]]:
+    ) -> tuple[str, key.Key|scale.ConcreteScale]:
         '''
         Creates .secondaryRomanNumeral object and .secondaryRomanNumeralKey Key object
         inside the RomanNumeral object (recursively in case of V/V/V/V etc.) and returns
@@ -2793,8 +2793,8 @@ class RomanNumeral(harmony.Harmony):
     def _parseRNAloneAmidstAug6(
         self,
         workingFigure: str,
-        useScale: t.Union[key.Key, scale.ConcreteScale],
-    ) -> tuple[str, t.Union[key.Key, scale.ConcreteScale]]:
+        useScale: key.Key|scale.ConcreteScale,
+    ) -> tuple[str, key.Key|scale.ConcreteScale]:
         # noinspection PyShadowingNames
         '''
         Sets and removes from workingFigure the roman numeral alone, possibly
@@ -2901,7 +2901,7 @@ class RomanNumeral(harmony.Harmony):
 
     def adjustMinorVIandVIIByQuality(
         self,
-        useScale: t.Union[key.Key, scale.ConcreteScale]
+        useScale: key.Key|scale.ConcreteScale
     ) -> None:
         '''
         Fix minor vi and vii to always be #vi and #vii if `.caseMatters`.
@@ -2933,7 +2933,7 @@ class RomanNumeral(harmony.Harmony):
     def _adjustMinorVIandVIIByQuality(
         self,
         workingFigure: str,
-        useScale: t.Union[key.Key, scale.ConcreteScale]
+        useScale: key.Key|scale.ConcreteScale
     ) -> str:
         '''
         Fix minor vi and vii to always be #vi and #vii if `.caseMatters`.
@@ -3045,7 +3045,7 @@ class RomanNumeral(harmony.Harmony):
         '''
         Utility function to update the pitches to the new figure etc.
         '''
-        useScale: t.Union[key.Key, scale.ConcreteScale]
+        useScale: key.Key|scale.ConcreteScale
         if self.secondaryRomanNumeralKey is not None:
             useScale = self.secondaryRomanNumeralKey
         elif self.useImpliedScale and self.impliedScale is not None:
@@ -3352,7 +3352,7 @@ class RomanNumeral(harmony.Harmony):
             #     ])
 
     @property
-    def scaleDegreeWithAlteration(self) -> tuple[int, t.Optional[pitch.Accidental]]:
+    def scaleDegreeWithAlteration(self) -> tuple[int, pitch.Accidental|None]:
         '''
         Returns a two element tuple of the scale degree and the
         accidental that alters the scale degree for things such as #ii or

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -606,7 +606,7 @@ def identifyAsTonicOrDominant(
     return rootScaleDeg + romanInversionName(inChord)
 
 
-def romanInversionName(inChord: chord.Chord, inv: t.Optional[int] = None) -> str:
+def romanInversionName(inChord: chord.Chord, inv: int|None = None) -> str:
     '''
     Extremely similar to Chord's inversionName() method, but returns string
     values and allows incomplete triads.
@@ -2246,10 +2246,10 @@ class RomanNumeral(harmony.Harmony):
         seventhMinor=Minor67Default.QUALITY,
     ):
         self.primaryFigure: str = ''
-        self.secondaryRomanNumeral: t.Optional[RomanNumeral] = None
-        self.secondaryRomanNumeralKey: t.Optional['key.Key'] = None
+        self.secondaryRomanNumeral: RomanNumeral|None = None
+        self.secondaryRomanNumeralKey: 'key.Key'|None = None
 
-        self.pivotChord: t.Optional[RomanNumeral] = None
+        self.pivotChord: RomanNumeral|None = None
         self.caseMatters: bool = caseMatters
         self.scaleCardinality: int = 7
 
@@ -2278,8 +2278,8 @@ class RomanNumeral(harmony.Harmony):
         self._scale = None
         self.scaleDegree: int = 0
         self.frontAlterationString: str = ''
-        self.frontAlterationTransposeInterval: t.Optional[interval.Interval] = None
-        self.frontAlterationAccidental: t.Optional[pitch.Accidental] = None
+        self.frontAlterationTransposeInterval: interval.Interval|None = None
+        self.frontAlterationAccidental: pitch.Accidental|None = None
         self.romanNumeralAlone: str = ''
         self.figuresWritten: str = ''
         self.figuresNotationObj: fbNotation.Notation = _NOTATION_SINGLETON
@@ -2288,7 +2288,7 @@ class RomanNumeral(harmony.Harmony):
 
         self.impliedQuality: str = ''
 
-        self.impliedScale: t.Optional[scale.ConcreteScale] = None
+        self.impliedScale: scale.ConcreteScale|None = None
         self.useImpliedScale: bool = False
         self.bracketedAlterations: list[tuple[str, int]] = []
         self.omittedSteps: list[int] = []
@@ -2301,7 +2301,7 @@ class RomanNumeral(harmony.Harmony):
 
         super().__init__(figure, updatePitches=updatePitches)
         self._parsingComplete = True
-        self._functionalityScore: t.Optional[int] = None
+        self._functionalityScore: int|None = None
         self.editorial.followsKeyChange = False
 
     # SPECIAL METHODS #
@@ -2580,7 +2580,7 @@ class RomanNumeral(harmony.Harmony):
     def _correctForSecondaryRomanNumeral(
         self,
         useScale: t.Union[key.Key, scale.ConcreteScale],
-        figure: t.Optional[str] = None
+        figure: str|None = None
     ) -> tuple[str, t.Union[key.Key, scale.ConcreteScale]]:
         '''
         Creates .secondaryRomanNumeral object and .secondaryRomanNumeralKey Key object
@@ -3376,7 +3376,7 @@ class RomanNumeral(harmony.Harmony):
 
     def bassScaleDegreeFromNotation(
         self,
-        notationObject: t.Optional[fbNotation.Notation] = None
+        notationObject: fbNotation.Notation|None = None
     ) -> int:
         '''
         Given a notationObject from

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -529,7 +529,7 @@ def figureTupleSolo(
 def identifyAsTonicOrDominant(
     inChord: list | tuple | chord.Chord,
     inKey: key.Key
-) -> t.Union[str, t.Literal[False]]:
+) -> str | t.Literal[False]:
     '''
     Returns the roman numeral string expression (either tonic or dominant) that
     best matches the inChord. Useful when you know inChord is either tonic or
@@ -3159,7 +3159,7 @@ class RomanNumeral(harmony.Harmony):
                 f'_updatePitches() was unable to derive pitches from the figure: {self.figure!r}'
             )  # pragma: no cover
 
-    def transpose(self: T, value, *, inPlace=False) -> t.Optional[T]:
+    def transpose(self: T, value, *, inPlace=False) -> T | None:
         '''
         Overrides :meth:`~music21.harmony.Harmony.transpose` so that `key`
         attribute is transposed as well.

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -737,7 +737,7 @@ def correctRNAlterationForMinor(
 
 def romanNumeralFromChord(
     chordObj: chord.Chord,
-    keyObj: t.Union[key.Key, str] = None,
+    keyObj: key.Key|str = None,
     preferSecondaryDominants: bool = False,
 ) -> RomanNumeral:
     # noinspection PyShadowingNames
@@ -2237,7 +2237,7 @@ class RomanNumeral(harmony.Harmony):
 
     def __init__(
         self,
-        figure: t.Union[str, int] = '',
+        figure: str|int = '',
         keyOrScale: t.Optional[t.Union[key.Key, scale.ConcreteScale, str]] = None,
         *,
         caseMatters=True,

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -21,7 +21,6 @@ import copy
 import io
 import pathlib
 import re
-import typing as t
 import unittest
 
 from collections import OrderedDict

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -296,7 +296,7 @@ class CTSong(prebase.ProtoM21Object):
             ''',
     }
 
-    def __init__(self, textFile: t.Union[str, pathlib.Path] = '', **keywords):
+    def __init__(self, textFile: str|pathlib.Path = '', **keywords):
         self._title = None
         self.text = ''
         self.lines: list[str] = []

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -296,7 +296,7 @@ class CTSong(prebase.ProtoM21Object):
             ''',
     }
 
-    def __init__(self, textFile: str|pathlib.Path = '', **keywords):
+    def __init__(self, textFile: str | pathlib.Path = '', **keywords):
         self._title = None
         self.text = ''
         self.lines: list[str] = []
@@ -328,7 +328,7 @@ class CTSong(prebase.ProtoM21Object):
         return f'title={self.title!r} year={self.year}'
 
     # --------------------------------------------------------------------------
-    def parse(self, textFile: str|pathlib.Path):
+    def parse(self, textFile: str | pathlib.Path):
         '''
         Called when a CTSong is created by passing a string or filename;
         in the second case, it opens the file

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -328,7 +328,7 @@ class CTSong(prebase.ProtoM21Object):
         return f'title={self.title!r} year={self.year}'
 
     # --------------------------------------------------------------------------
-    def parse(self, textFile: t.Union[str, pathlib.Path]):
+    def parse(self, textFile: str|pathlib.Path):
         '''
         Called when a CTSong is created by passing a string or filename;
         in the second case, it opens the file

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -228,7 +228,7 @@ def _copySingleMeasure(rtTagged, p, kCurrent):
 
 def _copyMultipleMeasures(rtMeasure: rtObjects.RTMeasure,
                           p: stream.Part,
-                          kCurrent: t.Optional[key.Key]):
+                          kCurrent: key.Key|None):
     '''
     Given a RomanText token for a RTMeasure, a
     Part used as the current container, and the current Key,
@@ -1701,7 +1701,7 @@ m1 C: I'''
             rn_iter = measure[roman.RomanNumeral]
             self.assertEqual(len(rn_iter), 1)
             # mypy complains about the next line because
-            #   RecursiveIterator.first() has t.Optional type, but we know
+            #   RecursiveIterator.first() has X|None type, but we know
             #   it will not be None because we have just asserted that rn_iter
             #   has length 1
             self.assertEqual(rn_iter.first().figure, 'I')  # type: ignore

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -228,7 +228,7 @@ def _copySingleMeasure(rtTagged, p, kCurrent):
 
 def _copyMultipleMeasures(rtMeasure: rtObjects.RTMeasure,
                           p: stream.Part,
-                          kCurrent: key.Key|None):
+                          kCurrent: key.Key | None):
     '''
     Given a RomanText token for a RTMeasure, a
     Part used as the current container, and the current Key,
@@ -1701,7 +1701,7 @@ m1 C: I'''
             rn_iter = measure[roman.RomanNumeral]
             self.assertEqual(len(rn_iter), 1)
             # mypy complains about the next line because
-            #   RecursiveIterator.first() has X|None type, but we know
+            #   RecursiveIterator.first() has X | None type, but we know
             #   it will not be None because we have just asserted that rn_iter
             #   has length 1
             self.assertEqual(rn_iter.first().figure, 'I')  # type: ignore

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -682,7 +682,7 @@ class TsvHandler:
 
         currentMeasureLength = ts.barDuration.quarterLength
 
-        currentOffset: t.Union[float, fractions.Fraction] = 0.0
+        currentOffset: float|fractions.Fraction = 0.0
 
         previousMeasure: int = self.chordList[0].measure - 1  # Covers pickups
         for entry in self.chordList:

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -534,7 +534,7 @@ class TsvHandler:
             raise ValueError(f'dcml_version {dcml_version} is not in (1, 2)')
         self.tsvFileName = tsvFile
         self.chordList: list[TabChordBase] = []
-        self.m21stream: t.Optional[stream.Score] = None
+        self.m21stream: stream.Score|None = None
         self._head_indices: dict[str, tuple[int, t.Union[type, t.Any]]] = {}
         self._extra_indices: dict[int, str] = {}
         self.dcml_version = dcml_version

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -535,7 +535,7 @@ class TsvHandler:
         self.tsvFileName = tsvFile
         self.chordList: list[TabChordBase] = []
         self.m21stream: stream.Score|None = None
-        self._head_indices: dict[str, tuple[int, t.Union[type, t.Any]]] = {}
+        self._head_indices: dict[str, tuple[int, type|t.Any]] = {}
         self._extra_indices: dict[int, str] = {}
         self.dcml_version = dcml_version
         self.tsvData = self._importTsv()  # converted to private

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -534,8 +534,8 @@ class TsvHandler:
             raise ValueError(f'dcml_version {dcml_version} is not in (1, 2)')
         self.tsvFileName = tsvFile
         self.chordList: list[TabChordBase] = []
-        self.m21stream: stream.Score|None = None
-        self._head_indices: dict[str, tuple[int, type|t.Any]] = {}
+        self.m21stream: stream.Score | None = None
+        self._head_indices: dict[str, tuple[int, type | t.Any]] = {}
         self._extra_indices: dict[int, str] = {}
         self.dcml_version = dcml_version
         self.tsvData = self._importTsv()  # converted to private
@@ -682,7 +682,7 @@ class TsvHandler:
 
         currentMeasureLength = ts.barDuration.quarterLength
 
-        currentOffset: float|fractions.Fraction = 0.0
+        currentOffset: float | fractions.Fraction = 0.0
 
         previousMeasure: int = self.chordList[0].measure - 1  # Covers pickups
         for entry in self.chordList:

--- a/music21/romanText/writeRoman.py
+++ b/music21/romanText/writeRoman.py
@@ -129,7 +129,7 @@ class RnWriter(prebase.ProtoM21Object):
         self.analyst = ''
         self.proofreader = ''
         self.combinedList: list[str] = []
-        self.container: t.Union[stream.Part, stream.Score]
+        self.container: stream.Part|stream.Score
 
         if isinstance(obj, stream.Stream):
             if isinstance(obj, stream.Opus):
@@ -182,7 +182,7 @@ class RnWriter(prebase.ProtoM21Object):
         self.prepSequentialListOfLines()
 
     def _makeContainer(self,
-                       obj: t.Union[stream.Stream, list]):
+                       obj: stream.Stream|list):
         '''
         Makes a placeholder container for the unusual cases where this class is called on
         generic- or non-stream object as opposed to
@@ -332,8 +332,8 @@ class RnWriter(prebase.ProtoM21Object):
 
 # ------------------------------------------------------------------------------
 
-def rnString(measureNumber: t.Union[int, str],
-             beat: t.Union[str, int, float, fractions.Fraction],
+def rnString(measureNumber: int|str,
+             beat: str|int|float|fractions.Fraction,
              chordString: str,
              inString: str|None = ''):
     '''
@@ -382,7 +382,7 @@ def rnString(measureNumber: t.Union[int, str],
     return newString
 
 
-def intBeat(beat: t.Union[str, int, float, fractions.Fraction],
+def intBeat(beat: str|int|float|fractions.Fraction,
             roundValue: int = 2):
     '''
     Converts beats to integers if possible, and otherwise to rounded decimals.

--- a/music21/romanText/writeRoman.py
+++ b/music21/romanText/writeRoman.py
@@ -335,7 +335,7 @@ class RnWriter(prebase.ProtoM21Object):
 def rnString(measureNumber: t.Union[int, str],
              beat: t.Union[str, int, float, fractions.Fraction],
              chordString: str,
-             inString: t.Optional[str] = ''):
+             inString: str|None = ''):
     '''
     Creates or extends a string of RomanText such that the output corresponds to a single
     measure line.

--- a/music21/romanText/writeRoman.py
+++ b/music21/romanText/writeRoman.py
@@ -17,8 +17,6 @@ import fractions
 import textwrap
 import unittest
 
-import typing as t
-
 from music21 import bar
 from music21 import base
 from music21 import metadata

--- a/music21/romanText/writeRoman.py
+++ b/music21/romanText/writeRoman.py
@@ -129,7 +129,7 @@ class RnWriter(prebase.ProtoM21Object):
         self.analyst = ''
         self.proofreader = ''
         self.combinedList: list[str] = []
-        self.container: stream.Part|stream.Score
+        self.container: stream.Part | stream.Score
 
         if isinstance(obj, stream.Stream):
             if isinstance(obj, stream.Opus):
@@ -182,7 +182,7 @@ class RnWriter(prebase.ProtoM21Object):
         self.prepSequentialListOfLines()
 
     def _makeContainer(self,
-                       obj: stream.Stream|list):
+                       obj: stream.Stream | list):
         '''
         Makes a placeholder container for the unusual cases where this class is called on
         generic- or non-stream object as opposed to
@@ -332,10 +332,10 @@ class RnWriter(prebase.ProtoM21Object):
 
 # ------------------------------------------------------------------------------
 
-def rnString(measureNumber: int|str,
-             beat: str|int|float|fractions.Fraction,
+def rnString(measureNumber: int | str,
+             beat: str | int | float | fractions.Fraction,
              chordString: str,
-             inString: str|None = ''):
+             inString: str | None = ''):
     '''
     Creates or extends a string of RomanText such that the output corresponds to a single
     measure line.
@@ -382,7 +382,7 @@ def rnString(measureNumber: int|str,
     return newString
 
 
-def intBeat(beat: str|int|float|fractions.Fraction,
+def intBeat(beat: str | int | float | fractions.Fraction,
             roundValue: int = 2):
     '''
     Converts beats to integers if possible, and otherwise to rounded decimals.

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -560,7 +560,7 @@ class AbstractScale(Scale):
                   pitchOrigin,
                   direction: Direction = Direction.ASCENDING,
                   stepSize=1,
-                  getNeighbor: t.Union[Direction, bool] = True):
+                  getNeighbor: Direction|bool = True):
         '''
         Expose functionality from :class:`~music21.intervalNetwork.IntervalNetwork`,
         passing on the stored alteredDegrees dictionary.
@@ -1571,8 +1571,8 @@ class ConcreteScale(Scale):
 
     def getPitches(
         self,
-        minPitch: t.Union[str, pitch.Pitch, None] = None,
-        maxPitch: t.Union[str, pitch.Pitch, None] = None,
+        minPitch: str|pitch.Pitch|None = None,
+        maxPitch: str|pitch.Pitch|None = None,
         direction: Direction|None = None
     ) -> list[pitch.Pitch]:
         '''
@@ -2052,9 +2052,9 @@ class ConcreteScale(Scale):
     def next(
         self,
         pitchOrigin=None,
-        direction: t.Union[Direction, int] = Direction.ASCENDING,
+        direction: Direction|int = Direction.ASCENDING,
         stepSize=1,
-        getNeighbor: t.Union[Direction, bool] = True,
+        getNeighbor: Direction|bool = True,
     ):  # pragma: no cover
         '''
         See :meth:`~music21.scale.ConcreteScale.nextPitch`.  This function
@@ -2076,9 +2076,9 @@ class ConcreteScale(Scale):
     def nextPitch(
         self,
         pitchOrigin=None,
-        direction: t.Union[Direction, int] = Direction.ASCENDING,
+        direction: Direction|int = Direction.ASCENDING,
         stepSize=1,
-        getNeighbor: t.Union[Direction, bool] = True,
+        getNeighbor: Direction|bool = True,
     ):
         '''
         Get the next pitch above (or below if direction is Direction.DESCENDING)
@@ -2170,7 +2170,7 @@ class ConcreteScale(Scale):
                pitchOrigin,
                direction: Direction = Direction.ASCENDING,
                stepSize=1,
-               getNeighbor: t.Union[Direction, bool] = True,
+               getNeighbor: Direction|bool = True,
                comparisonAttribute='name'):
         '''
         Given another pitch, as well as an origin and a direction,
@@ -3047,7 +3047,7 @@ class CyclicalScale(ConcreteScale):
     '''
 
     def __init__(self,
-                 tonic: t.Union[str, pitch.Pitch, note.Note, None] = None,
+                 tonic: str|pitch.Pitch|note.Note|None = None,
                  intervalList: list|None = None):
         super().__init__(tonic=tonic)
         mode = intervalList if intervalList else ['m2']
@@ -3152,7 +3152,7 @@ class SieveScale(ConcreteScale):
     def __init__(self,
                  tonic=None,
                  sieveString='2@0',
-                 eld: t.Union[int, float] = 1):
+                 eld: int|float = 1):
         super().__init__(tonic=tonic)
 
         # self.tonic is a Pitch

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -1258,8 +1258,8 @@ class ConcreteScale(Scale):
     usePitchDegreeCache = False
 
     def __init__(self,
-                 tonic: t.Optional[t.Union[str, pitch.Pitch, note.Note]] = None,
-                 pitches: t.Optional[list[t.Union[pitch.Pitch, str]]] = None):
+                 tonic: str|pitch.Pitch|note.Note|None = None,
+                 pitches: list[pitch.Pitch|str]|None = None):
         super().__init__()
 
         self.type = 'Concrete'
@@ -1281,7 +1281,7 @@ class ConcreteScale(Scale):
         # found on
         # no default tonic is defined; as such, it is mostly an abstract scale, and
         # can't be used concretely until it is created.
-        self.tonic: t.Optional[pitch.Pitch]
+        self.tonic: pitch.Pitch|None
         if tonic is None:
             self.tonic = None  # pitch.Pitch()
         elif isinstance(tonic, str):
@@ -1594,13 +1594,13 @@ class ConcreteScale(Scale):
             pitchObj = self.tonic
         stepOfPitch = self._abstract.tonicDegree
 
-        minPitchObj: t.Optional[pitch.Pitch]
+        minPitchObj: pitch.Pitch|None
         if isinstance(minPitch, str):
             minPitchObj = pitch.Pitch(minPitch)
         else:
             minPitchObj = minPitch
 
-        maxPitchObj: t.Optional[pitch.Pitch]
+        maxPitchObj: pitch.Pitch|None
         if isinstance(maxPitch, str):
             maxPitchObj = pitch.Pitch(maxPitch)
         else:

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -560,7 +560,7 @@ class AbstractScale(Scale):
                   pitchOrigin,
                   direction: Direction = Direction.ASCENDING,
                   stepSize=1,
-                  getNeighbor: Direction|bool = True):
+                  getNeighbor: Direction | bool = True):
         '''
         Expose functionality from :class:`~music21.intervalNetwork.IntervalNetwork`,
         passing on the stored alteredDegrees dictionary.
@@ -659,7 +659,7 @@ class AbstractDiatonicScale(AbstractScale):
     True
 
     '''
-    def __init__(self, mode: str|None = None):
+    def __init__(self, mode: str | None = None):
         super().__init__()
         self.mode = mode
         self.type = 'Abstract diatonic'
@@ -1258,14 +1258,14 @@ class ConcreteScale(Scale):
     usePitchDegreeCache = False
 
     def __init__(self,
-                 tonic: str|pitch.Pitch|note.Note|None = None,
-                 pitches: list[pitch.Pitch|str]|None = None):
+                 tonic: str | pitch.Pitch | note.Note | None = None,
+                 pitches: list[pitch.Pitch | str] | None = None):
         super().__init__()
 
         self.type = 'Concrete'
         # store an instance of an abstract scale
         # subclasses might use multiple abstract scales?
-        self._abstract: AbstractScale|None = None
+        self._abstract: AbstractScale | None = None
 
         # determine whether this is a limited range
         self.boundRange = False
@@ -1281,7 +1281,7 @@ class ConcreteScale(Scale):
         # found on
         # no default tonic is defined; as such, it is mostly an abstract scale, and
         # can't be used concretely until it is created.
-        self.tonic: pitch.Pitch|None
+        self.tonic: pitch.Pitch | None
         if tonic is None:
             self.tonic = None  # pitch.Pitch()
         elif isinstance(tonic, str):
@@ -1521,7 +1521,7 @@ class ConcreteScale(Scale):
                 pDstNew.octave = pEnh.octave  # copy octave
                 # need to adjust enharmonic
                 pDstNewEnh = pDstNew.getAllCommonEnharmonics(alterLimit=2)
-                match: pitch.Pitch|None = None
+                match: pitch.Pitch | None = None
                 for x in pDstNewEnh:
                     # try to match enharmonic with original alt
                     if x.name == pAlt.name:
@@ -1571,9 +1571,9 @@ class ConcreteScale(Scale):
 
     def getPitches(
         self,
-        minPitch: str|pitch.Pitch|None = None,
-        maxPitch: str|pitch.Pitch|None = None,
-        direction: Direction|None = None
+        minPitch: str | pitch.Pitch | None = None,
+        maxPitch: str | pitch.Pitch | None = None,
+        direction: Direction | None = None
     ) -> list[pitch.Pitch]:
         '''
         Return a list of Pitch objects, using a
@@ -1594,13 +1594,13 @@ class ConcreteScale(Scale):
             pitchObj = self.tonic
         stepOfPitch = self._abstract.tonicDegree
 
-        minPitchObj: pitch.Pitch|None
+        minPitchObj: pitch.Pitch | None
         if isinstance(minPitch, str):
             minPitchObj = pitch.Pitch(minPitch)
         else:
             minPitchObj = minPitch
 
-        maxPitchObj: pitch.Pitch|None
+        maxPitchObj: pitch.Pitch | None
         if isinstance(maxPitch, str):
             maxPitchObj = pitch.Pitch(maxPitch)
         else:
@@ -1697,7 +1697,7 @@ class ConcreteScale(Scale):
         if self._abstract is None:  # pragma: no cover
             raise ScaleException('Abstract scale underpinning this scale is not defined.')
 
-        cacheKey: _PitchDegreeCacheKey|None = None
+        cacheKey: _PitchDegreeCacheKey | None = None
         if (self.usePitchDegreeCache and self.tonic
                 and not minPitch and not maxPitch and getattr(self, 'type', None)):
             tonicCacheKey = self.tonic.nameWithOctave
@@ -2052,9 +2052,9 @@ class ConcreteScale(Scale):
     def next(
         self,
         pitchOrigin=None,
-        direction: Direction|int = Direction.ASCENDING,
+        direction: Direction | int = Direction.ASCENDING,
         stepSize=1,
-        getNeighbor: Direction|bool = True,
+        getNeighbor: Direction | bool = True,
     ):  # pragma: no cover
         '''
         See :meth:`~music21.scale.ConcreteScale.nextPitch`.  This function
@@ -2076,9 +2076,9 @@ class ConcreteScale(Scale):
     def nextPitch(
         self,
         pitchOrigin=None,
-        direction: Direction|int = Direction.ASCENDING,
+        direction: Direction | int = Direction.ASCENDING,
         stepSize=1,
-        getNeighbor: Direction|bool = True,
+        getNeighbor: Direction | bool = True,
     ):
         '''
         Get the next pitch above (or below if direction is Direction.DESCENDING)
@@ -2170,7 +2170,7 @@ class ConcreteScale(Scale):
                pitchOrigin,
                direction: Direction = Direction.ASCENDING,
                stepSize=1,
-               getNeighbor: Direction|bool = True,
+               getNeighbor: Direction | bool = True,
                comparisonAttribute='name'):
         '''
         Given another pitch, as well as an origin and a direction,
@@ -3018,7 +3018,7 @@ class OctaveRepeatingScale(ConcreteScale):
     [<music21.pitch.Pitch C4>, <music21.pitch.Pitch D-4>, <music21.pitch.Pitch C5>]
     '''
 
-    def __init__(self, tonic=None, intervalList: list|None = None):
+    def __init__(self, tonic=None, intervalList: list | None = None):
         super().__init__(tonic=tonic)
         mode = intervalList if intervalList else ['m2']
         self._abstract = AbstractOctaveRepeatingScale(mode=mode)
@@ -3047,8 +3047,8 @@ class CyclicalScale(ConcreteScale):
     '''
 
     def __init__(self,
-                 tonic: str|pitch.Pitch|note.Note|None = None,
-                 intervalList: list|None = None):
+                 tonic: str | pitch.Pitch | note.Note | None = None,
+                 intervalList: list | None = None):
         super().__init__(tonic=tonic)
         mode = intervalList if intervalList else ['m2']
         self._abstract = AbstractCyclicalScale(mode=mode)
@@ -3152,7 +3152,7 @@ class SieveScale(ConcreteScale):
     def __init__(self,
                  tonic=None,
                  sieveString='2@0',
-                 eld: int|float = 1):
+                 eld: int | float = 1):
         super().__init__(tonic=tonic)
 
         # self.tonic is a Pitch

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -659,7 +659,7 @@ class AbstractDiatonicScale(AbstractScale):
     True
 
     '''
-    def __init__(self, mode: t.Optional[str] = None):
+    def __init__(self, mode: str|None = None):
         super().__init__()
         self.mode = mode
         self.type = 'Abstract diatonic'
@@ -1265,7 +1265,7 @@ class ConcreteScale(Scale):
         self.type = 'Concrete'
         # store an instance of an abstract scale
         # subclasses might use multiple abstract scales?
-        self._abstract: t.Optional[AbstractScale] = None
+        self._abstract: AbstractScale|None = None
 
         # determine whether this is a limited range
         self.boundRange = False
@@ -1521,7 +1521,7 @@ class ConcreteScale(Scale):
                 pDstNew.octave = pEnh.octave  # copy octave
                 # need to adjust enharmonic
                 pDstNewEnh = pDstNew.getAllCommonEnharmonics(alterLimit=2)
-                match: t.Optional[pitch.Pitch] = None
+                match: pitch.Pitch|None = None
                 for x in pDstNewEnh:
                     # try to match enharmonic with original alt
                     if x.name == pAlt.name:
@@ -1573,7 +1573,7 @@ class ConcreteScale(Scale):
         self,
         minPitch: t.Union[str, pitch.Pitch, None] = None,
         maxPitch: t.Union[str, pitch.Pitch, None] = None,
-        direction: t.Optional[Direction] = None
+        direction: Direction|None = None
     ) -> list[pitch.Pitch]:
         '''
         Return a list of Pitch objects, using a
@@ -1697,7 +1697,7 @@ class ConcreteScale(Scale):
         if self._abstract is None:  # pragma: no cover
             raise ScaleException('Abstract scale underpinning this scale is not defined.')
 
-        cacheKey: t.Optional[_PitchDegreeCacheKey] = None
+        cacheKey: _PitchDegreeCacheKey|None = None
         if (self.usePitchDegreeCache and self.tonic
                 and not minPitch and not maxPitch and getattr(self, 'type', None)):
             tonicCacheKey = self.tonic.nameWithOctave
@@ -3018,7 +3018,7 @@ class OctaveRepeatingScale(ConcreteScale):
     [<music21.pitch.Pitch C4>, <music21.pitch.Pitch D-4>, <music21.pitch.Pitch C5>]
     '''
 
-    def __init__(self, tonic=None, intervalList: t.Optional[list] = None):
+    def __init__(self, tonic=None, intervalList: list|None = None):
         super().__init__(tonic=tonic)
         mode = intervalList if intervalList else ['m2']
         self._abstract = AbstractOctaveRepeatingScale(mode=mode)
@@ -3048,7 +3048,7 @@ class CyclicalScale(ConcreteScale):
 
     def __init__(self,
                  tonic: t.Union[str, pitch.Pitch, note.Note, None] = None,
-                 intervalList: t.Optional[list] = None):
+                 intervalList: list|None = None):
         super().__init__(tonic=tonic)
         mode = intervalList if intervalList else ['m2']
         self._abstract = AbstractCyclicalScale(mode=mode)

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -73,7 +73,7 @@ class Direction(enum.Enum):
 
 
 CacheKey = tuple[
-    t.Union[int, Terminus], str, t.Union[str, None], t.Union[str, None], bool, t.Optional[bool]]
+    int|Terminus, str, str|None, str|None, bool, bool|None]
 
 
 def _gte(a, b):
@@ -145,7 +145,7 @@ class Edge(prebase.ProtoM21Object):
     # noinspection PyShadowingBuiltins
     # pylint: disable=redefined-builtin
     def __init__(self,
-                 intervalData: t.Union[interval.Interval, str],
+                 intervalData: interval.Interval|str,
                  id=None,  # id is okay: @ReservedAssignment
                  direction=Direction.BI):
         if isinstance(intervalData, str):
@@ -161,7 +161,7 @@ class Edge(prebase.ProtoM21Object):
 
         # one or two pairs of Node ids that this Edge connects
         # if there are two, it is a bidirectional, w/ first ascending
-        self._connections: list[tuple[t.Union[int, Terminus], t.Union[int, Terminus]]] = []
+        self._connections: list[tuple[int|Terminus, int|Terminus]] = []
 
     def __eq__(self, other):
         '''
@@ -184,8 +184,8 @@ class Edge(prebase.ProtoM21Object):
 
     def addDirectedConnection(
         self,
-        node1: t.Union[Node, int, Terminus],
-        node2: t.Union[Node, int, Terminus],
+        node1: Node|int|Terminus,
+        node2: Node|int|Terminus,
         direction=None
     ) -> None:
         '''
@@ -252,7 +252,7 @@ class Edge(prebase.ProtoM21Object):
     def getConnections(
         self,
         direction: None|Direction = None
-    ) -> list[tuple[t.Union[int, Terminus], t.Union[int, Terminus]]]:
+    ) -> list[tuple[int|Terminus, int|Terminus]]:
         '''
         Callable as a property (.connections) or as a method
         (.getConnections(direction)):
@@ -303,7 +303,7 @@ class Edge(prebase.ProtoM21Object):
 
     # keep separate property, since getConnections takes a direction argument.
     @property
-    def connections(self) -> list[tuple[t.Union[int, Terminus], t.Union[int, Terminus]]]:
+    def connections(self) -> list[tuple[int|Terminus, int|Terminus]]:
         return self.getConnections()
 
 
@@ -328,7 +328,7 @@ class Node(prebase.ProtoM21Object, common.SlottedObjectMixin):
 
     # noinspection PyShadowingBuiltins
     # pylint: disable=redefined-builtin
-    def __init__(self, id: t.Union[Terminus, int], degree: int, weight: float = 1.0):
+    def __init__(self, id: Terminus|int, degree: int, weight: float = 1.0):
         # store id, either as string, such as terminusLow, or a number.
         # ids are unique to any node in the network
         self.id: Terminus|int = id
@@ -416,7 +416,7 @@ class IntervalNetwork:
     '''
 
     def __init__(self,
-                 edgeList: Sequence[t.Union[interval.Interval, str]] = (),
+                 edgeList: Sequence[interval.Interval|str] = (),
                  octaveDuplicating=False,
                  deterministic=True,
                  pitchSimplification='maxAccidental'):
@@ -427,10 +427,10 @@ class IntervalNetwork:
 
         # a dictionary of Edge object, where keys are edgeId values
         # Edges store directed connections between Node ids
-        self.edges: OrderedDict[t.Union[Terminus, int], Edge] = OrderedDict()
+        self.edges: OrderedDict[Terminus|int, Edge] = OrderedDict()
 
         # nodes suggest Pitches, but Pitches are not stored
-        self.nodes: OrderedDict[t.Union[Terminus, int], Node] = OrderedDict()
+        self.nodes: OrderedDict[Terminus|int, Node] = OrderedDict()
 
         if edgeList:  # auto initialize
             self.fillBiDirectedEdges(edgeList)
@@ -445,11 +445,11 @@ class IntervalNetwork:
         # store segments
         self._ascendingCache: OrderedDict[
             CacheKey,
-            tuple[list[pitch.Pitch], list[t.Union[Terminus, int]]]
+            tuple[list[pitch.Pitch], list[Terminus|int]]
         ] = OrderedDict()
         self._descendingCache: OrderedDict[
             CacheKey,
-            tuple[list[pitch.Pitch], list[t.Union[Terminus, int]]]
+            tuple[list[pitch.Pitch], list[Terminus|int]]
         ] = OrderedDict()
 
     def clear(self):
@@ -488,7 +488,7 @@ class IntervalNetwork:
         return (isinstance(other, self.__class__)
                 and self.__dict__ == other.__dict__)
 
-    def fillBiDirectedEdges(self, edgeList: Sequence[t.Union[interval.Interval, str]]):
+    def fillBiDirectedEdges(self, edgeList: Sequence[interval.Interval|str]):
         # noinspection PyShadowingNames
         '''
         Given an ordered list of bi-directed edges given as :class:`~music21.interval.Interval`
@@ -1008,7 +1008,7 @@ class IntervalNetwork:
         return ((degree - 1) % spanCount) + sMin
 
     def nodeNameToNodes(self,
-                        nodeId: t.Union[Node, int, Terminus, None],
+                        nodeId: Node|int|Terminus|None,
                         *,
                         equateTermini=True,
                         permitDegreeModuli=True):
@@ -1200,9 +1200,9 @@ class IntervalNetwork:
 
     def nextPitch(
         self,
-        pitchReference: t.Union[pitch.Pitch, str],
-        nodeName: t.Union[Node, int, Terminus, None],
-        pitchOrigin: t.Union[pitch.Pitch, str],
+        pitchReference: pitch.Pitch|str,
+        nodeName: Node|int|Terminus|None,
+        pitchOrigin: pitch.Pitch|str,
         *,
         direction: Direction = Direction.ASCENDING,
         stepSize=1,
@@ -1359,8 +1359,8 @@ class IntervalNetwork:
         self,
         nodeObj: Node,
         pitchReference: pitch.Pitch,
-        minPitch: t.Optional[pitch.Pitch],
-        maxPitch: t.Optional[pitch.Pitch],
+        minPitch: pitch.Pitch|None,
+        maxPitch: pitch.Pitch|None,
         *,
         includeFirst: bool,
         reverse: bool|None = None,  # only meaningful for descending
@@ -1387,14 +1387,14 @@ class IntervalNetwork:
 
     def realizeAscending(
         self,
-        pitchReference: t.Union[pitch.Pitch, str],
+        pitchReference: pitch.Pitch|str,
         nodeId: Node|int|Terminus|None = None,
         minPitch: pitch.Pitch|str|None = None,
         maxPitch: pitch.Pitch|str|None = None,
         *,
         alteredDegrees=None,
         fillMinMaxIfNone=False
-    ) -> tuple[list[pitch.Pitch], list[t.Union[Terminus, int]]]:
+    ) -> tuple[list[pitch.Pitch], list[Terminus|int]]:
         # noinspection PyShadowingNames
         '''
         Given a reference pitch, realize upwards to a maximum pitch.
@@ -1552,7 +1552,7 @@ class IntervalNetwork:
 
     def realizeDescending(
         self,
-        pitchReference: t.Union[pitch.Pitch, str],
+        pitchReference: pitch.Pitch|str,
         nodeId: Node|int|Terminus|None = None,
         minPitch: pitch.Pitch|str|None = None,
         maxPitch: pitch.Pitch|str|None = None,
@@ -1631,13 +1631,13 @@ class IntervalNetwork:
         else:
             nodeObj = self.nodeNameToNodes(nodeId)[0]
 
-        minPitchObj: t.Optional[pitch.Pitch]
+        minPitchObj: pitch.Pitch|None
         if isinstance(minPitch, str):
             minPitchObj = pitch.Pitch(minPitch)
         else:
             minPitchObj = minPitch
 
-        maxPitchObj: t.Optional[pitch.Pitch]
+        maxPitchObj: pitch.Pitch|None
         if isinstance(maxPitch, str):
             maxPitchObj = pitch.Pitch(maxPitch)
         else:
@@ -1751,7 +1751,7 @@ class IntervalNetwork:
         return pre, preNodeId
 
     def realize(self,
-                pitchReference: t.Union[str, pitch.Pitch],
+                pitchReference: str|pitch.Pitch,
                 nodeId: Node|int|Terminus|None = None,
                 minPitch: pitch.Pitch|str|None = None,
                 maxPitch: pitch.Pitch|str|None = None,
@@ -1807,13 +1807,13 @@ class IntervalNetwork:
         if pitchRef.octave is None:
             pitchRef.octave = pitchRef.implicitOctave
 
-        minPitchObj: t.Optional[pitch.Pitch]
+        minPitchObj: pitch.Pitch|None
         if isinstance(minPitch, str):
             minPitchObj = pitch.Pitch(minPitch)
         else:
             minPitchObj = minPitch
 
-        maxPitchObj: t.Optional[pitch.Pitch]
+        maxPitchObj: pitch.Pitch|None
         if isinstance(maxPitch, str):
             maxPitchObj = pitch.Pitch(maxPitch)
         else:
@@ -1951,7 +1951,7 @@ class IntervalNetwork:
 
     def realizePitch(
         self,
-        pitchReference: t.Union[str, pitch.Pitch],
+        pitchReference: str|pitch.Pitch,
         nodeId: Node|int|Terminus|None = None,
         minPitch: pitch.Pitch|str|None = None,
         maxPitch: pitch.Pitch|str|None = None,
@@ -2057,7 +2057,7 @@ class IntervalNetwork:
 
     def realizeTermini(
         self,
-        pitchReference: t.Union[str, pitch.Pitch],
+        pitchReference: str|pitch.Pitch,
         nodeId: Node|int|Terminus|None = None,
         alteredDegrees=None,
     ) -> tuple[pitch.Pitch, pitch.Pitch]:
@@ -2100,7 +2100,7 @@ class IntervalNetwork:
 
     def realizeMinMax(
         self,
-        pitchReference: t.Union[str, pitch.Pitch],
+        pitchReference: str|pitch.Pitch,
         nodeId: Node|int|Terminus|None = None,
         alteredDegrees=None,
     ) -> tuple[pitch.Pitch, pitch.Pitch]:
@@ -2199,7 +2199,7 @@ class IntervalNetwork:
 
     def realizePitchByDegree(
         self,
-        pitchReference: t.Union[pitch.Pitch, str],
+        pitchReference: pitch.Pitch|str,
         nodeId: Node|int|Terminus|None = None,
         nodeDegreeTargets=(1,),
         minPitch: pitch.Pitch|str|None = None,
@@ -2355,9 +2355,9 @@ class IntervalNetwork:
 
     def getRelativeNodeId(
         self,
-        pitchReference: t.Union[pitch.Pitch, str],
-        nodeId: t.Union[Node, int, Terminus, None],
-        pitchTarget: t.Union[pitch.Pitch, note.Note, str],
+        pitchReference: pitch.Pitch|str,
+        nodeId: Node|int|Terminus|None,
+        pitchTarget: pitch.Pitch|note.Note|str,
         *,
         comparisonAttribute: str = 'ps',
         direction: Direction = Direction.ASCENDING,
@@ -2460,9 +2460,9 @@ class IntervalNetwork:
 
     def getNeighborNodeIds(
         self,
-        pitchReference: t.Union[pitch.Pitch, str],
-        nodeName: t.Union[Node, int, Terminus, None],
-        pitchTarget: t.Union[pitch.Pitch, str],
+        pitchReference: pitch.Pitch|str,
+        nodeName: Node|int|Terminus|None,
+        pitchTarget: pitch.Pitch|str,
         direction: Direction = Direction.ASCENDING,
         alteredDegrees=None,
     ):
@@ -2521,9 +2521,9 @@ class IntervalNetwork:
 
     def getRelativeNodeDegree(
         self,
-        pitchReference: t.Union[pitch.Pitch, str],
+        pitchReference: pitch.Pitch|str,
         nodeId,
-        pitchTarget: t.Union[pitch.Pitch, str],
+        pitchTarget: pitch.Pitch|str,
         comparisonAttribute='ps',
         direction: Direction = Direction.ASCENDING,
         alteredDegrees=None,
@@ -2628,8 +2628,8 @@ class IntervalNetwork:
 
     def getPitchFromNodeDegree(
         self,
-        pitchReference: t.Union[pitch.Pitch, str],
-        nodeName: t.Union[Node, int, Terminus, None],
+        pitchReference: pitch.Pitch|str,
+        nodeName: Node|int|Terminus|None,
         nodeDegreeTarget,
         direction: Direction = Direction.ASCENDING,
         minPitch=None,
@@ -2809,7 +2809,7 @@ class IntervalNetwork:
         return pitchList, minPitch, maxPitch
 
     def match(self,
-              pitchReference: t.Union[pitch.Pitch, str],
+              pitchReference: pitch.Pitch|str,
               nodeId,
               pitchTarget,
               comparisonAttribute='pitchClass',
@@ -2885,7 +2885,7 @@ class IntervalNetwork:
         return matched, noMatch
 
     def findMissing(self,
-                    pitchReference: t.Union[pitch.Pitch, str],
+                    pitchReference: pitch.Pitch|str,
                     nodeId,
                     pitchTarget,
                     comparisonAttribute='pitchClass',

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -251,7 +251,7 @@ class Edge(prebase.ProtoM21Object):
 
     def getConnections(
         self,
-        direction: t.Union[None, Direction] = None
+        direction: None|Direction = None
     ) -> list[tuple[t.Union[int, Terminus], t.Union[int, Terminus]]]:
         '''
         Callable as a property (.connections) or as a method
@@ -331,7 +331,7 @@ class Node(prebase.ProtoM21Object, common.SlottedObjectMixin):
     def __init__(self, id: t.Union[Terminus, int], degree: int, weight: float = 1.0):
         # store id, either as string, such as terminusLow, or a number.
         # ids are unique to any node in the network
-        self.id: t.Union[Terminus, int] = id
+        self.id: Terminus|int = id
         # the degree is used to define ordered node counts from the bottom
         # the degree is analogous to scale degree or degree
         # more than one node may have the same degree
@@ -1207,7 +1207,7 @@ class IntervalNetwork:
         direction: Direction = Direction.ASCENDING,
         stepSize=1,
         alteredDegrees=None,
-        getNeighbor: t.Union[bool, Direction] = True
+        getNeighbor: bool|Direction = True
     ):
         # noinspection PyShadowingNames
         '''
@@ -1388,9 +1388,9 @@ class IntervalNetwork:
     def realizeAscending(
         self,
         pitchReference: t.Union[pitch.Pitch, str],
-        nodeId: t.Union[Node, int, Terminus, None] = None,
-        minPitch: t.Union[pitch.Pitch, str, None] = None,
-        maxPitch: t.Union[pitch.Pitch, str, None] = None,
+        nodeId: Node|int|Terminus|None = None,
+        minPitch: pitch.Pitch|str|None = None,
+        maxPitch: pitch.Pitch|str|None = None,
         *,
         alteredDegrees=None,
         fillMinMaxIfNone=False
@@ -1553,9 +1553,9 @@ class IntervalNetwork:
     def realizeDescending(
         self,
         pitchReference: t.Union[pitch.Pitch, str],
-        nodeId: t.Union[Node, int, Terminus, None] = None,
-        minPitch: t.Union[pitch.Pitch, str, None] = None,
-        maxPitch: t.Union[pitch.Pitch, str, None] = None,
+        nodeId: Node|int|Terminus|None = None,
+        minPitch: pitch.Pitch|str|None = None,
+        maxPitch: pitch.Pitch|str|None = None,
         *,
         alteredDegrees=None,
         includeFirst=False,
@@ -1752,9 +1752,9 @@ class IntervalNetwork:
 
     def realize(self,
                 pitchReference: t.Union[str, pitch.Pitch],
-                nodeId: t.Union[Node, int, Terminus, None] = None,
-                minPitch: t.Union[pitch.Pitch, str, None] = None,
-                maxPitch: t.Union[pitch.Pitch, str, None] = None,
+                nodeId: Node|int|Terminus|None = None,
+                minPitch: pitch.Pitch|str|None = None,
+                maxPitch: pitch.Pitch|str|None = None,
                 direction: Direction = Direction.ASCENDING,
                 alteredDegrees=None,
                 reverse=False):
@@ -1952,9 +1952,9 @@ class IntervalNetwork:
     def realizePitch(
         self,
         pitchReference: t.Union[str, pitch.Pitch],
-        nodeId: t.Union[Node, int, Terminus, None] = None,
-        minPitch: t.Union[pitch.Pitch, str, None] = None,
-        maxPitch: t.Union[pitch.Pitch, str, None] = None,
+        nodeId: Node|int|Terminus|None = None,
+        minPitch: pitch.Pitch|str|None = None,
+        maxPitch: pitch.Pitch|str|None = None,
         direction: Direction = Direction.ASCENDING,
         alteredDegrees=None,
         reverse=False,
@@ -2015,9 +2015,9 @@ class IntervalNetwork:
 
     def realizeIntervals(
         self,
-        nodeId: t.Union[Node, int, Terminus, None] = None,
-        minPitch: t.Union[pitch.Pitch, str, None] = None,
-        maxPitch: t.Union[pitch.Pitch, str, None] = None,
+        nodeId: Node|int|Terminus|None = None,
+        minPitch: pitch.Pitch|str|None = None,
+        maxPitch: pitch.Pitch|str|None = None,
         direction: Direction = Direction.ASCENDING,
         alteredDegrees=None,
         reverse=False,
@@ -2058,7 +2058,7 @@ class IntervalNetwork:
     def realizeTermini(
         self,
         pitchReference: t.Union[str, pitch.Pitch],
-        nodeId: t.Union[Node, int, Terminus, None] = None,
+        nodeId: Node|int|Terminus|None = None,
         alteredDegrees=None,
     ) -> tuple[pitch.Pitch, pitch.Pitch]:
         '''
@@ -2101,7 +2101,7 @@ class IntervalNetwork:
     def realizeMinMax(
         self,
         pitchReference: t.Union[str, pitch.Pitch],
-        nodeId: t.Union[Node, int, Terminus, None] = None,
+        nodeId: Node|int|Terminus|None = None,
         alteredDegrees=None,
     ) -> tuple[pitch.Pitch, pitch.Pitch]:
         '''
@@ -2200,10 +2200,10 @@ class IntervalNetwork:
     def realizePitchByDegree(
         self,
         pitchReference: t.Union[pitch.Pitch, str],
-        nodeId: t.Union[Node, int, Terminus, None] = None,
+        nodeId: Node|int|Terminus|None = None,
         nodeDegreeTargets=(1,),
-        minPitch: t.Union[pitch.Pitch, str, None] = None,
-        maxPitch: t.Union[pitch.Pitch, str, None] = None,
+        minPitch: pitch.Pitch|str|None = None,
+        maxPitch: pitch.Pitch|str|None = None,
         direction: Direction = Direction.ASCENDING,
         alteredDegrees=None,
     ):

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -1363,7 +1363,7 @@ class IntervalNetwork:
         maxPitch: t.Optional[pitch.Pitch],
         *,
         includeFirst: bool,
-        reverse: t.Optional[bool] = None,  # only meaningful for descending
+        reverse: bool|None = None,  # only meaningful for descending
     ) -> CacheKey:
         '''
         Return key for caching based on critical components.

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -73,7 +73,7 @@ class Direction(enum.Enum):
 
 
 CacheKey = tuple[
-    int|Terminus, str, str|None, str|None, bool, bool|None]
+    int | Terminus, str, str | None, str | None, bool, bool | None]
 
 
 def _gte(a, b):
@@ -145,7 +145,7 @@ class Edge(prebase.ProtoM21Object):
     # noinspection PyShadowingBuiltins
     # pylint: disable=redefined-builtin
     def __init__(self,
-                 intervalData: interval.Interval|str,
+                 intervalData: interval.Interval | str,
                  id=None,  # id is okay: @ReservedAssignment
                  direction=Direction.BI):
         if isinstance(intervalData, str):
@@ -161,7 +161,7 @@ class Edge(prebase.ProtoM21Object):
 
         # one or two pairs of Node ids that this Edge connects
         # if there are two, it is a bidirectional, w/ first ascending
-        self._connections: list[tuple[int|Terminus, int|Terminus]] = []
+        self._connections: list[tuple[int | Terminus, int | Terminus]] = []
 
     def __eq__(self, other):
         '''
@@ -184,8 +184,8 @@ class Edge(prebase.ProtoM21Object):
 
     def addDirectedConnection(
         self,
-        node1: Node|int|Terminus,
-        node2: Node|int|Terminus,
+        node1: Node | int | Terminus,
+        node2: Node | int | Terminus,
         direction=None
     ) -> None:
         '''
@@ -251,8 +251,8 @@ class Edge(prebase.ProtoM21Object):
 
     def getConnections(
         self,
-        direction: None|Direction = None
-    ) -> list[tuple[int|Terminus, int|Terminus]]:
+        direction: None | Direction = None
+    ) -> list[tuple[int | Terminus, int | Terminus]]:
         '''
         Callable as a property (.connections) or as a method
         (.getConnections(direction)):
@@ -303,7 +303,7 @@ class Edge(prebase.ProtoM21Object):
 
     # keep separate property, since getConnections takes a direction argument.
     @property
-    def connections(self) -> list[tuple[int|Terminus, int|Terminus]]:
+    def connections(self) -> list[tuple[int | Terminus, int | Terminus]]:
         return self.getConnections()
 
 
@@ -328,10 +328,10 @@ class Node(prebase.ProtoM21Object, common.SlottedObjectMixin):
 
     # noinspection PyShadowingBuiltins
     # pylint: disable=redefined-builtin
-    def __init__(self, id: Terminus|int, degree: int, weight: float = 1.0):
+    def __init__(self, id: Terminus | int, degree: int, weight: float = 1.0):
         # store id, either as string, such as terminusLow, or a number.
         # ids are unique to any node in the network
-        self.id: Terminus|int = id
+        self.id: Terminus | int = id
         # the degree is used to define ordered node counts from the bottom
         # the degree is analogous to scale degree or degree
         # more than one node may have the same degree
@@ -416,7 +416,7 @@ class IntervalNetwork:
     '''
 
     def __init__(self,
-                 edgeList: Sequence[interval.Interval|str] = (),
+                 edgeList: Sequence[interval.Interval | str] = (),
                  octaveDuplicating=False,
                  deterministic=True,
                  pitchSimplification='maxAccidental'):
@@ -427,10 +427,10 @@ class IntervalNetwork:
 
         # a dictionary of Edge object, where keys are edgeId values
         # Edges store directed connections between Node ids
-        self.edges: OrderedDict[Terminus|int, Edge] = OrderedDict()
+        self.edges: OrderedDict[Terminus | int, Edge] = OrderedDict()
 
         # nodes suggest Pitches, but Pitches are not stored
-        self.nodes: OrderedDict[Terminus|int, Node] = OrderedDict()
+        self.nodes: OrderedDict[Terminus | int, Node] = OrderedDict()
 
         if edgeList:  # auto initialize
             self.fillBiDirectedEdges(edgeList)
@@ -445,11 +445,11 @@ class IntervalNetwork:
         # store segments
         self._ascendingCache: OrderedDict[
             CacheKey,
-            tuple[list[pitch.Pitch], list[Terminus|int]]
+            tuple[list[pitch.Pitch], list[Terminus | int]]
         ] = OrderedDict()
         self._descendingCache: OrderedDict[
             CacheKey,
-            tuple[list[pitch.Pitch], list[Terminus|int]]
+            tuple[list[pitch.Pitch], list[Terminus | int]]
         ] = OrderedDict()
 
     def clear(self):
@@ -488,7 +488,7 @@ class IntervalNetwork:
         return (isinstance(other, self.__class__)
                 and self.__dict__ == other.__dict__)
 
-    def fillBiDirectedEdges(self, edgeList: Sequence[interval.Interval|str]):
+    def fillBiDirectedEdges(self, edgeList: Sequence[interval.Interval | str]):
         # noinspection PyShadowingNames
         '''
         Given an ordered list of bi-directed edges given as :class:`~music21.interval.Interval`
@@ -1008,7 +1008,7 @@ class IntervalNetwork:
         return ((degree - 1) % spanCount) + sMin
 
     def nodeNameToNodes(self,
-                        nodeId: Node|int|Terminus|None,
+                        nodeId: Node | int | Terminus | None,
                         *,
                         equateTermini=True,
                         permitDegreeModuli=True):
@@ -1200,14 +1200,14 @@ class IntervalNetwork:
 
     def nextPitch(
         self,
-        pitchReference: pitch.Pitch|str,
-        nodeName: Node|int|Terminus|None,
-        pitchOrigin: pitch.Pitch|str,
+        pitchReference: pitch.Pitch | str,
+        nodeName: Node | int | Terminus | None,
+        pitchOrigin: pitch.Pitch | str,
         *,
         direction: Direction = Direction.ASCENDING,
         stepSize=1,
         alteredDegrees=None,
-        getNeighbor: bool|Direction = True
+        getNeighbor: bool | Direction = True
     ):
         # noinspection PyShadowingNames
         '''
@@ -1359,11 +1359,11 @@ class IntervalNetwork:
         self,
         nodeObj: Node,
         pitchReference: pitch.Pitch,
-        minPitch: pitch.Pitch|None,
-        maxPitch: pitch.Pitch|None,
+        minPitch: pitch.Pitch | None,
+        maxPitch: pitch.Pitch | None,
         *,
         includeFirst: bool,
-        reverse: bool|None = None,  # only meaningful for descending
+        reverse: bool | None = None,  # only meaningful for descending
     ) -> CacheKey:
         '''
         Return key for caching based on critical components.
@@ -1387,14 +1387,14 @@ class IntervalNetwork:
 
     def realizeAscending(
         self,
-        pitchReference: pitch.Pitch|str,
-        nodeId: Node|int|Terminus|None = None,
-        minPitch: pitch.Pitch|str|None = None,
-        maxPitch: pitch.Pitch|str|None = None,
+        pitchReference: pitch.Pitch | str,
+        nodeId: Node | int | Terminus | None = None,
+        minPitch: pitch.Pitch | str | None = None,
+        maxPitch: pitch.Pitch | str | None = None,
         *,
         alteredDegrees=None,
         fillMinMaxIfNone=False
-    ) -> tuple[list[pitch.Pitch], list[Terminus|int]]:
+    ) -> tuple[list[pitch.Pitch], list[Terminus | int]]:
         # noinspection PyShadowingNames
         '''
         Given a reference pitch, realize upwards to a maximum pitch.
@@ -1552,10 +1552,10 @@ class IntervalNetwork:
 
     def realizeDescending(
         self,
-        pitchReference: pitch.Pitch|str,
-        nodeId: Node|int|Terminus|None = None,
-        minPitch: pitch.Pitch|str|None = None,
-        maxPitch: pitch.Pitch|str|None = None,
+        pitchReference: pitch.Pitch | str,
+        nodeId: Node | int | Terminus | None = None,
+        minPitch: pitch.Pitch | str | None = None,
+        maxPitch: pitch.Pitch | str | None = None,
         *,
         alteredDegrees=None,
         includeFirst=False,
@@ -1631,13 +1631,13 @@ class IntervalNetwork:
         else:
             nodeObj = self.nodeNameToNodes(nodeId)[0]
 
-        minPitchObj: pitch.Pitch|None
+        minPitchObj: pitch.Pitch | None
         if isinstance(minPitch, str):
             minPitchObj = pitch.Pitch(minPitch)
         else:
             minPitchObj = minPitch
 
-        maxPitchObj: pitch.Pitch|None
+        maxPitchObj: pitch.Pitch | None
         if isinstance(maxPitch, str):
             maxPitchObj = pitch.Pitch(maxPitch)
         else:
@@ -1751,10 +1751,10 @@ class IntervalNetwork:
         return pre, preNodeId
 
     def realize(self,
-                pitchReference: str|pitch.Pitch,
-                nodeId: Node|int|Terminus|None = None,
-                minPitch: pitch.Pitch|str|None = None,
-                maxPitch: pitch.Pitch|str|None = None,
+                pitchReference: str | pitch.Pitch,
+                nodeId: Node | int | Terminus | None = None,
+                minPitch: pitch.Pitch | str | None = None,
+                maxPitch: pitch.Pitch | str | None = None,
                 direction: Direction = Direction.ASCENDING,
                 alteredDegrees=None,
                 reverse=False):
@@ -1807,13 +1807,13 @@ class IntervalNetwork:
         if pitchRef.octave is None:
             pitchRef.octave = pitchRef.implicitOctave
 
-        minPitchObj: pitch.Pitch|None
+        minPitchObj: pitch.Pitch | None
         if isinstance(minPitch, str):
             minPitchObj = pitch.Pitch(minPitch)
         else:
             minPitchObj = minPitch
 
-        maxPitchObj: pitch.Pitch|None
+        maxPitchObj: pitch.Pitch | None
         if isinstance(maxPitch, str):
             maxPitchObj = pitch.Pitch(maxPitch)
         else:
@@ -1951,10 +1951,10 @@ class IntervalNetwork:
 
     def realizePitch(
         self,
-        pitchReference: str|pitch.Pitch,
-        nodeId: Node|int|Terminus|None = None,
-        minPitch: pitch.Pitch|str|None = None,
-        maxPitch: pitch.Pitch|str|None = None,
+        pitchReference: str | pitch.Pitch,
+        nodeId: Node | int | Terminus | None = None,
+        minPitch: pitch.Pitch | str | None = None,
+        maxPitch: pitch.Pitch | str | None = None,
         direction: Direction = Direction.ASCENDING,
         alteredDegrees=None,
         reverse=False,
@@ -2015,9 +2015,9 @@ class IntervalNetwork:
 
     def realizeIntervals(
         self,
-        nodeId: Node|int|Terminus|None = None,
-        minPitch: pitch.Pitch|str|None = None,
-        maxPitch: pitch.Pitch|str|None = None,
+        nodeId: Node | int | Terminus | None = None,
+        minPitch: pitch.Pitch | str | None = None,
+        maxPitch: pitch.Pitch | str | None = None,
         direction: Direction = Direction.ASCENDING,
         alteredDegrees=None,
         reverse=False,
@@ -2057,8 +2057,8 @@ class IntervalNetwork:
 
     def realizeTermini(
         self,
-        pitchReference: str|pitch.Pitch,
-        nodeId: Node|int|Terminus|None = None,
+        pitchReference: str | pitch.Pitch,
+        nodeId: Node | int | Terminus | None = None,
         alteredDegrees=None,
     ) -> tuple[pitch.Pitch, pitch.Pitch]:
         '''
@@ -2100,8 +2100,8 @@ class IntervalNetwork:
 
     def realizeMinMax(
         self,
-        pitchReference: str|pitch.Pitch,
-        nodeId: Node|int|Terminus|None = None,
+        pitchReference: str | pitch.Pitch,
+        nodeId: Node | int | Terminus | None = None,
         alteredDegrees=None,
     ) -> tuple[pitch.Pitch, pitch.Pitch]:
         '''
@@ -2199,11 +2199,11 @@ class IntervalNetwork:
 
     def realizePitchByDegree(
         self,
-        pitchReference: pitch.Pitch|str,
-        nodeId: Node|int|Terminus|None = None,
+        pitchReference: pitch.Pitch | str,
+        nodeId: Node | int | Terminus | None = None,
         nodeDegreeTargets=(1,),
-        minPitch: pitch.Pitch|str|None = None,
-        maxPitch: pitch.Pitch|str|None = None,
+        minPitch: pitch.Pitch | str | None = None,
+        maxPitch: pitch.Pitch | str | None = None,
         direction: Direction = Direction.ASCENDING,
         alteredDegrees=None,
     ):
@@ -2355,9 +2355,9 @@ class IntervalNetwork:
 
     def getRelativeNodeId(
         self,
-        pitchReference: pitch.Pitch|str,
-        nodeId: Node|int|Terminus|None,
-        pitchTarget: pitch.Pitch|note.Note|str,
+        pitchReference: pitch.Pitch | str,
+        nodeId: Node | int | Terminus | None,
+        pitchTarget: pitch.Pitch | note.Note | str,
         *,
         comparisonAttribute: str = 'ps',
         direction: Direction = Direction.ASCENDING,
@@ -2460,9 +2460,9 @@ class IntervalNetwork:
 
     def getNeighborNodeIds(
         self,
-        pitchReference: pitch.Pitch|str,
-        nodeName: Node|int|Terminus|None,
-        pitchTarget: pitch.Pitch|str,
+        pitchReference: pitch.Pitch | str,
+        nodeName: Node | int | Terminus | None,
+        pitchTarget: pitch.Pitch | str,
         direction: Direction = Direction.ASCENDING,
         alteredDegrees=None,
     ):
@@ -2521,9 +2521,9 @@ class IntervalNetwork:
 
     def getRelativeNodeDegree(
         self,
-        pitchReference: pitch.Pitch|str,
+        pitchReference: pitch.Pitch | str,
         nodeId,
-        pitchTarget: pitch.Pitch|str,
+        pitchTarget: pitch.Pitch | str,
         comparisonAttribute='ps',
         direction: Direction = Direction.ASCENDING,
         alteredDegrees=None,
@@ -2628,8 +2628,8 @@ class IntervalNetwork:
 
     def getPitchFromNodeDegree(
         self,
-        pitchReference: pitch.Pitch|str,
-        nodeName: Node|int|Terminus|None,
+        pitchReference: pitch.Pitch | str,
+        nodeName: Node | int | Terminus | None,
         nodeDegreeTarget,
         direction: Direction = Direction.ASCENDING,
         minPitch=None,
@@ -2809,7 +2809,7 @@ class IntervalNetwork:
         return pitchList, minPitch, maxPitch
 
     def match(self,
-              pitchReference: pitch.Pitch|str,
+              pitchReference: pitch.Pitch | str,
               nodeId,
               pitchTarget,
               comparisonAttribute='pitchClass',
@@ -2885,7 +2885,7 @@ class IntervalNetwork:
         return matched, noMatch
 
     def findMissing(self,
-                    pitchReference: pitch.Pitch|str,
+                    pitchReference: pitch.Pitch | str,
                     nodeId,
                     pitchTarget,
                     comparisonAttribute='pitchClass',

--- a/music21/scale/scala/__init__.py
+++ b/music21/scale/scala/__init__.py
@@ -63,7 +63,7 @@ environLocal = environment.Environment('scale.scala')
 
 # ------------------------------------------------------------------------------
 # global variable to cache the paths returned from getPaths()
-SCALA_PATHS: dict[str, t.Optional[dict[str, list[str]]]] = {'allPaths': None}
+SCALA_PATHS: dict[str, dict[str, list[str]]|None] = {'allPaths': None}
 
 def getPaths():
     '''

--- a/music21/scale/scala/__init__.py
+++ b/music21/scale/scala/__init__.py
@@ -63,7 +63,7 @@ environLocal = environment.Environment('scale.scala')
 
 # ------------------------------------------------------------------------------
 # global variable to cache the paths returned from getPaths()
-SCALA_PATHS: dict[str, dict[str, list[str]]|None] = {'allPaths': None}
+SCALA_PATHS: dict[str, dict[str, list[str]] | None] = {'allPaths': None}
 
 def getPaths():
     '''

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -206,7 +206,7 @@ class StreamSearcher:
 
         self.algorithms: list[
             Callable[[Stream, m21Base.Music21Object],
-                     t.Union[bool, None]]
+                     bool|None]
         ] = [StreamSearcher.wildcardAlgorithm]
 
         self.activeIterator = None

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -206,7 +206,7 @@ class StreamSearcher:
 
         self.algorithms: list[
             Callable[[Stream, m21Base.Music21Object],
-                     bool|None]
+                     bool | None]
         ] = [StreamSearcher.wildcardAlgorithm]
 
         self.activeIterator = None

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -20,7 +20,6 @@ from collections.abc import Callable
 import copy
 import difflib
 import math
-import typing as t
 import unittest
 
 from more_itertools import windowed

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -137,7 +137,7 @@ class LyricSearcher:
         self.includeIntermediateElements = False  # currently does nothing
         self.includeTrailingMelisma = False  # currently does nothing
 
-        self._indexText: str|None = None
+        self._indexText: str | None = None
         self._indexTuples: list[IndexedLyric] = []
 
     @property
@@ -197,10 +197,10 @@ class LyricSearcher:
         else:
             self.stream = s
 
-        indexByIdentifier: OrderedDict[str|int, list[IndexedLyric]] = OrderedDict()
-        iTextByIdentifier: OrderedDict[str|int, str] = OrderedDict()
-        lastSyllabicByIdentifier: OrderedDict[str|int,
-                                                str|None] = OrderedDict()
+        indexByIdentifier: OrderedDict[str | int, list[IndexedLyric]] = OrderedDict()
+        iTextByIdentifier: OrderedDict[str | int, str] = OrderedDict()
+        lastSyllabicByIdentifier: OrderedDict[str | int,
+                                                str | None] = OrderedDict()
 
         for n in s.recurse().notes:
             ls: list[note.Lyric] = n.lyrics

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -197,10 +197,10 @@ class LyricSearcher:
         else:
             self.stream = s
 
-        indexByIdentifier: OrderedDict[t.Union[str, int], list[IndexedLyric]] = OrderedDict()
-        iTextByIdentifier: OrderedDict[t.Union[str, int], str] = OrderedDict()
-        lastSyllabicByIdentifier: OrderedDict[t.Union[str, int],
-                                                t.Union[str, None]] = OrderedDict()
+        indexByIdentifier: OrderedDict[str|int, list[IndexedLyric]] = OrderedDict()
+        iTextByIdentifier: OrderedDict[str|int, str] = OrderedDict()
+        lastSyllabicByIdentifier: OrderedDict[str|int,
+                                                str|None] = OrderedDict()
 
         for n in s.recurse().notes:
             ls: list[note.Lyric] = n.lyrics

--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -137,7 +137,7 @@ class LyricSearcher:
         self.includeIntermediateElements = False  # currently does nothing
         self.includeTrailingMelisma = False  # currently does nothing
 
-        self._indexText: t.Optional[str] = None
+        self._indexText: str|None = None
         self._indexTuples: list[IndexedLyric] = []
 
     @property

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -1087,14 +1087,14 @@ class HistoricalTwelveToneRow(TwelveToneRow):
         'title': 'The title of the work, or None.  (String)',
     }
 
-    composer: t.Union[None, str] = None
-    opus: t.Union[None, str] = None
-    title: t.Union[None, str] = None
+    composer: None|str = None
+    opus: None|str = None
+    title: None|str = None
 
     def __init__(self,
-                 composer: t.Union[None, str] = None,
-                 opus: t.Union[None, str] = None,
-                 title: t.Union[None, str] = None,
+                 composer: None|str = None,
+                 opus: None|str = None,
+                 title: None|str = None,
                  row=None,
                  **keywords):
         super().__init__(row, **keywords)

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -1087,14 +1087,14 @@ class HistoricalTwelveToneRow(TwelveToneRow):
         'title': 'The title of the work, or None.  (String)',
     }
 
-    composer: None|str = None
-    opus: None|str = None
-    title: None|str = None
+    composer: None | str = None
+    opus: None | str = None
+    title: None | str = None
 
     def __init__(self,
-                 composer: None|str = None,
-                 opus: None|str = None,
-                 title: None|str = None,
+                 composer: None | str = None,
+                 opus: None | str = None,
+                 title: None | str = None,
                  row=None,
                  **keywords):
         super().__init__(row, **keywords)

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -1845,7 +1845,7 @@ class PitchSieve:
                  pitchLower: str|None = None,
                  pitchUpper: str|None = None,
                  pitchOrigin: str|None = None,
-                 eld: t.Union[int, float] = 1):
+                 eld: int|float = 1):
         self.sieveString = sieveString  # logical sieve string
 
         # should be in a try block

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -1842,10 +1842,10 @@ class PitchSieve:
 
     def __init__(self,
                  sieveString,
-                 pitchLower: str|None = None,
-                 pitchUpper: str|None = None,
-                 pitchOrigin: str|None = None,
-                 eld: int|float = 1):
+                 pitchLower: str | None = None,
+                 pitchUpper: str | None = None,
+                 pitchOrigin: str | None = None,
+                 eld: int | float = 1):
         self.sieveString = sieveString  # logical sieve string
 
         # should be in a try block
@@ -1978,7 +1978,7 @@ class PitchSieve:
         #            self.sieveObject.period())
         p = self.sieveObject.period()
 
-        z: list[int]|None
+        z: list[int] | None
         if p < 999999999:
             z = list(range(p + 1))
         else:  # too big to get z as list of values

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -1978,7 +1978,7 @@ class PitchSieve:
         #            self.sieveObject.period())
         p = self.sieveObject.period()
 
-        z: t.Optional[list[int]]
+        z: list[int]|None
         if p < 999999999:
             z = list(range(p + 1))
         else:  # too big to get z as list of values

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -1630,7 +1630,7 @@ class Sieve:
 
     def segment(
         self,
-        state: t.Union[t.Literal['cmp'], t.Literal['exp'], None] = None,
+        state: t.Literal['cmp'] | t.Literal['exp'] | None = None,
         n=0,
         z=None,
         segmentFormat=None

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -1842,9 +1842,9 @@ class PitchSieve:
 
     def __init__(self,
                  sieveString,
-                 pitchLower: t.Optional[str] = None,
-                 pitchUpper: t.Optional[str] = None,
-                 pitchOrigin: t.Optional[str] = None,
+                 pitchLower: str|None = None,
+                 pitchUpper: str|None = None,
+                 pitchOrigin: str|None = None,
                  eld: t.Union[int, float] = 1):
         self.sieveString = sieveString  # logical sieve string
 

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -44,7 +44,7 @@ WEAKREF_ACTIVE = True
 # that still exists, then restore it from the dictionary; otherwise, do not
 # sweat it.  Should make pickle deepcopies of music21 objects in Streams still
 # possible without needing to recreate the whole stream.
-GLOBAL_SITE_STATE_DICT: MutableMapping[str, t.Optional[t.Any]] = weakref.WeakValueDictionary()
+GLOBAL_SITE_STATE_DICT: MutableMapping[str, t.Any|None] = weakref.WeakValueDictionary()
 
 
 class SitesException(exceptions21.Music21Exception):
@@ -405,7 +405,7 @@ class Sites(common.SlottedObjectMixin):
                    excludeNone: bool = False,
                    sortByCreationTime: t.Union[bool, t.Literal['reverse']] = False,
                    priorityTarget=None,
-                   ) -> Generator[t.Union[stream.Stream, None], None, None]:
+                   ) -> Generator[stream.Stream|None, None, None]:
         yield None
 
     def yieldSites(self,
@@ -413,7 +413,7 @@ class Sites(common.SlottedObjectMixin):
                    excludeNone: bool = False,
                    sortByCreationTime: t.Union[bool, t.Literal['reverse']] = False,
                    priorityTarget=None,
-                   ) -> Generator[t.Union[stream.Stream, None], None, None]:
+                   ) -> Generator[stream.Stream|None, None, None]:
         # noinspection PyDunderSlots
         '''
         Yield references; order, based on dictionary keys, is from least

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -44,7 +44,7 @@ WEAKREF_ACTIVE = True
 # that still exists, then restore it from the dictionary; otherwise, do not
 # sweat it.  Should make pickle deepcopies of music21 objects in Streams still
 # possible without needing to recreate the whole stream.
-GLOBAL_SITE_STATE_DICT: MutableMapping[str, t.Any|None] = weakref.WeakValueDictionary()
+GLOBAL_SITE_STATE_DICT: MutableMapping[str, t.Any | None] = weakref.WeakValueDictionary()
 
 
 class SitesException(exceptions21.Music21Exception):
@@ -405,7 +405,7 @@ class Sites(common.SlottedObjectMixin):
                    excludeNone: bool = False,
                    sortByCreationTime: t.Union[bool, t.Literal['reverse']] = False,
                    priorityTarget=None,
-                   ) -> Generator[stream.Stream|None, None, None]:
+                   ) -> Generator[stream.Stream | None, None, None]:
         yield None
 
     def yieldSites(self,
@@ -413,7 +413,7 @@ class Sites(common.SlottedObjectMixin):
                    excludeNone: bool = False,
                    sortByCreationTime: t.Union[bool, t.Literal['reverse']] = False,
                    priorityTarget=None,
-                   ) -> Generator[stream.Stream|None, None, None]:
+                   ) -> Generator[stream.Stream | None, None, None]:
         # noinspection PyDunderSlots
         '''
         Yield references; order, based on dictionary keys, is from least

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -1278,12 +1278,12 @@ class RepeatBracket(Spanner):
     '''
     def __init__(self,
                  *spannedElements,
-                 number: t.Optional[int] = None,
-                 overrideDisplay: t.Optional[str] = None,
+                 number: int|None = None,
+                 overrideDisplay: str|None = None,
                  **keywords):
         super().__init__(*spannedElements, **keywords)
 
-        self._number: t.Optional[int] = None
+        self._number: int|None = None
         # store a range, inclusive of the single number assignment
         self._numberRange: list[int] = []
         # are there exactly two numbers that should be written as  3, 4 not 3-4.
@@ -1838,7 +1838,7 @@ class Glissando(Spanner):
     def __init__(self,
                  *spannedElements,
                  lineType: str = 'wavy',
-                 label: t.Optional[str] = None,
+                 label: str|None = None,
                  **keywords):
         super().__init__(*spannedElements, **keywords)
 

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -631,7 +631,7 @@ class SpannerBundle(prebase.ProtoM21Object):
     Changed in v7: only argument must be a List of spanners.
     Creators of SpannerBundles are required to check that this constraint is True
     '''
-    def __init__(self, spanners: list[Spanner]|None = None):
+    def __init__(self, spanners: list[Spanner] | None = None):
         self._cache: dict[str, t.Any] = {}  # cache is defined on Music21Object not ProtoM21Object
 
         self._storage: list[Spanner]
@@ -871,7 +871,7 @@ class SpannerBundle(prebase.ProtoM21Object):
 
         return replacedSpanners
 
-    def getByClass(self, className: str|type) -> 'SpannerBundle':
+    def getByClass(self, className: str | type) -> 'SpannerBundle':
         '''
         Given a spanner class, return a new SpannerBundle of all Spanners of the desired class.
 
@@ -1278,12 +1278,12 @@ class RepeatBracket(Spanner):
     '''
     def __init__(self,
                  *spannedElements,
-                 number: int|None = None,
-                 overrideDisplay: str|None = None,
+                 number: int | None = None,
+                 overrideDisplay: str | None = None,
                  **keywords):
         super().__init__(*spannedElements, **keywords)
 
-        self._number: int|None = None
+        self._number: int | None = None
         # store a range, inclusive of the single number assignment
         self._numberRange: list[int] = []
         # are there exactly two numbers that should be written as  3, 4 not 3-4.
@@ -1677,8 +1677,8 @@ class Line(Spanner):
         tick: str = 'down',
         startTick: str = 'down',
         endTick: str = 'down',
-        startHeight: int|float|None = None,
-        endHeight: int|float|None = None,
+        startHeight: int | float | None = None,
+        endHeight: int | float | None = None,
         **keywords
     ):
         super().__init__(*spannedElements, **keywords)
@@ -1838,7 +1838,7 @@ class Glissando(Spanner):
     def __init__(self,
                  *spannedElements,
                  lineType: str = 'wavy',
-                 label: str|None = None,
+                 label: str | None = None,
                  **keywords):
         super().__init__(*spannedElements, **keywords)
 

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -631,7 +631,7 @@ class SpannerBundle(prebase.ProtoM21Object):
     Changed in v7: only argument must be a List of spanners.
     Creators of SpannerBundles are required to check that this constraint is True
     '''
-    def __init__(self, spanners: t.Optional[list[Spanner]] = None):
+    def __init__(self, spanners: list[Spanner]|None = None):
         self._cache: dict[str, t.Any] = {}  # cache is defined on Music21Object not ProtoM21Object
 
         self._storage: list[Spanner]
@@ -871,7 +871,7 @@ class SpannerBundle(prebase.ProtoM21Object):
 
         return replacedSpanners
 
-    def getByClass(self, className: t.Union[str, type]) -> 'SpannerBundle':
+    def getByClass(self, className: str|type) -> 'SpannerBundle':
         '''
         Given a spanner class, return a new SpannerBundle of all Spanners of the desired class.
 
@@ -1677,8 +1677,8 @@ class Line(Spanner):
         tick: str = 'down',
         startTick: str = 'down',
         endTick: str = 'down',
-        startHeight: t.Optional[t.Union[int, float]] = None,
-        endHeight: t.Optional[t.Union[int, float]] = None,
+        startHeight: int|float|None = None,
+        endHeight: int|float|None = None,
         **keywords
     ):
         super().__init__(*spannedElements, **keywords)

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -336,7 +336,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         self.definesExplicitPageBreaks = False
 
         # property for transposition status;
-        self._atSoundingPitch: t.Union[bool, t.Literal['unknown']] = 'unknown'
+        self._atSoundingPitch: bool | t.Literal['unknown'] = 'unknown'
 
         # experimental
         self._mutable = True
@@ -712,7 +712,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             f'got {type(k)}'
         )
 
-    def first(self) -> t.Optional[M21ObjType]:
+    def first(self) -> M21ObjType|None:
         '''
         Return the first element of a Stream.  (Added for compatibility with StreamIterator)
         Or None if the Stream is empty.
@@ -738,7 +738,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         except IndexError:
             return None
 
-    def last(self) -> t.Optional[M21ObjType]:
+    def last(self) -> M21ObjType|None:
         '''
         Return the last element of a Stream.  (Added for compatibility with StreamIterator)
         Or None if the Stream is empty.
@@ -850,7 +850,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return tuple(self._cache['elements'])
 
     @elements.setter
-    def elements(self, value: t.Union[Stream, Iterable[base.Music21Object]]):
+    def elements(self, value: Stream|Iterable[base.Music21Object]):
         '''
         Sets this stream's elements to the elements in another stream (just give
         the stream, not the stream's .elements), or to a list of elements.
@@ -1052,7 +1052,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
     # ------------------------------
     @property
-    def clef(self) -> t.Optional[clef.Clef]:
+    def clef(self) -> clef.Clef|None:
         '''
         Finds or sets a :class:`~music21.clef.Clef` at offset 0.0 in the Stream
         (generally a Measure):
@@ -1093,7 +1093,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return clefList.first()
 
     @clef.setter
-    def clef(self, clefObj: t.Optional[clef.Clef]):
+    def clef(self, clefObj: clef.Clef|None):
         # if clef is None; remove object?
         oldClef = self.clef
         if oldClef is not None:
@@ -1106,7 +1106,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         self.insert(0.0, clefObj)
 
     @property
-    def timeSignature(self) -> t.Optional[meter.TimeSignature]:
+    def timeSignature(self) -> meter.TimeSignature|None:
         '''
         Gets or sets the timeSignature at offset 0.0 of the Stream (generally a Measure)
 
@@ -1158,7 +1158,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return tsList.first()
 
     @timeSignature.setter
-    def timeSignature(self, tsObj: t.Optional[meter.TimeSignature]):
+    def timeSignature(self, tsObj: meter.TimeSignature|None):
         oldTimeSignature = self.timeSignature
         if oldTimeSignature is not None:
             # environLocal.printDebug(['removing ts', oldTimeSignature])
@@ -1170,7 +1170,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         self.insert(0, tsObj)
 
     @property
-    def keySignature(self) -> t.Optional[key.KeySignature]:
+    def keySignature(self) -> key.KeySignature|None:
         '''
         Find or set a Key or KeySignature at offset 0.0 of a stream.
 
@@ -1207,7 +1207,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             return None
 
     @keySignature.setter
-    def keySignature(self, keyObj: t.Optional[key.KeySignature]):
+    def keySignature(self, keyObj: key.KeySignature|None):
         '''
         >>> a = stream.Measure()
         >>> a.keySignature = key.KeySignature(6)
@@ -1547,7 +1547,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         raise StreamException(f'cannot find object ({el}) in Stream')
 
     def remove(self,
-               targetOrList: t.Union[base.Music21Object, Sequence[base.Music21Object]],
+               targetOrList: base.Music21Object|Sequence[base.Music21Object],
                *,
                shiftOffsets=False,
                recurse=False):
@@ -2006,7 +2006,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     def setElementOffset(
         self,
         element: base.Music21Object,
-        offset: t.Union[int, float, Fraction, OffsetSpecial],
+        offset: int|float|Fraction|OffsetSpecial,
     ):
         '''
         Sets the Offset for an element that is already in a given stream.
@@ -3488,7 +3488,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
     @overload
     def getElementsByClass(self,
-                           classFilterList: t.Union[str, Iterable[str]]
+                           classFilterList: str|Iterable[str]
                            ) -> iterator.StreamIterator[M21ObjType]:
         # Remove all dummy code once Astroid #1015 is fixed
         x: iterator.StreamIterator[M21ObjType] = self.iter()
@@ -3656,7 +3656,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         '''
         return self.iter().getElementsByGroup(groupFilterList, returnClone=False)
 
-    def getElementById(self, elementId) -> t.Optional[base.Music21Object]:
+    def getElementById(self, elementId) -> base.Music21Object|None:
         '''
         Returns the first encountered element for a given id. Return None
         if no match. Note: this uses the id attribute stored on elements,
@@ -3942,7 +3942,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             sIterator = sIterator.getElementsByClass(classList)
         return sIterator
 
-    def getElementAtOrBefore(self, offset, classList=None) -> t.Optional[base.Music21Object]:
+    def getElementAtOrBefore(self, offset, classList=None) -> base.Music21Object|None:
         # noinspection PyShadowingNames
         '''
         Given an offset, find the element at this offset,
@@ -4062,7 +4062,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         else:
             return None
 
-    def getElementBeforeOffset(self, offset, classList=None) -> t.Optional[base.Music21Object]:
+    def getElementBeforeOffset(self, offset, classList=None) -> base.Music21Object|None:
         '''
         Get element before (and not at) a provided offset.
 
@@ -4413,7 +4413,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         <music21.layout.StaffGroup <music21.stream.PartStaff P5-Staff1><... P5-Staff2>>
         <music21.layout.StaffGroup <music21.stream.Part Soprano I><...Alto II>>
         '''
-        startMeasure: t.Optional[Measure]
+        startMeasure: Measure|None
 
         def hasMeasureNumberInformation(measureIterator):
             '''
@@ -4545,7 +4545,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     def measure(self,
                 measureNumber,
                 collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature'),
-                indicesNotNumbers=False) -> t.Optional[Measure]:
+                indicesNotNumbers=False) -> Measure|None:
         '''
         Given a measure number, return a single
         :class:`~music21.stream.Measure` object if the Measure number exists, otherwise return None.
@@ -4598,7 +4598,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                               collect=collect,
                               indicesNotNumbers=indicesNotNumbers)
             measureIter = s.getElementsByClass(Measure)
-            m: t.Optional[Measure]
+            m: Measure|None
             # noinspection PyTypeChecker
             m = measureIter.first()
             if m is None:  # not 'if not m' because m might be an empty measure.
@@ -5092,7 +5092,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     # handling transposition values and status
 
     @property
-    def atSoundingPitch(self) -> t.Union[bool, t.Literal['unknown']]:
+    def atSoundingPitch(self) -> bool|t.Literal['unknown']:
         '''
         Get or set the atSoundingPitch status, that is whether the
         score is at concert pitch or may have transposing instruments
@@ -5116,7 +5116,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return self._atSoundingPitch
 
     @atSoundingPitch.setter
-    def atSoundingPitch(self, value: t.Union[bool, t.Literal['unknown']]):
+    def atSoundingPitch(self, value: bool|t.Literal['unknown']):
         if value in [True, False, 'unknown']:
             self._atSoundingPitch = value
         else:
@@ -5183,7 +5183,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         return returnObj
 
-    def _treatAtSoundingPitch(self) -> t.Union[bool, str]:
+    def _treatAtSoundingPitch(self) -> bool|str:
         '''
         `atSoundingPitch` might be True, False, or 'unknown'. Given that
         setting the property does not automatically synchronize the corresponding
@@ -5590,7 +5590,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                       *,
                       searchActiveSite=True,
                       returnDefault=True,
-                      recurse=False) -> t.Optional[instrument.Instrument]:
+                      recurse=False) -> instrument.Instrument|None:
         '''
         Return the first Instrument found in this Stream, or None.
 
@@ -6527,18 +6527,18 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     def makeAccidentals(
         self,
         *,
-        pitchPast: t.Optional[list[pitch.Pitch]] = None,
-        pitchPastMeasure: t.Optional[list[pitch.Pitch]] = None,
-        otherSimultaneousPitches: t.Optional[list[pitch.Pitch]] = None,
+        pitchPast: list[pitch.Pitch]|None = None,
+        pitchPastMeasure: list[pitch.Pitch]|None = None,
+        otherSimultaneousPitches: list[pitch.Pitch]|None = None,
         useKeySignature: bool|key.KeySignature = True,
-        alteredPitches: t.Optional[list[pitch.Pitch]] = None,
+        alteredPitches: list[pitch.Pitch]|None = None,
         searchKeySignatureByContext: bool = False,
         cautionaryPitchClass: bool = True,
         cautionaryAll: bool = False,
         inPlace: bool = False,
         overrideStatus: bool = False,
         cautionaryNotImmediateRepeat: bool = True,
-        tiePitchSet: t.Optional[set[str]] = None
+        tiePitchSet: set[str]|None = None
     ):
         '''
         A method to set and provide accidentals given various conditions and contexts.
@@ -6612,9 +6612,11 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             addAlteredPitches = useKeySignature.alteredPitches
         elif useKeySignature is True:  # get from defined contexts
             # will search local, then activeSite
-            ksIter: t.Union[list[key.KeySignature],
-                          iterator.StreamIterator[key.KeySignature],
-                          None] = None
+            ksIter: t.Union[
+                list[key.KeySignature],
+                iterator.StreamIterator[key.KeySignature],
+                None,
+            ] = None
             if searchKeySignatureByContext:
                 ks = self.getContextByClass(key.KeySignature)
                 if ks is not None:
@@ -6730,15 +6732,15 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                      refStreamOrTimeRange=None,
                      inPlace=False,
                      bestClef=False,
-                     pitchPast: t.Optional[list[pitch.Pitch]] = None,
-                     pitchPastMeasure: t.Optional[list[pitch.Pitch]] = None,
+                     pitchPast: list[pitch.Pitch]|None = None,
+                     pitchPastMeasure: list[pitch.Pitch]|None = None,
                      useKeySignature: bool|key.KeySignature = True,
-                     alteredPitches: t.Optional[list[pitch.Pitch]] = None,
+                     alteredPitches: list[pitch.Pitch]|None = None,
                      cautionaryPitchClass: bool = True,
                      cautionaryAll: bool = False,
                      overrideStatus: bool = False,
                      cautionaryNotImmediateRepeat: bool = True,
-                     tiePitchSet: t.Optional[set[str]] = None
+                     tiePitchSet: set[str]|None = None
                      ):
         '''
         This method calls a sequence of Stream methods on this Stream to prepare
@@ -6773,7 +6775,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         'final'
         '''
         # determine what is the object to work on first
-        returnStream: t.Union[StreamType, Stream[t.Any]]
+        returnStream: StreamType | Stream[t.Any]
         if inPlace:
             returnStream = self
         else:
@@ -7981,7 +7983,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         el: base.Music21Object,
         *,
         setActiveSite=True
-    ) -> t.Optional[Stream]:
+    ) -> Stream|None:
         '''
         Returns the container in a hierarchy that this element belongs to.
 
@@ -8798,7 +8800,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
     def transpose(
         self,
-        value: t.Union[str, int, 'music21.interval.IntervalBase'],
+        value: str|int|'music21.interval.IntervalBase',
         /,
         *,
         inPlace=False,
@@ -9995,7 +9997,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         getOverlaps: bool = False,
         noNone: t.Literal[False] = False,
         **keywords
-    ) -> list[t.Union[note.NotRest, None]]:
+    ) -> list[note.NotRest|None]:
         return []
 
     def findConsecutiveNotes(
@@ -10010,7 +10012,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         noNone: bool = False,
         **keywords
     ) -> t.Union[
-            list[t.Union[note.NotRest, None]],
+            list[note.NotRest|None],
             list[note.NotRest],
             list[note.Note],
     ]:
@@ -10069,7 +10071,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         '''
         if self.isSorted is False and self.autoSort:
             self.sort()
-        returnList: list[t.Union[note.NotRest, None]] = []
+        returnList: list[note.NotRest|None] = []
         lastStart: OffsetQL = 0.0
         lastEnd: OffsetQL = 0.0
         lastContainerEnd: OffsetQL = 0.0
@@ -10965,7 +10967,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         if not inPlace:
             return returnObj
 
-    def _maxVoiceCount(self, *, countById=False) -> t.Union[int, tuple[int, list[str]]]:
+    def _maxVoiceCount(self, *, countById=False) -> int|tuple[int, list[str]]:
         '''
         Returns the maximum number of voices in a part.  Used by voicesToParts.
         Minimum returned is 1.  If `countById` is True, returns a tuple of
@@ -13878,7 +13880,7 @@ class Score(Stream):
             return returnObj
 
     def partsToVoices(self,
-                      voiceAllocation: t.Union[int, list[t.Union[list, int]]] = 2,
+                      voiceAllocation: int|list[list|int] = 2,
                       permitOneVoicePerPart=False,
                       setStems=True):
         # noinspection PyShadowingNames
@@ -13923,7 +13925,7 @@ class Score(Stream):
                 bundle.append(sub)
         # else, assume it is a list of groupings
         elif common.isIterable(voiceAllocation):
-            voiceAllocation = t.cast(list[t.Union[list, int]], voiceAllocation)
+            voiceAllocation = t.cast(list[list|int], voiceAllocation)
             for group in voiceAllocation:
                 sub = []
                 # if a single entry
@@ -13942,7 +13944,7 @@ class Score(Stream):
         s = self.cloneEmpty(derivationMethod='partsToVoices')
         s.metadata = self.metadata
 
-        pActive: t.Optional[Part]
+        pActive: Part|None
         for sub in bundle:  # each sub contains parts
             if len(sub) == 1 and not permitOneVoicePerPart:
                 # probably need to create a new part and measure

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -260,7 +260,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     # forms of checking class
     isStream = True
     isMeasure = False
-    classSortOrder: int|float = -20
+    classSortOrder: int | float = -20
     recursionType: RecursionType = RecursionType.ELEMENTS_FIRST
 
     _styleClass = style.StreamStyle
@@ -712,7 +712,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             f'got {type(k)}'
         )
 
-    def first(self) -> M21ObjType|None:
+    def first(self) -> M21ObjType | None:
         '''
         Return the first element of a Stream.  (Added for compatibility with StreamIterator)
         Or None if the Stream is empty.
@@ -738,7 +738,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         except IndexError:
             return None
 
-    def last(self) -> M21ObjType|None:
+    def last(self) -> M21ObjType | None:
         '''
         Return the last element of a Stream.  (Added for compatibility with StreamIterator)
         Or None if the Stream is empty.
@@ -850,7 +850,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return tuple(self._cache['elements'])
 
     @elements.setter
-    def elements(self, value: Stream|Iterable[base.Music21Object]):
+    def elements(self, value: Stream | Iterable[base.Music21Object]):
         '''
         Sets this stream's elements to the elements in another stream (just give
         the stream, not the stream's .elements), or to a list of elements.
@@ -1052,7 +1052,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
     # ------------------------------
     @property
-    def clef(self) -> clef.Clef|None:
+    def clef(self) -> clef.Clef | None:
         '''
         Finds or sets a :class:`~music21.clef.Clef` at offset 0.0 in the Stream
         (generally a Measure):
@@ -1093,7 +1093,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return clefList.first()
 
     @clef.setter
-    def clef(self, clefObj: clef.Clef|None):
+    def clef(self, clefObj: clef.Clef | None):
         # if clef is None; remove object?
         oldClef = self.clef
         if oldClef is not None:
@@ -1106,7 +1106,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         self.insert(0.0, clefObj)
 
     @property
-    def timeSignature(self) -> meter.TimeSignature|None:
+    def timeSignature(self) -> meter.TimeSignature | None:
         '''
         Gets or sets the timeSignature at offset 0.0 of the Stream (generally a Measure)
 
@@ -1158,7 +1158,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return tsList.first()
 
     @timeSignature.setter
-    def timeSignature(self, tsObj: meter.TimeSignature|None):
+    def timeSignature(self, tsObj: meter.TimeSignature | None):
         oldTimeSignature = self.timeSignature
         if oldTimeSignature is not None:
             # environLocal.printDebug(['removing ts', oldTimeSignature])
@@ -1170,7 +1170,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         self.insert(0, tsObj)
 
     @property
-    def keySignature(self) -> key.KeySignature|None:
+    def keySignature(self) -> key.KeySignature | None:
         '''
         Find or set a Key or KeySignature at offset 0.0 of a stream.
 
@@ -1207,7 +1207,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             return None
 
     @keySignature.setter
-    def keySignature(self, keyObj: key.KeySignature|None):
+    def keySignature(self, keyObj: key.KeySignature | None):
         '''
         >>> a = stream.Measure()
         >>> a.keySignature = key.KeySignature(6)
@@ -1314,7 +1314,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         '''
         self.elements = ()
 
-    def cloneEmpty(self: StreamType, derivationMethod: str|None = None) -> StreamType:
+    def cloneEmpty(self: StreamType, derivationMethod: str | None = None) -> StreamType:
         '''
         Create a Stream that is identical to this one except that the elements are empty
         and set derivation.
@@ -1547,7 +1547,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         raise StreamException(f'cannot find object ({el}) in Stream')
 
     def remove(self,
-               targetOrList: base.Music21Object|Sequence[base.Music21Object],
+               targetOrList: base.Music21Object | Sequence[base.Music21Object],
                *,
                shiftOffsets=False,
                recurse=False):
@@ -2006,7 +2006,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     def setElementOffset(
         self,
         element: base.Music21Object,
-        offset: int|float|Fraction|OffsetSpecial,
+        offset: int | float | Fraction | OffsetSpecial,
     ):
         '''
         Sets the Offset for an element that is already in a given stream.
@@ -3328,10 +3328,10 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     # display methods; in the same manner as show() and write()
 
     def plot(self,
-             plotFormat: str|None = None,
-             xValue: str|None = None,
-             yValue: str|None = None,
-             zValue: str|None = None,
+             plotFormat: str | None = None,
+             xValue: str | None = None,
+             yValue: str | None = None,
+             zValue: str | None = None,
              **keywords):
         '''
         Given a method and keyword configuration arguments, create and display a plot.
@@ -3488,7 +3488,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
     @overload
     def getElementsByClass(self,
-                           classFilterList: str|Iterable[str]
+                           classFilterList: str | Iterable[str]
                            ) -> iterator.StreamIterator[M21ObjType]:
         # Remove all dummy code once Astroid #1015 is fixed
         x: iterator.StreamIterator[M21ObjType] = self.iter()
@@ -3656,7 +3656,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         '''
         return self.iter().getElementsByGroup(groupFilterList, returnClone=False)
 
-    def getElementById(self, elementId) -> base.Music21Object|None:
+    def getElementById(self, elementId) -> base.Music21Object | None:
         '''
         Returns the first encountered element for a given id. Return None
         if no match. Note: this uses the id attribute stored on elements,
@@ -3942,7 +3942,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             sIterator = sIterator.getElementsByClass(classList)
         return sIterator
 
-    def getElementAtOrBefore(self, offset, classList=None) -> base.Music21Object|None:
+    def getElementAtOrBefore(self, offset, classList=None) -> base.Music21Object | None:
         # noinspection PyShadowingNames
         '''
         Given an offset, find the element at this offset,
@@ -4062,7 +4062,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         else:
             return None
 
-    def getElementBeforeOffset(self, offset, classList=None) -> base.Music21Object|None:
+    def getElementBeforeOffset(self, offset, classList=None) -> base.Music21Object | None:
         '''
         Get element before (and not at) a provided offset.
 
@@ -4413,7 +4413,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         <music21.layout.StaffGroup <music21.stream.PartStaff P5-Staff1><... P5-Staff2>>
         <music21.layout.StaffGroup <music21.stream.Part Soprano I><...Alto II>>
         '''
-        startMeasure: Measure|None
+        startMeasure: Measure | None
 
         def hasMeasureNumberInformation(measureIterator):
             '''
@@ -4545,7 +4545,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     def measure(self,
                 measureNumber,
                 collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature'),
-                indicesNotNumbers=False) -> Measure|None:
+                indicesNotNumbers=False) -> Measure | None:
         '''
         Given a measure number, return a single
         :class:`~music21.stream.Measure` object if the Measure number exists, otherwise return None.
@@ -4598,7 +4598,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                               collect=collect,
                               indicesNotNumbers=indicesNotNumbers)
             measureIter = s.getElementsByClass(Measure)
-            m: Measure|None
+            m: Measure | None
             # noinspection PyTypeChecker
             m = measureIter.first()
             if m is None:  # not 'if not m' because m might be an empty measure.
@@ -5092,7 +5092,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     # handling transposition values and status
 
     @property
-    def atSoundingPitch(self) -> bool|t.Literal['unknown']:
+    def atSoundingPitch(self) -> bool | t.Literal['unknown']:
         '''
         Get or set the atSoundingPitch status, that is whether the
         score is at concert pitch or may have transposing instruments
@@ -5116,7 +5116,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return self._atSoundingPitch
 
     @atSoundingPitch.setter
-    def atSoundingPitch(self, value: bool|t.Literal['unknown']):
+    def atSoundingPitch(self, value: bool | t.Literal['unknown']):
         if value in [True, False, 'unknown']:
             self._atSoundingPitch = value
         else:
@@ -5183,7 +5183,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         return returnObj
 
-    def _treatAtSoundingPitch(self) -> bool|str:
+    def _treatAtSoundingPitch(self) -> bool | str:
         '''
         `atSoundingPitch` might be True, False, or 'unknown'. Given that
         setting the property does not automatically synchronize the corresponding
@@ -5590,7 +5590,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                       *,
                       searchActiveSite=True,
                       returnDefault=True,
-                      recurse=False) -> instrument.Instrument|None:
+                      recurse=False) -> instrument.Instrument | None:
         '''
         Return the first Instrument found in this Stream, or None.
 
@@ -6527,18 +6527,18 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     def makeAccidentals(
         self,
         *,
-        pitchPast: list[pitch.Pitch]|None = None,
-        pitchPastMeasure: list[pitch.Pitch]|None = None,
-        otherSimultaneousPitches: list[pitch.Pitch]|None = None,
-        useKeySignature: bool|key.KeySignature = True,
-        alteredPitches: list[pitch.Pitch]|None = None,
+        pitchPast: list[pitch.Pitch] | None = None,
+        pitchPastMeasure: list[pitch.Pitch] | None = None,
+        otherSimultaneousPitches: list[pitch.Pitch] | None = None,
+        useKeySignature: bool | key.KeySignature = True,
+        alteredPitches: list[pitch.Pitch] | None = None,
         searchKeySignatureByContext: bool = False,
         cautionaryPitchClass: bool = True,
         cautionaryAll: bool = False,
         inPlace: bool = False,
         overrideStatus: bool = False,
         cautionaryNotImmediateRepeat: bool = True,
-        tiePitchSet: set[str]|None = None
+        tiePitchSet: set[str] | None = None
     ):
         '''
         A method to set and provide accidentals given various conditions and contexts.
@@ -6642,7 +6642,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         if tiePitchSet is None:
             tiePitchSet = set()
 
-        last_measure: Measure|None = None
+        last_measure: Measure | None = None
 
         for e in noteIterator:
             if e.activeSite is not None and e.activeSite.isMeasure:
@@ -6732,15 +6732,15 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                      refStreamOrTimeRange=None,
                      inPlace=False,
                      bestClef=False,
-                     pitchPast: list[pitch.Pitch]|None = None,
-                     pitchPastMeasure: list[pitch.Pitch]|None = None,
-                     useKeySignature: bool|key.KeySignature = True,
-                     alteredPitches: list[pitch.Pitch]|None = None,
+                     pitchPast: list[pitch.Pitch] | None = None,
+                     pitchPastMeasure: list[pitch.Pitch] | None = None,
+                     useKeySignature: bool | key.KeySignature = True,
+                     alteredPitches: list[pitch.Pitch] | None = None,
                      cautionaryPitchClass: bool = True,
                      cautionaryAll: bool = False,
                      overrideStatus: bool = False,
                      cautionaryNotImmediateRepeat: bool = True,
-                     tiePitchSet: set[str]|None = None
+                     tiePitchSet: set[str] | None = None
                      ):
         '''
         This method calls a sequence of Stream methods on this Stream to prepare
@@ -7983,7 +7983,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         el: base.Music21Object,
         *,
         setActiveSite=True
-    ) -> Stream|None:
+    ) -> Stream | None:
         '''
         Returns the container in a hierarchy that this element belongs to.
 
@@ -8800,7 +8800,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
     def transpose(
         self,
-        value: str|int|'music21.interval.IntervalBase',
+        value: str | int|'music21.interval.IntervalBase',
         /,
         *,
         inPlace=False,
@@ -9997,7 +9997,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         getOverlaps: bool = False,
         noNone: t.Literal[False] = False,
         **keywords
-    ) -> list[note.NotRest|None]:
+    ) -> list[note.NotRest | None]:
         return []
 
     def findConsecutiveNotes(
@@ -10012,7 +10012,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         noNone: bool = False,
         **keywords
     ) -> t.Union[
-            list[note.NotRest|None],
+            list[note.NotRest | None],
             list[note.NotRest],
             list[note.Note],
     ]:
@@ -10071,7 +10071,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         '''
         if self.isSorted is False and self.autoSort:
             self.sort()
-        returnList: list[note.NotRest|None] = []
+        returnList: list[note.NotRest | None] = []
         lastStart: OffsetQL = 0.0
         lastEnd: OffsetQL = 0.0
         lastContainerEnd: OffsetQL = 0.0
@@ -10967,7 +10967,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         if not inPlace:
             return returnObj
 
-    def _maxVoiceCount(self, *, countById=False) -> int|tuple[int, list[str]]:
+    def _maxVoiceCount(self, *, countById=False) -> int | tuple[int, list[str]]:
         '''
         Returns the maximum number of voices in a part.  Used by voicesToParts.
         Minimum returned is 1.  If `countById` is True, returns a tuple of
@@ -12765,7 +12765,7 @@ class Measure(Stream):
             for the amount of padding on the right side of a region.)''',
     }
 
-    def __init__(self, *args, number: int|str = 0, **keywords):
+    def __init__(self, *args, number: int | str = 0, **keywords):
         if len(args) == 1 and isinstance(args[0], int) and number == 0:
             number = args[0]
             args = ()
@@ -13880,7 +13880,7 @@ class Score(Stream):
             return returnObj
 
     def partsToVoices(self,
-                      voiceAllocation: int|list[list|int] = 2,
+                      voiceAllocation: int | list[list | int] = 2,
                       permitOneVoicePerPart=False,
                       setStems=True):
         # noinspection PyShadowingNames
@@ -13925,7 +13925,7 @@ class Score(Stream):
                 bundle.append(sub)
         # else, assume it is a list of groupings
         elif common.isIterable(voiceAllocation):
-            voiceAllocation = t.cast(list[list|int], voiceAllocation)
+            voiceAllocation = t.cast(list[list | int], voiceAllocation)
             for group in voiceAllocation:
                 sub = []
                 # if a single entry
@@ -13944,7 +13944,7 @@ class Score(Stream):
         s = self.cloneEmpty(derivationMethod='partsToVoices')
         s.metadata = self.metadata
 
-        pActive: Part|None
+        pActive: Part | None
         for sub in bundle:  # each sub contains parts
             if len(sub) == 1 and not permitOneVoicePerPart:
                 # probably need to create a new part and measure

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -260,7 +260,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     # forms of checking class
     isStream = True
     isMeasure = False
-    classSortOrder: t.Union[int, float] = -20
+    classSortOrder: int|float = -20
     recursionType: RecursionType = RecursionType.ELEMENTS_FIRST
 
     _styleClass = style.StreamStyle
@@ -6530,7 +6530,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         pitchPast: t.Optional[list[pitch.Pitch]] = None,
         pitchPastMeasure: t.Optional[list[pitch.Pitch]] = None,
         otherSimultaneousPitches: t.Optional[list[pitch.Pitch]] = None,
-        useKeySignature: t.Union[bool, key.KeySignature] = True,
+        useKeySignature: bool|key.KeySignature = True,
         alteredPitches: t.Optional[list[pitch.Pitch]] = None,
         searchKeySignatureByContext: bool = False,
         cautionaryPitchClass: bool = True,
@@ -6732,7 +6732,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                      bestClef=False,
                      pitchPast: t.Optional[list[pitch.Pitch]] = None,
                      pitchPastMeasure: t.Optional[list[pitch.Pitch]] = None,
-                     useKeySignature: t.Union[bool, key.KeySignature] = True,
+                     useKeySignature: bool|key.KeySignature = True,
                      alteredPitches: t.Optional[list[pitch.Pitch]] = None,
                      cautionaryPitchClass: bool = True,
                      cautionaryAll: bool = False,
@@ -12763,7 +12763,7 @@ class Measure(Stream):
             for the amount of padding on the right side of a region.)''',
     }
 
-    def __init__(self, *args, number: t.Union[int, str] = 0, **keywords):
+    def __init__(self, *args, number: int|str = 0, **keywords):
         if len(args) == 1 and isinstance(args[0], int) and number == 0:
             number = args[0]
             args = ()

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1314,7 +1314,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         '''
         self.elements = ()
 
-    def cloneEmpty(self: StreamType, derivationMethod: t.Optional[str] = None) -> StreamType:
+    def cloneEmpty(self: StreamType, derivationMethod: str|None = None) -> StreamType:
         '''
         Create a Stream that is identical to this one except that the elements are empty
         and set derivation.
@@ -3328,10 +3328,10 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     # display methods; in the same manner as show() and write()
 
     def plot(self,
-             plotFormat: t.Optional[str] = None,
-             xValue: t.Optional[str] = None,
-             yValue: t.Optional[str] = None,
-             zValue: t.Optional[str] = None,
+             plotFormat: str|None = None,
+             xValue: str|None = None,
+             yValue: str|None = None,
+             zValue: str|None = None,
              **keywords):
         '''
         Given a method and keyword configuration arguments, create and display a plot.
@@ -6640,7 +6640,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         if tiePitchSet is None:
             tiePitchSet = set()
 
-        last_measure: t.Optional[Measure] = None
+        last_measure: Measure|None = None
 
         for e in noteIterator:
             if e.activeSite is not None and e.activeSite.isMeasure:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -8800,7 +8800,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
     def transpose(
         self,
-        value: str | int|'music21.interval.IntervalBase',
+        value: str | int | 'music21.interval.IntervalBase',
         /,
         *,
         inPlace=False,

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -167,7 +167,7 @@ class StreamCore(Music21Object):
     def coreSetElementOffset(
         self,
         element: Music21Object,
-        offset: int|float|Fraction|OffsetSpecial,
+        offset: int | float | Fraction | OffsetSpecial,
         *,
         addElement=False,
         setActiveSite=True
@@ -569,8 +569,8 @@ class StreamCore(Music21Object):
         recurse=True,
         requireAllPresent=True,
         insert=True,
-        constrainingSpannerBundle: spanner.SpannerBundle|None = None
-    ) -> list[spanner.Spanner]|None:
+        constrainingSpannerBundle: spanner.SpannerBundle | None = None
+    ) -> list[spanner.Spanner] | None:
         '''
         find all spanners that are referenced by elements in the
         (recursed if recurse=True) stream and either inserts them in the Stream
@@ -715,7 +715,7 @@ class StreamCore(Music21Object):
         {1.0} <music21.note.Note D>
         '''
         sb = self.spannerBundle
-        sIter: StreamIterator|RecursiveIterator
+        sIter: StreamIterator | RecursiveIterator
         if recurse is True:
             sIter = self.recurse()  # type: ignore
         else:

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import copy
 from fractions import Fraction
-import typing as t
 from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -167,7 +167,7 @@ class StreamCore(Music21Object):
     def coreSetElementOffset(
         self,
         element: Music21Object,
-        offset: t.Union[int, float, Fraction, OffsetSpecial],
+        offset: int|float|Fraction|OffsetSpecial,
         *,
         addElement=False,
         setActiveSite=True
@@ -570,7 +570,7 @@ class StreamCore(Music21Object):
         requireAllPresent=True,
         insert=True,
         constrainingSpannerBundle: spanner.SpannerBundle|None = None
-    ) -> t.Optional[list[spanner.Spanner]]:
+    ) -> list[spanner.Spanner]|None:
         '''
         find all spanners that are referenced by elements in the
         (recursed if recurse=True) stream and either inserts them in the Stream
@@ -715,7 +715,7 @@ class StreamCore(Music21Object):
         {1.0} <music21.note.Note D>
         '''
         sb = self.spannerBundle
-        sIter: t.Union[StreamIterator, RecursiveIterator]
+        sIter: StreamIterator|RecursiveIterator
         if recurse is True:
             sIter = self.recurse()  # type: ignore
         else:

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -569,7 +569,7 @@ class StreamCore(Music21Object):
         recurse=True,
         requireAllPresent=True,
         insert=True,
-        constrainingSpannerBundle: t.Optional[spanner.SpannerBundle] = None
+        constrainingSpannerBundle: spanner.SpannerBundle|None = None
     ) -> t.Optional[list[spanner.Spanner]]:
         '''
         find all spanners that are referenced by elements in the

--- a/music21/stream/filters.py
+++ b/music21/stream/filters.py
@@ -74,7 +74,7 @@ class StreamFilter(prebase.ProtoM21Object):
     def reset(self):
         pass
 
-    def __call__(self, item, iterator: StreamIteratorType|None = None):
+    def __call__(self, item, iterator: StreamIteratorType | None = None):
         return True
 
 class IsFilter(StreamFilter):

--- a/music21/stream/filters.py
+++ b/music21/stream/filters.py
@@ -74,7 +74,7 @@ class StreamFilter(prebase.ProtoM21Object):
     def reset(self):
         pass
 
-    def __call__(self, item, iterator: t.Optional[StreamIteratorType] = None):
+    def __call__(self, item, iterator: StreamIteratorType|None = None):
         return True
 
 class IsFilter(StreamFilter):

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -136,7 +136,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
                  srcStream: StreamType,
                  *,
                  # restrictClass: type[M21ObjType] = base.Music21Object,
-                 filterList: t.Optional[list[FilterType]] = None,
+                 filterList: list[FilterType]|None = None,
                  restoreActiveSites: bool = True,
                  activeInformation: ActiveInformation|None = None,
                  ignoreSorting: bool = False):
@@ -172,7 +172,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         # whether it should be yielded.
         self.filters: list[FilterType] = filterList
         self._len: int|None = None
-        self._matchingElements: t.Optional[list[M21ObjType]] = None
+        self._matchingElements: list[M21ObjType]|None = None
         # keep track of where we are in the parse.
         # esp important for recursive streams...
         if activeInformation is not None:
@@ -336,12 +336,10 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         return self.matchingElements()
 
     @overload
-    def __getitem__(self, k: str) -> t.Optional[M21ObjType]:
+    def __getitem__(self, k: str) -> M21ObjType|None:
         return None
 
-    def __getitem__(self, k: t.Union[int, slice, str]) -> t.Union[M21ObjType,
-                                                                  list[M21ObjType],
-                                                                  None]:
+    def __getitem__(self, k: int|slice|str) -> M21ObjType|list[M21ObjType]|None:
         '''
         Iterators can request other items by index or slice.
 
@@ -532,7 +530,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         )
         return out
 
-    def first(self) -> t.Optional[M21ObjType]:
+    def first(self) -> M21ObjType|None:
         '''
         Efficiently return the first matching element, or None if no
         elements match.
@@ -582,7 +580,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         except StopIteration:
             return None
 
-    def last(self) -> t.Optional[M21ObjType]:
+    def last(self) -> M21ObjType|None:
         '''
         Returns the last matching element, or None if no elements match.
 
@@ -667,7 +665,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
 
             # cleanupOnStop is rarely used, so we put in
             # a dummy stream so that srcStream does not need
-            # to be t.Optional[]
+            # to be x|None
             SrcStreamClass = self.srcStream.__class__
 
             del self.srcStream
@@ -797,7 +795,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         x: StreamType = self.streamObj
         return x
 
-    def stream(self, returnStreamSubClass=True) -> t.Union[stream.Stream, StreamType]:
+    def stream(self, returnStreamSubClass=True) -> stream.Stream|StreamType:
         '''
         return a new stream from this iterator.
 
@@ -866,7 +864,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
 
         # if this stream was sorted, the resultant stream is sorted
         clearIsSorted = False
-        found: t.Union[stream.Stream, StreamType]
+        found: stream.Stream|StreamType
         if returnStreamSubClass is True:
             try:
                 found = ss.__class__()
@@ -971,7 +969,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
 
         return out
 
-    def getElementById(self, elementId: str) -> t.Optional[M21ObjType]:
+    def getElementById(self, elementId: str) -> M21ObjType|None:
         '''
         Returns a single element (or None) that matches elementId.
 
@@ -1794,7 +1792,7 @@ class RecursiveIterator(StreamIterator, Sequence[M21ObjType]):
 
         if streamsOnly is True:
             self.filters.append(filters.ClassFilter('Stream'))
-        self.childRecursiveIterator: t.Optional[RecursiveIterator[t.Any]] = None
+        self.childRecursiveIterator: RecursiveIterator[t.Any]|None = None
         # not yet used.
         # self.parentIterator = None
 

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -43,7 +43,7 @@ T = t.TypeVar('T')
 S = t.TypeVar('S')
 ChangedM21ObjType = t.TypeVar('ChangedM21ObjType', bound=base.Music21Object)
 StreamIteratorType = t.TypeVar('StreamIteratorType', bound='StreamIterator')
-FilterType = t.Union[Callable[[t.Any, t.Any|None], t.Any], filters.StreamFilter]
+FilterType = $1|$2|$3|$4 =[Callable[[t.Any, t.Any|None], t.Any], filters.StreamFilter]
 
 # -----------------------------------------------------------------------------
 

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -43,7 +43,7 @@ T = t.TypeVar('T')
 S = t.TypeVar('S')
 ChangedM21ObjType = t.TypeVar('ChangedM21ObjType', bound=base.Music21Object)
 StreamIteratorType = t.TypeVar('StreamIteratorType', bound='StreamIterator')
-FilterType = Callable[[t.Any, t.Any|None], t.Any]|filters.StreamFilter
+FilterType = Callable[[t.Any, t.Any | None], t.Any] | filters.StreamFilter
 
 # -----------------------------------------------------------------------------
 
@@ -57,11 +57,11 @@ class StreamIteratorInefficientWarning(UserWarning):
 
 
 class ActiveInformation(t.TypedDict, total=False):
-    stream: stream.Stream|None
+    stream: stream.Stream | None
     elementIndex: int
     iterSection: t.Literal['_elements', '_endElements']
     sectionIndex: int
-    lastYielded: base.Music21Object|None
+    lastYielded: base.Music21Object | None
 
 
 
@@ -136,9 +136,9 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
                  srcStream: StreamType,
                  *,
                  # restrictClass: type[M21ObjType] = base.Music21Object,
-                 filterList: list[FilterType]|None = None,
+                 filterList: list[FilterType] | None = None,
                  restoreActiveSites: bool = True,
-                 activeInformation: ActiveInformation|None = None,
+                 activeInformation: ActiveInformation | None = None,
                  ignoreSorting: bool = False):
         if not ignoreSorting and srcStream.isSorted is False and srcStream.autoSort:
             srcStream.sort()
@@ -159,7 +159,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         self.cleanupOnStop: bool = False
         self.restoreActiveSites: bool = restoreActiveSites
 
-        self.overrideDerivation: str|None = None
+        self.overrideDerivation: str | None = None
 
         if filterList is None:
             filterList = []
@@ -171,8 +171,8 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         # return True or False for an element for
         # whether it should be yielded.
         self.filters: list[FilterType] = filterList
-        self._len: int|None = None
-        self._matchingElements: list[M21ObjType]|None = None
+        self._len: int | None = None
+        self._matchingElements: list[M21ObjType] | None = None
         # keep track of where we are in the parse.
         # esp important for recursive streams...
         if activeInformation is not None:
@@ -336,10 +336,10 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         return self.matchingElements()
 
     @overload
-    def __getitem__(self, k: str) -> M21ObjType|None:
+    def __getitem__(self, k: str) -> M21ObjType | None:
         return None
 
-    def __getitem__(self, k: int|slice|str) -> M21ObjType|list[M21ObjType]|None:
+    def __getitem__(self, k: int | slice | str) -> M21ObjType | list[M21ObjType] | None:
         '''
         Iterators can request other items by index or slice.
 
@@ -530,7 +530,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         )
         return out
 
-    def first(self) -> M21ObjType|None:
+    def first(self) -> M21ObjType | None:
         '''
         Efficiently return the first matching element, or None if no
         elements match.
@@ -580,7 +580,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         except StopIteration:
             return None
 
-    def last(self) -> M21ObjType|None:
+    def last(self) -> M21ObjType | None:
         '''
         Returns the last matching element, or None if no elements match.
 
@@ -665,7 +665,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
 
             # cleanupOnStop is rarely used, so we put in
             # a dummy stream so that srcStream does not need
-            # to be x|None
+            # to be x | None
             SrcStreamClass = self.srcStream.__class__
 
             del self.srcStream
@@ -795,7 +795,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         x: StreamType = self.streamObj
         return x
 
-    def stream(self, returnStreamSubClass=True) -> stream.Stream|StreamType:
+    def stream(self, returnStreamSubClass=True) -> stream.Stream | StreamType:
         '''
         return a new stream from this iterator.
 
@@ -864,7 +864,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
 
         # if this stream was sorted, the resultant stream is sorted
         clearIsSorted = False
-        found: stream.Stream|StreamType
+        found: stream.Stream | StreamType
         if returnStreamSubClass is True:
             try:
                 found = ss.__class__()
@@ -969,7 +969,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
 
         return out
 
-    def getElementById(self, elementId: str) -> M21ObjType|None:
+    def getElementById(self, elementId: str) -> M21ObjType | None:
         '''
         Returns a single element (or None) that matches elementId.
 
@@ -1792,7 +1792,7 @@ class RecursiveIterator(StreamIterator, Sequence[M21ObjType]):
 
         if streamsOnly is True:
             self.filters.append(filters.ClassFilter('Stream'))
-        self.childRecursiveIterator: RecursiveIterator[t.Any]|None = None
+        self.childRecursiveIterator: RecursiveIterator[t.Any] | None = None
         # not yet used.
         # self.parentIterator = None
 

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -43,7 +43,7 @@ T = t.TypeVar('T')
 S = t.TypeVar('S')
 ChangedM21ObjType = t.TypeVar('ChangedM21ObjType', bound=base.Music21Object)
 StreamIteratorType = t.TypeVar('StreamIteratorType', bound='StreamIterator')
-FilterType = t.Union[Callable[[t.Any, t.Optional[t.Any]], t.Any], filters.StreamFilter]
+FilterType = t.Union[Callable[[t.Any, t.Any|None], t.Any], filters.StreamFilter]
 
 # -----------------------------------------------------------------------------
 
@@ -57,11 +57,11 @@ class StreamIteratorInefficientWarning(UserWarning):
 
 
 class ActiveInformation(t.TypedDict, total=False):
-    stream: t.Optional[stream.Stream]
+    stream: stream.Stream|None
     elementIndex: int
     iterSection: t.Literal['_elements', '_endElements']
     sectionIndex: int
-    lastYielded: t.Optional[base.Music21Object]
+    lastYielded: base.Music21Object|None
 
 
 
@@ -138,7 +138,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
                  # restrictClass: type[M21ObjType] = base.Music21Object,
                  filterList: t.Optional[list[FilterType]] = None,
                  restoreActiveSites: bool = True,
-                 activeInformation: t.Optional[ActiveInformation] = None,
+                 activeInformation: ActiveInformation|None = None,
                  ignoreSorting: bool = False):
         if not ignoreSorting and srcStream.isSorted is False and srcStream.autoSort:
             srcStream.sort()
@@ -159,7 +159,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         self.cleanupOnStop: bool = False
         self.restoreActiveSites: bool = restoreActiveSites
 
-        self.overrideDerivation: t.Optional[str] = None
+        self.overrideDerivation: str|None = None
 
         if filterList is None:
             filterList = []
@@ -171,7 +171,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         # return True or False for an element for
         # whether it should be yielded.
         self.filters: list[FilterType] = filterList
-        self._len: t.Optional[int] = None
+        self._len: int|None = None
         self._matchingElements: t.Optional[list[M21ObjType]] = None
         # keep track of where we are in the parse.
         # esp important for recursive streams...

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -43,7 +43,7 @@ T = t.TypeVar('T')
 S = t.TypeVar('S')
 ChangedM21ObjType = t.TypeVar('ChangedM21ObjType', bound=base.Music21Object)
 StreamIteratorType = t.TypeVar('StreamIteratorType', bound='StreamIterator')
-FilterType = $1|$2|$3|$4 =[Callable[[t.Any, t.Any|None], t.Any], filters.StreamFilter]
+FilterType = Callable[[t.Any, t.Any|None], t.Any]|filters.StreamFilter
 
 # -----------------------------------------------------------------------------
 

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -43,7 +43,9 @@ T = t.TypeVar('T')
 S = t.TypeVar('S')
 ChangedM21ObjType = t.TypeVar('ChangedM21ObjType', bound=base.Music21Object)
 StreamIteratorType = t.TypeVar('StreamIteratorType', bound='StreamIterator')
-FilterType = Callable[[t.Any, t.Any | None], t.Any] | filters.StreamFilter
+
+# pipe | version not passing mypy.
+FilterType = t.Union[Callable[[t.Any, t.Optional[t.Any]], t.Any], filters.StreamFilter]
 
 # -----------------------------------------------------------------------------
 

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -53,7 +53,7 @@ def makeBeams(
     inPlace=False,
     setStemDirections=True,
     failOnNoTimeSignature=False,
-) -> StreamType|None:
+) -> StreamType | None:
     # noinspection PyShadowingNames
     '''
     Return a new Measure, or Stream of Measures, with beams applied to all
@@ -237,7 +237,7 @@ def makeMeasures(
     finalBarline='final',
     bestClef=False,
     inPlace=False,
-) -> StreamType|None:
+) -> StreamType | None:
     '''
     Takes a stream and places all of its elements into
     measures (:class:`~music21.stream.Measure` objects)
@@ -716,7 +716,7 @@ def makeRests(
     timeRangeFromBarDuration=False,
     inPlace=False,
     hideRests=False,
-) -> StreamType|None:
+) -> StreamType | None:
     '''
     Given a Stream with an offset not equal to zero,
     fill with one Rest preceding this offset.
@@ -863,8 +863,8 @@ def makeRests(
             return returnObj
 
     def oHighTargetForMeasure(
-        m: stream.Measure|None = None,
-        ts: meter.TimeSignature|None = None
+        m: stream.Measure | None = None,
+        ts: meter.TimeSignature | None = None
     ) -> OffsetQL:
         '''
         Needed for timeRangeFromBarDuration.
@@ -890,7 +890,7 @@ def makeRests(
             if isinstance(refStreamOrTimeRange, stream.Measure):
                 oHighTarget = oHighTargetForMeasure(m=refStreamOrTimeRange)
             elif isinstance(refStreamOrTimeRange, meter.TimeSignature):
-                maybe_measure: stream.Measure|None = None
+                maybe_measure: stream.Measure | None = None
                 if isinstance(returnObj.activeSite, stream.Measure):
                     maybe_measure = returnObj.activeSite
                 oHighTarget = oHighTargetForMeasure(m=maybe_measure, ts=refStreamOrTimeRange)
@@ -921,7 +921,7 @@ def makeRests(
     else:
         bundle = [returnObj]
 
-    lastTimeSignature: meter.TimeSignature|None = None
+    lastTimeSignature: meter.TimeSignature | None = None
     # bundle components may be voices, measures, or a flat Stream
     for component in bundle:
         oLow = component.lowestOffset
@@ -993,7 +993,7 @@ def makeTies(
     inPlace=False,
     displayTiedAccidentals=False,
     classFilterList=(note.GeneralNote,),
-) -> StreamType|None:
+) -> StreamType | None:
     # noinspection PyShadowingNames
     '''
     Given a stream containing measures, examine each element in the
@@ -1338,7 +1338,7 @@ def makeTies(
         return None
 
 
-def makeTupletBrackets(s: StreamType, *, inPlace=False) -> StreamType|None:
+def makeTupletBrackets(s: StreamType, *, inPlace=False) -> StreamType | None:
     # noinspection PyShadowingNames
     '''
     Given a flat Stream of mixed durations, designates the first and last tuplet of any group
@@ -1377,7 +1377,7 @@ def makeTupletBrackets(s: StreamType, *, inPlace=False) -> StreamType|None:
         durationList.append(n.duration)
 
     # a list of (tuplet obj, Duration) pairs
-    tupletMap: list[tuple[duration.Tuplet|None, duration.Duration]] = []
+    tupletMap: list[tuple[duration.Tuplet | None, duration.Duration]] = []
 
     for dur in durationList:  # all Duration objects
         tupletList = dur.tuplets
@@ -1395,7 +1395,7 @@ def makeTupletBrackets(s: StreamType, *, inPlace=False) -> StreamType|None:
 
     # have a list of tuplet, Duration pairs
     completionCount: OffsetQL = 0.0  # qLen currently filled
-    completionTarget: OffsetQL|None = None  # qLen necessary to fill tuplet
+    completionTarget: OffsetQL | None = None  # qLen necessary to fill tuplet
     for i in range(len(tupletMap)):
         tupletObj, dur = tupletMap[i]
 
@@ -1556,7 +1556,7 @@ def moveNotesToVoices(source: StreamType,
     source.insert(0, dst)
 
 
-def getTiePitchSet(prior: 'music21.note.NotRest') -> set[str]|None:
+def getTiePitchSet(prior: 'music21.note.NotRest') -> set[str] | None:
     # noinspection PyShadowingNames,PyTypeChecker
     '''
     helper method for makeAccidentals to get the tie pitch set (or None)
@@ -1614,17 +1614,17 @@ def getTiePitchSet(prior: 'music21.note.NotRest') -> set[str]|None:
     return tiePitchSet
 
 def makeAccidentalsInMeasureStream(
-    s: StreamType|StreamIterator,
+    s: StreamType | StreamIterator,
     *,
-    pitchPast: list[pitch.Pitch]|None = None,
-    pitchPastMeasure: list[pitch.Pitch]|None = None,
-    useKeySignature: bool|key.KeySignature = True,
-    alteredPitches: list[pitch.Pitch]|None = None,
+    pitchPast: list[pitch.Pitch] | None = None,
+    pitchPastMeasure: list[pitch.Pitch] | None = None,
+    useKeySignature: bool | key.KeySignature = True,
+    alteredPitches: list[pitch.Pitch] | None = None,
     cautionaryPitchClass: bool = True,
     cautionaryAll: bool = False,
     overrideStatus: bool = False,
     cautionaryNotImmediateRepeat: bool = True,
-    tiePitchSet: set[str]|None = None
+    tiePitchSet: set[str] | None = None
 ) -> None:
     '''
     Makes accidentals in place on a stream that contains Measures.
@@ -1651,7 +1651,7 @@ def makeAccidentalsInMeasureStream(
     # because we are definitely searching key signature contexts
     # only key.KeySignature values are interesting
     # but method arg is typed this way for backwards compatibility
-    ksLast: bool|key.KeySignature = False
+    ksLast: bool | key.KeySignature = False
     ksLastDiatonic: list[str] = []
 
     if isinstance(useKeySignature, key.KeySignature):
@@ -1758,7 +1758,7 @@ def iterateBeamGroups(
     current_beam_group: list[note.NotRest] = []
     in_beam_group: bool = False
     for el in iterator.notes:
-        first_el_type: str|None = None
+        first_el_type: str | None = None
         if el.beams and el.beams.getByNumber(1):
             first_el_type = el.beams.getTypeByNumber(1)
 
@@ -1838,7 +1838,7 @@ def setStemDirectionOneGroup(
         has_consistent_stem_directions = False
 
     # noinspection PyTypeChecker
-    optional_clef_context: clef.Clef|None = group[0].getContextByClass(clef.Clef)
+    optional_clef_context: clef.Clef | None = group[0].getContextByClass(clef.Clef)
     if optional_clef_context is None:
         return
     clef_context: clef.Clef = optional_clef_context
@@ -1909,7 +1909,7 @@ def splitElementsToCompleteTuplets(
 
     for container in iterator:
         general_notes = list(container.notesAndRests)
-        last_tuplet: duration.Tuplet|None = None
+        last_tuplet: duration.Tuplet | None = None
         partial_tuplet_sum = 0.0
         for gn in general_notes:
             if (
@@ -2015,8 +2015,8 @@ def consolidateCompletedTuplets(
         reexpressible = [gn for gn in container.notesAndRests if is_reexpressible(gn)]
         to_consolidate: list[note.GeneralNote] = []
         partial_tuplet_sum: OffsetQL = 0.0
-        last_tuplet: duration.Tuplet|None = None
-        completion_target: OffsetQL|None = None
+        last_tuplet: duration.Tuplet | None = None
+        completion_target: OffsetQL | None = None
         for gn in reexpressible:
             prev_gn = gn.previous(note.GeneralNote, activeSiteOnly=True)
             if (

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -863,8 +863,8 @@ def makeRests(
             return returnObj
 
     def oHighTargetForMeasure(
-        m: t.Optional[stream.Measure] = None,
-        ts: t.Optional[meter.TimeSignature] = None
+        m: stream.Measure|None = None,
+        ts: meter.TimeSignature|None = None
     ) -> OffsetQL:
         '''
         Needed for timeRangeFromBarDuration.
@@ -890,7 +890,7 @@ def makeRests(
             if isinstance(refStreamOrTimeRange, stream.Measure):
                 oHighTarget = oHighTargetForMeasure(m=refStreamOrTimeRange)
             elif isinstance(refStreamOrTimeRange, meter.TimeSignature):
-                maybe_measure: t.Optional[stream.Measure] = None
+                maybe_measure: stream.Measure|None = None
                 if isinstance(returnObj.activeSite, stream.Measure):
                     maybe_measure = returnObj.activeSite
                 oHighTarget = oHighTargetForMeasure(m=maybe_measure, ts=refStreamOrTimeRange)
@@ -921,7 +921,7 @@ def makeRests(
     else:
         bundle = [returnObj]
 
-    lastTimeSignature: t.Optional[meter.TimeSignature] = None
+    lastTimeSignature: meter.TimeSignature|None = None
     # bundle components may be voices, measures, or a flat Stream
     for component in bundle:
         oLow = component.lowestOffset
@@ -1395,7 +1395,7 @@ def makeTupletBrackets(s: StreamType, *, inPlace=False) -> t.Optional[StreamType
 
     # have a list of tuplet, Duration pairs
     completionCount: OffsetQL = 0.0  # qLen currently filled
-    completionTarget: t.Optional[OffsetQL] = None  # qLen necessary to fill tuplet
+    completionTarget: OffsetQL|None = None  # qLen necessary to fill tuplet
     for i in range(len(tupletMap)):
         tupletObj, dur = tupletMap[i]
 
@@ -1758,7 +1758,7 @@ def iterateBeamGroups(
     current_beam_group: list[note.NotRest] = []
     in_beam_group: bool = False
     for el in iterator.notes:
-        first_el_type: t.Optional[str] = None
+        first_el_type: str|None = None
         if el.beams and el.beams.getByNumber(1):
             first_el_type = el.beams.getTypeByNumber(1)
 
@@ -1838,7 +1838,7 @@ def setStemDirectionOneGroup(
         has_consistent_stem_directions = False
 
     # noinspection PyTypeChecker
-    optional_clef_context: t.Optional[clef.Clef] = group[0].getContextByClass(clef.Clef)
+    optional_clef_context: clef.Clef|None = group[0].getContextByClass(clef.Clef)
     if optional_clef_context is None:
         return
     clef_context: clef.Clef = optional_clef_context
@@ -1909,7 +1909,7 @@ def splitElementsToCompleteTuplets(
 
     for container in iterator:
         general_notes = list(container.notesAndRests)
-        last_tuplet: t.Optional[duration.Tuplet] = None
+        last_tuplet: duration.Tuplet|None = None
         partial_tuplet_sum = 0.0
         for gn in general_notes:
             if (
@@ -2015,8 +2015,8 @@ def consolidateCompletedTuplets(
         reexpressible = [gn for gn in container.notesAndRests if is_reexpressible(gn)]
         to_consolidate: list[note.GeneralNote] = []
         partial_tuplet_sum: OffsetQL = 0.0
-        last_tuplet: t.Optional[duration.Tuplet] = None
-        completion_target: t.Optional[OffsetQL] = None
+        last_tuplet: duration.Tuplet|None = None
+        completion_target: OffsetQL|None = None
         for gn in reexpressible:
             prev_gn = gn.previous(note.GeneralNote, activeSiteOnly=True)
             if (

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -53,7 +53,7 @@ def makeBeams(
     inPlace=False,
     setStemDirections=True,
     failOnNoTimeSignature=False,
-) -> t.Optional[StreamType]:
+) -> StreamType|None:
     # noinspection PyShadowingNames
     '''
     Return a new Measure, or Stream of Measures, with beams applied to all
@@ -237,7 +237,7 @@ def makeMeasures(
     finalBarline='final',
     bestClef=False,
     inPlace=False,
-) -> t.Optional[StreamType]:
+) -> StreamType|None:
     '''
     Takes a stream and places all of its elements into
     measures (:class:`~music21.stream.Measure` objects)
@@ -716,7 +716,7 @@ def makeRests(
     timeRangeFromBarDuration=False,
     inPlace=False,
     hideRests=False,
-) -> t.Optional[StreamType]:
+) -> StreamType|None:
     '''
     Given a Stream with an offset not equal to zero,
     fill with one Rest preceding this offset.
@@ -993,7 +993,7 @@ def makeTies(
     inPlace=False,
     displayTiedAccidentals=False,
     classFilterList=(note.GeneralNote,),
-) -> t.Optional[StreamType]:
+) -> StreamType|None:
     # noinspection PyShadowingNames
     '''
     Given a stream containing measures, examine each element in the
@@ -1338,7 +1338,7 @@ def makeTies(
         return None
 
 
-def makeTupletBrackets(s: StreamType, *, inPlace=False) -> t.Optional[StreamType]:
+def makeTupletBrackets(s: StreamType, *, inPlace=False) -> StreamType|None:
     # noinspection PyShadowingNames
     '''
     Given a flat Stream of mixed durations, designates the first and last tuplet of any group
@@ -1377,7 +1377,7 @@ def makeTupletBrackets(s: StreamType, *, inPlace=False) -> t.Optional[StreamType
         durationList.append(n.duration)
 
     # a list of (tuplet obj, Duration) pairs
-    tupletMap: list[tuple[t.Optional[duration.Tuplet], duration.Duration]] = []
+    tupletMap: list[tuple[duration.Tuplet|None, duration.Duration]] = []
 
     for dur in durationList:  # all Duration objects
         tupletList = dur.tuplets
@@ -1556,7 +1556,7 @@ def moveNotesToVoices(source: StreamType,
     source.insert(0, dst)
 
 
-def getTiePitchSet(prior: 'music21.note.NotRest') -> t.Optional[set[str]]:
+def getTiePitchSet(prior: 'music21.note.NotRest') -> set[str]|None:
     # noinspection PyShadowingNames,PyTypeChecker
     '''
     helper method for makeAccidentals to get the tie pitch set (or None)
@@ -1614,17 +1614,17 @@ def getTiePitchSet(prior: 'music21.note.NotRest') -> t.Optional[set[str]]:
     return tiePitchSet
 
 def makeAccidentalsInMeasureStream(
-    s: t.Union[StreamType, StreamIterator],
+    s: StreamType|StreamIterator,
     *,
-    pitchPast: t.Optional[list[pitch.Pitch]] = None,
-    pitchPastMeasure: t.Optional[list[pitch.Pitch]] = None,
+    pitchPast: list[pitch.Pitch]|None = None,
+    pitchPastMeasure: list[pitch.Pitch]|None = None,
     useKeySignature: bool|key.KeySignature = True,
-    alteredPitches: t.Optional[list[pitch.Pitch]] = None,
+    alteredPitches: list[pitch.Pitch]|None = None,
     cautionaryPitchClass: bool = True,
     cautionaryAll: bool = False,
     overrideStatus: bool = False,
     cautionaryNotImmediateRepeat: bool = True,
-    tiePitchSet: t.Optional[set[str]] = None
+    tiePitchSet: set[str]|None = None
 ) -> None:
     '''
     Makes accidentals in place on a stream that contains Measures.

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -1618,7 +1618,7 @@ def makeAccidentalsInMeasureStream(
     *,
     pitchPast: t.Optional[list[pitch.Pitch]] = None,
     pitchPastMeasure: t.Optional[list[pitch.Pitch]] = None,
-    useKeySignature: t.Union[bool, key.KeySignature] = True,
+    useKeySignature: bool|key.KeySignature = True,
     alteredPitches: t.Optional[list[pitch.Pitch]] = None,
     cautionaryPitchClass: bool = True,
     cautionaryAll: bool = False,
@@ -1651,7 +1651,7 @@ def makeAccidentalsInMeasureStream(
     # because we are definitely searching key signature contexts
     # only key.KeySignature values are interesting
     # but method arg is typed this way for backwards compatibility
-    ksLast: t.Union[bool, key.KeySignature] = False
+    ksLast: bool|key.KeySignature = False
     ksLastDiatonic: list[str] = []
 
     if isinstance(useKeySignature, key.KeySignature):

--- a/music21/style.py
+++ b/music21/style.py
@@ -82,28 +82,28 @@ class Style(ProtoM21Object):
     def __init__(self):
         self.size = None
 
-        self.relativeX: float|int|None = None
-        self.relativeY: float|int|None = None
-        self.absoluteX: float|int|None = None
+        self.relativeX: float | int | None = None
+        self.relativeY: float | int | None = None
+        self.absoluteX: float | int | None = None
 
         # managed by property below.
-        self._absoluteY: float|int|None = None
+        self._absoluteY: float | int | None = None
 
-        self._enclosure: Enclosure|None = None
+        self._enclosure: Enclosure | None = None
 
         # how should this symbol be represented in the font?
         # SMuFL characters are allowed.
         self.fontRepresentation = None
 
-        self.color: str|None = None
+        self.color: str | None = None
 
         self.units: str = 'tenths'
         self.hideObjectOnPrint: bool = False
 
-    def _getEnclosure(self) -> Enclosure|None:
+    def _getEnclosure(self) -> Enclosure | None:
         return self._enclosure
 
-    def _setEnclosure(self, value: Enclosure|None):
+    def _setEnclosure(self, value: Enclosure | None):
         if value is None:
             self._enclosure = value
         elif value == Enclosure.NONE:
@@ -270,9 +270,9 @@ class NoteStyle(Style):
 
     def __init__(self):
         super().__init__()
-        self.stemStyle: Style|None = None
-        self.accidentalStyle: Style|None = None
-        self.noteSize: str|None = None  # can be 'cue' etc.
+        self.stemStyle: Style | None = None
+        self.accidentalStyle: Style | None = None
+        self.noteSize: str | None = None  # can be 'cue' etc.
 
 
 class TextStyle(Style):
@@ -626,8 +626,8 @@ class StyleMixin(common.SlottedObjectMixin):
     def __init__(self):
         # no need to call super().__init__() on SlottedObjectMixin
         # This might be dangerous though
-        self._style: Style|None = None
-        self._editorial: editorial.Editorial|None = None
+        self._style: Style | None = None
+        self._editorial: editorial.Editorial | None = None
 
     @property
     def hasStyleInformation(self) -> bool:

--- a/music21/style.py
+++ b/music21/style.py
@@ -82,12 +82,12 @@ class Style(ProtoM21Object):
     def __init__(self):
         self.size = None
 
-        self.relativeX: t.Optional[t.Union[float, int]] = None
-        self.relativeY: t.Optional[t.Union[float, int]] = None
-        self.absoluteX: t.Optional[t.Union[float, int]] = None
+        self.relativeX: float|int|None = None
+        self.relativeY: float|int|None = None
+        self.absoluteX: float|int|None = None
 
         # managed by property below.
-        self._absoluteY: t.Optional[t.Union[float, int]] = None
+        self._absoluteY: float|int|None = None
 
         self._enclosure: Enclosure|None = None
 
@@ -100,10 +100,10 @@ class Style(ProtoM21Object):
         self.units: str = 'tenths'
         self.hideObjectOnPrint: bool = False
 
-    def _getEnclosure(self) -> t.Optional[Enclosure]:
+    def _getEnclosure(self) -> Enclosure|None:
         return self._enclosure
 
-    def _setEnclosure(self, value: t.Optional[Enclosure]):
+    def _setEnclosure(self, value: Enclosure|None):
         if value is None:
             self._enclosure = value
         elif value == Enclosure.NONE:

--- a/music21/style.py
+++ b/music21/style.py
@@ -89,13 +89,13 @@ class Style(ProtoM21Object):
         # managed by property below.
         self._absoluteY: t.Optional[t.Union[float, int]] = None
 
-        self._enclosure: t.Optional[Enclosure] = None
+        self._enclosure: Enclosure|None = None
 
         # how should this symbol be represented in the font?
         # SMuFL characters are allowed.
         self.fontRepresentation = None
 
-        self.color: t.Optional[str] = None
+        self.color: str|None = None
 
         self.units: str = 'tenths'
         self.hideObjectOnPrint: bool = False
@@ -270,9 +270,9 @@ class NoteStyle(Style):
 
     def __init__(self):
         super().__init__()
-        self.stemStyle: t.Optional[Style] = None
-        self.accidentalStyle: t.Optional[Style] = None
-        self.noteSize: t.Optional[str] = None  # can be 'cue' etc.
+        self.stemStyle: Style|None = None
+        self.accidentalStyle: Style|None = None
+        self.noteSize: str|None = None  # can be 'cue' etc.
 
 
 class TextStyle(Style):
@@ -626,8 +626,8 @@ class StyleMixin(common.SlottedObjectMixin):
     def __init__(self):
         # no need to call super().__init__() on SlottedObjectMixin
         # This might be dangerous though
-        self._style: t.Optional[Style] = None
-        self._editorial: t.Optional[editorial.Editorial] = None
+        self._style: Style|None = None
+        self._editorial: editorial.Editorial|None = None
 
     @property
     def hasStyleInformation(self) -> bool:

--- a/music21/style.py
+++ b/music21/style.py
@@ -15,7 +15,6 @@ etc. such that precise positioning information, layout, size, etc. can be specif
 '''
 from __future__ import annotations
 
-import typing as t
 from typing import TYPE_CHECKING
 import unittest
 

--- a/music21/tablature.py
+++ b/music21/tablature.py
@@ -17,7 +17,6 @@ Chord from FretBoard Object with tuning.
 '''
 from __future__ import annotations
 
-import typing as t
 from typing import TYPE_CHECKING
 import unittest
 

--- a/music21/tablature.py
+++ b/music21/tablature.py
@@ -234,7 +234,7 @@ class FretBoard(prebase.ProtoM21Object):
                     self.numStrings
                 ))
 
-        pitchList: list[t.Optional[pitch.Pitch]] = [None] * self.numStrings
+        pitchList: list[pitch.Pitch|None] = [None] * self.numStrings
 
         if not self.fretNotes:
             return pitchList

--- a/music21/tablature.py
+++ b/music21/tablature.py
@@ -234,7 +234,7 @@ class FretBoard(prebase.ProtoM21Object):
                     self.numStrings
                 ))
 
-        pitchList: list[pitch.Pitch|None] = [None] * self.numStrings
+        pitchList: list[pitch.Pitch | None] = [None] * self.numStrings
 
         if not self.fretNotes:
             return pitchList

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -1146,7 +1146,7 @@ class MetricModulation(TempoIndication):
 
     def setOtherByReferent(
         self,
-        side: t.Optional[str] = None,
+        side: str|None = None,
         referent: t.Union[str, int, float] = 1.0
     ):
         '''

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -1145,8 +1145,8 @@ class MetricModulation(TempoIndication):
 
     def setOtherByReferent(
         self,
-        side: str|None = None,
-        referent: str|int|float = 1.0
+        side: str | None = None,
+        referent: str | int | float = 1.0
     ):
         '''
         Set the other side of the metric modulation not based on equality,

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -15,7 +15,6 @@ This module defines objects for describing tempo and changes in tempo.
 from __future__ import annotations
 
 import copy
-import typing as t
 import unittest
 
 from music21 import base

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -1147,7 +1147,7 @@ class MetricModulation(TempoIndication):
     def setOtherByReferent(
         self,
         side: str|None = None,
-        referent: t.Union[str, int, float] = 1.0
+        referent: str|int|float = 1.0
     ):
         '''
         Set the other side of the metric modulation not based on equality,

--- a/music21/test/coverageM21.py
+++ b/music21/test/coverageM21.py
@@ -40,13 +40,12 @@ def getCoverage(overrideVersion=False):
     # (The odds of a failure on the middle version are low if
     # the newest and oldest are passing)
     #
-    # Note the .minor == 9 -- that makes it only run on 3.9
-    # run on Py 3.9 -- to get Py3.10 timing...
+    # Note the .minor == 10 -- that makes it only run on 3.10
     #
     # When changing the version, be sure also to change
     # .github/maincheck.yml's line:
-    #           if: ${{ matrix.python-version == '3.9' }}
-    if overrideVersion or sys.version_info.minor == 9:
+    #           if: ${{ matrix.python-version == '3.10' }}
+    if overrideVersion or sys.version_info.minor == 10:
         try:
             # noinspection PyPackageRequirements
             import coverage  # type: ignore

--- a/music21/test/coverageM21.py
+++ b/music21/test/coverageM21.py
@@ -40,12 +40,12 @@ def getCoverage(overrideVersion=False):
     # (The odds of a failure on the middle version are low if
     # the newest and oldest are passing)
     #
-    # Note the .minor == 10 -- that makes it only run on 3.10
+    # Note the .minor == 10 -- that makes it only run on 3.10.6
     #
     # When changing the version, be sure also to change
     # .github/maincheck.yml's line:
     #           if: ${{ matrix.python-version == '3.10' }}
-    if overrideVersion or sys.version_info.minor == 10:
+    if overrideVersion or (sys.version_info.minor == 10 and sys.version_info.micro == 6):
         try:
             # noinspection PyPackageRequirements
             import coverage  # type: ignore

--- a/music21/test/multiprocessTest.py
+++ b/music21/test/multiprocessTest.py
@@ -40,9 +40,9 @@ environLocal = environment.Environment('test.multiprocessTest')
 
 @dataclasses.dataclass
 class ModuleResponse:
-    returnCode: str|None = None
+    returnCode: str | None = None
     fp: t.Any = None
-    moduleName: str|None = None
+    moduleName: str | None = None
     success: t.Any = None
     testRunner: t.Any = None
     errors: t.Any = None

--- a/music21/test/multiprocessTest.py
+++ b/music21/test/multiprocessTest.py
@@ -40,9 +40,9 @@ environLocal = environment.Environment('test.multiprocessTest')
 
 @dataclasses.dataclass
 class ModuleResponse:
-    returnCode: t.Optional[str] = None
+    returnCode: str|None = None
     fp: t.Any = None
-    moduleName: t.Optional[str] = None
+    moduleName: str|None = None
     success: t.Any = None
     testRunner: t.Any = None
     errors: t.Any = None

--- a/music21/test/testSingleCoreAll.py
+++ b/music21/test/testSingleCoreAll.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 import doctest
 import sys
-import typing as t
 import unittest
 import warnings
 

--- a/music21/test/testSingleCoreAll.py
+++ b/music21/test/testSingleCoreAll.py
@@ -40,7 +40,7 @@ cov = coverageM21.getCoverage()
 
 def main(testGroup: Sequence[str] = ('test',),
          restoreEnvironmentDefaults=False,
-         limit: t.Optional[bool] = None,
+         limit: bool|None = None,
          verbosity=2,
          show: bool = True,
          ):

--- a/music21/test/testSingleCoreAll.py
+++ b/music21/test/testSingleCoreAll.py
@@ -39,7 +39,7 @@ cov = coverageM21.getCoverage()
 
 def main(testGroup: Sequence[str] = ('test',),
          restoreEnvironmentDefaults=False,
-         limit: bool|None = None,
+         limit: bool | None = None,
          verbosity=2,
          show: bool = True,
          ):

--- a/music21/tree/core.py
+++ b/music21/tree/core.py
@@ -18,8 +18,6 @@ absolutely balanced by having O(log n) search times.
 '''
 from __future__ import annotations
 
-import typing as t
-
 from music21 import prebase
 from music21.exceptions21 import TreeException
 from music21 import common

--- a/music21/tree/core.py
+++ b/music21/tree/core.py
@@ -574,7 +574,7 @@ class AVLTree(prebase.ProtoM21Object):
         <AVLNode: Start:1 Height:1 L:0 R:0> '1'
         <AVLNode: Start:0 Height:0 L:None R:None> '0'
         '''
-        def recurse(subListOfTuples) -> t.Optional[AVLNode]:
+        def recurse(subListOfTuples) -> AVLNode|None:
             '''
             Divide and conquer.
             '''

--- a/music21/tree/core.py
+++ b/music21/tree/core.py
@@ -574,7 +574,7 @@ class AVLTree(prebase.ProtoM21Object):
         <AVLNode: Start:1 Height:1 L:0 R:0> '1'
         <AVLNode: Start:0 Height:0 L:None R:None> '0'
         '''
-        def recurse(subListOfTuples) -> AVLNode|None:
+        def recurse(subListOfTuples) -> AVLNode | None:
             '''
             Divide and conquer.
             '''

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -38,7 +38,7 @@ def listOfTreesByClass(
     classLists: Sequence[Sequence[type[M21ObjType]]] = (),
     currentParentage: t.Optional[tuple[stream.Stream, ...]] = None,
     initialOffset: float = 0.0,
-    flatten: t.Union[bool, str] = False,
+    flatten: bool|str = False,
     useTimespans: bool = False
 ) -> list[t.Union[trees.OffsetTree, timespanTree.TimespanTree]]:
     # noinspection PyShadowingNames
@@ -282,7 +282,7 @@ def asTree(
     if (inputStream.isSorted
             and groupOffsets is False  # currently we can't populate for an OffsetTree*
             and (inputStream.isFlat or flatten is False)):
-        outputTree: t.Union[trees.OffsetTree, trees.ElementTree] = treeClass(source=inputStream)
+        outputTree: trees.OffsetTree|trees.ElementTree = treeClass(source=inputStream)
         return makeFastShallowTreeFromSortedStream(inputStream,
                                                    outputTree=outputTree,
                                                    classList=classList)
@@ -321,7 +321,7 @@ def makeFastShallowTreeFromSortedStream(
 def asTimespans(
     inputStream,
     *,
-    flatten: t.Union[str, bool] = False,
+    flatten: str|bool = False,
     classList: t.Optional[Sequence[type[Music21Object]]] = None
 ) -> timespanTree.TimespanTree:
     r'''

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -36,11 +36,11 @@ def listOfTreesByClass(
     inputStream: StreamType,
     *,
     classLists: Sequence[Sequence[type[M21ObjType]]] = (),
-    currentParentage: tuple[stream.Stream, ...]|None = None,
+    currentParentage: tuple[stream.Stream, ...] | None = None,
     initialOffset: float = 0.0,
-    flatten: bool|str = False,
+    flatten: bool | str = False,
     useTimespans: bool = False
-) -> list[trees.OffsetTree|timespanTree.TimespanTree]:
+) -> list[trees.OffsetTree | timespanTree.TimespanTree]:
     # noinspection PyShadowingNames
     r'''
     To be DEPRECATED in v8: this is no faster than calling streamToTimespanTree
@@ -160,11 +160,11 @@ def listOfTreesByClass(
 def asTree(
     inputStream: StreamType,
     *,
-    flatten: t.Literal['semiFlat']|bool = False,
-    classList: Sequence[type]|None = None,
+    flatten: t.Literal['semiFlat'] | bool = False,
+    classList: Sequence[type] | None = None,
     useTimespans: bool = False,
     groupOffsets: bool = False
-) -> trees.OffsetTree|trees.ElementTree|timespanTree.TimespanTree:
+) -> trees.OffsetTree | trees.ElementTree | timespanTree.TimespanTree:
     '''
     Converts a Stream and constructs an :class:`~music21.tree.trees.ElementTree` based on this.
 
@@ -282,7 +282,7 @@ def asTree(
     if (inputStream.isSorted
             and groupOffsets is False  # currently we can't populate for an OffsetTree*
             and (inputStream.isFlat or flatten is False)):
-        outputTree: trees.OffsetTree|trees.ElementTree = treeClass(source=inputStream)
+        outputTree: trees.OffsetTree | trees.ElementTree = treeClass(source=inputStream)
         return makeFastShallowTreeFromSortedStream(inputStream,
                                                    outputTree=outputTree,
                                                    classList=classList)
@@ -294,9 +294,9 @@ def asTree(
 def makeFastShallowTreeFromSortedStream(
     inputStream: stream.Stream,
     *,
-    outputTree: trees.OffsetTree|trees.ElementTree,
-    classList: Sequence[type]|None = None,
-) -> trees.OffsetTree|trees.ElementTree:
+    outputTree: trees.OffsetTree | trees.ElementTree,
+    classList: Sequence[type] | None = None,
+) -> trees.OffsetTree | trees.ElementTree:
     '''
     Use populateFromSortedList to quickly make a tree from a stream.
 
@@ -321,8 +321,8 @@ def makeFastShallowTreeFromSortedStream(
 def asTimespans(
     inputStream,
     *,
-    flatten: str|bool = False,
-    classList: Sequence[type[Music21Object]]|None = None
+    flatten: str | bool = False,
+    classList: Sequence[type[Music21Object]] | None = None
 ) -> timespanTree.TimespanTree:
     r'''
     Recurses through a score and constructs a

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -36,11 +36,11 @@ def listOfTreesByClass(
     inputStream: StreamType,
     *,
     classLists: Sequence[Sequence[type[M21ObjType]]] = (),
-    currentParentage: t.Optional[tuple[stream.Stream, ...]] = None,
+    currentParentage: tuple[stream.Stream, ...]|None = None,
     initialOffset: float = 0.0,
     flatten: bool|str = False,
     useTimespans: bool = False
-) -> list[t.Union[trees.OffsetTree, timespanTree.TimespanTree]]:
+) -> list[trees.OffsetTree|timespanTree.TimespanTree]:
     # noinspection PyShadowingNames
     r'''
     To be DEPRECATED in v8: this is no faster than calling streamToTimespanTree
@@ -160,11 +160,11 @@ def listOfTreesByClass(
 def asTree(
     inputStream: StreamType,
     *,
-    flatten: t.Union[t.Literal['semiFlat'], bool] = False,
-    classList: t.Optional[Sequence[type]] = None,
+    flatten: t.Literal['semiFlat']|bool = False,
+    classList: Sequence[type]|None = None,
     useTimespans: bool = False,
     groupOffsets: bool = False
-) -> t.Union[trees.OffsetTree, trees.ElementTree, timespanTree.TimespanTree]:
+) -> trees.OffsetTree|trees.ElementTree|timespanTree.TimespanTree:
     '''
     Converts a Stream and constructs an :class:`~music21.tree.trees.ElementTree` based on this.
 
@@ -294,9 +294,9 @@ def asTree(
 def makeFastShallowTreeFromSortedStream(
     inputStream: stream.Stream,
     *,
-    outputTree: t.Union[trees.OffsetTree, trees.ElementTree],
-    classList: t.Optional[Sequence[type]] = None,
-) -> t.Union[trees.OffsetTree, trees.ElementTree]:
+    outputTree: trees.OffsetTree|trees.ElementTree,
+    classList: Sequence[type]|None = None,
+) -> trees.OffsetTree|trees.ElementTree:
     '''
     Use populateFromSortedList to quickly make a tree from a stream.
 
@@ -322,7 +322,7 @@ def asTimespans(
     inputStream,
     *,
     flatten: str|bool = False,
-    classList: t.Optional[Sequence[type[Music21Object]]] = None
+    classList: Sequence[type[Music21Object]]|None = None
 ) -> timespanTree.TimespanTree:
     r'''
     Recurses through a score and constructs a

--- a/music21/tree/trees.py
+++ b/music21/tree/trees.py
@@ -96,7 +96,7 @@ class ElementTree(core.AVLTree):
     6.0
     '''
     # TYPING #
-    rootNode: nodeModule.ElementNode|None
+    rootNode: nodeModule.ElementNode | None
 
     # CLASS VARIABLES #
     nodeClass = nodeModule.ElementNode
@@ -553,7 +553,7 @@ class ElementTree(core.AVLTree):
         <ElementNode: Start:36.0 <0.-5...> Indices:(l:193 *194* r:195)
             Payload:<music21.bar.Barline type=final>>
         '''
-        def recurse(subListOfTuples, globalStartOffset) -> core.AVLNode|None:
+        def recurse(subListOfTuples, globalStartOffset) -> core.AVLNode | None:
             '''
             Divide and conquer.
             '''
@@ -898,7 +898,7 @@ class OffsetTree(ElementTree):
     __slots__ = ()
 
     # TYPING #
-    rootNode: nodeModule.OffsetNode|None
+    rootNode: nodeModule.OffsetNode | None
 
     nodeClass = nodeModule.OffsetNode
 

--- a/music21/tree/trees.py
+++ b/music21/tree/trees.py
@@ -96,7 +96,7 @@ class ElementTree(core.AVLTree):
     6.0
     '''
     # TYPING #
-    rootNode: t.Optional[nodeModule.ElementNode]
+    rootNode: nodeModule.ElementNode|None
 
     # CLASS VARIABLES #
     nodeClass = nodeModule.ElementNode
@@ -553,7 +553,7 @@ class ElementTree(core.AVLTree):
         <ElementNode: Start:36.0 <0.-5...> Indices:(l:193 *194* r:195)
             Payload:<music21.bar.Barline type=final>>
         '''
-        def recurse(subListOfTuples, globalStartOffset) -> t.Optional[core.AVLNode]:
+        def recurse(subListOfTuples, globalStartOffset) -> core.AVLNode|None:
             '''
             Divide and conquer.
             '''
@@ -898,7 +898,7 @@ class OffsetTree(ElementTree):
     __slots__ = ()
 
     # TYPING #
-    rootNode: t.Optional[nodeModule.OffsetNode]
+    rootNode: nodeModule.OffsetNode|None
 
     nodeClass = nodeModule.OffsetNode
 

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -337,7 +337,7 @@ class Verticality(prebase.ProtoM21Object):
         return self.startTimespans[0].measureNumber
 
     @property
-    def nextStartOffset(self) -> float|None:
+    def nextStartOffset(self) -> float | None:
         r'''
         Gets the next start-offset in the verticality's offset-tree.
 
@@ -536,7 +536,7 @@ class Verticality(prebase.ProtoM21Object):
         return tuple(self.startTimespans[:] + self.overlapTimespans[:])
 
     @property
-    def timeToNextEvent(self) -> OffsetQL|None:
+    def timeToNextEvent(self) -> OffsetQL | None:
         '''
         Returns a float or Fraction of the quarterLength to the next
         event (usually the next Verticality, but also to the end of the piece).
@@ -555,7 +555,7 @@ class Verticality(prebase.ProtoM21Object):
 
     def makeElement(
         self,
-        quarterLength: OffsetQLIn|None = None,
+        quarterLength: OffsetQLIn | None = None,
         *,
         addTies=True,
         addPartIdAsGroup=False,
@@ -563,7 +563,7 @@ class Verticality(prebase.ProtoM21Object):
         gatherArticulations='single',
         gatherExpressions='single',
         copyPitches=True,
-    ) -> note.Rest|chord.Chord:
+    ) -> note.Rest | chord.Chord:
         # noinspection PyDunderSlots, PyShadowingNames
         r'''
         Makes a Chord or Rest from this verticality and quarterLength.

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -337,7 +337,7 @@ class Verticality(prebase.ProtoM21Object):
         return self.startTimespans[0].measureNumber
 
     @property
-    def nextStartOffset(self) -> t.Optional[float]:
+    def nextStartOffset(self) -> float|None:
         r'''
         Gets the next start-offset in the verticality's offset-tree.
 
@@ -536,7 +536,7 @@ class Verticality(prebase.ProtoM21Object):
         return tuple(self.startTimespans[:] + self.overlapTimespans[:])
 
     @property
-    def timeToNextEvent(self) -> t.Optional[OffsetQL]:
+    def timeToNextEvent(self) -> OffsetQL|None:
         '''
         Returns a float or Fraction of the quarterLength to the next
         event (usually the next Verticality, but also to the end of the piece).
@@ -563,7 +563,7 @@ class Verticality(prebase.ProtoM21Object):
         gatherArticulations='single',
         gatherExpressions='single',
         copyPitches=True,
-    ) -> t.Union[note.Rest, chord.Chord]:
+    ) -> note.Rest|chord.Chord:
         # noinspection PyDunderSlots, PyShadowingNames
         r'''
         Makes a Chord or Rest from this verticality and quarterLength.

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 import copy
 import itertools
-import typing as t
 import unittest
 
 from music21 import chord

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -555,7 +555,7 @@ class Verticality(prebase.ProtoM21Object):
 
     def makeElement(
         self,
-        quarterLength: t.Union[OffsetQLIn, None] = None,
+        quarterLength: OffsetQLIn|None = None,
         *,
         addTies=True,
         addPartIdAsGroup=False,

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -1387,8 +1387,8 @@ def mergePartAsOssia(mainPart, ossiaPart, ossiaName,
 
 def addVariant(
     s: stream.Stream,
-    startOffset: t.Union[int, float],
-    sVariant: t.Union[stream.Stream, Variant],
+    startOffset: int|float,
+    sVariant: stream.Stream|Variant,
     variantName=None,
     variantGroups=None,
     replacementDuration=None

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -97,7 +97,7 @@ class Variant(base.Music21Object):
         givenElements: t.Union[None,
                                base.Music21Object,
                                Sequence[base.Music21Object]] = None,
-        name: str|None = None,
+        name: str | None = None,
         givenElementsBehavior: GivenElementsBehavior = GivenElementsBehavior.OFFSETS,
         **music21ObjectKeywords,
     ):
@@ -1387,8 +1387,8 @@ def mergePartAsOssia(mainPart, ossiaPart, ossiaName,
 
 def addVariant(
     s: stream.Stream,
-    startOffset: int|float,
-    sVariant: stream.Stream|Variant,
+    startOffset: int | float,
+    sVariant: stream.Stream | Variant,
     variantName=None,
     variantGroups=None,
     replacementDuration=None

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -97,7 +97,7 @@ class Variant(base.Music21Object):
         givenElements: t.Union[None,
                                base.Music21Object,
                                Sequence[base.Music21Object]] = None,
-        name: t.Optional[str] = None,
+        name: str|None = None,
         givenElementsBehavior: GivenElementsBehavior = GivenElementsBehavior.OFFSETS,
         **music21ObjectKeywords,
     ):

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -135,7 +135,7 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
             self.velocityIsRelative = other.velocityIsRelative
 
     def getRealizedStr(self,
-                       useDynamicContext: dynamics.Dynamic|bool = True,
+                       useDynamicContext: dynamics.Dynamic | bool = True,
                        useVelocity=True,
                        useArticulations: t.Union[bool,
                                                  articulations.Articulation,
@@ -159,7 +159,7 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
 
     def getRealized(
         self,
-        useDynamicContext: bool|dynamics.Dynamic = True,
+        useDynamicContext: bool | dynamics.Dynamic = True,
         useVelocity=True,
         useArticulations: t.Union[
             bool, articulations.Articulation, Iterable[articulations.Articulation]

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -135,7 +135,7 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
             self.velocityIsRelative = other.velocityIsRelative
 
     def getRealizedStr(self,
-                       useDynamicContext: t.Union[dynamics.Dynamic, bool] = True,
+                       useDynamicContext: dynamics.Dynamic|bool = True,
                        useVelocity=True,
                        useArticulations: t.Union[bool,
                                                  articulations.Articulation,
@@ -159,7 +159,7 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
 
     def getRealized(
         self,
-        useDynamicContext: t.Union[bool, dynamics.Dynamic] = True,
+        useDynamicContext: bool|dynamics.Dynamic = True,
         useVelocity=True,
         useArticulations: t.Union[
             bool, articulations.Articulation, Iterable[articulations.Articulation]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = [
 description = "A Toolkit for Computer-Aided Musical Analysis and Computational Musicology."
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -29,7 +29,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Artistic Software",


### PR DESCRIPTION
To make music21 able to be developed faster and more of a joy for the dev team to work on, music21 will now support only Python 3.10+ for now, and drop its prior policy of supporting previous 3 versions.

Major bug fixes might appear in patches to older versions.

Because we want one fast build that is required to pass and one slower build to measure code coverage, but Py 3.11 is not ready to run dependencies yet, we're running coverage on 3.10.6 and fast tests on 3.10-latest (currently 3.10.7)