### PR TITLE
Strike through deprecated in docs

### DIFF
--- a/documentation/docbuild/documenters.py
+++ b/documentation/docbuild/documenters.py
@@ -80,7 +80,7 @@ class Documenter:
 
 class ObjectDocumenter(Documenter):
     '''
-    Base class for object documenting sub-classes. such as ClassDocumenter
+    Base class for object documenting subclasses. such as ClassDocumenter
     '''
 
     _DOC_ATTR: dict[str, str] = {
@@ -195,15 +195,15 @@ class MemberDocumenter(ObjectDocumenter):
     '''
     _DOC_ATTR: dict[str, str] = {
         'memberName': 'the short name of the member, for instance "mode"',
-        'referent': '''the attribute or method itself, such as (no quotes)
-                       key.KeySignature.mode''',
-        'definingClass': '''the class the referent belongs to, such as (no quotes)
-                            key.KeySignature''',
+        'referent': '''the attribute or method itself, such as
+                       <function KeySignature.mode at ...>''',
+        'definingClass': '''the class the referent belongs to, such as
+                            <class 'music21.key.KeySignature'>''',
     }
 
     # INITIALIZER #
 
-    def __init__(self, referent, memberName, definingClass):
+    def __init__(self, referent, memberName: str, definingClass: type):
         if not isinstance(definingClass, type):
             raise Music21Exception(f'referent must be a class, not {referent}')
         super().__init__(referent)
@@ -271,7 +271,12 @@ class MethodDocumenter(MemberDocumenter):
     @property
     def rstAutodocDirectiveFormat(self):
         result = []
-        result.append(f'.. automethod:: {self.referentPackageSystemPath}')
+        indent = ''
+        if getattr(self.referent, '_isDeprecated', False):
+            indent = '    '
+            result.append(f'.. cssclass:: strike')
+            result.append('')
+        result.append(f'{indent}.. automethod:: {self.referentPackageSystemPath}')
         result.append('')
         return result
 
@@ -1453,7 +1458,8 @@ class ModuleDocumenter(ObjectDocumenter):
 
     @property
     def referenceName(self):
-        '''The short name of the module:
+        '''
+        The short name of the module:
 
         >>> from music21 import serial
         >>> module = serial

--- a/documentation/docbuild/documenters.py
+++ b/documentation/docbuild/documenters.py
@@ -274,7 +274,7 @@ class MethodDocumenter(MemberDocumenter):
         indent = ''
         if getattr(self.referent, '_isDeprecated', False):
             indent = '    '
-            result.append(f'.. cssclass:: strike')
+            result.append('.. cssclass:: strike')
             result.append('')
         result.append(f'{indent}.. automethod:: {self.referentPackageSystemPath}')
         result.append('')

--- a/documentation/docbuild/make.py
+++ b/documentation/docbuild/make.py
@@ -91,6 +91,7 @@ class DocBuilder:
 
     def runSphinx(self):
         try:
+            # noinspection PyPackageRequirements
             import sphinx
         except ImportError:
             message = 'Sphinx is required to build documentation; '

--- a/documentation/source/_themes/m21/static/m21.css
+++ b/documentation/source/_themes/m21/static/m21.css
@@ -27,6 +27,10 @@ body {
     padding: 0 0 0 0;
 }
 
+.strike {
+  text-decoration: line-through;
+}
+
 pre, div[class*="highlight-"] {
     clear: left;
 }

--- a/music21/articulations.py
+++ b/music21/articulations.py
@@ -111,8 +111,8 @@ class Articulation(base.Music21Object):
     '''
     _styleClass: type[style.Style] = style.TextStyle
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.placement = None
         # declare a unit interval shift for the performance of this articulation
         self._volumeShift: float = 0.0
@@ -214,8 +214,8 @@ class LengthArticulation(Articulation):
     '''
     Superclass for all articulations that change the length of a note.
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.tieAttach = 'last'
 
 class DynamicArticulation(Articulation):
@@ -240,8 +240,8 @@ class Accent(DynamicArticulation):
 
     >>> a = articulations.Accent()
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self._volumeShift = 0.1
 
 
@@ -257,8 +257,8 @@ class StrongAccent(Accent):
     >>> a.pointDirection
     'down'
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self._volumeShift = 0.15
         self.pointDirection = 'up'
 
@@ -267,8 +267,8 @@ class Staccato(LengthArticulation):
 
     >>> a = articulations.Staccato()
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self._volumeShift = 0.05
         self.lengthShift = 0.7
 
@@ -279,8 +279,8 @@ class Staccatissimo(Staccato):
 
     >>> a = articulations.Staccatissimo()
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self._volumeShift = 0.05
         self.lengthShift = 0.5
 
@@ -296,7 +296,7 @@ class Spiccato(Staccato, Accent):
     >>> spiccato.volumeShift == accent.volumeShift
     True
     '''
-    def __init__(self):
+    def __init__(self, **keywords):
         Staccato.__init__(self)
         with tempAttribute(self, 'lengthShift'):
             Accent.__init__(self)  # order matters...
@@ -306,8 +306,8 @@ class Tenuto(LengthArticulation):
     '''
     >>> a = articulations.Tenuto()
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self._volumeShift = -0.05  # is this the right thing to do?
         self.lengthShift = 1.1
 
@@ -315,8 +315,8 @@ class DetachedLegato(LengthArticulation):
     '''
     >>> a = articulations.DetachedLegato()
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.lengthShift = 0.9
 
 # --------- indeterminate slides
@@ -353,8 +353,8 @@ class Doit(IndeterminateSlide):
 
     >>> a = articulations.Doit()
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.tieAttach = 'last'
 
 class Falloff(IndeterminateSlide):
@@ -363,8 +363,8 @@ class Falloff(IndeterminateSlide):
 
     >>> a = articulations.Falloff()
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.tieAttach = 'last'
 
 # --------- end indeterminate slide
@@ -377,8 +377,8 @@ class BreathMark(LengthArticulation):
     >>> a = articulations.BreathMark()
     >>> a.symbol = 'comma'
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.lengthShift = 0.7
         self.symbol = None
 
@@ -393,8 +393,8 @@ class Stress(DynamicArticulation, LengthArticulation):
 
     >>> a = articulations.Stress()
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self._volumeShift = 0.05
         self.lengthShift = 1.1
 
@@ -404,8 +404,8 @@ class Unstress(DynamicArticulation):
 
     >>> a = articulations.Unstress()
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self._volumeShift = -0.05
 
 
@@ -461,8 +461,8 @@ class Fingering(TechnicalIndication):
     are mapped implicitly to the notes of a chord in order. Superfluous
     Fingerings will be ignored and may be discarded when serializing.
     '''
-    def __init__(self, fingerNumber=None):
-        super().__init__()
+    def __init__(self, fingerNumber=None, **keywords):
+        super().__init__(**keywords)
         self.fingerNumber = fingerNumber
         self.substitution = False
         self.alternate = False
@@ -496,8 +496,8 @@ class StringHarmonic(Bowing, Harmonic):
 
     >>> h.pitchType = 'base'
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.harmonicType = 'natural'
         self.pitchType = None
 
@@ -518,8 +518,8 @@ class StringIndication(Bowing):
 
     If no argument to the constructor is specified, number defaults to 0.
     '''
-    def __init__(self, number=0):
-        super().__init__()
+    def __init__(self, number=0, **keywords):
+        super().__init__(**keywords)
         self.number = number
 
     def _reprInternal(self):
@@ -570,8 +570,8 @@ class FretIndication(TechnicalIndication):
 
     If no argument to the constructor is specified, number defaults to 0.
     '''
-    def __init__(self, number=0):
-        super().__init__()
+    def __init__(self, number=0, **keywords):
+        super().__init__(**keywords)
         self.number = number
 
     def _reprInternal(self):
@@ -629,8 +629,8 @@ class OrganIndication(TechnicalIndication):
     Has one attribute, "substitution" default to False, which
     indicates whether the mark is a substitution mark
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.substitution = False
 
 

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -102,8 +102,8 @@ class Clef(base.Music21Object):
     _styleClass = style.TextStyle
     classSortOrder = 0
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.sign: str | None = None
         # line counts start from the bottom up, the reverse of musedata
         self.line: int | None = None
@@ -288,8 +288,8 @@ class PitchClef(Clef):
             ''',
     }
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.lowestLine: int = 31
 
     @property
@@ -346,8 +346,8 @@ class PercussionClef(Clef):
     '''
     _DOC_ATTR: dict[str, str] = {}
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.sign = 'percussion'
         self.lowestLine = (7 * 4) + 3  # 4 octaves + 3 notes = e4
 
@@ -367,8 +367,8 @@ class NoClef(Clef):
     '''
     _DOC_ATTR: dict[str, str] = {}
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.sign = 'none'
 
 
@@ -382,8 +382,8 @@ class JianpuClef(NoClef):
     'jianpu'
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.sign = 'jianpu'
 
 
@@ -396,8 +396,8 @@ class TabClef(PitchClef):
     'TAB'
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.sign = 'TAB'
         self.line = 5
 
@@ -430,8 +430,8 @@ class GClef(PitchClef):
     31
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.sign = 'G'
 
 
@@ -448,8 +448,8 @@ class FrenchViolinClef(GClef):
     1
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 1
         self.lowestLine = (7 * 4) + 5
 
@@ -469,8 +469,8 @@ class TrebleClef(GClef):
     31
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 2
         self.lowestLine = (7 * 4) + 3  # 4 octaves + 3 notes = e4
 
@@ -486,8 +486,8 @@ class Treble8vbClef(TrebleClef):
     -1
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.octaveChange = -1
         self.lowestLine = (7 * 3) + 3
 
@@ -503,8 +503,8 @@ class Treble8vaClef(TrebleClef):
     1
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.octaveChange = 1
         self.lowestLine = (7 * 3) + 3
 
@@ -521,8 +521,8 @@ class GSopranoClef(GClef):
     3
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 3
         self.lowestLine = (7 * 4) + 1
 
@@ -538,8 +538,8 @@ class CClef(PitchClef):
     'C'
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.sign = 'C'
 
 
@@ -555,8 +555,8 @@ class SopranoClef(CClef):
     1
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 1
         self.lowestLine = (7 * 4) + 1
 
@@ -573,8 +573,8 @@ class MezzoSopranoClef(CClef):
     2
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 2
         self.lowestLine = (7 * 3) + 6
 
@@ -590,8 +590,8 @@ class AltoClef(CClef):
     3
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 3
         self.lowestLine = (7 * 3) + 4
 
@@ -609,8 +609,8 @@ class TenorClef(CClef):
 
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 4
         self.lowestLine = (7 * 3) + 2
 
@@ -626,8 +626,8 @@ class CBaritoneClef(CClef):
     5
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 5
         self.lowestLine = (7 * 2) + 7
 
@@ -642,8 +642,8 @@ class FClef(PitchClef):
     'F'
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.sign = 'F'
 
 
@@ -663,8 +663,8 @@ class FBaritoneClef(FClef):
     False
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 3
         self.lowestLine = (7 * 2) + 7
 
@@ -678,8 +678,8 @@ class BassClef(FClef):
     'F'
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 4
         self.lowestLine = (7 * 2) + 5
 
@@ -695,8 +695,8 @@ class Bass8vbClef(FClef):
     -1
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 4
         self.octaveChange = -1
         self.lowestLine = (7 * 2) + 5
@@ -711,8 +711,8 @@ class Bass8vaClef(FClef):
     'F'
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 4
         self.octaveChange = 1
         self.lowestLine = (7 * 2) + 5
@@ -727,8 +727,8 @@ class SubBassClef(FClef):
     'F'
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.line = 5
         self.lowestLine = (7 * 2) + 3
 

--- a/music21/common/decorators.py
+++ b/music21/common/decorators.py
@@ -112,6 +112,8 @@ def deprecated(method, startDate=None, removeDate=None, message=None):
     else:
         funcName = method.__name__
 
+    method._isDeprecated = True
+
     if startDate is not None:
         startDate = ' on ' + startDate
     else:

--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -127,7 +127,6 @@ class Dynamic(base.Music21Object):
     >>> pp1.englishName
     'very soft'
 
-
     Dynamics can also be specified on a 0 to 1 scale with 1 being the
     loudest (see dynamicStrFromDecimal() above)
 
@@ -136,7 +135,6 @@ class Dynamic(base.Music21Object):
     'ppp'
     >>> print('%.2f' % ppp.volumeScalar)
     0.15
-
 
     Note that we got lucky last time because the dynamic 0.15 exactly corresponds
     to what we've considered the default for 'ppp'.  Here we assign 0.98 which
@@ -158,7 +156,6 @@ class Dynamic(base.Music21Object):
     >>> print('%.2f' % loud2.volumeScalar)
     0.90
 
-
     Custom dynamics are possible:
 
     >>> myDyn = dynamics.Dynamic('rfzsfmp')
@@ -169,9 +166,6 @@ class Dynamic(base.Music21Object):
     >>> myDyn.volumeScalar = 0.87
     >>> myDyn.volumeScalar
     0.87
-
-
-
 
     Dynamics can be placed anywhere in a stream.
 
@@ -184,10 +178,8 @@ class Dynamic(base.Music21Object):
     >>> s.insert(3, dynamics.Dynamic('fff'))
     >>> #_DOCS_SHOW s.show()
 
-
     .. image:: images/dynamics_simple.*
         :width: 344
-
 
     '''
     classSortOrder = 10
@@ -225,9 +217,8 @@ class Dynamic(base.Music21Object):
             only to the left hand.
             ''',
     }
-
-    def __init__(self, value=None):
-        super().__init__()
+    def __init__(self, value=None, **keywords):
+        super().__init__(**keywords)
 
         # the scalar is used to calculate the final output of a note
         # under this dynamic. if this property is set, it will override

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -151,8 +151,8 @@ class Instrument(base.Music21Object):
     '''
     classSortOrder = -25
 
-    def __init__(self, instrumentName=None):
-        super().__init__()
+    def __init__(self, instrumentName=None, **keywords):
+        super().__init__(**keywords)
 
         self.partId = None
         self._partIdIsRandom = False
@@ -322,8 +322,8 @@ class Instrument(base.Music21Object):
 
 class KeyboardInstrument(Instrument):
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.instrumentName = 'Keyboard'
         self.instrumentAbbreviation = 'Kb'
         self.instrumentSound = 'keyboard.piano'
@@ -339,8 +339,8 @@ class Piano(KeyboardInstrument):
     0
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Piano'
         self.instrumentAbbreviation = 'Pno'
@@ -351,8 +351,8 @@ class Piano(KeyboardInstrument):
 
 
 class Harpsichord(KeyboardInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Harpsichord'
         self.instrumentAbbreviation = 'Hpschd'
@@ -364,8 +364,8 @@ class Harpsichord(KeyboardInstrument):
 
 
 class Clavichord(KeyboardInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Clavichord'
         self.instrumentAbbreviation = 'Clv'
@@ -377,8 +377,8 @@ class Clavichord(KeyboardInstrument):
 
 
 class Celesta(KeyboardInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Celesta'
         self.instrumentAbbreviation = 'Clst'
@@ -387,8 +387,8 @@ class Celesta(KeyboardInstrument):
 
 
 class Sampler(KeyboardInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Sampler'
         self.instrumentAbbreviation = 'Samp'
@@ -405,8 +405,8 @@ class ElectricPiano(Piano):
     2
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Electric Piano'
         self.instrumentAbbreviation = 'E.Pno'
@@ -417,16 +417,16 @@ class ElectricPiano(Piano):
 
 
 class Organ(Instrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.instrumentName = 'Organ'
         self.midiProgram = 19
         self.instrumentSound = 'keyboard.organ'
 
 
 class PipeOrgan(Organ):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Pipe Organ'
         self.instrumentAbbreviation = 'P Org'
@@ -437,8 +437,8 @@ class PipeOrgan(Organ):
 
 
 class ElectricOrgan(Organ):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Electric Organ'
         self.instrumentAbbreviation = 'Elec Org'
@@ -449,8 +449,8 @@ class ElectricOrgan(Organ):
 
 
 class ReedOrgan(Organ):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Reed Organ'
         # TODO self.instrumentAbbreviation = ''
@@ -462,8 +462,8 @@ class ReedOrgan(Organ):
 
 
 class Accordion(Organ):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Accordion'
         self.instrumentAbbreviation = 'Acc'
@@ -475,8 +475,8 @@ class Accordion(Organ):
 
 
 class Harmonica(Instrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Harmonica'
         self.instrumentAbbreviation = 'Hmca'
@@ -490,8 +490,8 @@ class Harmonica(Instrument):
 # -----------------------------------------------------
 class StringInstrument(Instrument):
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self._stringPitches = None
         self._cachedPitches = None
         self.instrumentName = 'StringInstrument'
@@ -544,8 +544,8 @@ class StringInstrument(Instrument):
 
 
 class Violin(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Violin'
         self.instrumentAbbreviation = 'Vln'
@@ -557,8 +557,8 @@ class Violin(StringInstrument):
 
 
 class Viola(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Viola'
         self.instrumentAbbreviation = 'Vla'
@@ -570,8 +570,8 @@ class Viola(StringInstrument):
 
 
 class Violoncello(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Violoncello'
         self.instrumentAbbreviation = 'Vc'
@@ -588,8 +588,8 @@ class Contrabass(StringInstrument):
     of each string; whereas the lowestNote attribute refers to the lowest written note.
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Contrabass'
         self.instrumentAbbreviation = 'Cb'
@@ -602,8 +602,8 @@ class Contrabass(StringInstrument):
 
 
 class Harp(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Harp'
         self.instrumentAbbreviation = 'Hp'
@@ -615,8 +615,8 @@ class Harp(StringInstrument):
 
 
 class Guitar(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Guitar'
         self.instrumentAbbreviation = 'Gtr'
@@ -628,8 +628,8 @@ class Guitar(StringInstrument):
 
 
 class AcousticGuitar(Guitar):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Acoustic Guitar'
         self.instrumentAbbreviation = 'Ac Gtr'
@@ -638,8 +638,8 @@ class AcousticGuitar(Guitar):
 
 
 class ElectricGuitar(Guitar):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Electric Guitar'
         self.instrumentAbbreviation = 'Elec Gtr'
@@ -648,8 +648,8 @@ class ElectricGuitar(Guitar):
 
 
 class AcousticBass(Guitar):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Acoustic Bass'
         self.instrumentAbbreviation = 'Ac b'
@@ -661,8 +661,8 @@ class AcousticBass(Guitar):
 
 
 class ElectricBass(Guitar):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Electric Bass'
         self.instrumentAbbreviation = 'Elec b'
@@ -674,8 +674,8 @@ class ElectricBass(Guitar):
 
 
 class FretlessBass(Guitar):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Fretless Bass'
         # TODO: self.instrumentAbbreviation = ''
@@ -687,8 +687,8 @@ class FretlessBass(Guitar):
 
 
 class Mandolin(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Mandolin'
         self.instrumentAbbreviation = 'Mdln'
@@ -699,8 +699,8 @@ class Mandolin(StringInstrument):
 
 
 class Ukulele(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Ukulele'
         self.instrumentAbbreviation = 'Uke'
@@ -711,8 +711,8 @@ class Ukulele(StringInstrument):
 
 
 class Banjo(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Banjo'
         self.instrumentAbbreviation = 'Bjo'
@@ -725,8 +725,8 @@ class Banjo(StringInstrument):
 
 
 class Lute(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Lute'
         self.instrumentAbbreviation = 'Lte'
@@ -735,8 +735,8 @@ class Lute(StringInstrument):
 
 
 class Sitar(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Sitar'
         self.instrumentAbbreviation = 'Sit'
@@ -745,8 +745,8 @@ class Sitar(StringInstrument):
 
 
 class Shamisen(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Shamisen'
         # TODO: self.instrumentAbbreviation = ''
@@ -755,8 +755,8 @@ class Shamisen(StringInstrument):
 
 
 class Koto(StringInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Koto'
         # TODO: self.instrumentAbbreviation = ''
@@ -768,15 +768,15 @@ class Koto(StringInstrument):
 
 
 class WoodwindInstrument(Instrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.instrumentName = 'Woodwind'
         self.instrumentAbbreviation = 'Ww'
 
 
 class Flute(WoodwindInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Flute'
         self.instrumentAbbreviation = 'Fl'
@@ -787,8 +787,8 @@ class Flute(WoodwindInstrument):
 
 
 class Piccolo(Flute):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Piccolo'
         self.instrumentAbbreviation = 'Picc'
@@ -800,8 +800,8 @@ class Piccolo(Flute):
 
 
 class Recorder(Flute):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Recorder'
         self.instrumentAbbreviation = 'Rec'
@@ -812,8 +812,8 @@ class Recorder(Flute):
 
 
 class PanFlute(Flute):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Pan Flute'
         self.instrumentAbbreviation = 'P Fl'
@@ -822,8 +822,8 @@ class PanFlute(Flute):
 
 
 class Shakuhachi(Flute):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Shakuhachi'
         self.instrumentAbbreviation = 'Shk Fl'
@@ -832,8 +832,8 @@ class Shakuhachi(Flute):
 
 
 class Whistle(Flute):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Whistle'
         self.instrumentAbbreviation = 'Whs'
@@ -845,8 +845,8 @@ class Whistle(Flute):
 
 
 class Ocarina(Flute):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Ocarina'
         self.instrumentAbbreviation = 'Oc'
@@ -855,8 +855,8 @@ class Ocarina(Flute):
 
 
 class Oboe(WoodwindInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Oboe'
         self.instrumentAbbreviation = 'Ob'
@@ -867,8 +867,8 @@ class Oboe(WoodwindInstrument):
 
 
 class EnglishHorn(WoodwindInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'English Horn'
         self.instrumentAbbreviation = 'Eng Hn'
@@ -880,8 +880,8 @@ class EnglishHorn(WoodwindInstrument):
 
 
 class Clarinet(WoodwindInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Clarinet'
         self.instrumentAbbreviation = 'Cl'
@@ -903,8 +903,8 @@ class BassClarinet(Clarinet):
     True
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Bass clarinet'
         self.instrumentAbbreviation = 'Bs Cl'
@@ -915,8 +915,8 @@ class BassClarinet(Clarinet):
 
 
 class Bassoon(WoodwindInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Bassoon'
         self.instrumentAbbreviation = 'Bsn'
@@ -927,8 +927,8 @@ class Bassoon(WoodwindInstrument):
 
 
 class Contrabassoon(Bassoon):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Contrabassoon'
         self.instrumentAbbreviation = 'C Bsn'
@@ -939,8 +939,8 @@ class Contrabassoon(Bassoon):
 
 
 class Saxophone(WoodwindInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Saxophone'
         self.instrumentAbbreviation = 'Sax'
@@ -951,8 +951,8 @@ class Saxophone(WoodwindInstrument):
 
 
 class SopranoSaxophone(Saxophone):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Soprano Saxophone'
         self.instrumentAbbreviation = 'S Sax'
@@ -963,8 +963,8 @@ class SopranoSaxophone(Saxophone):
 
 
 class AltoSaxophone(Saxophone):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Alto Saxophone'
         self.instrumentAbbreviation = 'A Sax'
@@ -975,8 +975,8 @@ class AltoSaxophone(Saxophone):
 
 
 class TenorSaxophone(Saxophone):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Tenor Saxophone'
         self.instrumentAbbreviation = 'T Sax'
@@ -987,8 +987,8 @@ class TenorSaxophone(Saxophone):
 
 
 class BaritoneSaxophone(Saxophone):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Baritone Saxophone'
         self.instrumentAbbreviation = 'Bar Sax'
@@ -999,8 +999,8 @@ class BaritoneSaxophone(Saxophone):
 
 
 class Bagpipes(WoodwindInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Bagpipes'
         self.instrumentAbbreviation = 'Bag'
@@ -1009,8 +1009,8 @@ class Bagpipes(WoodwindInstrument):
 
 
 class Shehnai(WoodwindInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Shehnai'
         self.instrumentAbbreviation = 'Shn'
@@ -1023,8 +1023,8 @@ class Shehnai(WoodwindInstrument):
 
 
 class BrassInstrument(Instrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.instrumentName = 'Brass'
         self.instrumentAbbreviation = 'Brs'
         self.midiProgram = 61
@@ -1041,8 +1041,8 @@ class Horn(BrassInstrument):
     True
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Horn'
         self.instrumentAbbreviation = 'Hn'
@@ -1054,8 +1054,8 @@ class Horn(BrassInstrument):
 
 
 class Trumpet(BrassInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Trumpet'
         self.instrumentAbbreviation = 'Tpt'
@@ -1067,8 +1067,8 @@ class Trumpet(BrassInstrument):
 
 
 class Trombone(BrassInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Trombone'
         self.instrumentAbbreviation = 'Trb'
@@ -1079,8 +1079,8 @@ class Trombone(BrassInstrument):
 
 
 class BassTrombone(Trombone):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Bass Trombone'
         self.instrumentAbbreviation = 'BTrb'
@@ -1090,8 +1090,8 @@ class BassTrombone(Trombone):
 
 
 class Tuba(BrassInstrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Tuba'
         self.instrumentAbbreviation = 'Tba'
@@ -1104,8 +1104,8 @@ class Tuba(BrassInstrument):
 # ------------
 
 class Percussion(Instrument):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.inGMPercMap = False
         self.percMapPitch = None
         self.instrumentName = 'Percussion'
@@ -1117,8 +1117,8 @@ class PitchedPercussion(Percussion):
 
 
 class UnpitchedPercussion(Percussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self._modifier = None
         self._modifierToPercMapPitch = {}
         self._percMapPitchToModifier = {}
@@ -1172,8 +1172,8 @@ class UnpitchedPercussion(Percussion):
 
 
 class Vibraphone(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Vibraphone'
         self.instrumentAbbreviation = 'Vbp'
@@ -1182,8 +1182,8 @@ class Vibraphone(PitchedPercussion):
 
 
 class Marimba(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Marimba'
         self.instrumentAbbreviation = 'Mar'
@@ -1192,8 +1192,8 @@ class Marimba(PitchedPercussion):
 
 
 class Xylophone(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Xylophone'
         self.instrumentAbbreviation = 'Xyl.'
@@ -1202,8 +1202,8 @@ class Xylophone(PitchedPercussion):
 
 
 class Glockenspiel(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Glockenspiel'
         self.instrumentAbbreviation = 'Gsp'
@@ -1212,8 +1212,8 @@ class Glockenspiel(PitchedPercussion):
 
 
 class ChurchBells(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Church Bells'
         self.instrumentAbbreviation = 'Bells'
@@ -1222,8 +1222,8 @@ class ChurchBells(PitchedPercussion):
 
 
 class TubularBells(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Tubular Bells'
         self.instrumentAbbreviation = 'Tbells'
@@ -1232,8 +1232,8 @@ class TubularBells(PitchedPercussion):
 
 
 class Gong(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Gong'
         self.instrumentAbbreviation = 'Gng'
@@ -1241,8 +1241,8 @@ class Gong(PitchedPercussion):
 
 
 class Handbells(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Handbells'
         # TODO: self.instrumentAbbreviation = ''
@@ -1250,8 +1250,8 @@ class Handbells(PitchedPercussion):
 
 
 class Dulcimer(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Dulcimer'
         # TODO: self.instrumentAbbreviation = ''
@@ -1260,8 +1260,8 @@ class Dulcimer(PitchedPercussion):
 
 
 class SteelDrum(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Steel Drum'
         self.instrumentAbbreviation = 'St Dr'
@@ -1270,8 +1270,8 @@ class SteelDrum(PitchedPercussion):
 
 
 class Timpani(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Timpani'
         self.instrumentAbbreviation = 'Timp'
@@ -1280,8 +1280,8 @@ class Timpani(PitchedPercussion):
 
 
 class Kalimba(PitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Kalimba'
         self.instrumentAbbreviation = 'Kal'
@@ -1290,8 +1290,8 @@ class Kalimba(PitchedPercussion):
 
 
 class Woodblock(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Woodblock'
         self.instrumentAbbreviation = 'Wd Bl'
@@ -1306,8 +1306,8 @@ class Woodblock(UnpitchedPercussion):
 
 
 class TempleBlock(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Temple Block'
         self.instrumentAbbreviation = 'Temp Bl'
@@ -1315,8 +1315,8 @@ class TempleBlock(UnpitchedPercussion):
 
 
 class Castanets(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Castanets'
         self.instrumentAbbreviation = 'Cas'
@@ -1324,8 +1324,8 @@ class Castanets(UnpitchedPercussion):
 
 
 class Maracas(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Maracas'
         self.inGMPercMap = True
@@ -1335,8 +1335,8 @@ class Maracas(UnpitchedPercussion):
 
 
 class Vibraslap(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Vibraslap'
         self.instrumentAbbreviation = 'Vbslp'
@@ -1349,15 +1349,15 @@ class Vibraslap(UnpitchedPercussion):
 
 
 class Cymbals(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.instrumentName = 'Cymbals'
         self.instrumentAbbreviation = 'Cym'
 
 
 class FingerCymbals(Cymbals):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Finger Cymbals'
         self.instrumentAbbreviation = 'Fing Cym'
@@ -1365,8 +1365,8 @@ class FingerCymbals(Cymbals):
 
 
 class CrashCymbals(Cymbals):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Crash Cymbals'
         self.instrumentAbbreviation = 'Cym'
@@ -1384,8 +1384,8 @@ class CrashCymbals(Cymbals):
 
 
 class SuspendedCymbal(Cymbals):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Suspended Cymbal'
         # TODO: self.instrumentAbbreviation = ''
@@ -1393,8 +1393,8 @@ class SuspendedCymbal(Cymbals):
 
 
 class SizzleCymbal(Cymbals):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Sizzle Cymbal'
         # TODO: self.instrumentAbbreviation = ''
@@ -1402,8 +1402,8 @@ class SizzleCymbal(Cymbals):
 
 
 class SplashCymbals(Cymbals):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Splash Cymbals'
         # TODO: self.instrumentAbbreviation = ''
@@ -1411,8 +1411,8 @@ class SplashCymbals(Cymbals):
 
 
 class RideCymbals(Cymbals):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Ride Cymbals'
         # TODO: self.instrumentAbbreviation = ''
@@ -1420,8 +1420,8 @@ class RideCymbals(Cymbals):
 
 
 class HiHatCymbal(Cymbals):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Hi-Hat Cymbal'
         self.instrumentSound = 'metal.hi-hat'
@@ -1443,8 +1443,8 @@ class HiHatCymbal(Cymbals):
 
 
 class Triangle(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Triangle'
         self.instrumentAbbreviation = 'Tri'
@@ -1462,8 +1462,8 @@ class Triangle(UnpitchedPercussion):
 
 
 class Cowbell(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Cowbell'
         self.instrumentAbbreviation = 'Cwb'
@@ -1473,8 +1473,8 @@ class Cowbell(UnpitchedPercussion):
 
 
 class Agogo(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Agogo'
         # TODO: self.instrumentAbbreviation = ''
@@ -1485,8 +1485,8 @@ class Agogo(UnpitchedPercussion):
 
 
 class TamTam(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Tam-Tam'
         # TODO: self.instrumentAbbreviation = ''
@@ -1494,8 +1494,8 @@ class TamTam(UnpitchedPercussion):
 
 
 class SleighBells(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Sleigh Bells'
         # TODO: self.instrumentAbbreviation = ''
@@ -1503,8 +1503,8 @@ class SleighBells(UnpitchedPercussion):
 
 
 class SnareDrum(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Snare Drum'
         self.instrumentAbbreviation = 'Sn Dr'
@@ -1523,8 +1523,8 @@ class SnareDrum(UnpitchedPercussion):
 
 
 class TenorDrum(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Tenor Drum'
         self.instrumentAbbreviation = 'Ten Dr'
@@ -1532,8 +1532,8 @@ class TenorDrum(UnpitchedPercussion):
 
 
 class BongoDrums(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Bongo Drums'
         self.instrumentAbbreviation = 'Bgo Dr'
@@ -1547,8 +1547,8 @@ class BongoDrums(UnpitchedPercussion):
 
 
 class TomTom(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Tom-Tom'
         # TODO: self.instrumentAbbreviation = ''
@@ -1563,8 +1563,8 @@ class TomTom(UnpitchedPercussion):
 
 
 class Timbales(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Timbales'
         self.instrumentAbbreviation = 'Tim'
@@ -1577,8 +1577,8 @@ class Timbales(UnpitchedPercussion):
 
 
 class CongaDrum(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Conga Drum'
         self.instrumentAbbreviation = 'Cga Dr'
@@ -1591,8 +1591,8 @@ class CongaDrum(UnpitchedPercussion):
 
 
 class BassDrum(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Bass Drum'
         self.instrumentAbbreviation = 'B Dr'
@@ -1605,8 +1605,8 @@ class BassDrum(UnpitchedPercussion):
 
 
 class Taiko(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Taiko'
         # TODO: self.instrumentAbbreviation = ''
@@ -1615,8 +1615,8 @@ class Taiko(UnpitchedPercussion):
 
 
 class Tambourine(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Tambourine'
         self.instrumentAbbreviation = 'Tmbn'
@@ -1626,8 +1626,8 @@ class Tambourine(UnpitchedPercussion):
 
 
 class Whip(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Whip'
         # TODO: self.instrumentAbbreviation = ''
@@ -1635,8 +1635,8 @@ class Whip(UnpitchedPercussion):
 
 
 class Ratchet(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Ratchet'
         # TODO: self.instrumentAbbreviation = ''
@@ -1644,8 +1644,8 @@ class Ratchet(UnpitchedPercussion):
 
 
 class Siren(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Siren'
         # TODO: self.instrumentAbbreviation = ''
@@ -1653,8 +1653,8 @@ class Siren(UnpitchedPercussion):
 
 
 class SandpaperBlocks(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Sandpaper Blocks'
         self.instrumentAbbreviation = 'Sand Bl'
@@ -1662,8 +1662,8 @@ class SandpaperBlocks(UnpitchedPercussion):
 
 
 class WindMachine(UnpitchedPercussion):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Wind Machine'
         # TODO: self.instrumentAbbreviation = ''
@@ -1678,8 +1678,8 @@ class Vocalist(Instrument):
     n.b. called Vocalist to not be confused with stream.Voice
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Voice'
         self.instrumentAbbreviation = 'V'
@@ -1687,8 +1687,8 @@ class Vocalist(Instrument):
 
 
 class Soprano(Vocalist):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Soprano'
         self.instrumentAbbreviation = 'S'
@@ -1696,8 +1696,8 @@ class Soprano(Vocalist):
 
 
 class MezzoSoprano(Soprano):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Mezzo-Soprano'
         self.instrumentAbbreviation = 'Mez'
@@ -1705,8 +1705,8 @@ class MezzoSoprano(Soprano):
 
 
 class Alto(Vocalist):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Alto'
         self.instrumentAbbreviation = 'A'
@@ -1714,8 +1714,8 @@ class Alto(Vocalist):
 
 
 class Tenor(Vocalist):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Tenor'
         self.instrumentAbbreviation = 'T'
@@ -1723,8 +1723,8 @@ class Tenor(Vocalist):
 
 
 class Baritone(Vocalist):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Baritone'
         self.instrumentAbbreviation = 'Bar'
@@ -1732,8 +1732,8 @@ class Baritone(Vocalist):
 
 
 class Bass(Vocalist):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Bass'
         self.instrumentAbbreviation = 'B'
@@ -1741,8 +1741,8 @@ class Bass(Vocalist):
 
 
 class Choir(Vocalist):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.instrumentName = 'Choir'
         self.instrumentAbbreviation = 'Ch'
@@ -1757,8 +1757,8 @@ class Conductor(Instrument):
     '''Presently used only for tracking the MIDI track containing tempo,
     key signature, and related metadata.'''
 
-    def __init__(self):
-        super().__init__(instrumentName='Conductor')
+    def __init__(self, **keywords):
+        super().__init__(instrumentName='Conductor', **keywords)
 
 
 # -----------------------------------------------------------------------------

--- a/music21/key.py
+++ b/music21/key.py
@@ -342,8 +342,8 @@ class KeySignature(base.Music21Object):
 
     classSortOrder = 2
 
-    def __init__(self, sharps: int | None = 0):
-        super().__init__()
+    def __init__(self, sharps: int | None = 0, **keywords):
+        super().__init__(**keywords)
         # position on the circle of fifths, where 1 is one sharp, -1 is one flat
 
         try:
@@ -943,7 +943,8 @@ class Key(KeySignature, scale.DiatonicScale):
 
     def __init__(self,
                  tonic: str | pitch.Pitch | note.Note = 'C',
-                 mode=None):
+                 mode=None,
+                 **keywords):
         if isinstance(tonic, (note.Note, pitch.Pitch)):
             tonicStr = tonic.name
         else:
@@ -973,8 +974,8 @@ class Key(KeySignature, scale.DiatonicScale):
         else:
             tonicPitch = pitch.Pitch(tonicStr)
 
-        KeySignature.__init__(self, sharps)
-        scale.DiatonicScale.__init__(self, tonic=tonicPitch)
+        KeySignature.__init__(self, sharps, **keywords)
+        scale.DiatonicScale.__init__(self, tonic=tonicPitch, **keywords)
 
         self.tonic = tonicPitch
         self.type: str = mode

--- a/music21/note.py
+++ b/music21/note.py
@@ -583,6 +583,10 @@ class GeneralNote(base.Music21Object):
                 tempDuration = Duration(1.0)
             else:
                 tempDuration = Duration(**keywords)
+                if 'quarterLength' in keywords:
+                    del keywords['quarterLength']
+                if 'type' in keywords:
+                    del keywords['type']
                 # only apply default if components are empty
                 # looking at currentComponents so as not to trigger
                 # _updateComponents

--- a/music21/note.py
+++ b/music21/note.py
@@ -592,7 +592,7 @@ class GeneralNote(base.Music21Object):
         else:
             tempDuration = duration
         # this sets the stored duration defined in Music21Object
-        super().__init__(duration=tempDuration)
+        super().__init__(duration=tempDuration, **keywords)
 
         self.lyrics: list[Lyric] = []  # a list of lyric objects
         self.expressions: list[expressions.Expression] = []

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -53,8 +53,8 @@ class RepeatMark(prebase.ProtoM21Object):
 
 
     >>> class PartialRepeat(repeat.RepeatMark, base.Music21Object):
-    ...    def __init__(self):
-    ...        super().__init__()
+    ...    def __init__(self, **keywords):
+    ...        super().__init__(**keywords)
 
     >>> s = stream.Stream()
     >>> s.append(note.Note())
@@ -88,8 +88,8 @@ class RepeatExpression(RepeatMark, expressions.Expression):
     '''
     _styleClass = style.TextStyle
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         # store a text version of this expression
         self._textExpression = None
         # store a lost of alternative text representations
@@ -182,8 +182,8 @@ class RepeatExpressionMarker(RepeatExpression):
     such as Coda, Segno, and Fine, which are subclassed below.
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         # these are generally centered
         self.style.justify = 'center'
 
@@ -196,8 +196,8 @@ class Coda(RepeatExpressionMarker):
     '''
     # note that only Coda and Segno have non-text expression forms
 
-    def __init__(self, text=None):
-        super().__init__()
+    def __init__(self, text=None, **keywords):
+        super().__init__(**keywords)
         # default text expression is coda
         self.style.justify = 'center'
 
@@ -220,8 +220,8 @@ class Segno(RepeatExpressionMarker):
     '''
     # note that only Coda and Segno have non-text expression forms
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         # default text expression is coda
         self._textAlternatives = ['Segno']
         self.setText(self._textAlternatives[0])
@@ -235,8 +235,8 @@ class Fine(RepeatExpressionMarker):
     >>> rm = repeat.Fine()
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         # default text expression is coda
         self._textAlternatives = ['fine']
         self.setText(self._textAlternatives[0])
@@ -249,8 +249,8 @@ class RepeatExpressionCommand(RepeatExpression):
     the reader to go somewhere else. DaCapo and
     related are examples.
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         # whether any internal repeats encountered within a jumped region are also repeated.
         self.repeatAfterJump = False
         # generally these should be right aligned, as they are placed
@@ -265,8 +265,8 @@ class DaCapo(RepeatExpressionCommand):
     `repeatAfterJump` is False, indicating that any repeats
     encountered on the Da Capo repeat not be repeated.
     '''
-    def __init__(self, text=None):
-        super().__init__()
+    def __init__(self, text=None, **keywords):
+        super().__init__(**keywords)
         # default text expression is coda
         self._textAlternatives = ['Da Capo', 'D.C.']
         if text is not None and self.isValidText(text):
@@ -286,8 +286,8 @@ class DaCapoAlFine(RepeatExpressionCommand):
 
     >>> rm = repeat.DaCapoAlFine()
     '''
-    def __init__(self, text=None):
-        super().__init__()
+    def __init__(self, text=None, **keywords):
+        super().__init__(**keywords)
         # default text expression is coda
         self._textAlternatives = ['Da Capo al fine', 'D.C. al fine']
         if text is not None and self.isValidText(text):
@@ -310,8 +310,8 @@ class DaCapoAlCoda(RepeatExpressionCommand):
     >>> rm = repeat.DaCapoAlCoda()
     '''
 
-    def __init__(self, text=None):
-        super().__init__()
+    def __init__(self, text=None, **keywords):
+        super().__init__(**keywords)
 
         self._textAlternatives = ['Da Capo al Coda', 'D.C. al Coda']
         if text is not None and self.isValidText(text):
@@ -326,8 +326,8 @@ class AlSegno(RepeatExpressionCommand):
 
     >>> rm = repeat.AlSegno()
     '''
-    def __init__(self, text=None):
-        super().__init__()
+    def __init__(self, text=None, **keywords):
+        super().__init__(**keywords)
         self._textAlternatives = ['al Segno']
         if text is not None and self.isValidText(text):
             self.setText(text)
@@ -344,8 +344,8 @@ class DalSegno(RepeatExpressionCommand):
 
     >>> rm = repeat.DaCapoAlFine()
     '''
-    def __init__(self, text=None):
-        super().__init__()
+    def __init__(self, text=None, **keywords):
+        super().__init__(**keywords)
         self._textAlternatives = ['Dal Segno', 'D.S.']
         if text is not None and self.isValidText(text):
             self.setText(text)
@@ -363,8 +363,8 @@ class DalSegnoAlFine(RepeatExpressionCommand):
 
     >>> rm = repeat.DaCapoAlFine()
     '''
-    def __init__(self, text=None):
-        super().__init__()
+    def __init__(self, text=None, **keywords):
+        super().__init__(**keywords)
         self._textAlternatives = ['Dal Segno al fine', 'D.S. al fine']
         if text is not None and self.isValidText(text):
             self.setText(text)
@@ -383,8 +383,8 @@ class DalSegnoAlCoda(RepeatExpressionCommand):
 
     >>> rm = repeat.DaCapoAlCoda()
     '''
-    def __init__(self, text=None):
-        super().__init__()
+    def __init__(self, text=None, **keywords):
+        super().__init__(**keywords)
         self._textAlternatives = ['Dal Segno al Coda', 'D.S. al Coda']
         if text is not None and self.isValidText(text):
             self.setText(text)

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -105,7 +105,7 @@ class Scale(base.Music21Object):
     '''
     Generic base class for all scales, both abstract and concrete.
 
-    >>> s = scale.Scale
+    >>> s = scale.Scale()
     >>> s.type
     'Scale'
     >>> s.name  # default same as type.

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -104,10 +104,19 @@ class ScaleException(exceptions21.Music21Exception):
 class Scale(base.Music21Object):
     '''
     Generic base class for all scales, both abstract and concrete.
-    '''
 
-    def __init__(self):
-        super().__init__()
+    >>> s = scale.Scale
+    >>> s.type
+    'Scale'
+    >>> s.name  # default same as type.
+    'Scale'
+    >>> s.isConcrete
+    False
+
+    Not a useful class on its own.  See its subclasses.
+    '''
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.type = 'Scale'  # could be mode, could be other indicator
 
     @property
@@ -224,8 +233,8 @@ class AbstractScale(Scale):
 
     # TODO: make a subclass of IntervalNetwork and remove the ._net aspect.
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         # store interval network within abstract scale
         self._net = None
         # in most cases tonic/final of scale is step one, but not always
@@ -295,7 +304,7 @@ class AbstractScale(Scale):
         [<music21.pitch.Pitch D5>, <music21.pitch.Pitch F#5>,
          <music21.pitch.Pitch A#5>, <music21.pitch.Pitch D6>]
 
-        Also possible with implicit octaves:
+        It is also possible to use implicit octaves:
 
         >>> abstract_scale = scale.AbstractScale()
         >>> abstract_scale.buildNetworkFromPitches(['C', 'F'])
@@ -659,8 +668,8 @@ class AbstractDiatonicScale(AbstractScale):
     True
 
     '''
-    def __init__(self, mode: str | None = None):
-        super().__init__()
+    def __init__(self, mode: str | None = None, **keywords):
+        super().__init__(**keywords)
         self.mode = mode
         self.type = 'Abstract diatonic'
         self.tonicDegree = None  # step of tonic
@@ -814,8 +823,8 @@ class AbstractOctatonicScale(AbstractScale):
     Abstract scale representing the two octatonic scales.
     '''
 
-    def __init__(self, mode=None):
-        super().__init__()
+    def __init__(self, mode=None, **keywords):
+        super().__init__(**keywords)
         self.type = 'Abstract Octatonic'
         # all octatonic scales are octave duplicating
         self.octaveDuplicating = True
@@ -857,8 +866,8 @@ class AbstractHarmonicMinorScale(AbstractScale):
     This is the only scale to use the "_alteredDegrees" property.
     '''
 
-    def __init__(self, mode=None):
-        super().__init__()
+    def __init__(self, mode=None, **keywords):
+        super().__init__(**keywords)
         self.type = 'Abstract Harmonic Minor'
         self.octaveDuplicating = True
         self.dominantDegree: int = -1
@@ -885,8 +894,8 @@ class AbstractMelodicMinorScale(AbstractScale):
     A directional scale.
     '''
 
-    def __init__(self, mode=None):
-        super().__init__()
+    def __init__(self, mode=None, **keywords):
+        super().__init__(**keywords)
         self.type = 'Abstract Melodic Minor'
         self.octaveDuplicating = True
         self.dominantDegree: int = -1
@@ -907,8 +916,8 @@ class AbstractCyclicalScale(AbstractScale):
     The resulting scale may be non octave repeating.
     '''
 
-    def __init__(self, mode=None):
-        super().__init__()
+    def __init__(self, mode=None, **keywords):
+        super().__init__(**keywords)
         self.type = 'Abstract Cyclical'
         self.octaveDuplicating = False
         self.buildNetwork(mode=mode)
@@ -939,8 +948,8 @@ class AbstractOctaveRepeatingScale(AbstractScale):
     be provided.
     '''
 
-    def __init__(self, mode=None):
-        super().__init__()
+    def __init__(self, mode=None, **keywords):
+        super().__init__(**keywords)
         self.type = 'Abstract Octave Repeating'
 
         if mode is None:
@@ -974,8 +983,8 @@ class AbstractRagAsawari(AbstractScale):
     '''
     A pseudo raga-scale.
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.type = 'Abstract Rag Asawari'
         self.octaveDuplicating = True
         self.dominantDegree: int = -1
@@ -1062,8 +1071,8 @@ class AbstractRagMarwa(AbstractScale):
     '''
     A pseudo raga-scale.
     '''
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.type = 'Abstract Rag Marwa'
         self.octaveDuplicating = True
         self.dominantDegree: int = -1
@@ -1148,8 +1157,8 @@ class AbstractWeightedHexatonicBlues(AbstractScale):
     A dynamic, probabilistic mixture of minor pentatonic and a hexatonic blues scale
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
         self.type = 'Abstract Weighted Hexatonic Blues'
         # probably not, as all may not have some pitches in each octave
         self.octaveDuplicating = True
@@ -1259,8 +1268,9 @@ class ConcreteScale(Scale):
 
     def __init__(self,
                  tonic: str | pitch.Pitch | note.Note | None = None,
-                 pitches: list[pitch.Pitch | str] | None = None):
-        super().__init__()
+                 pitches: list[pitch.Pitch | str] | None = None,
+                 **keywords):
+        super().__init__(**keywords)
 
         self.type = 'Concrete'
         # store an instance of an abstract scale
@@ -2556,9 +2566,9 @@ class DiatonicScale(ConcreteScale):
     '''
     usePitchDegreeCache = True
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
-        self._abstract: AbstractDiatonicScale = AbstractDiatonicScale()
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
+        self._abstract: AbstractDiatonicScale = AbstractDiatonicScale(**keywords)
         self.type = 'diatonic'
 
     def getTonic(self):
@@ -2704,8 +2714,8 @@ class MajorScale(DiatonicScale):
     'C#'
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'major'
         # build the network for the appropriate scale
         self._abstract.buildNetwork(self.type)
@@ -2722,8 +2732,8 @@ class MinorScale(DiatonicScale):
     ['G4', 'A4', 'B-4', 'C5', 'D5', 'E-5', 'F5', 'G5']
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'minor'
         self._abstract.buildNetwork(self.type)
 
@@ -2737,8 +2747,8 @@ class DorianScale(DiatonicScale):
     ['D4', 'E4', 'F4', 'G4', 'A4', 'B4', 'C5', 'D5']
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'dorian'
         self._abstract.buildNetwork(self.type)
 
@@ -2751,8 +2761,8 @@ class PhrygianScale(DiatonicScale):
     ['E4', 'F4', 'G4', 'A4', 'B4', 'C5', 'D5', 'E5']
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'phrygian'
         self._abstract.buildNetwork(self.type)
 
@@ -2771,8 +2781,8 @@ class LydianScale(DiatonicScale):
     ['C4', 'D4', 'E4', 'F#4', 'G4', 'A4', 'B4', 'C5']
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'lydian'
         self._abstract.buildNetwork(self.type)
 
@@ -2789,8 +2799,8 @@ class MixolydianScale(DiatonicScale):
     ['C4', 'D4', 'E4', 'F4', 'G4', 'A4', 'B-4', 'C5']
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'mixolydian'
         self._abstract.buildNetwork(self.type)
 
@@ -2807,8 +2817,8 @@ class HypodorianScale(DiatonicScale):
     ['G3', 'A3', 'B-3', 'C4', 'D4', 'E-4', 'F4', 'G4']
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'hypodorian'
         self._abstract.buildNetwork(self.type)
 
@@ -2828,8 +2838,8 @@ class HypophrygianScale(DiatonicScale):
     >>> sc.pitchFromDegree(1)  # scale degree 1 is treated as lowest
     <music21.pitch.Pitch B3>
     '''
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'hypophrygian'
         self._abstract.buildNetwork(self.type)
 
@@ -2844,8 +2854,8 @@ class HypolydianScale(DiatonicScale):
     >>> [str(p) for p in sc.pitches]
     ['G3', 'A3', 'B3', 'C4', 'D4', 'E4', 'F#4', 'G4']
     '''
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'hypolydian'
         self._abstract.buildNetwork(self.type)
 
@@ -2860,8 +2870,8 @@ class HypomixolydianScale(DiatonicScale):
     >>> [str(p) for p in sc.pitches]
     ['G3', 'A3', 'B-3', 'C4', 'D4', 'E4', 'F4', 'G4']
     '''
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'hypomixolydian'
         self._abstract.buildNetwork(self.type)
 
@@ -2878,8 +2888,8 @@ class LocrianScale(DiatonicScale):
     ['C4', 'D-4', 'E-4', 'F4', 'G-4', 'A-4', 'B-4', 'C5']
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'locrian'
         self._abstract.buildNetwork(self.type)
 
@@ -2896,8 +2906,8 @@ class HypolocrianScale(DiatonicScale):
     ['G-3', 'A-3', 'B-3', 'C4', 'D-4', 'E-4', 'F4', 'G-4']
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'hypolocrian'
         self._abstract.buildNetwork(self.type)
 
@@ -2913,8 +2923,8 @@ class HypoaeolianScale(DiatonicScale):
     >>> [str(p) for p in sc.pitches]
     ['G3', 'A-3', 'B-3', 'C4', 'D4', 'E-4', 'F4', 'G4']
     '''
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'hypoaeolian'
         self._abstract.buildNetwork(self.type)
 
@@ -2952,8 +2962,8 @@ class HarmonicMinorScale(DiatonicScale):
     chooses among ties.
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'harmonic minor'
 
         # note: this changes the previously assigned AbstractDiatonicScale
@@ -2971,8 +2981,8 @@ class MelodicMinorScale(DiatonicScale):
     >>> sc = scale.MelodicMinorScale('e4')
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self.type = 'melodic minor'
 
         # note: this changes the previously assigned AbstractDiatonicScale
@@ -2989,8 +2999,8 @@ class OctatonicScale(ConcreteScale):
     '''
     usePitchDegreeCache = True
 
-    def __init__(self, tonic=None, mode=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, mode=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self._abstract = AbstractOctatonicScale(mode=mode)
         self.type = 'Octatonic'
 
@@ -3018,8 +3028,8 @@ class OctaveRepeatingScale(ConcreteScale):
     [<music21.pitch.Pitch C4>, <music21.pitch.Pitch D-4>, <music21.pitch.Pitch C5>]
     '''
 
-    def __init__(self, tonic=None, intervalList: list | None = None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, intervalList: list | None = None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         mode = intervalList if intervalList else ['m2']
         self._abstract = AbstractOctaveRepeatingScale(mode=mode)
         self.type = 'Octave Repeating'
@@ -3048,8 +3058,9 @@ class CyclicalScale(ConcreteScale):
 
     def __init__(self,
                  tonic: str | pitch.Pitch | note.Note | None = None,
-                 intervalList: list | None = None):
-        super().__init__(tonic=tonic)
+                 intervalList: list | None = None,
+                 **keywords):
+        super().__init__(tonic=tonic, **keywords)
         mode = intervalList if intervalList else ['m2']
         self._abstract = AbstractCyclicalScale(mode=mode)
         self.type = 'Cyclical'
@@ -3084,8 +3095,8 @@ class ChromaticScale(ConcreteScale):
     '''
     usePitchDegreeCache = True
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self._abstract = AbstractCyclicalScale(mode=[
             'm2', 'm2', 'm2',
             'm2', 'm2', 'm2', 'm2', 'm2', 'm2', 'm2', 'm2', 'm2'])
@@ -3118,8 +3129,8 @@ class WholeToneScale(ConcreteScale):
     '''
     usePitchDegreeCache = True
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self._abstract = AbstractCyclicalScale(mode=['M2', 'M2', 'M2', 'M2', 'M2', 'M2'])
         self.type = 'Whole tone'
 
@@ -3152,8 +3163,9 @@ class SieveScale(ConcreteScale):
     def __init__(self,
                  tonic=None,
                  sieveString='2@0',
-                 eld: int | float = 1):
-        super().__init__(tonic=tonic)
+                 eld: int | float = 1,
+                 **keywords):
+        super().__init__(tonic=tonic, **keywords)
 
         # self.tonic is a Pitch
         if self.tonic is not None:
@@ -3199,7 +3211,7 @@ class ScalaScale(ConcreteScale):
     music21.scale.ScaleException: Could not find a file named badFileName.scl in the scala database
     '''
 
-    def __init__(self, tonic=None, scalaString=None):
+    def __init__(self, tonic=None, scalaString=None, **keywords):
         if (tonic is not None
             and scalaString is None
             and isinstance(tonic, str)
@@ -3209,7 +3221,7 @@ class ScalaScale(ConcreteScale):
             scalaString = tonic
             tonic = 'C4'
 
-        super().__init__(tonic=tonic)
+        super().__init__(tonic=tonic, **keywords)
 
         self._scalaData = None
         self.description = None
@@ -3249,8 +3261,8 @@ class RagAsawari(ConcreteScale):
     ['C3', 'B-2', 'A-2', 'G2', 'F2', 'E-2', 'D2', 'C2']
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self._abstract = AbstractRagAsawari()
         self.type = 'Rag Asawari'
 
@@ -3267,8 +3279,8 @@ class RagMarwa(ConcreteScale):
     ['C2', 'D-2', 'E2', 'F#2', 'A2', 'B2', 'A2', 'C3', 'D-3']
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self._abstract = AbstractRagMarwa()
         self.type = 'Rag Marwa'
         # >>> sc.getPitches(direction=Direction.DESCENDING)
@@ -3281,8 +3293,8 @@ class WeightedHexatonicBlues(ConcreteScale):
     and the hexatonic blues scale.
     '''
 
-    def __init__(self, tonic=None):
-        super().__init__(tonic=tonic)
+    def __init__(self, tonic=None, **keywords):
+        super().__init__(tonic=tonic, **keywords)
         self._abstract = AbstractWeightedHexatonicBlues()
         self.type = 'Weighted Hexatonic Blues'
 

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -51,6 +51,10 @@ from music21 import prebase
 environLocal = environment.Environment('scale.intervalNetwork')
 
 class Terminus(enum.Enum):
+    '''
+    One of the two Termini of a scale, either Terminus.LOW or
+    Terminus.HIGH
+    '''
     LOW = 'terminusLow'
     HIGH = 'terminusHigh'
 
@@ -61,6 +65,10 @@ class Terminus(enum.Enum):
         return 'Terminus.' + self.name
 
 class Direction(enum.Enum):
+    '''
+    An enumerated Direction for a scale, either Direction.ASCENDING,
+    Direction.DESCENDING, or Direction.BI (bidirectional)
+    '''
     BI = 'bi'
     ASCENDING = 'ascending'
     DESCENDING = 'descending'

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -131,8 +131,8 @@ class TempoIndication(base.Music21Object):
     classSortOrder = 1
     _styleClass = style.TextStyle
 
-    # def __init__(self):
-    #     super().__init__()
+    # def __init__(self, **keywords):
+    #     super().__init__(**keywords)
     #     # self.style.justify = 'left'  # creates a style object to share.
 
     def getSoundingMetronomeMark(self, found=None):
@@ -184,8 +184,8 @@ class TempoText(TempoIndication):
     >>> print(tm.text)
     adagio
     '''
-    def __init__(self, text=None):
-        super().__init__()
+    def __init__(self, text=None, **keywords):
+        super().__init__(**keywords)
 
         # store text in a TextExpression instance
         self._textExpression = None  # a stored object
@@ -394,8 +394,8 @@ class MetronomeMark(TempoIndication):
             ''',
     }
 
-    def __init__(self, text=None, number=None, referent=None, parentheses=False):
-        super().__init__()
+    def __init__(self, text=None, number=None, referent=None, *, parentheses=False, **keywords):
+        super().__init__(**keywords)
 
         if number is None and isinstance(text, int):
             number = text
@@ -899,8 +899,8 @@ class MetricModulation(TempoIndication):
             Quarter=60>=<music21.tempo.MetronomeMark larghetto Eighth=60>>
     '''
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **keywords):
+        super().__init__(**keywords)
 
         self.classicalStyle = False
         self.maintainBeat = False

--- a/music21/text.py
+++ b/music21/text.py
@@ -303,8 +303,8 @@ class TextBox(base.Music21Object):
     _styleClass = style.TextStyle
     classSortOrder = -31  # text expressions are -30
 
-    def __init__(self, content=None, x=500, y=500):
-        super().__init__()
+    def __init__(self, content=None, x=500, y=500, **keywords):
+        super().__init__(**keywords)
         # numerous properties are inherited from TextFormat
         # the text string to be displayed; not that line breaks
         # are given in the xml with this non-printing character: (#)

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -97,8 +97,8 @@ class VoiceLeadingQuartet(base.Music21Object):
             ''',
     }
 
-    def __init__(self, v1n1=None, v1n2=None, v2n1=None, v2n2=None, analyticKey=None):
-        super().__init__()
+    def __init__(self, v1n1=None, v1n2=None, v2n1=None, v2n2=None, analyticKey=None, **keywords):
+        super().__init__(**keywords)
         if not intervalCache:
             # populate interval cache if not done yet
             # more efficient than doing it as Class level variables
@@ -1425,8 +1425,8 @@ class Verticality(base.Music21Object):
             in a single part)''',
     }
 
-    def __init__(self, contentDict: dict):
-        super().__init__()
+    def __init__(self, contentDict: dict, **keywords):
+        super().__init__(**keywords)
         for partNum, element in contentDict.items():
             if not isinstance(element, list):
                 contentDict[partNum] = [element]
@@ -1792,8 +1792,8 @@ class VerticalityNTuplet(base.Music21Object):
     motion and music theory elements such as passing tones
     '''
 
-    def __init__(self, listOfVerticalities):
-        super().__init__()
+    def __init__(self, listOfVerticalities, **keywords):
+        super().__init__(**keywords)
 
         self.verticalities = listOfVerticalities
         self.nTupletNum = len(listOfVerticalities)
@@ -1814,8 +1814,8 @@ class VerticalityNTuplet(base.Music21Object):
 class VerticalityTriplet(VerticalityNTuplet):
     '''a collection of three Verticalities'''
 
-    def __init__(self, listOfVerticalities):
-        super().__init__(listOfVerticalities)
+    def __init__(self, listOfVerticalities, **keywords):
+        super().__init__(listOfVerticalities, **keywords)
 
         self.tnlsDict = {}  # defaultdict(int)  # Three Note Linear Segments
         self._calcTNLS()
@@ -1925,8 +1925,8 @@ class NNoteLinearSegment(base.Music21Object):
     [<music21.note.Note A>, <music21.note.Note C>, <music21.note.Note D>]
     '''
 
-    def __init__(self, noteList):
-        super().__init__()
+    def __init__(self, noteList, **keywords):
+        super().__init__(**keywords)
         self._noteList = []
         for value in noteList:
             if value is None:
@@ -2037,11 +2037,11 @@ class ThreeNoteLinearSegment(NNoteLinearSegment):
                   'couldBeDiatonicNeighborTone',
                   'couldBeChromaticNeighborTone']
 
-    def __init__(self, noteListOrN1=None, n2=None, n3=None):
+    def __init__(self, noteListOrN1=None, n2=None, n3=None, **keywords):
         if common.isIterable(noteListOrN1):
-            super().__init__(noteListOrN1)
+            super().__init__(noteListOrN1, **keywords)
         else:
-            super().__init__([noteListOrN1, n2, n3])
+            super().__init__([noteListOrN1, n2, n3], **keywords)
 
     def _getN1(self):
         return self.noteList[0]
@@ -2317,8 +2317,8 @@ class NChordLinearSegmentException(exceptions21.Music21Exception):
 
 
 class NObjectLinearSegment(base.Music21Object):
-    def __init__(self, objectList):
-        super().__init__()
+    def __init__(self, objectList, **keywords):
+        super().__init__(**keywords)
         self.objectList = objectList
 
     def _reprInternal(self):
@@ -2326,8 +2326,8 @@ class NObjectLinearSegment(base.Music21Object):
 
 
 class NChordLinearSegment(NObjectLinearSegment):
-    def __init__(self, chordList):
-        super().__init__(chordList)
+    def __init__(self, chordList, **keywords):
+        super().__init__(chordList, **keywords)
         self._chordList = []
         for value in chordList:
             if value is None:
@@ -2365,15 +2365,15 @@ class NChordLinearSegment(NObjectLinearSegment):
         return f'chordList={self.chordList}'
 
 class TwoChordLinearSegment(NChordLinearSegment):
-    def __init__(self, chordList, chord2=None):
+    def __init__(self, chordList, chord2=None, **keywords):
         if isinstance(chordList, (list, tuple)):
             if len(chordList) != 2:  # pragma: no cover
                 raise ValueError(
                     f'First argument must be a list of length 2, not {chordList!r}'
                 )
-            super().__init__(chordList)
+            super().__init__(chordList, **keywords)
         else:
-            super().__init__([chordList, chord2])
+            super().__init__([chordList, chord2], **keywords)
 
     def rootInterval(self):
         '''


### PR DESCRIPTION
Can't yet do deprecated properties.

Mark deprecated methods as `._isDeprecated` in their dicts.

Add many missing `**keywords`

Improve docs for enums