### PR TITLE
romanText/numerals substantial improvements; MXL4.0

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ Changing this number invalidates old pickles -- do it if the old pickles create 
 '''
 from __future__ import annotations
 
-__version__ = '9.0.0a1'
+__version__ = '9.0.0a2'
 
 
 def get_version_tuple(vv):

--- a/music21/base.py
+++ b/music21/base.py
@@ -27,7 +27,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'9.0.0a1'
+'9.0.0a2'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/defaults.py
+++ b/music21/defaults.py
@@ -34,7 +34,7 @@ class DefaultsException(Exception):
 title = 'Music21 Fragment'
 author = 'Music21'
 software = 'music21 v.' + _version.__version__  # used in xml encoding source software
-musicxmlVersion = '3.1'
+musicxmlVersion = '4.0'
 
 meterNumerator = 4
 meterDenominator = 'quarter'

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -429,7 +429,7 @@ class Harmony(chord.Chord):
             if not self.pitches:
                 return roman.RomanNumeral()
 
-
+            # what is manipulating this so that write as chord matters?
             storedWriteAsChord = self._writeAsChord
             self.writeAsChord = True
             if self.key is None:
@@ -760,7 +760,7 @@ def changeAbbreviationFor(chordType, changeTo):
     CHORD_TYPES[chordType][1].insert(0, changeTo)
 
 
-def chordSymbolFigureFromChord(inChord, includeChordType=False):
+def chordSymbolFigureFromChord(inChord: chord.Chord, includeChordType=False):
     # noinspection SpellCheckingInspection
     '''
     Analyze the given chord, and attempt to describe its pitches using a
@@ -1323,7 +1323,7 @@ def chordSymbolFigureFromChord(inChord, includeChordType=False):
         return cs
 
 
-def chordSymbolFromChord(inChord):
+def chordSymbolFromChord(inChord: chord.Chord) -> ChordSymbol:
     '''
     Get the :class:`~music21.harmony.chordSymbol` object from the chord, using
     :meth:`music21.harmony.Harmony.chordSymbolFigureFromChord`

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -5398,6 +5398,41 @@ class MeasureExporter(XMLExporterBase):
           <kind>diminished-seventh</kind>
           <inversion>1</inversion>
         </harmony>
+
+        >>> maj6 = roman.RomanNumeral('VI7', 'd')
+        >>> maj6.writeAsChord = False
+        >>> mxHarmonyFromRN = MEX.romanNumeralToXml(maj6)
+        >>> MEX.dump(mxHarmonyFromRN)
+        <harmony>
+          <numeral>
+            <numeral-root text="VI7">6</numeral-root>
+            <numeral-key print-object="no">
+              <numeral-fifths>-1</numeral-fifths>
+              <numeral-mode>natural minor</numeral-mode>
+            </numeral-key>
+          </numeral>
+          <kind>major-seventh</kind>
+        </harmony>
+
+        >>> min6 = roman.RomanNumeral('vi', 'd')
+        >>> min6.writeAsChord = False
+        >>> mxHarmonyFromRN = MEX.romanNumeralToXml(min6)
+        >>> mxHarmonyFromRN.find('.//numeral-mode').text
+        'melodic minor'
+
+        >>> dim7 = roman.RomanNumeral('viiø65', 'd')
+        >>> dim7.writeAsChord = False
+        >>> mxHarmonyFromRN = MEX.romanNumeralToXml(dim7)
+        >>> mxHarmonyFromRN.find('.//numeral-mode').text
+        'harmonic minor'
+        >>> mxHarmonyFromRN.find('kind').text
+        'half-diminished'
+
+        >>> maj7 = roman.RomanNumeral('VII64', 'd')
+        >>> maj7.writeAsChord = False
+        >>> mxHarmonyFromRN = MEX.romanNumeralToXml(maj7)
+        >>> mxHarmonyFromRN.find('.//numeral-mode').text
+        'natural minor'
         '''
         if rn.writeAsChord is True:
             return self.chordToXml(rn)
@@ -5406,6 +5441,7 @@ class MeasureExporter(XMLExporterBase):
         # create a new chordSymbol in order to get the musicxml "kind"
         # a little slower than needs to be.
         cs = harmony.chordSymbolFromChord(rn)
+        cs.offset = rn.offset  # needed for not getting an extra offset tag w/ forward.
         mxHarmony = self.chordSymbolToXml(cs, append=False)
         mxRoot = mxHarmony.find('root')
         mxHarmony.remove(mxRoot)
@@ -5437,12 +5473,12 @@ class MeasureExporter(XMLExporterBase):
                 modeText = 'minor'
             elif rn.scaleDegree == 6:
                 # simplest way to figure this out.
-                if (rnRoot.pitchClass - rn.key.tonic.pitchClass) % 12 == 8:
+                if (rn.root().pitchClass - rn.key.tonic.pitchClass) % 12 == 8:
                     modeText = 'natural minor'
                 else:
                     modeText = 'melodic minor'
             else:
-                if (rnRoot.pitchClass - rn.key.tonic.pitchClass) % 12 == 10:
+                if (rn.root().pitchClass - rn.key.tonic.pitchClass) % 12 == 10:
                     modeText = 'natural minor'
                 else:
                     modeText = 'harmonic minor'

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -3252,9 +3252,12 @@ class MeasureExporter(XMLExporterBase):
 
             notesForLater = []
             for obj in objGroup:
-                # we do all non-note elements (including ChordSymbols)
+                # we do all non-note elements (including ChordSymbols not written as chord)
                 # first before note elements, in musicxml
-                if isinstance(obj, note.GeneralNote) and not isinstance(obj, harmony.Harmony):
+                if isinstance(obj, note.GeneralNote) and (
+                    not (isHarm := isinstance(obj, harmony.Harmony))
+                    or (isHarm and obj.writeAsChord)
+                ):
                     notesForLater.append(obj)
                 else:
                     self.parseOneElement(obj)

--- a/music21/musicxml/test_m21ToXml.py
+++ b/music21/musicxml/test_m21ToXml.py
@@ -780,7 +780,7 @@ class Test(unittest.TestCase):
 
     def test_roman_musicxml_two_kinds(self):
         from music21.roman import RomanNumeral
-        
+
         # normal roman numerals take up no time in xml output.
         rn1 = RomanNumeral('I', 'C')
         rn1.duration.type = 'half'

--- a/music21/musicxml/test_m21ToXml.py
+++ b/music21/musicxml/test_m21ToXml.py
@@ -778,6 +778,41 @@ class Test(unittest.TestCase):
         # No <forward> tag is necessary to finish the incomplete measure (3.9979 -> 4.0)
         self.assertEqual(len(tree.findall('.//forward')), 1)
 
+    def test_roman_musicxml_two_kinds(self):
+        from music21.roman import RomanNumeral
+        
+        # normal roman numerals take up no time in xml output.
+        rn1 = RomanNumeral('I', 'C')
+        rn1.duration.type = 'half'
+        rn2 = RomanNumeral('V', 'C')
+        rn2.duration.type = 'half'
+
+        m = stream.Measure()
+        m.insert(0.0, rn1)
+        m.insert(2.0, rn2)
+
+        # with writeAsChord=True, they get their own Chord objects and durations.
+        self.assertTrue(rn1.writeAsChord)
+        xmlOut = GeneralObjectExporter().parse(m).decode('utf-8')
+        self.assertNotIn('<forward>', xmlOut)
+        self.assertIn('<chord', xmlOut)
+
+        rn1.writeAsChord = False
+        rn2.writeAsChord = False
+        xmlOut = GeneralObjectExporter().parse(m).decode('utf-8')
+        self.assertIn('<numeral', xmlOut)
+        self.assertIn('<forward>', xmlOut)
+        self.assertNotIn('<chord', xmlOut)
+        self.assertNotIn('<offset', xmlOut)
+        self.assertNotIn('<rest', xmlOut)
+
+        rn1.duration.quarterLength = 0.0
+        rn2.duration.quarterLength = 0.0
+        xmlOut = GeneralObjectExporter().parse(m).decode('utf-8')
+        self.assertIn('<rest', xmlOut)
+        self.assertNotIn('<forward>', xmlOut)
+
+
 
 class TestExternal(unittest.TestCase):
     show = True

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -853,7 +853,7 @@ class MusicXMLImporter(XMLParserBase):
         self.partGroupList = []
         self.parts = []
 
-        self.musicXmlVersion = '3.1'
+        self.musicXmlVersion = defaults.musicxmlVersion
 
     def scoreFromFile(self, filename):
         '''

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2303,9 +2303,10 @@ class RomanNumeral(harmony.Harmony):
         self.seventhMinor = seventhMinor
 
         super().__init__(figure, updatePitches=updatePitches, **keywords)
+        self.writeAsChord = True  # override from Harmony/ChordSymbol
         self._parsingComplete = True
         self._functionalityScore: t.Optional[int] = None
-        self.editorial.followsKeyChange = False
+        self.followsKeyChange = False
 
     # SPECIAL METHODS #
 
@@ -4381,6 +4382,31 @@ class Test(unittest.TestCase):
         self.assertEqual(rn.seventh.name, 'A-')
         rn = RomanNumeral('bVII7', 'C', seventhMinor=Minor67Default.CAUTIONARY)
         self.assertEqual(rn.seventh.name, 'A')
+
+    def test_musicxml_two_kinds(self):
+        from music21.musicxml.m21ToXml import GeneralObjectExporter
+        from music21 import stream
+
+        # normal roman numerals take up no time in xml output.
+        rn1 = RomanNumeral('I', 'C')
+        rn2 = RomanNumeral('V', 'C')
+
+        m = stream.Measure()
+        m.insert(0.0, rn1)
+        m.insert(2.0, rn2)
+
+        # with writeAsChord=True, they get their own Chord objects and durations.
+        self.assertTrue(rn1.writeAsChord)
+        xmlOut = GeneralObjectExporter().parse(m).decode('utf-8')
+        self.assertNotIn('<forward>', xmlOut)
+        self.assertIn('<chord', xmlOut)
+
+        rn1.writeAsChord = True
+        rn2.writeAsChord = True
+        rn1.duration.type = 'half'
+        xmlOut = GeneralObjectExporter().parse(m).decode('utf-8')
+        self.assertIn('<forward>', xmlOut)
+        self.assertNotIn('<chord', xmlOut)
 
 
 class TestExternal(unittest.TestCase):

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -4383,31 +4383,6 @@ class Test(unittest.TestCase):
         rn = RomanNumeral('bVII7', 'C', seventhMinor=Minor67Default.CAUTIONARY)
         self.assertEqual(rn.seventh.name, 'A')
 
-    def test_musicxml_two_kinds(self):
-        from music21.musicxml.m21ToXml import GeneralObjectExporter
-        from music21 import stream
-
-        # normal roman numerals take up no time in xml output.
-        rn1 = RomanNumeral('I', 'C')
-        rn2 = RomanNumeral('V', 'C')
-
-        m = stream.Measure()
-        m.insert(0.0, rn1)
-        m.insert(2.0, rn2)
-
-        # with writeAsChord=True, they get their own Chord objects and durations.
-        self.assertTrue(rn1.writeAsChord)
-        xmlOut = GeneralObjectExporter().parse(m).decode('utf-8')
-        self.assertNotIn('<forward>', xmlOut)
-        self.assertIn('<chord', xmlOut)
-
-        rn1.writeAsChord = True
-        rn2.writeAsChord = True
-        rn1.duration.type = 'half'
-        xmlOut = GeneralObjectExporter().parse(m).decode('utf-8')
-        self.assertIn('<forward>', xmlOut)
-        self.assertNotIn('<chord', xmlOut)
-
 
 class TestExternal(unittest.TestCase):
     show = True

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2244,6 +2244,7 @@ class RomanNumeral(harmony.Harmony):
         updatePitches=True,
         sixthMinor=Minor67Default.QUALITY,
         seventhMinor=Minor67Default.QUALITY,
+        **keywords,
     ):
         self.primaryFigure: str = ''
         self.secondaryRomanNumeral: t.Optional[RomanNumeral] = None
@@ -2299,7 +2300,7 @@ class RomanNumeral(harmony.Harmony):
         self.sixthMinor = sixthMinor
         self.seventhMinor = seventhMinor
 
-        super().__init__(figure, updatePitches=updatePitches)
+        super().__init__(figure, updatePitches=updatePitches, **keywords)
         self._parsingComplete = True
         self._functionalityScore: t.Optional[int] = None
         self.editorial.followsKeyChange = False

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -210,7 +210,7 @@ def _copySingleMeasure(rtTagged, p, kCurrent):
                     # should not happen
                     raise RomanTextTranslateException(
                         'attempting to copy a measure but no past key definitions are found')
-                if rnPast.editorial.get('followsKeyChange'):
+                if rnPast.followsKeyChange:
                     kCurrent = rnPast.key
                 elif rnPast.pivotChord is not None:
                     kCurrent = rnPast.pivotChord.key
@@ -279,7 +279,7 @@ def _copyMultipleMeasures(rtMeasure: rtObjects.RTMeasure,
                     # should not happen
                     raise RomanTextTranslateException(
                         'attempting to copy a measure but no past key definitions are found')
-                if rnPast.editorial.get('followsKeyChange'):
+                if rnPast.followsKeyChange:
                     kCurrent = rnPast.key
                 elif rnPast.pivotChord is not None:
                     kCurrent = rnPast.pivotChord.key
@@ -880,10 +880,10 @@ class PartTranslator:
             # 19.01
 
             if self.setKeyChangeToken is True:
-                rn.editorial.followsKeyChange = True
+                rn.followsKeyChange = True
                 self.setKeyChangeToken = False
             else:
-                rn.editorial.followsKeyChange = False
+                rn.followsKeyChange = False
         except (roman.RomanNumeralException,
                 exceptions21.Music21CommonException):  # pragma: no cover
             # environLocal.printDebug(f' cannot create RN from: {a.src}')

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -217,7 +217,8 @@ def _copySingleMeasure(rtTagged, p, kCurrent):
                 else:
                     rnPast.key = kCurrent
                 if rnPast.secondaryRomanNumeral is not None:
-                    newRN = roman.RomanNumeral(rnPast.figure, kCurrent)
+                    newRN = roman.RomanNumeral(rnPast.figure, copy.deepcopy(kCurrent))
+                    newRN.writeAsChord = True
                     newRN.duration = copy.deepcopy(rnPast.duration)
                     newRN.lyrics = copy.deepcopy(rnPast.lyrics)
                     m.replace(rnPast, newRN)
@@ -283,7 +284,8 @@ def _copyMultipleMeasures(rtMeasure: rtObjects.RTMeasure,
                 else:
                     rnPast.key = kCurrent
                 if rnPast.secondaryRomanNumeral is not None:
-                    newRN = roman.RomanNumeral(rnPast.figure, kCurrent)
+                    newRN = roman.RomanNumeral(rnPast.figure, copy.deepcopy(kCurrent))
+                    newRN.writeAsChord = True
                     newRN.duration = copy.deepcopy(rnPast.duration)
                     newRN.lyrics = copy.deepcopy(rnPast.lyrics)
                     m.replace(rnPast, newRN)
@@ -849,6 +851,7 @@ class PartTranslator:
                                         sixthMinor=self.sixthMinor,
                                         seventhMinor=self.seventhMinor,
                                         )
+                rn.writeAsChord = True
                 _rnKeyCache[cacheTuple] = rn
             # surprisingly, not faster... and more dangerous
             # rn = roman.RomanNumeral(aSrc, kCurrent)

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -217,7 +217,9 @@ def _copySingleMeasure(rtTagged, p, kCurrent):
                 else:
                     rnPast.key = kCurrent
                 if rnPast.secondaryRomanNumeral is not None:
-                    newRN = roman.RomanNumeral(rnPast.figure, copy.deepcopy(kCurrent))
+                    newRN = roman.RomanNumeral(
+                        rnPast.figure, copy.deepcopy(kCurrent)
+                    )
                     newRN.writeAsChord = True
                     newRN.duration = copy.deepcopy(rnPast.duration)
                     newRN.lyrics = copy.deepcopy(rnPast.lyrics)
@@ -284,7 +286,9 @@ def _copyMultipleMeasures(rtMeasure: rtObjects.RTMeasure,
                 else:
                     rnPast.key = kCurrent
                 if rnPast.secondaryRomanNumeral is not None:
-                    newRN = roman.RomanNumeral(rnPast.figure, copy.deepcopy(kCurrent))
+                    newRN = roman.RomanNumeral(
+                        rnPast.figure, copy.deepcopy(kCurrent)
+                    )
                     newRN.writeAsChord = True
                     newRN.duration = copy.deepcopy(rnPast.duration)
                     newRN.lyrics = copy.deepcopy(rnPast.lyrics)
@@ -1084,7 +1088,8 @@ def fixPickupMeasure(partObject):
     Fix a pickup measure if any.
 
     We determine a pickup measure by being measure 0 and not having an RN
-    object at the beginning.
+    object at the beginning.  Will also pad the last measure right and
+    cut the duration of the final chord to match.
 
     Demonstration: an otherwise incorrect part
 
@@ -1094,11 +1099,13 @@ def fixPickupMeasure(partObject):
     >>> k0 = key.Key('G')
     >>> m0.insert(0, k0)
     >>> m0.insert(0, meter.TimeSignature('4/4'))
-    >>> m0.insert(2, roman.RomanNumeral('V', k0))
+    >>> m0.insert(3, roman.RomanNumeral('I', k0, quarterLength=1.0))
     >>> m1 = stream.Measure()
     >>> m1.number = 1
+    >>> m1.append(roman.RomanNumeral('V', k0, quarterLength=4.0))
     >>> m2 = stream.Measure()
     >>> m2.number = 2
+    >>> m2.append(roman.RomanNumeral('I', k0, quarterLength=4.0))
     >>> p.insert(0, m0)
     >>> p.insert(4, m1)
     >>> p.insert(8, m2)
@@ -1110,32 +1117,51 @@ def fixPickupMeasure(partObject):
     {0.0} <music21.stream.Measure 0 offset=0.0>
         {0.0} <music21.key.Key of G major>
         {0.0} <music21.meter.TimeSignature 4/4>
+        {0.0} <music21.roman.RomanNumeral I in G major>
+    {1.0} <music21.stream.Measure 1 offset=1.0>
         {0.0} <music21.roman.RomanNumeral V in G major>
-    {2.0} <music21.stream.Measure 1 offset=2.0>
-    <BLANKLINE>
-    {6.0} <music21.stream.Measure 2 offset=6.0>
-    <BLANKLINE>
+    {5.0} <music21.stream.Measure 2 offset=5.0>
+        {0.0} <music21.roman.RomanNumeral I in G major>
+
     >>> m0.paddingLeft
-    2.0
+    3.0
+    >>> m2.paddingRight
+    1.0
+    >>> m2[roman.RomanNumeral].last().duration
+    <music21.duration.Duration 3.0>
     '''
     m0 = partObject.measure(0)
     if m0 is None:
         return
-    rnObjects = m0.getElementsByClass(roman.RomanNumeral)
+    rnObjects = m0.getElementsByClass([roman.RomanNumeral, harmony.NoChord])
     if not rnObjects:
         return
     if rnObjects[0].offset == 0:
         return
-    newPadding = rnObjects[0].offset
+    leftPadding = rnObjects[0].offset
     for el in m0:
-        if el.offset < newPadding:  # should be zero for Clefs, etc.
+        if el.offset < leftPadding:  # should be zero for Clefs, etc.
             pass
         else:
-            el.offset = el.offset - newPadding
-    m0.paddingLeft = newPadding
-    for el in partObject:  # adjust all other measures backwards
+            el.offset = el.offset - leftPadding
+    m0.paddingLeft = leftPadding
+    for el in partObject:  # adjust all other measures etc. backwards
         if el.offset > 0:
-            el.offset -= newPadding
+            el.offset -= leftPadding
+    mLast = partObject.getElementsByClass(stream.Measure).last()
+    if mLast is m0:
+        return
+
+    lastRN = mLast.getElementsByClass([roman.RomanNumeral, harmony.NoChord]).last()
+    if lastRN and lastRN.duration.quarterLength > leftPadding:
+        curLastLength = mLast.duration.quarterLength
+        lastRN.duration.quarterLength -= curLastLength - leftPadding
+        mLast.paddingRight = curLastLength - leftPadding
+        i = -1
+        while partObject[i] is not mLast:
+            # unprocessed metadata after last object
+            partObject[i].setOffsetBySite(partObject, partObject[i].offset - mLast.paddingRight)
+            i -= 1
 
 
 def romanTextToStreamOpus(rtHandler, inputM21=None):


### PR DESCRIPTION
RomanNumerals were creating false forwards.

RomanNumerals did not have "writeAsChord" on by default as had been documented, but they were being written as chords all the time no matter what.

Write out MusicXML 4.0 compatible harmony/numeral figures.

Also fix problem for RN transposition from RomanText that measure copied RNs share a Key.