### PR TITLE
cleanup docstrings; LanguageDetector speed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,8 @@ Conventions:
 
   - **strings MUST be 'single-quoted', but "double quotes" are allowed internally**
     - this rule applies to triple quotes and doc strings also, contrary to PEP 257.
+    - Docstrings must begin and end on their own lines.  No one-line doc-strings or text
+      immediately following the triple quotes.
     - when there is a hyphen or single quote in the string, double quotes should be used, 
       not escaping/backslashing.
     - For long streams of TinyNotation or Lilypond code, which both use single quotes to indicate octave,
@@ -97,8 +99,8 @@ Conventions:
        discussing code.  So for instance, a quotation in documentation is in double quotes.
   - variable names:
     - need to be unambiguous, even if rather long.
-    - must begin with lowercase
-    - snake_case is allowed/encouraged for private variables
+    - must begin with lowercase (or underscore + lowercase) unless they represent classes.
+    - snake_case is allowed/encouraged for private variables for accessibility.
     - camelCase is required for public.
   - line lengths are capped at 100, but if approaching this limit, look for ways to avoid one-lining.
     - if it's easy to split your line into two which are both under 80 characters, do so.
@@ -119,7 +121,7 @@ Conventions:
       it hard for people whose native language is not English to parse and impossible for
       screen readers.
   - methods:
-    - no more than three positional arguments (in addition to `self`)
+    - no more than three positional arguments (four, if the first is `self`)
     - keyword arguments should be keyword-only by using `*`
       to consume any other positional arguments: `def makeNoise(self, volume, *, color=noise.PINK):`
     - avoid generic `**keywords`; make keywords explicit. 
@@ -130,7 +132,8 @@ Conventions:
       It is permitted and encouraged to have an `inPlace: bool = False` argument that allows for
       manipulation of the original object.  When `inPlace` is True, nothing should be returned
       (not true for `music21j` since passing through objects is so expected in JavaScript thanks
-      to JQuery and other libraries).
+      to JQuery and other libraries).  Use the `@overload` decorator to show how this parameter
+      affects the return value.
   - New classes should strongly endeavor to follow Liskov Substitution Principle.
     - Exceptions may be granted if the class structures follow names that are in common musical use
       but whose real world objects do not follow this principle.  For instance, a `Manx` is a subclass
@@ -169,9 +172,10 @@ lowered the overall coverage, but that's okay).
 
 For changes to file parsing, please test both import and export (when supported for
 that format), and please increment the most minor version number in `music21.__version__`
-so that cached files will be invalidated. Your tests can use `converter.parse(fp, forceSource=True)`
-so that tests have a chance to fail locally, but in most cases we will ask you to 
-remove this keyword when polishing the patch.
+so that cached files will be invalidated. When writing a PR that changes imports, feel
+free to use `converter.parse(fp, forceSource=True)` so that tests have a chance 
+to fail locally, but in most cases we will ask you to remove this keyword 
+when polishing the patch.
 
 
 ## Finally ##

--- a/documentation/docbuild/documenters.py
+++ b/documentation/docbuild/documenters.py
@@ -1485,11 +1485,11 @@ class ModuleDocumenter(ObjectDocumenter):
 
 
 class CorpusDocumenter(Documenter):
-    '''A documenter for music21's corpus:
+    '''
+    A documenter for music21's corpus:
 
     >>> documenter = CorpusDocumenter()
     >>> restructuredText = documenter.run()
-
     '''
 
     # SPECIAL METHODS #

--- a/documentation/docbuild/extensions.py
+++ b/documentation/docbuild/extensions.py
@@ -5,7 +5,7 @@
 #
 # Authors:      Josiah Wolf Oberholtzer
 #
-# Copyright:    Copyright © 2013 Michael Scott Asato Cuthbert
+# Copyright:    Copyright © 2013-22 Michael Scott Asato Cuthbert
 # License:      BSD, see license.txt
 # -----------------------------------------------------------------------------
 from __future__ import annotations
@@ -40,7 +40,9 @@ def fixLines(lines):
     lines[:] = newLines
 
 def processDocstring(app, what, name, obj, options, lines):
-    '''Process the ``lines`` of each docstring, in place.'''
+    '''
+    Process the ``lines`` of each docstring, in place.
+    '''
     #    print('WHAT ', what)
     #    print('NAME ', name)
     #    print('OBJ  ', obj)

--- a/documentation/scripts/find-docstrings-with-unindented-code-blocks
+++ b/documentation/scripts/find-docstrings-with-unindented-code-blocks
@@ -1,8 +1,16 @@
 #! /usr/bin/env python
+'''
+Not used: we do not indent code blocks.
+'''
 
 import inspect
+import pathlib
+import sys
 import types
-from music21.documentation.iterators import CodebaseIterator
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from docbuild.iterators import CodebaseIterator
 
 
 def hasUnindentedCodeBlocks(docstring):
@@ -14,15 +22,14 @@ def hasUnindentedCodeBlocks(docstring):
 
 
 def main():
-    print 'Inspecting docstrings...'
-    print 
+    print('Inspecting docstrings...\n')
     count = 0
     for x in CodebaseIterator():
         address = '.'.join((x.__module__, x.__name__))
         # inspect.getdoc() strips whitespace for us
         docstring = inspect.getdoc(x)
         if docstring is not None and hasUnindentedCodeBlocks(docstring):
-            print address
+            print(address)
             count += 1
         if isinstance(x, type):
             for attr in inspect.classify_class_attrs(x):
@@ -31,13 +38,12 @@ def main():
                 attrAddress = ':'.join((address, attr.name)) 
                 docstring = inspect.getdoc(attr.object)
                 if docstring is not None and hasUnindentedCodeBlocks(docstring):
-                    print attrAddress
+                    print(attrAddress)
                     count += 1
     if count:
-        print
-        print 'Found {} docstring(s) with unindented code blocks.'.format(count)
+        print(f'Found {count} docstring(s) with unindented code blocks.')
     else:
-        print 'Found no docstrings with unindented code blocks.'
+        print('Found no docstrings with unindented code blocks.')
 
 
 if __name__ == '__main__':

--- a/documentation/scripts/find-docstrings-without-leading-newline
+++ b/documentation/scripts/find-docstrings-without-leading-newline
@@ -1,34 +1,42 @@
 #! /usr/bin/env python
 
+import enum
 import inspect
+import pathlib
+import sys
 import types
-from music21.documentation.iterators import CodebaseIterator
 
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from docbuild.iterators import CodebaseIterator
 
 def main():
-    print 'Inspecting docstrings...'
-    print 
+    print('Inspecting docstrings...\n')
     count = 0
-    for x in CodebaseIterator():
+    for x in CodebaseIterator(verbose=False):
+        if isinstance(x, type) and issubclass(x, (tuple, enum.Enum)):  # named tuple
+            continue
         address = '.'.join((x.__module__, x.__name__))
         docstring = x.__doc__
-        if docstring is not None and not docstring.startswith('\n'):
-            print address
+        if docstring and not docstring.startswith('\n'):
+            print(address)
             count += 1
         if isinstance(x, type):
             for attr in inspect.classify_class_attrs(x):
                 if attr.defining_class is not x or attr.name.startswith('_'):
                     continue
+                if attr.kind == 'data':
+                    continue
                 attrAddress = ':'.join((address, attr.name)) 
                 docstring = attr.object.__doc__
-                if docstring is not None and not docstring.startswith('\n'):
-                    print attrAddress
+                if docstring and not docstring.startswith('\n'):
+                    print(attrAddress)
                     count += 1
     if count:
-        print
-        print 'Found {} docstring(s) without leading newlines.'.format(count)
+        print()
+        print(f'Found {count} docstring(s) without leading newlines.')
     else:
-        print 'Found no docstrings without leading newlines.'
+        print('Found no docstrings without leading newlines.')
 
 
 if __name__ == '__main__':

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -1243,7 +1243,8 @@ class ABCBrokenRhythmMarker(ABCToken):
         self.data: str | None = None
 
     def preParse(self):
-        '''Called before context adjustments: need to have access to data
+        '''
+        Called before context adjustments: need to have access to data
 
         >>> brokenRhythm = abcFormat.ABCBrokenRhythmMarker('>>>')
         >>> brokenRhythm.preParse()

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -453,7 +453,8 @@ def abcToStreamScore(abcHandler, inputM21=None):
     return s
 
 def abcToStreamOpus(abcHandler, inputM21=None, number=None):
-    '''Convert a multi-work stream into one or more complete works packed into an Opus Stream.
+    '''
+    Convert a multi-work stream into one or more complete works packed into an Opus Stream.
 
     If a `number` argument is given, and a work is defined by
     that number, that work is returned.

--- a/music21/analysis/correlate.py
+++ b/music21/analysis/correlate.py
@@ -33,7 +33,8 @@ class CorrelateException(exceptions21.Music21Exception):
 
 # ------------------------------------------------------------------------------
 class ActivityMatch:
-    '''Given a Stream, find if one object is active while another is also active.
+    '''
+    Given a Stream, find if one object is active while another is also active.
 
     Plotting routines to graph the output of dedicated methods in this class are available.
 
@@ -55,8 +56,8 @@ class ActivityMatch:
 
 
     def _findActive(self, objNameSrc=None, objNameDst=None):
-        '''D
-        o the analysis, finding correlations of src with dst
+        '''
+        Do the analysis, finding correlations of src with dst
         returns an ordered list of dictionaries, in the form
         {'src': obj, 'dst': [objs]}
 

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -156,7 +156,8 @@ class DiscreteAnalysis:
         return post
 
     def solutionLegend(self, compress=False):
-        '''A list of pairs showing all discrete results and the assigned color.
+        '''
+        A list of pairs showing all discrete results and the assigned color.
         Data should be organized to be passed to
         :class:`music21.graph.GraphColorGridLegend`.
 
@@ -911,7 +912,8 @@ class TemperleyKostkaPayne(KeyWeightKeyAnalysis):
         super().__init__(referenceStream=referenceStream)
 
     def getWeights(self, weightType='major'):
-        ''' Returns the key weights.
+        '''
+        Returns the key weights.
 
         >>> a = analysis.discrete.TemperleyKostkaPayne()
         >>> len(a.getWeights('major'))
@@ -1283,7 +1285,8 @@ class MelodicIntervalDiversity(DiscreteAnalysis):
         return len(uniqueIntervals), self.solutionToColor(len(uniqueIntervals))
 
     def getSolution(self, sStream):
-        '''Solution is the number of unique intervals.
+        '''
+        Solution is the number of unique intervals.
         '''
         solution, unused_color = self.process(sStream.flatten())
         return solution

--- a/music21/analysis/metrical.py
+++ b/music21/analysis/metrical.py
@@ -169,7 +169,8 @@ class TestExternal(unittest.TestCase):
     show = True
 
     def testSingle(self):
-        '''Need to test direct meter creation w/o stream
+        '''
+        Need to test direct meter creation w/o stream
         '''
         from music21 import note
         from music21 import meter

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -420,7 +420,8 @@ class ScoreReduction:
         return s
 
     def reduce(self):
-        '''Given a score, populate this Score reduction
+        '''
+        Given a score, populate this Score reduction
         '''
         # if not set here or before
         if self.score is None and self.chordReduction is None:
@@ -827,7 +828,8 @@ class PartReduction:
 #                 print(ds)
 
     def _normalize(self, byPart=False):
-        '''Normalize, either within each Part, or for all parts
+        '''
+        Normalize, either within each Part, or for all parts
         '''
         partMaxRef = {}
         for partBundle in self._partBundles:
@@ -855,7 +857,8 @@ class PartReduction:
                     ds['weight'] = 1  # error?
 
     def process(self):
-        '''Core processing routines.
+        '''
+        Core processing routines.
         '''
         self._createPartBundles()
         self._createEventSpans()
@@ -1011,7 +1014,6 @@ class Test(unittest.TestCase):
         unused_post = sr.reduce()
         # post.show()
 
-
     def testExtractionD2(self):
         # this shows a score, extracting a single pitch
         from music21 import analysis
@@ -1035,8 +1037,6 @@ class Test(unittest.TestCase):
         unused_post = sr.reduce()
         # post.show()
 
-
-
     def testExtractionE(self):
         from music21 import analysis
         from music21 import corpus
@@ -1050,8 +1050,6 @@ class Test(unittest.TestCase):
         sr.score = src
         unused_post = sr.reduce()
         # post.show()
-
-
 
     def testPartReductionA(self):
         from music21 import analysis
@@ -1078,7 +1076,8 @@ class Test(unittest.TestCase):
 
 
     def _matchWeightedData(self, match, target):
-        '''Utility function to compare known data but not compare floating point weights.
+        '''
+        Utility function to compare known data but not compare floating point weights.
         '''
         for partId, b in enumerate(target):
             a = match[partId]
@@ -1098,11 +1097,12 @@ class Test(unittest.TestCase):
                 )
 
     def testPartReductionB(self, show=False):
-        '''Artificially create test cases.
         '''
+        Artificially create test cases.
+        '''
+        from music21 import analysis
         from music21 import dynamics
         from music21 import graph
-        from music21 import analysis
         durDynPairsA = [(1, 'mf'), (3, 'f'), (2, 'p'), (4, 'ff'), (2, 'mf')]
         durDynPairsB = [(1, 'mf'), (3, 'f'), (2, 'p'), (4, 'ff'), (2, 'mf')]
 
@@ -1145,10 +1145,11 @@ class Test(unittest.TestCase):
 
 
     def testPartReductionC(self):
-        '''Artificially create test cases.
         '''
-        from music21 import dynamics
+        Artificially create test cases.
+        '''
         from music21 import analysis
+        from music21 import dynamics
 
         s = stream.Score()
         p1 = stream.Part()
@@ -1180,10 +1181,11 @@ class Test(unittest.TestCase):
 
 
     def testPartReductionD(self):
-        '''Artificially create test cases. Here, uses rests.
         '''
-        from music21 import dynamics
+        Artificially create test cases. Here, uses rests.
+        '''
         from music21 import analysis
+        from music21 import dynamics
 
         s = stream.Score()
         p1 = stream.Part()
@@ -1221,10 +1223,11 @@ class Test(unittest.TestCase):
 
 
     def testPartReductionE(self):
-        '''Artificially create test cases.
         '''
-        from music21 import dynamics
+        Artificially create test cases.
+        '''
         from music21 import analysis
+        from music21 import dynamics
         s = stream.Score()
         p1 = stream.Part()
         p1.id = 0

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -356,7 +356,8 @@ class TestExternal(unittest.TestCase):
 class TestMockProcessor:
 
     def process(self, subStream):
-        '''Simply count the number of notes found
+        '''
+        Simply count the number of notes found
         '''
         return len(subStream.flatten().notesAndRests), None
 
@@ -381,7 +382,8 @@ class Test(unittest.TestCase):
                 unused_x, unused_y, unused_z = wa.process(i, i)
 
     def testWindowing(self):
-        '''Test that windows are doing what they are supposed to do
+        '''
+        Test that windows are doing what they are supposed to do
         '''
         p = TestMockProcessor()
 

--- a/music21/bar.py
+++ b/music21/bar.py
@@ -93,10 +93,10 @@ def standardizeBarType(value):
 
 # ------------------------------------------------------------------------------
 class Barline(base.Music21Object):
-    '''A representation of a barline.
+    '''
+    A representation of a barline.
     Barlines are conventionally assigned to Measure objects
     using the leftBarline and rightBarline attributes.
-
 
     >>> bl = bar.Barline('double')
     >>> bl

--- a/music21/base.py
+++ b/music21/base.py
@@ -4114,7 +4114,8 @@ class ElementWrapper(Music21Object):
             object.__setattr__(self, name, value)
 
     def __getattr__(self, name: str) -> t.Any:
-        '''This method is only called when __getattribute__() fails.
+        '''
+        This method is only called when __getattribute__() fails.
         Using this also avoids the potential recursion problems of subclassing
         __getattribute__()_
 

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -805,8 +805,10 @@ class Test(unittest.TestCase):
         self.assertEqual([len(line) for line in x.splitlines()], [12, 12, 12])
 
     def testSplitNoteGroupingLineLength(self):
-        '''Tests loosening the constraint on trailing spaces when there is
-        no other solution.'''
+        '''
+        Tests loosening the constraint on trailing spaces when there is
+        no other solution.
+        '''
         from music21 import converter
         s = converter.parse('tinyNotation: 2/4 c4 d e f8 g a2 B2 c4. d8 e2')
         x = objectToBraille(s, maxLineLength=10)

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -160,7 +160,8 @@ class ChordBase(note.NotRest):
         return True
 
     def __deepcopy__(self: _ChordBaseType, memo=None) -> _ChordBaseType:
-        '''As Chord objects have one or more Volume, objects, and Volume
+        '''
+        As Chord objects have one or more Volume, objects, and Volume
         objects store weak refs to the client object, need to specialize
         deepcopy handling depending on if the chord has its own volume object.
         '''
@@ -1947,7 +1948,8 @@ class Chord(ChordBase):
             return None
 
     def getNotehead(self, p):
-        '''Given a pitch in this Chord, return an associated notehead
+        '''
+        Given a pitch in this Chord, return an associated notehead
         attribute, or return 'normal' if not defined for that Pitch.
 
         If the pitch is not found, None will be returned.
@@ -1982,7 +1984,8 @@ class Chord(ChordBase):
         return None
 
     def getNoteheadFill(self, p):
-        '''Given a pitch in this Chord, return an associated noteheadFill
+        '''
+        Given a pitch in this Chord, return an associated noteheadFill
         attribute, or return None if not defined for that Pitch.
 
         If the pitch is not found, None will also be returned.
@@ -2020,7 +2023,8 @@ class Chord(ChordBase):
         return None
 
     def getStemDirection(self, p):
-        '''Given a pitch in this Chord, return an associated stem attribute, or
+        '''
+        Given a pitch in this Chord, return an associated stem attribute, or
         return 'unspecified' if not defined for that Pitch or None.
 
         If the pitch is not found, None will be returned.
@@ -2763,14 +2767,14 @@ class Chord(ChordBase):
 
     @cacheMethod
     def isDiminishedSeventh(self):
-        '''Returns True if chord is a Diminished Seventh, that is,
+        '''
+        Returns True if chord is a Diminished Seventh, that is,
         if it contains only notes that are
         either in unison with the root, a minor third above the root,
         a diminished fifth, or a minor seventh
         above the root. Additionally, must contain at least one of
         each third and fifth above the root.
         Chord must be spelled correctly. Otherwise returns false.
-
 
         >>> a = chord.Chord(['c', 'e-', 'g-', 'b--'])
         >>> a.isDiminishedSeventh()
@@ -2813,14 +2817,14 @@ class Chord(ChordBase):
 
     @cacheMethod
     def isDiminishedTriad(self) -> bool:
-        '''Returns True if chord is a Diminished Triad, that is,
+        '''
+        Returns True if chord is a Diminished Triad, that is,
         if it contains only notes that are
         either in unison with the root, a minor third above the
         root, or a diminished fifth above the
         root. Additionally, must contain at least one of each
         third and fifth above the root.
         Chord must be spelled correctly. Otherwise returns false.
-
 
         >>> cChord = chord.Chord(['C', 'E-', 'G-'])
         >>> cChord.isDiminishedTriad()
@@ -2837,6 +2841,7 @@ class Chord(ChordBase):
         >>> other.isDiminishedTriad()
         False
 
+        This is in an OMIT section
         '''
         return self._checkTriadType((3, 10, 0), 3, 6)
 
@@ -4186,7 +4191,8 @@ class Chord(ChordBase):
                 f'the given pitch is not in the Chord: {pitchTarget}')
 
     def setNotehead(self, nh, pitchTarget):
-        '''Given a notehead attribute as a string and a pitch object in this
+        '''
+        Given a notehead attribute as a string and a pitch object in this
         Chord, set the notehead attribute of that pitch to the value of that
         notehead. Valid notehead type names are found in note.noteheadTypeNames
         (see below):
@@ -4285,7 +4291,8 @@ class Chord(ChordBase):
             raise ChordException(f'the given pitch is not in the Chord: {pitchTarget}')
 
     def setNoteheadFill(self, nh, pitchTarget):
-        '''Given a noteheadFill attribute as a string and a pitch object in this
+        '''
+        Given a noteheadFill attribute as a string (or False) and a pitch object in this
         Chord, set the noteheadFill attribute of that pitch to the value of that
         notehead. Valid noteheadFill names are True, False, None (default)
 
@@ -4896,7 +4903,9 @@ class Chord(ChordBase):
         # forteClassTn = self.forteClassTn
 
         def _isSeventhWithPerfectFifthAboveRoot(c: Chord) -> bool:
-            '''For testing minor-minor sevenths and major-major sevenths'''
+            '''
+            For testing minor-minor sevenths and major-major sevenths
+            '''
             if not c.isSeventh():
                 return False
             hypothetical_fifth = c.root().transpose('P5')
@@ -5038,7 +5047,8 @@ class Chord(ChordBase):
 
     @property
     def forteClass(self):
-        '''Return the Forte set class name as a string. This assumes a Tn
+        '''
+        Return the Forte set class name as a string. This assumes a Tn
         formation, where inversion distinctions are represented.
 
         (synonym: forteClassTn)

--- a/music21/common/classTools.py
+++ b/music21/common/classTools.py
@@ -204,7 +204,8 @@ def holdsType(usrData: t.Any, checkType: type[_T]) -> t.TypeGuard[Collection[_T]
 
 
 def classToClassStr(classObj: type) -> str:
-    '''Convert a class object to a class string.
+    '''
+    Convert a class object to a class string.
 
     >>> common.classToClassStr(note.Note)
     'Note'

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -609,7 +609,9 @@ def decimalToTuplet(decNum: float) -> tuple[int, int]:
     ZeroDivisionError: number must be greater than zero
     '''
     def findSimpleFraction(inner_working):
-        '''Utility function.'''
+        '''
+        Utility function.
+        '''
         for index in range(1, 1000):
             for j in range(index, index * 2):
                 if isclose(inner_working, j / index, abs_tol=1e-7):
@@ -734,7 +736,8 @@ def weightedSelection(values: list[int],
 
 
 def approximateGCD(values: list[int | float], grain: float = 1e-4) -> float:
-    '''Given a list of values, find the lowest common divisor of floating point values.
+    '''
+    Given a list of values, find the lowest common divisor of floating point values.
 
     >>> common.approximateGCD([2.5, 10, 0.25])
     0.25
@@ -823,7 +826,9 @@ def lcm(filterList: Iterable[int]) -> int:
     and math.lcm works in C and is faster
     '''
     def _lcm(a, b):
-        '''find the least common multiple of a, b'''
+        '''
+        find the least common multiple of a, b
+        '''
         # // forces integer style division (no remainder)
         return abs(a * b) // gcd(a, b)
 

--- a/music21/common/pathTools.py
+++ b/music21/common/pathTools.py
@@ -59,7 +59,8 @@ def getMetadataCacheFilePath() -> pathlib.Path:
 
 
 def getCorpusFilePath() -> pathlib.Path:
-    r'''Get the stored music21 directory that contains the corpus metadata cache.
+    r'''
+    Get the stored music21 directory that contains the corpus metadata cache.
 
     >>> fp = common.getCorpusFilePath()
     >>> fp.name == 'corpus' and fp.parent.name == 'music21'

--- a/music21/configure.py
+++ b/music21/configure.py
@@ -272,12 +272,14 @@ class Dialog:
         self._platforms = ['win', 'darwin', 'nix']
 
     def _writeToUser(self, msg):
-        '''Write output to user. Call module-level function
+        '''
+        Write output to user. Call module-level function
         '''
         writeToUser(msg)
 
     def _readFromUser(self):
-        '''Collect from user; return None if an empty response.
+        '''
+        Collect from user; return None if an empty response.
         '''
         # noinspection PyBroadException
         try:
@@ -290,8 +292,8 @@ class Dialog:
             return DialogError()
 
     def prependPromptHeader(self, msg):
-        '''Add a message to the front of the stored prompt header.
-
+        '''
+        Add a message to the front of the stored prompt header.
 
         >>> d = configure.Dialog()
         >>> d.prependPromptHeader('test')
@@ -354,7 +356,8 @@ class Dialog:
             return post
 
     def _rawQueryPrepareHeader(self, msg=''):
-        '''Prepare the header, given a string.
+        '''
+        Prepare the header, given a string.
 
         >>> from music21 import configure
         >>> d = configure.Dialog()
@@ -381,7 +384,8 @@ class Dialog:
         return msg
 
     def _rawQueryPrepareFooter(self, msg=''):
-        '''Prepare the end of the query message
+        '''
+        Prepare the end of the query message
         '''
         if self._default is not None:
             msg = msg.strip()
@@ -397,12 +401,14 @@ class Dialog:
         return msg
 
     def _rawIntroduction(self):
-        '''Return a multiline presentation of an introduction.
+        '''
+        Return a multiline presentation of an introduction.
         '''
         return None
 
     def _rawQuery(self):
-        '''Return a multiline presentation of the question.
+        '''
+        Return a multiline presentation of the question.
         '''
         pass
 
@@ -719,7 +725,8 @@ class AskOpenInBrowser(YesOrNo):
             self.appendPromptHeader(msg)
 
     def _performAction(self, simulate=False):
-        '''The action here is to open the stored URL in a browser, if the user agrees.
+        '''
+        The action here is to open the stored URL in a browser, if the user agrees.
         '''
         result = self.getResult()
         if result is True:
@@ -825,7 +832,8 @@ class SelectFromList(Dialog):
             return []
 
     def _formatResultForUser(self, result):
-        '''Reduce each complete file path to stub, or otherwise compact display
+        '''
+        Reduce each complete file path to stub, or otherwise compact display
         '''
         return result
 
@@ -959,7 +967,8 @@ class AskAutoDownload(SelectFromList):
         super().__init__(default=default, tryAgain=tryAgain, promptHeader=promptHeader)
 
     def _rawIntroduction(self):
-        '''Return a multiline presentation of an introduction.
+        '''
+        Return a multiline presentation of an introduction.
         '''
         return ['The BSD-licensed music21 software is distributed with a corpus of encoded '
                 'compositions which are distributed with the permission of the encoders '
@@ -987,7 +996,8 @@ class AskAutoDownload(SelectFromList):
                 ]
 
     def _getValidResults(self, force=None):
-        '''Just return number options
+        '''
+        Just return number options
         '''
         if force is not None:
             return force
@@ -1000,7 +1010,8 @@ class AskAutoDownload(SelectFromList):
             ]
 
     def _evaluateUserInput(self, raw):
-        '''Evaluate the user's string entry after parsing; do not return None:
+        '''
+        Evaluate the user's string entry after parsing; do not return None:
         either return a valid response, default if available, IncompleteInput, NoInput objects.
         '''
         rawParsed = self._parseUserInput(raw)

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1358,7 +1358,8 @@ def toData(obj: base.Music21Object, fmt: str, **keywords) -> str | bytes:
 
 def freeze(streamObj, fmt=None, fp=None, fastButUnsafe=False, zipType='zlib') -> pathlib.Path:
     # noinspection PyShadowingNames
-    '''Given a StreamObject and a file path, serialize and store the Stream to a file.
+    '''
+    Given a StreamObject and a file path, serialize and store the Stream to a file.
 
     This function is based on the :class:`~music21.converter.StreamFreezer` object.
 
@@ -1408,7 +1409,8 @@ def freeze(streamObj, fmt=None, fp=None, fastButUnsafe=False, zipType='zlib') ->
 
 
 def thaw(fp, zipType='zlib'):
-    '''Given a file path of a serialized Stream, defrost the file into a Stream.
+    '''
+    Given a file path of a serialized Stream, defrost the file into a Stream.
 
     This function is based on the :class:`~music21.converter.StreamFreezer` object.
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -866,7 +866,8 @@ class ConverterNoteworthy(SubConverter):
     # --------------------------------------------------------------------------
     def parseData(self, nwcData):
         # noinspection PyShadowingNames
-        r'''Open Noteworthy data from a string or list
+        r'''
+        Open Noteworthy data from a string or list
 
         >>> nwcData = ('!NoteWorthyComposer(2.0)\n|AddStaff\n|Clef|' +
         ...     'Type:Treble\n|Note|Dur:Whole|Pos:1^')
@@ -1339,7 +1340,8 @@ class ConverterABC(SubConverter):
 
 
 class ConverterRomanText(SubConverter):
-    '''Simple class wrapper for parsing roman text harmonic definitions.
+    '''
+    Simple class wrapper for parsing roman text harmonic definitions.
     '''
     registerFormats = ('romantext', 'rntext')
     registerInputExtensions = ('rntxt', 'rntext', 'romantext', 'rtxt')
@@ -1444,14 +1446,15 @@ class ConverterCapella(SubConverter):
 
 # ------------------------------------------------------------------------------
 class ConverterMuseData(SubConverter):
-    '''Simple class wrapper for parsing MuseData.
+    '''
+    Simple class wrapper for parsing MuseData.
     '''
     registerFormats = ('musedata',)
     registerInputExtensions = ('md', 'musedata', 'zip')
 
     def parseData(self, strData, number=None):  # pragma: no cover
-        '''Get musedata from a string representation.
-
+        '''
+        Get musedata from a string representation.
         '''
         from music21 import musedata as musedataModule
         from music21.musedata import translate as musedataTranslate

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -1412,25 +1412,32 @@ class Iterator:
             raise BachException(f'{value} is not a valid numbering system for Bach Chorales.')
 
     numberingSystem = property(_getNumberingSystem, _setNumberingSystem,
-                               doc='''This property determines which numbering
-                                system to iterate through chorales with.
-                                It can be set to 'bwv', 'kalmus', 'baerenreiter',
-                                'budapest', or 'riemenschneider'.
-                                It can also be set to 'title' in which case the
-                                iterator needs to be given a list
-                                of chorale titles in .titleList. At this time,
-                                the titles need to be exactly as they
-                                appear in the dictionary it queries.''')
+                               doc='''
+                                    This property determines which numbering
+                                    system to iterate through chorales with.
+                                    It can be set to 'bwv', 'kalmus', 'baerenreiter',
+                                    'budapest', or 'riemenschneider'.
+                                    It can also be set to 'title' in which case the
+                                    iterator needs to be given a list
+                                    of chorale titles in .titleList. At this time,
+                                    the titles need to be exactly as they
+                                    appear in the dictionary it queries.''')
 
     # - Title List
 
-    def _getTitleList(self):
+    @property
+    def titleList(self):
+        '''
+        A list of titles to iterate over
+        if `.numberingSystem` is set to 'title'.
+        '''
         if self._titleList is None:
             return []
         else:
             return self._titleList
 
-    def _setTitleList(self, value=None):
+    @titleList.setter
+    def titleList(self, value=None):
         if value is None:
             self._titleList = None
             value = []
@@ -1448,19 +1455,24 @@ class Iterator:
 
         self._initializeNumberList()
 
-    titleList = property(_getTitleList, _setTitleList,
-                         doc='''This is to store the list of titles to iterate
-                                 over if .numberingSystem is set to 'title'.''')
-
     # - Number List
 
-    def _getNumberList(self):
+    @property
+    def numberList(self):
+        '''
+        Allows access to the catalogue numbers
+        (or indices if iterationType == 'index')
+        that will be iterated over. This can be
+        set to a specific list of numbers.
+        The list will be sorted.
+        '''
         if self._numberList is None:
             return []
         else:
             return self._numberList
 
-    def _setNumberList(self, value):
+    @numberList.setter
+    def numberList(self, value):
         if not isinstance(value, list):
             raise BachException(f'{value} is not and must be a list.')
         if self._numberingSystem == 'title':
@@ -1528,22 +1540,28 @@ class Iterator:
             self.currentNumber = 0
             self.highestNumber = len(self._numberList) - 1
 
-    numberList = property(_getNumberList, _setNumberList,
-                          doc='''Allows access to the catalogue numbers
-                                (or indices if iterationType == 'index')
-                                that will be iterated over. This can be
-                                set to a specific list of numbers.
-                                They will be sorted.''')
-
     # - Current Number
 
-    def _getCurrentNumber(self):
+    @property
+    def currentNumber(self):
+        '''
+        The currentNumber is the number of the
+        chorale (in the set numberingSystem) for the
+        next chorale to be parsed by the iterator.
+        It is initially the first chorale in whatever
+        numberingSystem is set, but it can be changed
+        to any other number in the numberingSystem
+        as desired as long as it does not go above
+        the highestNumber which is the boundary
+        of the iteration.
+        '''
         if self._iterationType == 'index' or self._numberingSystem == 'title':
             return self._currentIndex
         else:
             return self._numberList[self._currentIndex]
 
-    def _setCurrentNumber(self, value):
+    @currentNumber.setter
+    def currentNumber(self, value):
         if self._numberingSystem is None:
             raise Exception('Numbering System is not set.')
         if self._iterationType == 'number':
@@ -1608,26 +1626,27 @@ class Iterator:
                         + f'{self.numberingSystem} numbering system'
                     )
 
-    currentNumber = property(_getCurrentNumber, _setCurrentNumber,
-                             doc='''The currentNumber is the number of the
-                                    chorale (in the set numberingSystem) for the
-                                    next chorale to be parsed by the iterator.
-                                    It is initially the first chorale in whatever
-                                    numberingSystem is set, but it can be changed
-                                    to any other number in the numberingSystem
-                                    as desired as long as it does not go above
-                                    the highestNumber which is the boundary
-                                    of the iteration.''')
-
     # - Highest Number
 
-    def _getHighestNumber(self):
+    @property
+    def highestNumber(self):
+        '''
+        The highestNumber is the number of the chorale
+        (in the set numberingSystem) for the
+        last chorale to be parsed by the iterator.
+        It is initially the highest numbered chorale in whatever
+        numberingSystem is set, but it can be changed
+        to any other number in the numberingSystem
+        as desired as long as it does not go below
+        the currentNumber of the iteration.
+        '''
         if self.iterationType == 'index' or self._numberingSystem == 'title':
             return self._highestIndex
         else:
             return self._numberList[self._highestIndex]
 
-    def _setHighestNumber(self, value):
+    @highestNumber.setter
+    def highestNumber(self, value):
         if self._numberingSystem is None:
             raise Exception('Numbering System is not set.')
         if self.iterationType == 'number':
@@ -1693,42 +1712,37 @@ class Iterator:
                         + f'{self.numberingSystem} numbering system'
                     )
 
-    highestNumber = property(_getHighestNumber, _setHighestNumber,
-                             doc='''The highestNumber is the number of the chorale
-                                    (in the set numberingSystem) for the
-                                    last chorale to be parsed by the iterator.
-                                    It is initially the highest numbered chorale in whatever
-                                    numberingSystem is set, but it can be changed
-                                    to any other number in the numberingSystem
-                                    as desired as long as it does not go below
-                                    the currentNumber of the iteration.''')
-
     # - Return Type
-    def _getReturnType(self):
+    @property
+    def returnType(self):
+        '''
+        This property determines what the iterator
+        returns; 'stream' is the default and causes the iterator to parse
+        each chorale. If this is set to 'filename', the
+        iterator will return the filename of each chorale but not
+        parse it.
+        '''
         return self._returnType
 
-    def _setReturnType(self, value):
+    @returnType.setter
+    def returnType(self, value):
         if value in ['stream', 'filename']:
             self._returnType = value
         else:
             raise BachException(f'{value} is not a proper returnType for this iterator. '
                                 + "Only 'stream' and 'filename' are acceptable.")
 
-    returnType = property(_getReturnType,
-                          _setReturnType,
-                          doc='''
-        This property determines what the iterator
-        returns; 'stream' is the default and causes the iterator to parse
-        each chorale. If this is set to 'filename', the
-        iterator will return the filename of each chorale but not
-        parse it.''')
-
     # - Iteration Type
-
-    def _getIterationType(self):
+    @property
+    def iterationType(self):
+        '''
+        This property determines how boundary numbers are
+        interpreted, as indices or as catalogue numbers.
+        '''
         return self._iterationType
 
-    def _setIterationType(self, value):
+    @iterationType.setter
+    def iterationType(self, value):
         if value in ['number', 'index']:
             self._iterationType = value
             self._initializeNumberList()
@@ -1736,9 +1750,6 @@ class Iterator:
             raise BachException(
                 f'{value} is not a proper iterationType for this iterator. '
                 + "Only 'number' and 'index' are acceptable.")
-    iterationType = property(_getIterationType, _setIterationType,
-                             doc='''This property determines how boundary numbers are
-                                 interpreted, as indices or as catalogue numbers.''')
 
 
 def getByTitle(title):

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -1007,7 +1007,7 @@ class Iterator:
     >>> BCI.titleList = ['Jesu, meine Freude',
     ...                  'Gott hat das Evangelium',
     ...                  'Not a Chorale']
-    Not a Chorale will be skipped because it is not a recognized title
+    'Not a Chorale' will be skipped because it is not a recognized title.
 
     >>> for chorale in BCI:
     ...    print(chorale)
@@ -1095,7 +1095,7 @@ class Iterator:
         '''
         self._currentIndex = None
         self._highestIndex = None
-        self._titleList = []
+        self._titleList: list[str] = []
         self._numberList = None
         self._numberingSystem = None
         self._returnType = 'stream'
@@ -1427,7 +1427,7 @@ class Iterator:
     # - Title List
 
     @property
-    def titleList(self):
+    def titleList(self) -> list[str]:
         '''
         A list of titles to iterate over
         if `.numberingSystem` is set to 'title'.
@@ -1435,16 +1435,15 @@ class Iterator:
         return self._titleList
 
     @titleList.setter
-    def titleList(self, value):
+    def titleList(self, value: list[str]):
         if not common.isIterable(value):
             raise BachException(f'{value!r} must be a list.')
-        else:
-            self._titleList = []
-            for v in value:
-                if v in self._choraleList2.byTitle:
-                    self._titleList.append(v)
-                else:
-                    print(f'{v} will be skipped because it is not a recognized title')
+        self._titleList = []
+        for v in value:
+            if v in self._choraleList2.byTitle:
+                self._titleList.append(v)
+            else:
+                print(f'{v!r} will be skipped because it is not a recognized title.')
         self._initializeNumberList()
 
     # - Number List

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import copy
 import unittest
 
+from music21 import common
 from music21 import environment
 from music21 import exceptions21
 from music21 import metadata
@@ -1094,7 +1095,7 @@ class Iterator:
         '''
         self._currentIndex = None
         self._highestIndex = None
-        self._titleList = None
+        self._titleList = []
         self._numberList = None
         self._numberingSystem = None
         self._returnType = 'stream'
@@ -1243,7 +1244,7 @@ class Iterator:
             raise BachException('Cannot parse Chorales because no .numberingSystem set.')
 
         if self.numberingSystem == 'title':
-            if self._titleList is None:
+            if not self._titleList:
                 raise BachException('Cannot parse Chorales because no titles to parse.')
             title = self.titleList[choraleIndex]
             filename = 'bach/bwv' + str(self._choraleList2.byTitle[title]['bwv'])
@@ -1354,7 +1355,7 @@ class Iterator:
         if self._numberingSystem == 'title':
             self._numberList = None
             self.currentNumber = 0
-            if self._titleList is None:
+            if not self._titleList:
                 self.highestNumber = 0
             else:
                 self.highestNumber = len(self.titleList) - 1
@@ -1407,7 +1408,7 @@ class Iterator:
             self._initializeNumberList()
         elif value == 'title':
             self._numberingSystem = 'title'
-            self._setTitleList()
+            self.titleList = []
         else:
             raise BachException(f'{value} is not a valid numbering system for Bach Chorales.')
 
@@ -1431,18 +1432,12 @@ class Iterator:
         A list of titles to iterate over
         if `.numberingSystem` is set to 'title'.
         '''
-        if self._titleList is None:
-            return []
-        else:
-            return self._titleList
+        return self._titleList
 
     @titleList.setter
-    def titleList(self, value=None):
-        if value is None:
-            self._titleList = None
-            value = []
-        elif not isinstance(value, list):
-            raise BachException(f'{value} is not and must be a list.')
+    def titleList(self, value):
+        if not common.isIterable(value):
+            raise BachException(f'{value!r} must be a list.')
         else:
             self._titleList = []
             for v in value:
@@ -1450,9 +1445,6 @@ class Iterator:
                     self._titleList.append(v)
                 else:
                     print(f'{v} will be skipped because it is not a recognized title')
-        if not self._titleList:
-            self._titleList = None
-
         self._initializeNumberList()
 
     # - Number List
@@ -1474,7 +1466,7 @@ class Iterator:
     @numberList.setter
     def numberList(self, value):
         if not isinstance(value, list):
-            raise BachException(f'{value} is not and must be a list.')
+            raise BachException(f'{value!r} must be a list.')
         if self._numberingSystem == 'title':
             self._numberList = None
             raise BachException("Cannot set numberList when .numberingSystem == 'title'")
@@ -1566,7 +1558,7 @@ class Iterator:
             raise Exception('Numbering System is not set.')
         if self._iterationType == 'number':
             if self._numberingSystem == 'title':
-                if self._titleList is None:
+                if not self._titleList:
                     self._currentIndex = 0
                     return
                 else:
@@ -1597,7 +1589,7 @@ class Iterator:
 
         elif self._iterationType == 'index':
             if self._numberingSystem == 'title':
-                if self._titleList is None:
+                if not self._titleList:
                     self._currentIndex = 0
                     return
                 else:
@@ -1651,7 +1643,7 @@ class Iterator:
             raise Exception('Numbering System is not set.')
         if self.iterationType == 'number':
             if self._numberingSystem == 'title':
-                if self._titleList is None:
+                if not self._titleList:
                     self._highestIndex = 0
                     return
                 else:
@@ -1683,7 +1675,7 @@ class Iterator:
 
         elif self.iterationType == 'index':
             if self._numberingSystem == 'title':
-                if self._titleList is None:
+                if not self._titleList:
                     self._highestIndex = 0
                     return
                 else:

--- a/music21/corpus/virtual.py
+++ b/music21/corpus/virtual.py
@@ -42,18 +42,20 @@ class VirtualWork:
         # these probably should all be the same format
         self.urlList = []
 
-#     def _getDstFp(self, dir):
-#         '''Given a directory (usually the users scratch directory) create
-#         a file path based on the md5 of the works title. This means that all
-#         works must have unique titles in the virtual corpus.
-#         '''
-#         dir = pathlib.Path(dir)
-#         if dir is None:
-#             raise ValueError
-#         return dir / ('m21-' + common.getMd5(self.title) + '.p')
+    # def _getDstFp(self, dir):
+    #     '''
+    #     Given a directory (usually the users scratch directory) create
+    #     a file path based on the md5 of the works title. This means that all
+    #     works must have unique titles in the virtual corpus.
+    #     '''
+    #     dir = pathlib.Path(dir)
+    #     if dir is None:
+    #         raise ValueError
+    #     return dir / ('m21-' + common.getMd5(self.title) + '.p')
 
     def getUrlByExt(self, extList=None):
-        '''Given a request for an extension, find the best match for a URL from
+        '''
+        Given a request for an extension, find the best match for a URL from
         the list of known URLs. If ext is None, return the first URL.
         '''
         if not common.isListLike(extList):
@@ -192,7 +194,8 @@ class TestExternal(unittest.TestCase):
 class Test(unittest.TestCase):
 
     def testBasic(self):
-        '''Test copying all objects defined in the virtual corpus module
+        '''
+        Test instantiating all objects defined in the virtual corpus module
         '''
         a = BachBWV1007Prelude()
         self.assertNotEqual(a.getUrlByExt(['.xml']), [])

--- a/music21/defaults.py
+++ b/music21/defaults.py
@@ -66,7 +66,8 @@ clefLine = 2
 # define a default notehead for notes that know they are unpitched
 noteheadUnpitched = 'square'
 
-'''Divisions are a MusicXML concept that music21 does not share
+'''
+Divisions are a MusicXML concept that music21 does not share
 It basically represents the lowest time unit that all other notes
 are integer multiples of.  Useful for compatibility with MIDI, but
 ultimately restricting since it must be less than 16384, so thus
@@ -118,12 +119,9 @@ minIdNumberToConsiderMemoryLocation = 100_000_001
 
 
 class Test(unittest.TestCase):
-    '''Unit tests
     '''
-
-    def setUp(self):
-        pass
-
+    Unit tests
+    '''
     def testTest(self):
         self.assertEqual(1, 1)
 

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -1296,7 +1296,8 @@ class Tuplet(prebase.ProtoM21Object):
         self.durationNormal = durationTupleFromTypeDots(durType, dots)
 
     def setRatio(self, actual, normal):
-        '''Set the ratio of actual divisions to represented in normal divisions.
+        '''
+        Set the ratio of actual divisions to represented in normal divisions.
         A triplet is 3 actual in the time of 2 normal.
 
         >>> a = duration.Tuplet()

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -932,7 +932,8 @@ class Environment:
         return dstDir
 
     def getKeysToPaths(self):
-        ''' Get the keys that refer to file paths.
+        '''
+        Get the keys that refer to file paths.
 
         >>> a = environment.Environment()
         >>> for x in sorted(a.getKeysToPaths()):

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -398,19 +398,24 @@ class TextExpression(Expression):
             return
         self.style.enclosure = value
 
-    def _getContent(self):
-        return self._content
-
-    def _setContent(self, value):
-        self._content = str(value)
-
-    content = property(_getContent, _setContent,
-                       doc='''Get or set the content.
+    @property
+    def content(self):
+        '''
+        Get or set the content.
 
         >>> te = expressions.TextExpression('dolce')
         >>> te.content
         'dolce'
-        ''')
+        >>> te.content = 'sweeter'
+        >>> te
+        <music21.expressions.TextExpression 'sweeter'>
+        '''
+        return self._content
+
+    @content.setter
+    def content(self, value):
+        self._content = str(value)
+
 
     # --------------------------------------------------------------------------
     # text expression in musicxml may be repeat expressions
@@ -517,7 +522,8 @@ class Ornament(Expression):
 
 # ------------------------------------------------------------------------------
 class GeneralMordent(Ornament):
-    '''Base class for all Mordent types.
+    '''
+    Base class for all Mordent types.
     '''
 
     def __init__(self):

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -1650,7 +1650,8 @@ class Test(unittest.TestCase):
     # all these are written using orange-Py2 code; need better.
 
     # def xtestOrangeBayesA(self):  # pragma: no cover
-    #     '''Using an already created test file with a BayesLearner.
+    #     '''
+    #     Using an already created test file with a BayesLearner.
     #     '''
     #     import orange  # pylint: disable=import-error
     #     data = orange.ExampleTable(
@@ -1662,7 +1663,8 @@ class Test(unittest.TestCase):
 
 
     # def xtestClassifiersA(self):  # pragma: no cover
-    #     '''Using an already created test file with a BayesLearner.
+    #     '''
+    #     Using an already created test file with a BayesLearner.
     #     '''
     #     import orange, orngTree  # pylint: disable=import-error
     #     data1 = orange.ExampleTable(
@@ -1702,7 +1704,8 @@ class Test(unittest.TestCase):
 
 
     # def xtestClassifiersB(self):  # pragma: no cover
-    #     '''Using an already created test file with a BayesLearner.
+    #     '''
+    #     Using an already created test file with a BayesLearner.
     #     '''
     #     import orange, orngTree  # pylint: disable=import-error
     #     data1 = orange.ExampleTable(

--- a/music21/features/jSymbolic.py
+++ b/music21/features/jSymbolic.py
@@ -11,8 +11,6 @@
 '''
 The features implemented here are based on those found in jSymbolic and
 defined in Cory McKay's MA Thesis, "Automatic Genre Classification of MIDI Recordings"
-
-The LGPL jSymbolic system can be found here: http://jmir.sourceforge.net/jSymbolic.html
 '''
 from __future__ import annotations
 
@@ -21,6 +19,7 @@ import copy
 import math
 from math import isclose
 import statistics
+from textwrap import dedent
 import unittest
 
 from music21 import base
@@ -64,7 +63,8 @@ class MelodicIntervalHistogramFeature(featuresModule.FeatureExtractor):
         self.normalize = True
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         for i, value in enumerate(self.data['midiIntervalHistogram']):
             self.feature.vector[i] = value
@@ -91,7 +91,8 @@ class AverageMelodicIntervalFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         values = []
         # already summed by part if parts exist
@@ -124,7 +125,8 @@ class MostCommonMelodicIntervalFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # already summed by part if parts exist
         histo = self.data['midiIntervalHistogram']
@@ -156,7 +158,8 @@ class DistanceBetweenMostCommonMelodicIntervalsFeature(
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # copy b/c will manipulate
         histo = copy.deepcopy(self.data['midiIntervalHistogram'])
@@ -191,7 +194,8 @@ class MostCommonMelodicIntervalPrevalenceFeature(
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # copy b/c will manipulate
         histo = copy.deepcopy(self.data['midiIntervalHistogram'])
@@ -225,7 +229,8 @@ class RelativeStrengthOfMostCommonIntervalsFeature(
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # copy b/c will manipulate
         histo = copy.deepcopy(self.data['midiIntervalHistogram'])
@@ -262,7 +267,8 @@ class NumberOfCommonMelodicIntervalsFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['midiIntervalHistogram']
         total = sum(histo)
@@ -301,7 +307,8 @@ class AmountOfArpeggiationFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['midiIntervalHistogram']
         total = sum(histo)
@@ -339,7 +346,8 @@ class RepeatedNotesFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['midiIntervalHistogram']
         total = sum(histo)
@@ -377,7 +385,8 @@ class ChromaticMotionFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['midiIntervalHistogram']
         total = sum(histo)
@@ -413,7 +422,8 @@ class StepwiseMotionFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['midiIntervalHistogram']
         total = sum(histo)
@@ -448,7 +458,8 @@ class MelodicThirdsFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['midiIntervalHistogram']
         total = sum(histo)
@@ -483,7 +494,8 @@ class MelodicFifthsFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['midiIntervalHistogram']
         total = sum(histo)
@@ -518,7 +530,8 @@ class MelodicTritonesFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['midiIntervalHistogram']
         total = sum(histo)
@@ -553,7 +566,8 @@ class MelodicOctavesFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['midiIntervalHistogram']
         total = sum(histo)
@@ -589,7 +603,8 @@ class DirectionOfMotionFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         rising = 0
         falling = 0
@@ -650,7 +665,8 @@ class DurationOfMelodicArcsFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # `cList` contains a list of melodic intervals in a part.
         # For example, C4 E4 G4 E4 C4 results in a cList of [4, 3, -3, -4].
@@ -743,7 +759,8 @@ class SizeOfMelodicArcsFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # `cList` contains a list of melodic intervals in a part.
         # For example, C4 E4 G4 E4 C4 results in a cList of [4, 3, -3, -4].
@@ -830,7 +847,8 @@ class MostCommonPitchPrevalenceFeature(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.midiPitchHistogram']
         if not histo:
@@ -864,7 +882,8 @@ class MostCommonPitchClassPrevalenceFeature(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.pitchClassHistogram']
         # if a tie this will return the first
@@ -899,7 +918,8 @@ class RelativeStrengthOfTopPitchesFeature(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.midiPitchHistogram']
         # if a tie this will return the first
@@ -934,7 +954,8 @@ class RelativeStrengthOfTopPitchClassesFeature(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # copy b/c will edit
         histo = copy.deepcopy(self.data['pitches.pitchClassHistogram'])
@@ -973,7 +994,8 @@ class IntervalBetweenStrongestPitchesFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.midiPitchHistogram']
         # if a tie this will return the first
@@ -1007,7 +1029,8 @@ class IntervalBetweenStrongestPitchClassesFeature(
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = copy.deepcopy(self.data['pitches.pitchClassHistogram'])
         # if a tie this will return the first
@@ -1042,7 +1065,8 @@ class NumberOfCommonPitchesFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.midiPitchHistogram']
         total = sum(histo.values())
@@ -1073,7 +1097,8 @@ class PitchVarietyFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.midiPitchHistogram']
         post = 0
@@ -1103,7 +1128,8 @@ class PitchClassVarietyFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.pitchClassHistogram']
         post = 0
@@ -1133,7 +1159,8 @@ class RangeFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.midiPitchHistogram']
         if not histo:
@@ -1165,7 +1192,8 @@ class MostCommonPitchFeature(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.midiPitchHistogram']
         try:
@@ -1226,7 +1254,8 @@ class ImportanceOfBassRegisterFeature(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.midiPitchHistogram']
         if not histo:
@@ -1262,7 +1291,8 @@ class ImportanceOfMiddleRegisterFeature(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.midiPitchHistogram']
         if not histo:
@@ -1298,7 +1328,8 @@ class ImportanceOfHighRegisterFeature(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.midiPitchHistogram']
         if not histo:
@@ -1333,7 +1364,8 @@ class MostCommonPitchClassFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['pitches.pitchClassHistogram']
         pIndexMax = histo.index(max(histo))
@@ -1421,7 +1453,8 @@ class BasicPitchHistogramFeature(featuresModule.FeatureExtractor):
         self.normalize = True
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         for i, count in self.data['pitches.midiPitchHistogram'].items():
             self.feature.vector[i] = count
@@ -1457,7 +1490,8 @@ class PitchClassDistributionFeature(featuresModule.FeatureExtractor):
         self.normalize = True
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # Create vector with [C, C#, D...]
         temp = [0] * self.dimensions
@@ -1505,7 +1539,8 @@ class FifthsPitchHistogramFeature(featuresModule.FeatureExtractor):
             self._mapping[i] = (7 * i) % 12
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         for i, count in enumerate(self.data['pitches.pitchClassHistogram']):
             self.feature.vector[self._mapping[i]] = count
@@ -1548,7 +1583,8 @@ class QualityFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         allKeys = self.data['flat.getElementsByClass(Key)']
         keyFeature = None
@@ -1972,8 +2008,8 @@ class NumberOfRelativelyStrongPulsesFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Number of Relatively Strong Pulses'
-        self.description = '''Number of beat peaks with frequencies at least 30% as high as
-                'the frequency of the bin with the highest frequency.'''
+        self.description = ('Number of beat peaks with frequencies at least 30% as high as '
+                            'the frequency of the bin with the highest frequency.')
         self.isSequential = True
         self.dimensions = 1
 
@@ -1993,10 +2029,11 @@ class RhythmicLoosenessFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Rhythmic Looseness'
-        self.description = '''Average width of beat histogram peaks (in beats per minute).
-        Width is measured for all peaks with frequencies at least 30% as high as the
-        highest peak, and is defined by the distance between the points on the peak in
-        question that are 30% of the height of the peak.'''
+        self.description = dedent('''
+            Average width of beat histogram peaks (in beats per minute).
+            Width is measured for all peaks with frequencies at least 30% as high as the
+            highest peak, and is defined by the distance between the points on the peak in
+            question that are 30% of the height of the peak.''')
         self.isSequential = True
         self.dimensions = 1
 
@@ -2163,7 +2200,8 @@ class AverageNoteDurationFeature(featuresModule.FeatureExtractor):
 
 
 class VariabilityOfNoteDurationFeature(featuresModule.FeatureExtractor):
-    '''Standard deviation of note durations in seconds.
+    '''
+    Standard deviation of note durations in seconds.
 
     # In this piece, we have:
     #     9 half notes or tied pair of quarters
@@ -2172,6 +2210,7 @@ class VariabilityOfNoteDurationFeature(featuresModule.FeatureExtractor):
     # BPM = 120 means a half note is a second.
     # Mean duration should thus be 0.44171779141104295
     # and standard deviation should be  0.17854763448902145
+
     >>> s = corpus.parse('bwv66.6')
     >>> for p in s.parts:
     ...     p.insert(0, tempo.MetronomeMark(number=120))
@@ -2767,7 +2806,8 @@ class QuintupleMeterFeature(featuresModule.FeatureExtractor):
 
 
 class ChangesOfMeterFeature(featuresModule.FeatureExtractor):
-    '''Returns 1 if the time signature is changed one or more
+    '''
+    Returns 1 if the time signature is changed one or more
     times during the recording.
 
     >>> s1 = stream.Stream()
@@ -2812,7 +2852,8 @@ class ChangesOfMeterFeature(featuresModule.FeatureExtractor):
 
 
 class DurationFeature(featuresModule.FeatureExtractor):
-    '''A feature extractor that extracts the duration of the piece in seconds.
+    '''
+    A feature extractor that extracts the duration of the piece in seconds.
 
     >>> s = corpus.parse('bwv66.6')
     >>> for p in s.parts:
@@ -3149,8 +3190,10 @@ class VoiceEqualityMelodicLeapsFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Voice Equality - Melodic Leaps'
-        self.description = '''Standard deviation of the average melodic leap in MIDI pitches
-        for each channel that contains at least one note.'''
+        self.description = dedent('''
+            Standard deviation
+            of the average melodic leap in MIDI pitches
+            for each channel that contains at least one note.''')
         self.isSequential = True
         self.dimensions = 1
 
@@ -3168,8 +3211,9 @@ class VoiceEqualityRangeFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Voice Equality - Range'
-        self.description = '''Standard deviation of the differences between the
-        highest and lowest pitches in each channel that contains at least one note.'''
+        self.description = dedent('''
+            Standard deviation of the differences between the
+            highest and lowest pitches in each channel that contains at least one note.''')
         self.isSequential = True
         self.dimensions = 1
 
@@ -3178,10 +3222,7 @@ class ImportanceOfLoudestVoiceFeature(featuresModule.FeatureExtractor):
     '''
     Not implemented
 
-
-
     TODO: implement
-
     '''
     id = 'T9'
 
@@ -3189,8 +3230,10 @@ class ImportanceOfLoudestVoiceFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Importance of Loudest Voice'
-        self.description = '''Difference between the average loudness of the loudest channel
-        and the average loudness of the other channels that contain at least one note.'''
+        self.description = dedent('''
+            Difference between the average loudness
+            of the loudest channel and the average loudness of the other channels
+            that contain at least one note.''')
         self.isSequential = True
         self.dimensions = 1
 
@@ -3199,10 +3242,7 @@ class RelativeRangeOfLoudestVoiceFeature(featuresModule.FeatureExtractor):
     '''
     Not implemented
 
-
-
     TODO: implement
-
     '''
     id = 'T10'
 
@@ -3210,9 +3250,10 @@ class RelativeRangeOfLoudestVoiceFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Relative Range of Loudest Voice'
-        self.description = '''Difference between the highest note and the lowest note
-        played in the channel with the highest average loudness divided by the difference
-        between the highest note and the lowest note overall in the piece.'''
+        self.description = dedent('''
+            Difference between the highest note and the lowest note
+            played in the channel with the highest average loudness divided by the difference
+            between the highest note and the lowest note overall in the piece.''')
         self.isSequential = True
         self.dimensions = 1
 
@@ -3221,10 +3262,7 @@ class RangeOfHighestLineFeature(featuresModule.FeatureExtractor):
     '''
     Not implemented
 
-
-
     TODO: implement
-
     '''
     id = 'T12'
 
@@ -3232,9 +3270,10 @@ class RangeOfHighestLineFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Range of Highest Line'
-        self.description = '''Difference between the highest note and the lowest note
-        played in the channel with the highest average pitch divided by the difference
-        between the highest note and the lowest note in the piece.'''
+        self.description = dedent('''
+            Difference between the highest note and the lowest note
+            played in the channel with the highest average pitch divided by the difference
+            between the highest note and the lowest note in the piece.''')
         self.isSequential = True
         self.dimensions = 1
 
@@ -3254,9 +3293,10 @@ class RelativeNoteDensityOfHighestLineFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Relative Note Density of Highest Line'
-        self.description = '''Number of Note Ons in the channel with the highest average
-        pitch divided by the average number of Note Ons in all channels that contain at
-        least one note.'''
+        self.description = dedent('''
+            Number of Note Ons in the channel with the highest average
+            pitch divided by the average number of Note Ons in all channels that contain at
+            least one note.''')
         self.isSequential = True
         self.dimensions = 1
 
@@ -3265,10 +3305,7 @@ class MelodicIntervalsInLowestLineFeature(featuresModule.FeatureExtractor):
     '''
     Not implemented
 
-
-
     TODO: implement
-
     '''
     id = 'T15'
 
@@ -3276,9 +3313,10 @@ class MelodicIntervalsInLowestLineFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Melodic Intervals in Lowest Line'
-        self.description = '''Average melodic interval in semitones of the channel
-        with the lowest average pitch divided by the average melodic interval of all
-        channels that contain at least two notes.'''
+        self.description = dedent('''
+            Average melodic interval in semitones of the channel
+            with the lowest average pitch divided by the average melodic interval of all
+            channels that contain at least two notes.''')
         self.isSequential = True
         self.dimensions = 1
 
@@ -3296,9 +3334,10 @@ class VoiceSeparationFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Voice Separation'
-        self.description = '''Average separation in semi-tones between the average pitches of
-        consecutive channels (after sorting based/non average pitch) that contain at
-        least one note.'''
+        self.description = dedent('''
+            Average separation in semi-tones between the average pitches of
+            consecutive channels (after sorting based/non average pitch) that contain at
+            least one note.''')
         self.isSequential = True
         self.dimensions = 1
 
@@ -3347,15 +3386,17 @@ class PitchedInstrumentsPresentFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Pitched Instruments Present'
-        self.description = '''Which pitched General MIDI Instruments are present.
-        There is one entry for each instrument, which is set to 1.0 if there is at
-        least one Note On in the recording corresponding to the instrument and to
-        0.0 if there is not.'''
+        self.description = dedent('''
+            Which pitched General MIDI Instruments are present.
+            There is one entry for each instrument, which is set to 1.0 if there is at
+            least one Note On in the recording corresponding to the instrument and to
+            0.0 if there is not.''')
         self.isSequential = True
         self.dimensions = 128
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         s = self.data['partitionByInstrument']
         # each part has content for each instrument
@@ -3392,11 +3433,12 @@ class UnpitchedInstrumentsPresentFeature(featuresModule.FeatureExtractor):
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Unpitched Instruments Present'
-        self.description = '''Which unpitched MIDI Percussion Key Map instruments are present.
-        There is one entry for each instrument, which is set to 1.0 if there is at least one
-        Note On in the recording corresponding to the instrument and to 0.0 if there is not.
-        It should be noted that only instruments 35 to 81 are included here, as they are the
-        ones that meet the official standard. They are numbered in this array from 0 to 46.'''
+        self.description = dedent('''
+            Which unpitched MIDI Percussion Key Map instruments are present.
+            There is one entry for each instrument, which is set to 1.0 if there is at least one
+            Note On in the recording corresponding to the instrument and to 0.0 if there is not.
+            It should be noted that only instruments 35 to 81 are included here, as they are the
+            ones that meet the official standard. They are numbered in this array from 0 to 46.''')
         self.isSequential = True
         self.dimensions = 47
 
@@ -3447,7 +3489,8 @@ class NotePrevalenceOfPitchedInstrumentsFeature(
         self.dimensions = 128
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         s = self.data['partitionByInstrument']
         total = sum(self.data['pitches.pitchClassHistogram'])
@@ -3482,12 +3525,13 @@ class NotePrevalenceOfUnpitchedInstrumentsFeature(
         super().__init__(dataOrStream=dataOrStream, **keywords)
 
         self.name = 'Note Prevalence of Unpitched Instruments'
-        self.description = '''The fraction of (unpitched) notes played by each General MIDI
-        Percussion Key Map Instrument. There is one entry for each instrument, which is set
-        to the number of Note Ons played using the corresponding MIDI note value divided by
-        the total number of Note Ons in the recording. It should be noted that only instruments
-        35 to 81 are included here, as they are the ones that meet the official standard.
-        They are numbered in this array from 0 to 46.'''
+        self.description = dedent('''
+            The fraction of (unpitched) notes played by each General MIDI
+            Percussion Key Map Instrument. There is one entry for each instrument, which is set
+            to the number of Note Ons played using the corresponding MIDI note value divided by
+            the total number of Note Ons in the recording. It should be noted that only instruments
+            35 to 81 are included here, as they are the ones that meet the official standard.
+            They are numbered in this array from 0 to 46.''')
         self.isSequential = True
         self.dimensions = 47
 
@@ -3632,7 +3676,8 @@ class NumberOfPitchedInstrumentsFeature(featuresModule.FeatureExtractor):
         self.dimensions = 1
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         s = self.data['partitionByInstrument']
         # each part has content for each instrument
@@ -3705,7 +3750,8 @@ class InstrumentFractionFeature(featuresModule.FeatureExtractor):
         self._targetPrograms = []
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         s = self.data['partitionByInstrument']
         total = sum(self.data['pitches.pitchClassHistogram'])

--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -182,7 +182,8 @@ class TonalCertainty(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         self.feature.vector[0] = self.data['flat.analyzedKey.tonalCertainty']
 
@@ -236,7 +237,8 @@ class UniqueNoteQuarterLengths(featuresModule.FeatureExtractor):
         self.discrete = True
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         count = 0
         histo = self.data['flat.notes.quarterLengthHistogram']
@@ -265,7 +267,8 @@ class MostCommonNoteQuarterLength(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['flat.notes.quarterLengthHistogram']
         maximum = 0
@@ -280,6 +283,8 @@ class MostCommonNoteQuarterLength(featuresModule.FeatureExtractor):
 
 class MostCommonNoteQuarterLengthPrevalence(featuresModule.FeatureExtractor):
     '''
+    Fraction of notes that have the most common quarter length.
+
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.native.MostCommonNoteQuarterLengthPrevalence(s)
     >>> fe.extract().vector
@@ -296,7 +301,8 @@ class MostCommonNoteQuarterLengthPrevalence(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         summation = 0  # count of all
         histo = self.data['flat.notes.quarterLengthHistogram']
@@ -313,7 +319,8 @@ class MostCommonNoteQuarterLengthPrevalence(featuresModule.FeatureExtractor):
 
 
 class RangeOfNoteQuarterLengths(featuresModule.FeatureExtractor):
-    '''Difference between the longest and shortest quarter lengths.
+    '''
+    Difference between the longest and shortest quarter lengths.
 
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.native.RangeOfNoteQuarterLengths(s)
@@ -331,7 +338,8 @@ class RangeOfNoteQuarterLengths(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         histo = self.data['flat.notes.quarterLengthHistogram']
         if not histo:
@@ -352,7 +360,8 @@ class RangeOfNoteQuarterLengths(featuresModule.FeatureExtractor):
 
 
 class UniquePitchClassSetSimultaneities(featuresModule.FeatureExtractor):
-    '''Number of unique pitch class simultaneities.
+    '''
+    Number of unique pitch class simultaneities.
 
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.native.UniquePitchClassSetSimultaneities(s)
@@ -370,7 +379,8 @@ class UniquePitchClassSetSimultaneities(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         count = 0
         histo = self.data['chordify.flat.getElementsByClass(Chord).pitchClassSetHistogram']
@@ -382,7 +392,8 @@ class UniquePitchClassSetSimultaneities(featuresModule.FeatureExtractor):
 
 
 class UniqueSetClassSimultaneities(featuresModule.FeatureExtractor):
-    '''Number of unique set class simultaneities.
+    '''
+    Number of unique set class simultaneities.
 
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.native.UniqueSetClassSimultaneities(s)
@@ -400,7 +411,8 @@ class UniqueSetClassSimultaneities(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         count = 0
         histo = self.data['chordify.flat.getElementsByClass(Chord).setClassHistogram']
@@ -413,7 +425,8 @@ class UniqueSetClassSimultaneities(featuresModule.FeatureExtractor):
 
 class MostCommonPitchClassSetSimultaneityPrevalence(
         featuresModule.FeatureExtractor):
-    '''Fraction of all pitch class simultaneities that are the most common simultaneity.
+    '''
+    Fraction of all pitch class simultaneities that are the most common simultaneity.
 
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.native.MostCommonPitchClassSetSimultaneityPrevalence(s)
@@ -432,7 +445,8 @@ class MostCommonPitchClassSetSimultaneityPrevalence(
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         summation = 0  # count of all
         histo = self.data['chordify.flat.getElementsByClass(Chord).pitchClassSetHistogram']
@@ -517,7 +531,8 @@ class MajorTriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # use for total number of chords
         total = len(self.data['chordify.flat.getElementsByClass(Chord)'])
@@ -531,7 +546,8 @@ class MajorTriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
 
 
 class MinorTriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
-    '''Percentage of all simultaneities that are minor triads.
+    '''
+    Percentage of all simultaneities that are minor triads.
 
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.native.MinorTriadSimultaneityPrevalence(s)
@@ -549,7 +565,8 @@ class MinorTriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # use for total number of chords
         total = len(self.data['chordify.flat.getElementsByClass(Chord)'])
@@ -563,7 +580,8 @@ class MinorTriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
 
 
 class DominantSeventhSimultaneityPrevalence(featuresModule.FeatureExtractor):
-    '''Percentage of all simultaneities that are dominant seventh.
+    '''
+    Percentage of all simultaneities that are dominant seventh.
 
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.native.DominantSeventhSimultaneityPrevalence(s)
@@ -581,7 +599,8 @@ class DominantSeventhSimultaneityPrevalence(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # use for total number of chords
         total = len(self.data['chordify.flat.getElementsByClass(Chord)'])
@@ -595,7 +614,8 @@ class DominantSeventhSimultaneityPrevalence(featuresModule.FeatureExtractor):
 
 
 class DiminishedTriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
-    '''Percentage of all simultaneities that are diminished triads.
+    '''
+    Percentage of all simultaneities that are diminished triads.
 
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.native.DiminishedTriadSimultaneityPrevalence(s)
@@ -613,7 +633,8 @@ class DiminishedTriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # use for total number of chords
         total = len(self.data['chordify.flat.getElementsByClass(Chord)'])
@@ -652,7 +673,8 @@ class TriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # use for total number of chords
         total = len(self.data['chordify.flat.getElementsByClass(Chord)'])
@@ -666,7 +688,8 @@ class TriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
 
 
 class DiminishedSeventhSimultaneityPrevalence(featuresModule.FeatureExtractor):
-    '''Percentage of all simultaneities that are diminished seventh chords.
+    '''
+    Percentage of all simultaneities that are diminished seventh chords.
 
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.native.DiminishedSeventhSimultaneityPrevalence(s)
@@ -684,7 +707,8 @@ class DiminishedSeventhSimultaneityPrevalence(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # use for total number of chords
         total = len(self.data['chordify.flat.getElementsByClass(Chord)'])
@@ -727,7 +751,8 @@ class IncorrectlySpelledTriadPrevalence(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # use for total number of chords
         histo = self.data['chordify.flat.getElementsByClass(Chord).typesHistogram']
@@ -790,7 +815,8 @@ class ChordBassMotionFeature(featuresModule.FeatureExtractor):
         self.discrete = False
 
     def process(self):
-        '''Do processing necessary, storing result in feature.
+        '''
+        Do processing necessary, storing result in feature.
         '''
         # use for total number of chords
         harms = self.data['flat.getElementsByClass(Harmony)']

--- a/music21/features/outputFormats.py
+++ b/music21/features/outputFormats.py
@@ -23,7 +23,8 @@ class OutputFormat:
         self._dataSet = dataSet
 
     def getHeaderLines(self):
-        '''Get the header as a list of lines.
+        '''
+        Get the header as a list of lines.
         '''
         pass  # define in subclass
 
@@ -109,7 +110,8 @@ class OutputTabOrange(OutputFormat):
         return post
 
     def getString(self, includeClassLabel=True, includeId=True, lineBreak=None):
-        '''Get the complete DataSet as a string with the appropriate headers.
+        '''
+        Get the complete DataSet as a string with the appropriate headers.
         '''
         if lineBreak is None:
             lineBreak = '\n'
@@ -136,7 +138,8 @@ class OutputCSV(OutputFormat):
         self.ext = '.csv'
 
     def getHeaderLines(self, includeClassLabel=True, includeId=True):
-        '''Get the header as a list of lines.
+        '''
+        Get the header as a list of lines.
 
 
         >>> f = [features.jSymbolic.ChangesOfMeterFeature]
@@ -168,7 +171,8 @@ class OutputCSV(OutputFormat):
 
 
 class OutputARFF(OutputFormat):
-    '''An ARFF (Attribute-Relation File Format) file.
+    '''
+    An ARFF (Attribute-Relation File Format) file.
 
     See
     https://web.archive.org/web/20160212022757/http://weka.wikispaces.com/ARFF+%28stable+version%29
@@ -185,8 +189,8 @@ class OutputARFF(OutputFormat):
         self.ext = '.arff'
 
     def getHeaderLines(self, includeClassLabel=True, includeId=True):
-        '''Get the header as a list of lines.
-
+        '''
+        Get the header as a list of lines.
 
         >>> f = [features.jSymbolic.ChangesOfMeterFeature]
         >>> ds = features.DataSet(classLabel='Composer')

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -414,8 +414,8 @@ class Scatter(primitives.GraphScatter, PlotStreamMixin):
 
 
 class ScatterPitchSpaceQuarterLength(Scatter):
-    r'''A scatter plot of pitch space and quarter length
-
+    r'''
+    A scatter plot of pitch space and quarter length
 
     >>> s = corpus.parse('bach/bwv324.xml')
     >>> p = graph.plot.ScatterPitchSpaceQuarterLength(s)
@@ -445,7 +445,8 @@ class ScatterPitchSpaceQuarterLength(Scatter):
 
 
 class ScatterPitchClassQuarterLength(ScatterPitchSpaceQuarterLength):
-    '''A scatter plot of pitch class and quarter length
+    '''
+    A scatter plot of pitch class and quarter length
 
     >>> s = corpus.parse('bach/bwv324.xml') #_DOCS_HIDE
     >>> p = graph.plot.ScatterPitchClassQuarterLength(s, doneAction=None) #_DOCS_HIDE
@@ -470,7 +471,8 @@ class ScatterPitchClassQuarterLength(ScatterPitchSpaceQuarterLength):
 
 
 class ScatterPitchClassOffset(Scatter):
-    '''A scatter plot of pitch class and offset
+    '''
+    A scatter plot of pitch class and offset
 
     >>> s = corpus.parse('bach/bwv324.xml') #_DOCS_HIDE
     >>> p = graph.plot.ScatterPitchClassOffset(s, doneAction=None) #_DOCS_HIDE
@@ -618,8 +620,8 @@ class Histogram(primitives.GraphHistogram, PlotStreamMixin):
 
 
 class HistogramPitchSpace(Histogram):
-    '''A histogram of pitch space.
-
+    '''
+    A histogram of pitch space.
 
     >>> s = corpus.parse('bach/bwv324.xml') #_DOCS_HIDE
     >>> p = graph.plot.HistogramPitchSpace(s, doneAction=None) #_DOCS_HIDE
@@ -676,8 +678,8 @@ class HistogramPitchClass(Histogram):
 
 
 class HistogramQuarterLength(Histogram):
-    '''A histogram of pitch class
-
+    '''
+    A histogram of pitch class.
 
     >>> s = corpus.parse('bach/bwv324.xml') #_DOCS_HIDE
     >>> p = graph.plot.HistogramQuarterLength(s, doneAction=None) #_DOCS_HIDE
@@ -727,8 +729,8 @@ class ScatterWeighted(primitives.GraphScatterWeighted, PlotStreamMixin):
 
 
 class ScatterWeightedPitchSpaceQuarterLength(ScatterWeighted):
-    '''A graph of event, sorted by pitch, over time
-
+    '''
+    A graph of event, sorted by pitch, over time.
 
     >>> s = corpus.parse('bach/bwv324.xml') #_DOCS_HIDE
     >>> p = graph.plot.ScatterWeightedPitchSpaceQuarterLength(s, doneAction=None) #_DOCS_HIDE
@@ -758,8 +760,8 @@ class ScatterWeightedPitchSpaceQuarterLength(ScatterWeighted):
 
 
 class ScatterWeightedPitchClassQuarterLength(ScatterWeighted):
-    '''A graph of event, sorted by pitch class, over time.
-
+    '''
+    A graph of event, sorted by pitch class, over time.
 
     >>> s = corpus.parse('bach/bwv324.xml') #_DOCS_HIDE
     >>> p = graph.plot.ScatterWeightedPitchClassQuarterLength(s, doneAction=None) #_DOCS_HIDE
@@ -791,7 +793,8 @@ class ScatterWeightedPitchClassQuarterLength(ScatterWeighted):
 
 
 class ScatterWeightedPitchSpaceDynamicSymbol(ScatterWeighted):
-    '''A graph of dynamics used by pitch space.
+    '''
+    A graph of dynamics used by pitch space.
 
     >>> #_DOCS_SHOW s = corpus.parse('schumann_robert/opus41no1/movement2.xml')
     >>> s = converter.parse('tinynotation: 4/4 C4 d E f', makeNotation=False) #_DOCS_HIDE

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1866,7 +1866,8 @@ class ChordSymbol(Harmony):
         return False
 
     def _notationString(self):
-        '''returns NotationString of ChordSymbolObject which dictates which scale
+        '''
+        returns NotationString of ChordSymbolObject which dictates which scale
         degrees and how those scale degrees are altered in this chord.
 
         >>> h = harmony.ChordSymbol('F-dim7')

--- a/music21/humdrum/harmparser.py
+++ b/music21/humdrum/harmparser.py
@@ -117,7 +117,9 @@ def convertHarmToRoman(harmStr):
 
 
 class HarmDefs:
-    ''' Regular expression definitions for the HarmParser class '''
+    '''
+    Regular expression definitions for the HarmParser class
+    '''
 
     # Detect lowered or raised root (-|lowered, #|raised)
     accidental = r'''
@@ -195,7 +197,9 @@ class HarmDefs:
 
 
 class HarmParser:
-    '''Parses an expression in `**harm` syntax'''
+    '''
+    Parses an expression in `**harm` syntax
+    '''
 
     defs = HarmDefs()
 

--- a/music21/humdrum/questions.py
+++ b/music21/humdrum/questions.py
@@ -20,7 +20,8 @@ class Test(unittest.TestCase):
 
     # thoughts on how to do this...
     # def xtest001(self):
-    #    '''Above G4 do higher pitches tend to be louder?
+    #    '''
+    #    Above G4 do higher pitches tend to be louder?
     #    Is this asking if all pitches above G4 are louder, or if, above G4,
     #    as pitches get higher, are they louder?
     #    '''
@@ -39,60 +40,62 @@ class Test(unittest.TestCase):
     #    # to determine trends
     #    table = analysis.correlate(notesAbove, 'pitchSpace', 'dynamics')
 
-# Thoughts on how to do this...
-#    def xtest002(self):
-#        '''Add explicit breath marks after each phrase.'''
-#        from music21 import analysis
-#        from music21 import converter
-#
-#        partStream = converter.parse('dichterliebe1.xml')
-#        # we are frequently going to need a way to partition data into
-#        # phrases. this will be a very common operation that will
-#        # need a number of different approaches
-#
-#        # a phrase stream is partitioned stream of phrases
-#        # might provide a list of criteria that are used to partition
-#        # phrases
-#        phraseStream = analysis.phraseExtract(partStream,
-#                               ['rest', 'slur', 'register'])
-#        for phrase in phraseStream:
-#            phraseNew = phrase.clone()
-#            phraseNew.append(articulations.BreathMark)
-#            # how do we edit/update the old score? assuming that
-#            # the objects are not linked, we need to find and replace
-#            partStream.replace(phrase, phraseNew)
+    # def xtest002(self):
+    #     '''
+    #     Add explicit breath marks after each phrase.  Incomplete
+    #     '''
+    #     from music21 import analysis
+    #     from music21 import converter
+    #
+    #     partStream = converter.parse('dichterliebe1.xml')
+    #     # we are frequently going to need a way to partition data into
+    #     # phrases. this will be a very common operation that will
+    #     # need a number of different approaches
+    #
+    #     # a phrase stream is partitioned stream of phrases
+    #     # might provide a list of criteria that are used to partition
+    #     # phrases
+    #     phraseStream = analysis.phraseExtract(partStream,
+    #                           ['rest', 'slur', 'register'])
+    #     for phrase in phraseStream:
+    #         phraseNew = phrase.clone()
+    #         phraseNew.append(articulations.BreathMark)
+    #         # how do we edit/update the old score? assuming that
+    #         # the objects are not linked, we need to find and replace
+    #         partStream.replace(phrase, phraseNew)
 
-    def xtest003(self):
-        '''Add key velocities to some MIDI data that reflect accent levels arising from the meter.
-
-        Modify this to just adjust dynamics based on meter; this should be
-        reflected in musical output
-        '''
-        from music21 import articulations
-        from music21 import converter
-        from music21 import stream
-
-        partStream = converter.parse('dichterliebe1.xml')
-        # for part in partStream.partData:
-        # a part stream could have an iterator that partitions itself
-        # into measure-length part streams
-        for measure in partStream.getElementsByClass(stream.Measure)():  # () ?
-            # measure is a partStream isolated for just the desired measure
-            # assuming only one meter per measure
-            meterObj = measure['meter']
-            # get a list of pairs, specifying offset and accent
-            for offset, accent in meterObj.accentPattern():
-                if accent > 'mf':  # assuming symbolic representation
-                    # get all relevant elements
-                    subStream = measure.getElementsByOffset(offset,
-                                                            offset + meterObj.denominator)
-                    # get a stream of just dynamics
-                    dynamics = subStream.filterClass(articulations.DynamicArticulation)
-                    for unused_obj in dynamics:
-                        # can we increment dynamics by dynamics?
-                        # obj += 'pppp'
-                        pass
-                    # will these changes be reflected in the source part stream?
+    # def xtest003(self):
+    #     '''
+    #     Add key velocities to some MIDI data that reflect accent levels arising from the meter.
+    #
+    #     Modify this to just adjust dynamics based on meter; this should be
+    #     reflected in musical output
+    #     '''
+    #     from music21 import articulations
+    #     from music21 import converter
+    #     from music21 import stream
+    #
+    #     partStream = converter.parse('dichterliebe1.xml')
+    #     # for part in partStream.partData:
+    #     # a part stream could have an iterator that partitions itself
+    #     # into measure-length part streams
+    #     for measure in partStream.getElementsByClass(stream.Measure)():  # () ?
+    #         # measure is a partStream isolated for just the desired measure
+    #         # assuming only one meter per measure
+    #         meterObj = measure['meter']
+    #         # get a list of pairs, specifying offset and accent
+    #         for offset, accent in meterObj.accentPattern():
+    #             if accent > 'mf':  # assuming symbolic representation
+    #                 # get all relevant elements
+    #                 subStream = measure.getElementsByOffset(offset,
+    #                                                         offset + meterObj.denominator)
+    #                 # get a stream of just dynamics
+    #                 dynamics = subStream.filterClass(articulations.DynamicArticulation)
+    #                 for unused_obj in dynamics:
+    #                     # can we increment dynamics by dynamics?
+    #                     # obj += 'pppp'
+    #                     pass
+    #                 # will these changes be reflected in the source part stream?
 
     def xtest004(self):
         '''
@@ -100,126 +103,125 @@ class Test(unittest.TestCase):
         '''
         pass
 
-#    def xtest005(self):
-#        '''Alphabetize a list of titles.'''
-#        from music21 import analysis
-#        from music21 import converter
-#
-#        corpusDir = 'path/to/files'
-#        sort = []
-#        for fn in os.listdir(corpusDir):
-#            if not fn.endswith('.xml'): continue
-#            # we may have more than one thing that looks like a title
-#            titleCandidates = []
-#            partStream = converter.parse(fn)
-#            # pages might be represented as a stream of Page objects
-#            # this could be contained w/n a part stream
-#            pageStream = partStream['pages']
-#            # assuming we have classes for things on pages, such as
-#            # titles and other tex annotations
-#            # here, we get these only from the first page
-#            titleCandidates += pageStream[0].getElementsByClass(TextAnnotation)
-#            # an additional slot might be used to store metadata, also
-#            # as a stream
-#            metaStream = partStream['meta']
-#            titleCandidates += metaStream.getElementsByClass(TextAnnotation)
-#            sort.append(titleCandidates)
-#
-#        sort.sort()
+    # def xtest005(self):
+    #     '''
+    #     Alphabetize a list of titles.
+    #     '''
+    #     from music21 import analysis
+    #     from music21 import converter
+    #
+    #     corpusDir = 'path/to/files'
+    #     sort = []
+    #     for fn in os.listdir(corpusDir):
+    #         if not fn.endswith('.xml'): continue
+    #         # we may have more than one thing that looks like a title
+    #         titleCandidates = []
+    #         partStream = converter.parse(fn)
+    #         # pages might be represented as a stream of Page objects
+    #         # this could be contained w/n a part stream
+    #         pageStream = partStream['pages']
+    #         # assuming we have classes for things on pages, such as
+    #         # titles and other tex annotations
+    #         # here, we get these only from the first page
+    #         titleCandidates += pageStream[0].getElementsByClass(TextAnnotation)
+    #         # an additional slot might be used to store metadata, also
+    #         # as a stream
+    #         metaStream = partStream['meta']
+    #         titleCandidates += metaStream.getElementsByClass(TextAnnotation)
+    #         sort.append(titleCandidates)
+    #
+    #     sort.sort()
 
 
-#    def xtest006(self):
-#        '''Amalgamate arpeggios into chords and display as notation.
-#
-#        How are the arpeggios delineated? Is it a part with only arpeggios, or
-#        are they intermingled?
-#        '''
-#        from music21 import analysis
-#        from music21 import converter
-#
-#        partStream = converter.parse('dichterliebe1.xml')
-#
-#        # we might look at arpeggios as a type of extractable phrase,
-#        # looking fo open spacings, even rhythms, and chordal forms
-#        phraseStream = analysis.phraseExtract(partStream, ['arpeggio'])
-#        newStream = Stream()
-#        newStream.append(partStream.notationStream)
-#        for phrase in phraseStream:
-#            chord = chord.Chord()
-#            for note in Phrase:
-#                chord.addPitch(note.pitch)
-#            chord.duration = phrase.duration
-#            chord.showJazzName = True ## something
-#            chord.showFiguredBass = True ##
-#            newStream.appendNext(chord)
-#
-#        newStream.append(partStream)  # this puts them in parallel
-#        newStream.show()
+    # def xtest006(self):
+    #     '''
+    #     Amalgamate arpeggios into chords and display as notation.
+    #
+    #     How are the arpeggios delineated? Is it a part with only arpeggios, or
+    #     are they intermingled?
+    #     '''
+    #     from music21 import analysis
+    #     from music21 import converter
+    #
+    #     partStream = converter.parse('dichterliebe1.xml')
+    #
+    #     # we might look at arpeggios as a type of extractable phrase,
+    #     # looking fo open spacings, even rhythms, and chordal forms
+    #     phraseStream = analysis.phraseExtract(partStream, ['arpeggio'])
+    #     newStream = Stream()
+    #     newStream.append(partStream.notationStream)
+    #     for phrase in phraseStream:
+    #         chord = chord.Chord()
+    #         for note in Phrase:
+    #             chord.addPitch(note.pitch)
+    #         chord.duration = phrase.duration
+    #         chord.showJazzName = True ## something
+    #         chord.showFiguredBass = True ##
+    #         newStream.appendNext(chord)
+    #
+    #     newStream.append(partStream)  # this puts them in parallel
+    #     newStream.show()
 
-#    def xtest007(self):
-#        '''Annotate a score identifying possible cadential 6-4 chords.'''
-#
-#        chordSequenceMatch = chord.factory('V64'), chord.factory('I')
-#
-#        partStream = music21.converter.parse('dichterliebe1.xml')
-#        ## when we have a passing-tone etc. removal program run here...
-#
-#        chordStream = analysis.phraseExtract(partStream, ['simultaneities'])
-#
-#        # might have many different approaches to key analysis
-#        # all return a stream of keys, with key objects at the appropriate
-#        # offsets
-#        keyStream = analysis.key(partStream, 'chew.spiralArray')
-#
-#        for i in range(len(chordStream) - 1):
-#            chordThis = chordStream[i]
-#            chordNext = chordStream[i + 1]
-#
-#            # get key at this offset
-#            # here, it is important that the offsets of the chords
-#            # are the same scale as the offsets of the keyStream
-#            # may need a method here that looks for elements that
-#            # are active, not just present
-#            # keys thus do not need a duration
-#
-#            ### getElementsByOffsetRange....
-#            key = keyStream.getElementsByOffset(chordThis.offset,
-#                            chordNext.offset, lastActive=True)
-# if (common.toRoman(chordThis.scaleDegree(key)) == "V" and
-# chordThis.inversionName == "64" and
-# common.toRoman(chordThis.scaleDegree(key)) == "I" and
-#                chordThis.inversionName == "53"
-# )
-# OR>:::
-#            if (chordThis.setKey(key) == chordSequenceMatch[0](key) and
-#                chordNext.setKey(key) == chordSequenceMatch[1](key)):
-#                # here it is important that the offsets match that
-#                # of the source
-#                # not sure where/how part stream places this
-#                annotation = articulations.Annotation('big cadential moment')
-#                partStream.insert(chordThis.offset, annotation)
+    # def xtest007(self):
+    #     '''
+    #     Annotate a score identifying possible cadential 6-4 chords.'''
+    #
+    #     chordSequenceMatch = chord.factory('V64'), chord.factory('I')
+    #
+    #     partStream = music21.converter.parse('dichterliebe1.xml')
+    #     ## when we have a passing-tone etc. removal program run here...
+    #
+    #     chordStream = analysis.phraseExtract(partStream, ['simultaneities'])
+    #
+    #     # might have many different approaches to key analysis
+    #     # all return a stream of keys, with key objects at the appropriate
+    #     # offsets
+    #     keyStream = analysis.key(partStream, 'chew.spiralArray')
+    #
+    #     for i in range(len(chordStream) - 1):
+    #         chordThis = chordStream[i]
+    #         chordNext = chordStream[i + 1]
+    #
+    #         # get key at this offset
+    #         # here, it is important that the offsets of the chords
+    #         # are the same scale as the offsets of the keyStream
+    #         # may need a method here that looks for elements that
+    #         # are active, not just present
+    #         # keys thus do not need a duration
+    #
+    #         ### getElementsByOffsetRange....
+    #         key = keyStream.getElementsByOffset(chordThis.offset,
+    #                         chordNext.offset, lastActive=True)
+    #        if (chordThis.setKey(key) == chordSequenceMatch[0](key) and
+    #            chordNext.setKey(key) == chordSequenceMatch[1](key)):
+    #            # here it is important that the offsets match that
+    #            # of the source
+    #            # not sure where/how part stream places this
+    #            annotation = articulations.Annotation('big cadential moment')
+    #            partStream.insert(chordThis.offset, annotation)
 
-#    def xtest008(self):
-#        '''Are dynamic swells (crescendo-diminuendos) more
-#        common than dips (diminuendos-crescendos)?'''
-#        partStream = music21.converter.parse('dichterliebe1.xml')
-#
-#        # an analysis package can identify dynamic contours, movements from
-#        # low to high or vice versa, and return these as a stream of
-#        # DynamicMovement objects
-#
-#        dynMovementStream = analysis.dynamicContour(partStream)
-#        swells = dynMovementStream.getElementsByClass(DynamicCrescendo)
-#        dips = dynMovementStream.getElementsByClass(DynamicDecrescendo)
-#        if len(swells) > len(dips):
-#            return 'swells win'
-#        else:
-#            return 'dips win'
-
+    # def xtest008(self):
+    #     '''
+    #     Are dynamic swells (crescendo-diminuendos) more
+    #     common than dips (diminuendos-crescendos)?'''
+    #     partStream = music21.converter.parse('dichterliebe1.xml')
+    #
+    #     # an analysis package can identify dynamic contours, movements from
+    #     # low to high or vice versa, and return these as a stream of
+    #     # DynamicMovement objects
+    #
+    #     dynMovementStream = analysis.dynamicContour(partStream)
+    #     swells = dynMovementStream.getElementsByClass(DynamicCrescendo)
+    #     dips = dynMovementStream.getElementsByClass(DynamicDecrescendo)
+    #     if len(swells) > len(dips):
+    #         return 'swells win'
+    #     else:
+    #         return 'dips win'
 
     def xtest009(self):
-        '''Are lower pitches likely to be shorter and higher pitches likely to be longer?'''
-
+        '''
+        Are lower pitches likely to be shorter and higher pitches likely to be longer?
+        '''
         partStream = music21.converter.parse('dichterliebe1.xml')
         unused_noteStream = partStream['notes']
         # unused_table = analysis.correlate(noteStream, 'pitchSpace', 'duration')
@@ -227,22 +229,29 @@ class Test(unittest.TestCase):
         # we must examine and interpolate the table in order to distinguish
         # trends
 
-#    def xtest010(self):
-#        '''Assemble individual parts into a full scores.'''
-#        partStream = PartStream()
-#        for part in PartsList:
-#            partStream['id'].add(part)
+    # def xtest010(self):
+    #     '''
+    #     Assemble individual parts into a full scores.
+    #     '''
+    #     partStream = PartStream()
+    #     for part in PartsList:
+    #         partStream['id'].add(part)
 
     def xtest011(self):
-        '''Assemble syllables into words for some vocal text.'''
+        '''
+        Assemble syllables into words for some vocal text.
+        '''
         pass
 
-    def xtest012(self):
-        '''Calculate all the permuted harmonic intervals in a chord.'''
-        pass
+    # def xtest012(self):
+    #     '''
+    #     Calculate all the permuted harmonic intervals in a chord.
+    #     '''
+    #     pass
 
     def xtest013(self):
-        '''Calculate changes of listeners' heart-rate from physiological data.
+        '''
+        Calculate changes of listeners' heart-rate from physiological data.
 
         We'll do something different from the Humdrum example which assumes you already
         have the data in spines.  Let's suppose you have the data in a Google Spreadsheet
@@ -256,12 +265,16 @@ class Test(unittest.TestCase):
         '''
         pass
 
-    def xtest014(self):
-        '''Calculate harmonic intervals between concurrent parts.'''
-        pass
+    # def xtest014(self):
+    #     '''
+    #     Calculate harmonic intervals between concurrent parts.
+    #     '''
+    #     pass
 
     def xtest015(self):
-        '''Calculate harmonic intervals ignoring unisons.'''
+        '''
+        Calculate harmonic intervals ignoring unisons.
+        '''
         from collections import defaultdict
         score1 = music21.converter.parse('dichterliebe1.xml')
         monoScore = score1.chordsToNotes()    # returns a new Stream
@@ -276,156 +289,210 @@ class Test(unittest.TestCase):
             print(key, intervals2[key])
 
     def test016(self):
-        '''Calculate harmonic intervals in semitones.'''
+        '''
+        Calculate harmonic intervals in semitones.
+        '''
         pass
 
     def test017(self):
-        '''Calculate melodic intervals not including intervals
-        between the last note of one phrase and the first note of the next phrase.'''
+        '''
+        Calculate melodic intervals not including intervals
+        between the last note of one phrase and the first note of the next phrase.
+        '''
         pass
 
-    def test018(self):
-        '''Calculate melodic intervals not including intervals
-        between the last note of one phrase and the first note of the next phrase.'''
-        pass
+    # def test018(self):
+    #     '''
+    #     Calculate melodic intervals not including intervals
+    #     between the last note of one phrase and the first note of the next phrase.'''
+    #     pass
 
     def test019(self):
-        '''Calculate pitch-class sets for melodic passages segmented by rests.'''
+        '''
+        Calculate pitch-class sets for melodic passages segmented by rests.
+        '''
         pass
 
     def test020(self):
-        '''Calculate pitch-class sets for melodic passages segmented by slurs/phrases.'''
+        '''
+        Calculate pitch-class sets for melodic passages segmented by slurs/phrases.
+        '''
         pass
 
     def test021(self):
-        '''Calculate the difference in duration between the recapitulation and the exposition.'''
+        '''
+        Calculate the difference in duration between the recapitulation and the exposition.
+        '''
         pass
 
     def test022(self):
-        '''Calculate the interval vector for some set.'''
+        '''
+        Calculate the interval vector for some set.
+        '''
         pass
 
     def test023(self):
-        '''Calculate the normal form for some set.'''
+        '''
+        Calculate the normal form for some set.
+        '''
         pass
 
     def test024(self):
-        '''Calculate the prime form for some set.'''
+        '''
+        Calculate the prime form for some set.
+        '''
         pass
 
     def test025(self):
-        '''Calculate the proportion of sonorities where both the oboe and bassoon are active.'''
+        '''
+        Calculate the proportion of sonorities where both the oboe and bassoon are active.
+        '''
         pass
 
     def test026(self):
-        '''Change all pizzicato marks to spiccato marks.'''
+        '''
+        Change all pizzicato marks to spiccato marks.
+        '''
         pass
 
     def test027(self):
-        '''Change all up-stems in measures 34 through 38 to down-stems.'''
+        '''
+        Change all up-stems in measures 34 through 38 to down-stems.
+        '''
         pass
 
     def test028(self):
-        '''Classify cadences as either authentic, plagal or deceptive.'''
+        '''
+        Classify cadences as either authentic, plagal or deceptive.
+        '''
         pass
 
     def test029(self):
-        '''Classify flute fingering transitions as either easy, moderate, or difficult.'''
+        '''
+        Classify flute fingering transitions as either easy, moderate, or difficult.
+        '''
         pass
 
     def test030(self):
-        '''Classify phonemes in a vocal text as fricatives, nasals, plosives, etc.'''
+        '''
+        Classify phonemes in a vocal text as fricatives, nasals, plosives, etc.
+        '''
         pass
 
     def test031(self):
-        '''.'''
         pass
 
     def test032(self):
-        '''.'''
         pass
 
     def test033(self):
-        '''.'''
         pass
 
     def test034(self):
-        '''.'''
         pass
 
     def test035(self):
-        '''Compare the average overall dynamic level between the
-        exposition and development sections.'''
+        '''
+        Compare the average overall dynamic level between the
+        exposition and development sections.
+        '''
         pass
 
     def test036(self):
-        '''Compare the estimated keys for the 2nd theme in the
-        exposition versus the 2nd theme in the recapitulation.'''
+        '''
+        Compare the estimated keys for the 2nd theme in the
+        exposition versus the 2nd theme in the recapitulation.
+        '''
         pass
 
     def test037(self):
-        '''Compare the first phrase of the Exposition with
-        the first phrase of the Recapitulation.'''
+        '''
+        Compare the first phrase of the Exposition with
+        the first phrase of the Recapitulation.
+        '''
         pass
 
     def test038(self):
-        '''Compare the number of syllables in the first and second verses.'''
+        '''
+        Compare the number of syllables in the first and second verses.
+        '''
         pass
 
     def test039(self):
-        '''Contrast the sonorities that occur on the
-        first versus the third beats in a waltz repertory.'''
+        '''
+        Contrast the sonorities that occur on the
+        first versus the third beats in a waltz repertory.
+        '''
         pass
 
     def test040(self):
-        '''Count how many measures contain at least one trill.'''
+        '''
+        Count how many measures contain at least one trill.
+        '''
         pass
 
     def test041(self):
-        '''Count the number of ascending major sixth
-        intervals that occur in phrases that end on the dominant.'''
+        '''
+        Count the number of ascending major sixth
+        intervals that occur in phrases that end on the dominant.
+        '''
         pass
 
     def test042(self):
-        '''Count the number of barlines in a work.'''
+        '''
+        Count the number of barlines in a work.
+        '''
         pass
 
     def test043(self):
-        '''Count the number of closed-position chords.'''
+        '''
+        Count the number of closed-position chords.
+        '''
         pass
 
     def test044(self):
-        '''Count the number of harmonic functions in each phrase.'''
+        '''
+        Count the number of harmonic functions in each phrase.
+        '''
         pass
 
     def test045(self):
-        '''Count the number of notes in a work that
-        belong to the same whole-tone set.'''
+        '''
+        Count the number of notes in a work that
+        belong to the same whole-tone set.
+        '''
         pass
 
     def test046(self):
-        '''Count the number of notes in measures 8 to 16.'''
+        '''
+        Count the number of notes in measures 8 to 16.
+        '''
         pass
 
     def test047(self):
-        '''Count the number of notes in the exposition.'''
+        '''
+        Count the number of notes in the exposition.
+        '''
         pass
 
     def test048(self):
-        '''Count the number of phrases in a score.'''
+        '''
+        Count the number of phrases in a score.
+        '''
         pass
 
     def test049(self):
-        '''Count the number of phrases that begin on the subdominant pitch.'''
+        '''
+        Count the number of phrases that begin on the subdominant pitch.
+        '''
         pass
 
     def test050(self):
-        '''Count the number of phrases in the development.'''
+        '''
+        Count the number of phrases in the development.
+        '''
         pass
 
-
-#
-#
 #     1.    Above G4 do higher pitches tend to be louder?
 #     2.    Add explicit breath marks after each phrase.
 #     3.    Add key velocities to some MIDI data that reflect accent levels arising from the meter.

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1619,12 +1619,16 @@ class SpineCollection(prebase.ProtoM21Object):
         self.newSpine = None
 
     def __iter__(self):
-        '''Resets the counter to len(self.spines) so that iteration is correct'''
+        '''
+        Resets the counter to len(self.spines) so that iteration is correct
+        '''
         self.iterIndex = len(self.spines) - 1
         return self
 
     def __next__(self):
-        '''Returns the current spine and decrements the iteration index.'''
+        '''
+        Returns the current spine and decrements the iteration index.
+        '''
         if self.iterIndex < 0:
             raise StopIteration
         thisSpine = self.spines[self.iterIndex]

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -1754,8 +1754,10 @@ class Choir(Vocalist):
 
 
 class Conductor(Instrument):
-    '''Presently used only for tracking the MIDI track containing tempo,
-    key signature, and related metadata.'''
+    '''
+    Presently used only for tracking the MIDI track containing tempo,
+    key signature, and related metadata.
+    '''
 
     def __init__(self, **keywords):
         super().__init__(instrumentName='Conductor', **keywords)

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -127,7 +127,8 @@ class LayoutBase(base.Music21Object):
 
 
 class ScoreLayout(LayoutBase):
-    '''Parameters for configuring a score's layout.
+    '''
+    Parameters for configuring a score's layout.
 
     PageLayout objects may be found on Measure or Part Streams.
 

--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -227,22 +227,30 @@ _IGNORE_UNPROCESSED = (
 # Exceptions
 # -----------------------------------------------------------------------------
 class MeiValidityError(exceptions21.Music21Exception):
-    '''When there is an otherwise-unspecified validity error that prevents parsing.'''
+    '''
+    When there is an otherwise-unspecified validity error that prevents parsing.
+    '''
     pass
 
 
 class MeiValueError(exceptions21.Music21Exception):
-    '''When an attribute has an invalid value.'''
+    '''
+    When an attribute has an invalid value.
+    '''
     pass
 
 
 class MeiAttributeError(exceptions21.Music21Exception):
-    '''When an element has an invalid attribute.'''
+    '''
+    When an element has an invalid attribute.
+    '''
     pass
 
 
 class MeiElementError(exceptions21.Music21Exception):
-    '''When an element itself is invalid.'''
+    '''
+    When an element itself is invalid.
+    '''
     pass
 
 
@@ -1178,7 +1186,9 @@ def addSlurs(elem, obj, slurBundle):
     addedSlur = False
 
     def wrapGetByIdLocal(theId):
-        '''Avoid crashing when getByIdLocl() doesn't find the slur'''
+        '''
+        Avoid crashing when getByIdLocl() doesn't find the slur
+        '''
         try:
             slurBundle.getByIdLocal(theId)[0].addSpannedElements(obj)
             return True

--- a/music21/mei/test_base.py
+++ b/music21/mei/test_base.py
@@ -61,18 +61,22 @@ from music21.mei.base import MEI_NS
 
 
 class Test(unittest.TestCase):
-    # class TestMeiToM21Class(unittest.TestCase):
-    # '''Tests for the MeiToM21Converter class.'''
+    # -----------------------------------------
+    #   Tests for the MeiToM21Converter class.
 
     def testInit1(self):
-        '''__init__(): no argument gives an "empty" MeiToM21Converter instance'''
+        '''
+        __init__(): no argument gives an "empty" MeiToM21Converter instance
+        '''
         actual = base.MeiToM21Converter()
         self.assertIsNotNone(actual.documentRoot)
         self.assertIsInstance(actual.m21Attr, defaultdict)
         self.assertIsInstance(actual.slurBundle, spanner.SpannerBundle)
 
     def testInit2(self):
-        '''__init__(): a valid MEI file is prepared properly'''
+        '''
+        __init__(): a valid MEI file is prepared properly
+        '''
         inputFile = '''<?xml version="1.0" encoding="UTF-8"?>
                        <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="2013">
                        <music><score></score></music></mei>'''
@@ -86,7 +90,9 @@ class Test(unittest.TestCase):
         self.assertIsInstance(actual.slurBundle, spanner.SpannerBundle)
 
     def testInit3(self):
-        '''__init__(): an invalid XML file causes an MeiValidityError'''
+        '''
+        __init__(): an invalid XML file causes an MeiValidityError
+        '''
         inputFile = 'this is not an XML file'
         self.assertRaises(base.MeiValidityError, base.MeiToM21Converter, inputFile)
         try:
@@ -95,7 +101,9 @@ class Test(unittest.TestCase):
             self.assertEqual(base._INVALID_XML_DOC, theError.args[0])
 
     def testInit4(self):
-        '''__init__(): a MusicXML file causes an MeiElementError'''
+        '''
+        __init__(): a MusicXML file causes an MeiElementError
+        '''
         inputFile = '''<?xml version="1.0" encoding="UTF-8"?>
                        <!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
                                                        "http://www.musicxml.org/dtds/partwise.dtd">
@@ -139,11 +147,12 @@ class Test(unittest.TestCase):
         mockMeta.assert_called_once_with(testConv.documentRoot)
 
     # -----------------------------------------------------------------------------
-    # class TestThings(unittest.TestCase):
-    # '''Tests for utility functions.'''
+    # Tests for utility functions.
 
     def testSafePitch1(self):
-        '''safePitch(): when ``name`` is a valid pitch name'''
+        '''
+        safePitch(): when ``name`` is a valid pitch name
+        '''
         name = 'D#6'
         expected = pitch.Pitch('D#6')
         actual = base.safePitch(name)
@@ -152,7 +161,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.octave, actual.octave)
 
     def testSafePitch2(self):
-        '''safePitch(): when ``name`` is not a valid pitch name'''
+        '''
+        safePitch(): when ``name`` is not a valid pitch name
+        '''
         name = ''
         expected = pitch.Pitch()
         actual = base.safePitch(name)
@@ -161,7 +172,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.octave, actual.octave)
 
     def testSafePitch3(self):
-        '''safePitch(): when ``name`` is not given, but there are various **keywords'''
+        '''
+        safePitch(): when ``name`` is not given, but there are various **keywords
+        '''
         expected = pitch.Pitch('D#6')
         actual = base.safePitch(name='D', accidental='#', octave='6')
         self.assertEqual(expected.name, actual.name)
@@ -169,7 +182,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.octave, actual.octave)
 
     def testSafePitch4(self):
-        '''safePitch(): when 2nd argument is None'''
+        '''
+        safePitch(): when 2nd argument is None
+        '''
         expected = pitch.Pitch('D6')
         actual = base.safePitch(name='D', accidental=None, octave='6')
         self.assertEqual(expected.name, actual.name)
@@ -177,7 +192,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.octave, actual.octave)
 
     def testAllPartsPresent1(self):
-        '''allPartsPresent(): one <staffDef>, no repeats'''
+        '''
+        allPartsPresent(): one <staffDef>, no repeats
+        '''
         staffDefs = [mock.MagicMock(spec_set=ETree.Element)]
         staffDefs[0].get = mock.MagicMock(return_value='1')
         elem = mock.MagicMock(spec_set=ETree.Element)
@@ -187,7 +204,9 @@ class Test(unittest.TestCase):
         self.assertSequenceEqual(expected, actual)
 
     def testAllPartsPresent2(self):
-        '''allPartsPresent(): four <staffDef>s'''
+        '''
+        allPartsPresent(): four <staffDef>s
+        '''
         staffDefs = [mock.MagicMock(spec_set=ETree.Element) for _ in range(4)]
         for i in range(4):
             staffDefs[i].get = mock.MagicMock(return_value=str(i + 1))
@@ -198,7 +217,9 @@ class Test(unittest.TestCase):
         self.assertSequenceEqual(expected, actual)
 
     def testAllPartsPresent3(self):
-        '''allPartsPresent(): four unique <staffDef>s, several repeats'''
+        '''
+        allPartsPresent(): four unique <staffDef>s, several repeats
+        '''
         staffDefs = [mock.MagicMock(spec_set=ETree.Element) for _ in range(12)]
         for i in range(12):
             staffDefs[i].get = mock.MagicMock(return_value=str((i % 4) + 1))
@@ -209,7 +230,9 @@ class Test(unittest.TestCase):
         self.assertSequenceEqual(expected, actual)
 
     def testAllPartsPresent4(self):
-        '''allPartsPresent(): error: no <staffDef>s'''
+        '''
+        allPartsPresent(): error: no <staffDef>s
+        '''
         elem = mock.MagicMock(spec_set=ETree.Element)
         self.assertRaises(base.MeiValidityError, base.allPartsPresent, elem)
         try:
@@ -218,14 +241,18 @@ class Test(unittest.TestCase):
             self.assertEqual(base._SEEMINGLY_NO_PARTS, mvErr.args[0])
 
     def testTimeSigFromAttrs(self):
-        '''_timeSigFromAttrs(): that it works (integration test)'''
+        '''
+        _timeSigFromAttrs(): that it works (integration test)
+        '''
         elem = ETree.Element('{mei}staffDef', attrib={'meter.count': '3', 'meter.unit': '8'})
         expectedRatioString = '3/8'
         actual = base._timeSigFromAttrs(elem)
         self.assertEqual(expectedRatioString, actual.ratioString)
 
     def testKeySigFromAttrs1(self):
-        '''_keySigFromAttrs(): using @key.pname, @key.accid, and @key.mode (integration test)'''
+        '''
+        _keySigFromAttrs(): using @key.pname, @key.accid, and @key.mode (integration test)
+        '''
         elem = ETree.Element('{mei}staffDef', attrib={'key.pname': 'B', 'key.accid': 'f',
                                                       'key.mode': 'minor'})
         expectedTPNWC = 'b-'
@@ -234,7 +261,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expectedTPNWC, actual.tonicPitchNameWithCase)
 
     def testKeySigFromAttrs2(self):
-        '''_keySigFromAttrs(): using @key.sig, and @key.mode (integration test)'''
+        '''
+        _keySigFromAttrs(): using @key.sig, and @key.mode (integration test)
+        '''
         elem = ETree.Element('{mei}staffDef', attrib={'key.sig': '6s', 'key.mode': 'minor'})
         expectedSharps = 6
         expectedMode = 'minor'
@@ -244,7 +273,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expectedMode, actual.mode)
 
     def testTranspositionFromAttrs1(self):
-        '''_transpositionFromAttrs(): descending transposition (integration test)'''
+        '''
+        _transpositionFromAttrs(): descending transposition (integration test)
+        '''
         elem = ETree.Element('{mei}staffDef', attrib={'trans.semi': '-3', 'trans.diat': '-2'})
         expectedName = 'm-3'
         actual = base._transpositionFromAttrs(elem)
@@ -252,7 +283,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expectedName, actual.directedName)
 
     def testTranspositionFromAttrs2(self):
-        '''_transpositionFromAttrs(): ascending transposition (integration test)'''
+        '''
+        _transpositionFromAttrs(): ascending transposition (integration test)
+        '''
         elem = ETree.Element('{mei}staffDef', attrib={'trans.semi': '7', 'trans.diat': '4'})
         expectedName = 'P5'
         actual = base._transpositionFromAttrs(elem)
@@ -260,7 +293,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expectedName, actual.directedName)
 
     def testTranspositionFromAttrs3(self):
-        '''_transpositionFromAttrs(): large ascending interval (integration test)'''
+        '''
+        _transpositionFromAttrs(): large ascending interval (integration test)
+        '''
         elem = ETree.Element('{mei}staffDef', attrib={'trans.semi': '19', 'trans.diat': '11'})
         expectedName = 'P12'
         actual = base._transpositionFromAttrs(elem)
@@ -268,7 +303,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expectedName, actual.directedName)
 
     def testTranspositionFromAttrs4(self):
-        '''_transpositionFromAttrs(): alternate octave spec (integration test)'''
+        '''
+        _transpositionFromAttrs(): alternate octave spec (integration test)
+        '''
         elem = ETree.Element('{mei}staffDef', attrib={'trans.semi': '12', 'trans.diat': '0'})
         expectedName = 'P8'
         actual = base._transpositionFromAttrs(elem)
@@ -276,7 +313,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expectedName, actual.directedName)
 
     def testTranspositionFromAttrs5(self):
-        '''_transpositionFromAttrs(): alternate large descending interval (integration test)'''
+        '''
+        _transpositionFromAttrs(): alternate large descending interval (integration test)
+        '''
         elem = ETree.Element('{mei}staffDef', attrib={'trans.semi': '-19', 'trans.diat': '-4'})
         expectedName = 'P-12'
         actual = base._transpositionFromAttrs(elem)
@@ -284,7 +323,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expectedName, actual.directedName)
 
     def testTranspositionFromAttrs6(self):
-        '''_transpositionFromAttrs(): alternate ascending sixteenth interval (integration test)'''
+        '''
+        _transpositionFromAttrs(): alternate ascending sixteenth interval (integration test)
+        '''
         elem = ETree.Element('{mei}staffDef', attrib={'trans.semi': '26', 'trans.diat': '1'})
         expectedName = 'M16'
         actual = base._transpositionFromAttrs(elem)
@@ -292,14 +333,18 @@ class Test(unittest.TestCase):
         self.assertEqual(expectedName, actual.directedName)
 
     def testRemoveOctothorpe1(self):
-        '''removeOctothorpe(): when there's an octothorpe'''
+        '''
+        removeOctothorpe(): when there's an octothorpe
+        '''
         xmlid = '#14ccdc11-8090-49f4-b094-5935f534131a'
         expected = '14ccdc11-8090-49f4-b094-5935f534131a'
         actual = base.removeOctothorpe(xmlid)
         self.assertEqual(expected, actual)
 
     def testRemoveOctothorpe2(self):
-        '''removeOctothorpe(): when there's not an octothorpe'''
+        '''
+        removeOctothorpe(): when there's not an octothorpe
+        '''
         xmlid = 'b05c3007-bc49-4bc2-a970-bb5700cb634d'
         expected = 'b05c3007-bc49-4bc2-a970-bb5700cb634d'
         actual = base.removeOctothorpe(xmlid)
@@ -307,7 +352,9 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base._makeArticList')
     def testArticFromElement(self, mockMakeList):
-        '''articFromElement(): very straight-forward test'''
+        '''
+        articFromElement(): very straight-forward test
+        '''
         elem = ETree.Element('artic', attrib={'artic': 'yes'})
         mockMakeList.return_value = 5
         actual = base.articFromElement(elem)
@@ -316,7 +363,9 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base._accidentalFromAttr')
     def testAccidFromElement(self, mockAccid):
-        '''accidFromElement(): very straight-forward test'''
+        '''
+        accidFromElement(): very straight-forward test
+        '''
         elem = ETree.Element('accid', attrib={'accid': 'yes'})
         mockAccid.return_value = 5
         actual = base.accidFromElement(elem)
@@ -324,7 +373,9 @@ class Test(unittest.TestCase):
         mockAccid.assert_called_once_with('yes')
 
     def testGetVoiceId1(self):
-        '''getVoiceId(): usual case'''
+        '''
+        getVoiceId(): usual case
+        '''
         theVoice = stream.Voice()
         theVoice.id = 42
         fromThese = [None, theVoice, stream.Stream(), stream.Part(), 900]
@@ -333,12 +384,16 @@ class Test(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def testGetVoiceId2(self):
-        '''getVoiceId(): no Voice objects causes RuntimeError'''
+        '''
+        getVoiceId(): no Voice objects causes RuntimeError
+        '''
         fromThese = [None, stream.Stream(), stream.Part(), 900]
         self.assertRaises(RuntimeError, base.getVoiceId, fromThese)
 
     def testGetVoiceId3(self):
-        '''getVoiceId(): three Voice objects causes RuntimeError'''
+        '''
+        getVoiceId(): three Voice objects causes RuntimeError
+        '''
         firstVoice = stream.Voice()
         firstVoice.id = 42
         otherVoice = stream.Voice()
@@ -347,8 +402,7 @@ class Test(unittest.TestCase):
         self.assertRaises(RuntimeError, base.getVoiceId, fromThese)
 
     # -----------------------------------------------------------------------------
-    # class TestMetadata(unittest.TestCase):
-    # '''Tests for the metadata-fetching functions.'''
+    # Tests for the metadata-fetching functions.
 
     @mock.patch('music21.mei.base.metaSetTitle')
     @mock.patch('music21.mei.base.metaSetComposer')
@@ -625,11 +679,12 @@ class Test(unittest.TestCase):
         self.assertEqual(expDate, actual.dateCreated)
 
     # -----------------------------------------------------------------------------
-    # class TestAttrTranslators(unittest.TestCase):
-    # '''Tests for the one-to-one (string-to-simple-datatype) converter functions.'''
+    # Tests for the one-to-one (string-to-simple-datatype) converter functions.
 
     def testAttrTranslator1(self):
-        '''_attrTranslator(): the usual case works properly when "attr" is in "mapping"'''
+        '''
+        _attrTranslator(): the usual case works properly when "attr" is in "mapping"
+        '''
         attr = 'two'
         name = 'numbers'
         mapping = {'one': 1, 'two': 2, 'three': 3}
@@ -638,7 +693,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def testAttrTranslator2(self):
-        '''_attrTranslator(): exception is raised properly when "attr" isn't found'''
+        '''
+        _attrTranslator(): exception is raised properly when "attr" isn't found
+        '''
         attr = 'four'
         name = 'numbers'
         mapping = {'one': 1, 'two': 2, 'three': 3}
@@ -651,28 +708,36 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base._attrTranslator')
     def testAccidental(self, mockTrans):
-        '''_accidentalFromAttr(): ensure proper arguments to _attrTranslator'''
+        '''
+        _accidentalFromAttr(): ensure proper arguments to _attrTranslator
+        '''
         attr = 's'
         base._accidentalFromAttr(attr)
         mockTrans.assert_called_once_with(attr, 'accid', base._ACCID_ATTR_DICT)
 
     @mock.patch('music21.mei.base._attrTranslator')
     def testAccidGes(self, mockTrans):
-        '''_accidGesFromAttr(): ensure proper arguments to _attrTranslator'''
+        '''
+        _accidGesFromAttr(): ensure proper arguments to _attrTranslator
+        '''
         attr = 's'
         base._accidGesFromAttr(attr)
         mockTrans.assert_called_once_with(attr, 'accid.ges', base._ACCID_GES_ATTR_DICT)
 
     @mock.patch('music21.mei.base._attrTranslator')
     def testDuration(self, mockTrans):
-        '''_qlDurationFromAttr(): ensure proper arguments to _attrTranslator'''
+        '''
+        _qlDurationFromAttr(): ensure proper arguments to _attrTranslator
+        '''
         attr = 's'
         base._qlDurationFromAttr(attr)
         mockTrans.assert_called_once_with(attr, 'dur', base._DUR_ATTR_DICT)
 
     @mock.patch('music21.mei.base._attrTranslator')
     def testArticulation1(self, mockTrans):
-        '''_articulationFromAttr(): ensure proper arguments to _attrTranslator'''
+        '''
+        _articulationFromAttr(): ensure proper arguments to _attrTranslator
+        '''
         attr = 'marc'
         mockTrans.return_value = mock.MagicMock(name='asdf', return_value=5)
         expected = (5,)
@@ -682,7 +747,9 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base._attrTranslator')
     def testArticulation2(self, mockTrans):
-        '''_articulationFromAttr(): proper handling of "marc-stacc"'''
+        '''
+        _articulationFromAttr(): proper handling of "marc-stacc"
+        '''
         attr = 'marc-stacc'
         expected = (articulations.StrongAccent, articulations.Staccato)
         actual = base._articulationFromAttr(attr)
@@ -694,7 +761,9 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base._attrTranslator')
     def testArticulation3(self, mockTrans):
-        '''_articulationFromAttr(): proper handling of "ten-stacc"'''
+        '''
+        _articulationFromAttr(): proper handling of "ten-stacc"
+        '''
         attr = 'ten-stacc'
         expected = (articulations.Tenuto, articulations.Staccato)
         actual = base._articulationFromAttr(attr)
@@ -706,7 +775,9 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base._attrTranslator')
     def testArticulation4(self, mockTrans):
-        '''_articulationFromAttr(): proper handling of not-found'''
+        '''
+        _articulationFromAttr(): proper handling of not-found
+        '''
         attr = 'garbage'
         expected = 'error message'
         mockTrans.side_effect = base.MeiValueError(expected)
@@ -719,7 +790,9 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base._articulationFromAttr')
     def testArticList1(self, mockArtic):
-        '''_makeArticList(): properly handles single-articulation lists'''
+        '''
+        _makeArticList(): properly handles single-articulation lists
+        '''
         attr = 'acc'
         mockArtic.return_value = ['accent']
         expected = ['accent']
@@ -728,7 +801,9 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base._articulationFromAttr')
     def testArticList2(self, mockArtic):
-        '''_makeArticList(): properly handles multi-articulation lists'''
+        '''
+        _makeArticList(): properly handles multi-articulation lists
+        '''
         attr = 'acc stacc marc'
         mockReturns = [['accent'], ['staccato'], ['marcato']]
         mockArtic.side_effect = lambda unused: mockReturns.pop(0)
@@ -738,7 +813,9 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base._articulationFromAttr')
     def testArticList3(self, mockArtic):
-        '''_makeArticList(): properly handles the compound articulations'''
+        '''
+        _makeArticList(): properly handles the compound articulations
+        '''
         attr = 'acc marc-stacc marc'
         mockReturns = [['accent'], ['marcato', 'staccato'], ['marcato']]
         mockArtic.side_effect = lambda *unused: mockReturns.pop(0)
@@ -747,7 +824,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def testOctaveShift1(self):
-        '''_getOctaveShift(): properly handles positive displacement'''
+        '''
+        _getOctaveShift(): properly handles positive displacement
+        '''
         dis = '15'
         disPlace = 'above'
         expected = 2
@@ -755,7 +834,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def testOctaveShift2(self):
-        '''_getOctaveShift(): properly handles negative displacement'''
+        '''
+        _getOctaveShift(): properly handles negative displacement
+        '''
         dis = '22'
         disPlace = 'below'
         expected = -3
@@ -763,7 +844,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def testOctaveShift3(self):
-        '''_getOctaveShift(): properly handles positive displacement with "None"'''
+        '''
+        _getOctaveShift(): properly handles positive displacement with "None"
+        '''
         dis = '8'
         disPlace = None
         expected = 1
@@ -771,7 +854,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def testOctaveShift4(self):
-        '''_getOctaveShift(): properly positive two "None" args'''
+        '''
+        _getOctaveShift(): properly positive two "None" args
+        '''
         dis = None
         disPlace = None
         expected = 0
@@ -779,7 +864,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def testBarlineFromAttr1(self):
-        '''_barlineFromAttr(): rptboth'''
+        '''
+        _barlineFromAttr(): rptboth
+        '''
         right = 'rptboth'
         expected = (bar.Repeat('end', times=2), bar.Repeat('start'))
         actual = base._barlineFromAttr(right)
@@ -787,7 +874,9 @@ class Test(unittest.TestCase):
         self.assertEqual(type(expected[1]), type(actual[1]))
 
     def testBarlineFromAttr2(self):
-        '''_barlineFromAttr(): rptend'''
+        '''
+        _barlineFromAttr(): rptend
+        '''
         right = 'rptend'
         expected = bar.Repeat('end', times=2)
         actual = base._barlineFromAttr(right)
@@ -796,7 +885,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.times, expected.times)
 
     def testBarlineFromAttr3(self):
-        '''_barlineFromAttr(): rptstart'''
+        '''
+        _barlineFromAttr(): rptstart
+        '''
         right = 'rptstart'
         expected = bar.Repeat('start')
         actual = base._barlineFromAttr(right)
@@ -805,7 +896,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.times, expected.times)
 
     def testBarlineFromAttr4(self):
-        '''_barlineFromAttr(): end (--> final)'''
+        '''
+        _barlineFromAttr(): end (--> final)
+        '''
         right = 'end'
         expected = bar.Barline('final')
         actual = base._barlineFromAttr(right)
@@ -813,7 +906,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.type, expected.type)
 
     def testTieFromAttr1(self):
-        '''_tieFromAttr(): "i"'''
+        '''
+        _tieFromAttr(): "i"
+        '''
         right = ''
         expected = tie.Tie('start')
         actual = base._tieFromAttr(right)
@@ -821,7 +916,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.type, expected.type)
 
     def testTieFromAttr2(self):
-        '''_tieFromAttr(): "ti"'''
+        '''
+        _tieFromAttr(): "ti"
+        '''
         right = ''
         expected = tie.Tie('continue')
         actual = base._tieFromAttr(right)
@@ -829,7 +926,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.type, expected.type)
 
     def testTieFromAttr3(self):
-        '''_tieFromAttr(): "m"'''
+        '''
+        _tieFromAttr(): "m"
+        '''
         right = ''
         expected = tie.Tie('continue')
         actual = base._tieFromAttr(right)
@@ -837,7 +936,9 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.type, expected.type)
 
     def testTieFromAttr4(self):
-        '''_tieFromAttr(): "t"'''
+        '''
+        _tieFromAttr(): "t"
+        '''
         right = ''
         expected = tie.Tie('stop')
         actual = base._tieFromAttr(right)
@@ -845,8 +946,7 @@ class Test(unittest.TestCase):
         self.assertEqual(expected.type, expected.type)
 
     # -----------------------------------------------------------------------------
-    # class TestLyrics(unittest.TestCase):
-    # '''Tests for sylFromElement() and verseFromElement()'''
+    # Tests for sylFromElement() and verseFromElement()
 
     def testSyl1(self):
         '''
@@ -984,8 +1084,7 @@ class Test(unittest.TestCase):
         mockEnviron.warn.assert_called_once_with(base._BAD_VERSE_NUMBER.format('None'))
 
     # -----------------------------------------------------------------------------
-    # class TestNoteFromElement(unittest.TestCase):
-    # '''Tests for noteFromElement()'''
+    # Tests for noteFromElement()
     # NOTE: For this TestCase, in the unit tests, if you get...
     #       AttributeError: 'str' object has no attribute 'call_count'
     #       ... it means a test failure, because the str should have been a MagicMock but was
@@ -1315,7 +1414,9 @@ class Test(unittest.TestCase):
                       [mock.MagicMock(name='sun')]]
 
         def mockVerseFESideEffect(inner_elem, backupN):
-            '''Check that it gets called with the right elements'''
+            '''
+            Check that it gets called with the right elements
+            '''
             assert f'{MEI_NS}verse' == inner_elem.tag
             return vfeReturns.pop(0)
         mockVerseFE.side_effect = mockVerseFESideEffect
@@ -1360,8 +1461,7 @@ class Test(unittest.TestCase):
     # NOTE: consider adding to previous tests rather than making new ones
 
     # -----------------------------------------------------------------------------
-    # class TestRestFromElement(unittest.TestCase):
-    # '''Tests for restFromElement() and spaceFromElement()'''
+    # Tests for restFromElement() and spaceFromElement()
 
     @mock.patch('music21.note.Rest')
     @mock.patch('music21.mei.base.makeDuration')
@@ -1492,8 +1592,7 @@ class Test(unittest.TestCase):
         self.assertTrue(actual.m21wasMRest)
 
     # -----------------------------------------------------------------------------
-    # class TestChordFromElement(unittest.TestCase):
-    # '''Tests for chordFromElement()'''
+    # Tests for chordFromElement()
     # NOTE: For this TestCase, in the unit tests, if you get...
     #       AttributeError: 'str' object has no attribute 'call_count'
     #       ... it means a test failure, because the str should have been a MagicMock but was
@@ -1501,7 +1600,9 @@ class Test(unittest.TestCase):
 
     @staticmethod
     def makeNoteElemsChordFromElement(pname, accid, octArg, dur, dots):
-        '''Factory function for the Element objects that are a <note>.'''
+        '''
+        Factory function for the Element objects that are a <note>.
+        '''
         return ETree.Element(f'{MEI_NS}note', pname=pname, accid=accid,
                              oct=octArg, dur=dur, dots=dots)
 
@@ -1779,8 +1880,7 @@ class Test(unittest.TestCase):
     # NOTE: consider adding to previous tests rather than making new ones
 
     # -----------------------------------------------------------------------------
-    # class TestClefFromElement(unittest.TestCase):
-    # '''Tests for clefFromElement()'''
+    # Tests for clefFromElement()
     # NOTE: in this function's integration tests, the Element.tag attribute doesn't actually matter
 
     @mock.patch('music21.clef.clefFromString')
@@ -1933,8 +2033,7 @@ class Test(unittest.TestCase):
         self.assertEqual('theXMLID', actual.id)
 
     # -----------------------------------------------------------------------------
-    # class TestLayerFromElement(unittest.TestCase):
-    # '''Tests for layerFromElement()'''
+    # Tests for layerFromElement()
 
     @mock.patch('music21.mei.base.noteFromElement')
     @mock.patch('music21.stream.Voice')
@@ -2131,8 +2230,7 @@ class Test(unittest.TestCase):
             self.assertEqual(base._MISSING_VOICE_ID, maError.args[0])
 
     # -----------------------------------------------------------------------------
-    # class TestStaffFromElement(unittest.TestCase):
-    # '''Tests for staffFromElement()'''
+    # Tests for staffFromElement()
 
     @mock.patch('music21.mei.base.layerFromElement')
     def testUnit1StaffFromElement(self, mockLayerFromElement):
@@ -2201,8 +2299,7 @@ class Test(unittest.TestCase):
         self.assertEqual('C2', actual[2][0].nameWithOctave)
 
     # -----------------------------------------------------------------------------
-    # class TestStaffDefFromElement(unittest.TestCase):
-    # '''Tests for staffDefFromElement()'''
+    # Tests for staffDefFromElement()
 
     # noinspection SpellCheckingInspection
     @mock.patch('music21.mei.base.instrDefFromElement')
@@ -2592,8 +2689,7 @@ class Test(unittest.TestCase):
         self.assertDictEqual(expected, actual)
 
     # -----------------------------------------------------------------------------
-    # class TestScoreDefFromElement(unittest.TestCase):
-    # '''Tests for scoreDefFromElement()'''
+    # Tests for scoreDefFromElement()
 
     @mock.patch('music21.mei.base._timeSigFromAttrs')
     @mock.patch('music21.mei.base._keySigFromAttrs')
@@ -2696,8 +2792,7 @@ class Test(unittest.TestCase):
         self.assertIsInstance(actual['1']['instrument'], instrument.Clarinet)
 
     # -----------------------------------------------------------------------------
-    # class TestEmbeddedElements(unittest.TestCase):
-    # '''Tests for _processesEmbeddedElements()'''
+    # Tests for _processesEmbeddedElements()
 
     def testUnit1EmbeddedElements(self):
         '''
@@ -2748,10 +2843,8 @@ class Test(unittest.TestCase):
         mockTranslator.assert_called_once_with(elements[0], None)
         mockEnviron.printDebug.assert_called_once_with(expErr)
 
-
-# -----------------------------------------------------------------------------
-# class TestAddSlurs(unittest.TestCase):
-    '''Tests for addSlurs()'''
+    # -----------------------------------------------------------------------------
+    # Tests for addSlurs()
 
     def testUnit1AddSlurs(self):
         '''
@@ -2935,9 +3028,8 @@ class Test(unittest.TestCase):
         self.assertSequenceEqual([], list(slurBundle))
 
 
-# -----------------------------------------------------------------------------
-# class TestBeams(unittest.TestCase):
-    '''Tests for beams in all their guises.'''
+    # -----------------------------------------------------------------------------
+    # Tests for beams in all their guises.
 
     def testBeamTogether1(self):
         '''
@@ -3011,9 +3103,8 @@ class Test(unittest.TestCase):
         someThings[3].beams.setAll.assert_called_once_with('stop')
 
 
-# -----------------------------------------------------------------------------
-# class TestPreprocessors(unittest.TestCase):
-    '''Tests for the pre-processing helper functions for convertFromString().'''
+    # -----------------------------------------------------------------------------
+    # Tests for the pre-processing helper functions for convertFromString().
 
     # noinspection SpellCheckingInspection
     def testUnitTies1(self):
@@ -3343,9 +3434,8 @@ class Test(unittest.TestCase):
         self.assertEqual(expNoteTwoAttrib, noteTwo.attrib)
 
 
-# -----------------------------------------------------------------------------
-# class TestTuplets(unittest.TestCase):
-    '''Tests for the tuplet-processing helper function, scaleToTuplet().'''
+    # -----------------------------------------------------------------------------
+    # Tests for the tuplet-processing helper function, scaleToTuplet().
 
     # noinspection SpellCheckingInspection
     def testTuplets1(self):
@@ -3640,13 +3730,14 @@ class Test(unittest.TestCase):
             self.assertFalse(hasattr(theLayer[i], 'm21TupletNumbase'))
 
 
-# -----------------------------------------------------------------------------
-# class TestInstrDef(unittest.TestCase):
-    '''Tests for instrDefFromElement().'''
+    # -----------------------------------------------------------------------------
+    # Tests for instrDefFromElement().
 
     @mock.patch('music21.instrument.instrumentFromMidiProgram')
     def testUnit1InstrDef(self, mockFromProg):
-        '''instrDefFromElement(): when @midi.instrnum is given'''
+        '''
+        instrDefFromElement(): when @midi.instrnum is given
+        '''
         elem = ETree.Element('instrDef', attrib={'midi.instrnum': '71'})
         expFromProgArg = 71
         mockFromProg.return_value = 'Guess Which Instrument'
@@ -3659,7 +3750,9 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.instrument.fromString')
     def testUnit2InstrDef(self, mockFromString):
-        '''instrDefFromElement(): when @midi.instrname is given, and it works'''
+        '''
+        instrDefFromElement(): when @midi.instrname is given, and it works
+        '''
         elem = ETree.Element('instrDef', attrib={'midi.instrname': 'Tuba'})
         expFromStringArg = 'Tuba'
         mockFromString.return_value = "That's right: tuba"
@@ -3672,7 +3765,9 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base.instrument')
     def testUnit3aInstrDef(self, mockInstr):
-        '''instrDefFromElement(): when @midi.instrname is given, and it explodes (AttributeError)'''
+        '''
+        instrDefFromElement(): when @midi.instrname is given, and it explodes (AttributeError)
+        '''
         # For Py3 we have to replace the exception, since it's not okay to catch classes that don't
         # inherit from BaseException (which a MagicMock obviously doesn't)
         mockInstr.InstrumentException = instrument.InstrumentException
@@ -3692,8 +3787,10 @@ class Test(unittest.TestCase):
 
     @mock.patch('music21.mei.base.instrument')
     def testUnit3bInstrDef(self, mockInstr):
-        '''instrDefFromElement(): when @midi.instrname is given,
-        and it explodes (InstrumentException)'''
+        '''
+        instrDefFromElement(): when @midi.instrname is given,
+        and it explodes (InstrumentException)
+        '''
         # For Py3 we have to replace the exception, since it's not okay to catch classes that don't
         # inherit from BaseException (which a MagicMock obviously doesn't)
         mockInstr.InstrumentException = instrument.InstrumentException
@@ -3712,9 +3809,8 @@ class Test(unittest.TestCase):
         self.assertEqual(expFromStringArg, actual.partName)
 
 
-# -----------------------------------------------------------------------------
-# class TestMeasureFromElement(unittest.TestCase):
-    '''Tests for measureFromElement() and its helper functions.'''
+    # -----------------------------------------------------------------------------
+    # Tests for measureFromElement() and its helper functions.
 
     def testMakeBarline1(self):
         '''
@@ -4203,10 +4299,12 @@ class Test(unittest.TestCase):
         self.assertTrue(foundClef)
 
 
-# -----------------------------------------------------------------------------
-# class TestSectionScore(unittest.TestCase):
-    '''Tests for scoreFromElement(), sectionFromElement(), and
-    their helper function sectionScoreCore().'''
+    # -----------------------------------------------------------------------------
+    # class TestSectionScore(unittest.TestCase):
+    # '''
+    # Tests for scoreFromElement(), sectionFromElement(), and
+    # their helper function sectionScoreCore().
+    # '''
 
     @mock.patch('music21.mei.base.sectionScoreCore')
     def testSection1(self, mockCore):
@@ -4993,9 +5091,8 @@ class Test(unittest.TestCase):
         self.assertEqual('C2', meas[0][0].nameWithOctave)
 
 
-# -----------------------------------------------------------------------------
-# class TestBarLineFromElement(unittest.TestCase):
-    '''Tests for barLineFromElement()'''
+    # -----------------------------------------------------------------------------
+    # Tests for barLineFromElement()
 
     def testBarLine1(self):
         '''

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -624,7 +624,9 @@ class Metadata(base.Music21Object):
 
     @copyright.setter
     def copyright(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'copyright', value)
 
     # SPECIAL METHODS #
@@ -1226,7 +1228,9 @@ class Metadata(base.Music21Object):
 
     @alternativeTitle.setter
     def alternativeTitle(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'alternativeTitle', value)
 
     @property
@@ -1258,7 +1262,9 @@ class Metadata(base.Music21Object):
 
     @composer.setter
     def composer(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'composer', value)
 
     @property
@@ -1292,7 +1298,9 @@ class Metadata(base.Music21Object):
 
     @composers.setter
     def composers(self, value: Iterable[str]) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'composers', value)
 
     @property
@@ -1305,7 +1313,9 @@ class Metadata(base.Music21Object):
 
     @date.setter
     def date(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'date', value)
 
     @property
@@ -1336,7 +1346,9 @@ class Metadata(base.Music21Object):
 
     @dateCreated.setter
     def dateCreated(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'dateCreated', value)
 
     @property
@@ -1348,7 +1360,9 @@ class Metadata(base.Music21Object):
 
     @fileFormat.setter
     def fileFormat(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'fileFormat', value)
 
     @property
@@ -1360,7 +1374,9 @@ class Metadata(base.Music21Object):
 
     @filePath.setter
     def filePath(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'filePath', value)
 
     @property
@@ -1372,7 +1388,9 @@ class Metadata(base.Music21Object):
 
     @fileNumber.setter
     def fileNumber(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'fileNumber', value)
 
     @property
@@ -1389,7 +1407,9 @@ class Metadata(base.Music21Object):
 
     @localeOfComposition.setter
     def localeOfComposition(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'localeOfComposition', value)
 
     @property
@@ -1410,7 +1430,9 @@ class Metadata(base.Music21Object):
 
     @librettist.setter
     def librettist(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'librettist', value)
 
     @property
@@ -1429,7 +1451,9 @@ class Metadata(base.Music21Object):
 
     @librettists.setter
     def librettists(self, value: Iterable[str]) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'librettists', value)
 
     @property
@@ -1453,7 +1477,9 @@ class Metadata(base.Music21Object):
 
     @lyricist.setter
     def lyricist(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'lyricist', value)
 
     @property
@@ -1472,7 +1498,9 @@ class Metadata(base.Music21Object):
 
     @lyricists.setter
     def lyricists(self, value: Iterable[str]) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'lyricists', value)
 
     @property
@@ -1493,7 +1521,9 @@ class Metadata(base.Music21Object):
 
     @movementName.setter
     def movementName(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'movementName', value)
 
     @property
@@ -1514,7 +1544,9 @@ class Metadata(base.Music21Object):
 
     @movementNumber.setter
     def movementNumber(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'movementNumber', value)
 
     @property
@@ -1542,7 +1574,9 @@ class Metadata(base.Music21Object):
 
     @number.setter
     def number(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'number', value)
 
     @property
@@ -1570,7 +1604,9 @@ class Metadata(base.Music21Object):
 
     @opusNumber.setter
     def opusNumber(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'opusNumber', value)
 
     @property
@@ -1590,7 +1626,9 @@ class Metadata(base.Music21Object):
 
     @title.setter
     def title(self, value: str) -> None:
-        '''For type checking only. Does not run.'''
+        '''
+        For type checking only. Does not run.
+        '''
         setattr(self, 'title', value)
 
     @property

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -1686,7 +1686,8 @@ class TimeSignature(TimeSignatureBase):
 
     def getAccentWeight(self, qLenPos, level=0, forcePositionMatch=False,
                         permitMeterModulus=False):
-        '''Given a qLenPos,  return an accent level. In general, accents are assumed to
+        '''
+        Given a qLenPos,  return an accent level. In general, accents are assumed to
         define only a first-level weight.
 
         If `forcePositionMatch` is True, an accent will only be returned if the
@@ -1696,11 +1697,9 @@ class TimeSignature(TimeSignatureBase):
         If `permitMeterModulus` is True, quarter length positions greater than
         the duration of the Meter will be accepted as the modulus of the total meter duration.
 
-
         >>> ts1 = meter.TimeSignature('3/4')
         >>> [ts1.getAccentWeight(x) for x in range(3)]
         [1.0, 0.5, 0.5]
-
 
         Returns an error...
 
@@ -1713,7 +1712,6 @@ class TimeSignature(TimeSignatureBase):
 
         >>> [ts1.getAccentWeight(x, permitMeterModulus=True) for x in range(6)]
         [1.0, 0.5, 0.5, 1.0, 0.5, 0.5]
-
         '''
         qLenPos = opFrac(qLenPos)
         # might store this weight every time it is set, rather than
@@ -1759,7 +1757,8 @@ class TimeSignature(TimeSignatureBase):
         return self.beatSequence.offsetToIndex(offset) + 1
 
     def getBeatOffsets(self):
-        '''Return offset positions in a list for the start of each beat,
+        '''
+        Return offset positions in a list for the start of each beat,
         assuming this object is found at offset zero.
 
         >>> a = meter.TimeSignature('3/4')
@@ -1967,7 +1966,8 @@ class TimeSignature(TimeSignatureBase):
         return opFrac(beatIndex + 1 + (progress / totalRange))
 
     def getBeatProportionStr(self, qLenPos):
-        '''Return a string presentation of the beat.
+        '''
+        Return a string presentation of the beat.
 
         >>> ts1 = meter.TimeSignature('3/4')
         >>> ts1.getBeatProportionStr(0.0)
@@ -1997,7 +1997,8 @@ class TimeSignature(TimeSignatureBase):
         return post
 
     def getBeatDepth(self, qLenPos, align='quantize'):
-        '''Return the number of levels of beat partitioning given a QL into the TimeSignature.
+        '''
+        Return the number of levels of beat partitioning given a QL into the TimeSignature.
         Note that by default beat partitioning always has a single, top-level partition.
 
         The `align` parameter is passed to the :meth:`~music21.meter.MeterSequence.offsetToDepth`

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -315,7 +315,8 @@ class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
     denominator = property(_getDenominator, _setDenominator)
 
     def _ratioChanged(self):
-        '''If ratio has been changed, call this to update duration
+        '''
+        If ratio has been changed, call this to update duration
         '''
         # NOTE: this is a performance critical method and should only be
         # called when necessary
@@ -418,7 +419,8 @@ class MeterSequence(MeterTerminal):
     # SPECIAL METHODS #
 
     def __deepcopy__(self, memo=None):
-        '''Helper method to copy.py's deepcopy function. Call it from there.
+        '''
+        Helper method to copy.py's deepcopy function. Call it from there.
 
         Defining a custom __deepcopy__ here is a performance boost,
         particularly in not copying _duration and other benefits.
@@ -450,8 +452,8 @@ class MeterSequence(MeterTerminal):
         return new
 
     def __getitem__(self, key):
-        '''Get an MeterTerminal from _partition
-
+        '''
+        Get an MeterTerminal from _partition
 
         >>> a = meter.MeterSequence('4/4', 4)
         >>> a[3].numerator
@@ -916,7 +918,8 @@ class MeterSequence(MeterTerminal):
 
     def _subdivideNested(self, processObjList, divisions):
         # noinspection PyShadowingNames
-        '''Recursive nested call routine. Return a reference to the newly created level.
+        '''
+        Recursive nested call routine. Return a reference to the newly created level.
 
         >>> ms = meter.MeterSequence('2/4')
         >>> ms.partition(2)
@@ -1257,7 +1260,9 @@ class MeterSequence(MeterTerminal):
         return self._denominator
 
     def _getFlatList(self):
-        '''Return a flat version of this MeterSequence as a list of MeterTerminals.
+        '''
+        Return a flattened version of this
+        MeterSequence as a list of MeterTerminals.
 
         This return a list and not a new MeterSequence b/c MeterSequence objects
         are generally immutable and thus it does not make sense

--- a/music21/meter/tests.py
+++ b/music21/meter/tests.py
@@ -26,7 +26,8 @@ class TestExternal(unittest.TestCase):
     show = True
 
     def testSingle(self):
-        '''Need to test direct meter creation w/o stream
+        '''
+        Need to test direct meter creation w/o stream
         '''
         a = TimeSignature('3/16')
         if self.show:

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -1546,7 +1546,8 @@ class MidiFile(prebase.ProtoM21Object):
         self.file = open(filename, attrib)
 
     def openFileLike(self, fileLike):
-        '''Assign a file-like object, such as those provided by BytesIO, as an open file object.
+        '''
+        Assign a file-like object, such as those provided by BytesIO, as an open file object.
 
         >>> from io import BytesIO
         >>> fileLikeOpen = BytesIO()

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -3642,7 +3642,9 @@ class Test(unittest.TestCase):
             self.assertIn(ts, m)
 
     def testMidiExportConductorA(self):
-        '''Export conductor data to MIDI conductor track.'''
+        '''
+        Export conductor data to MIDI conductor track.
+        '''
         p1 = stream.Part()
         p1.repeatAppend(note.Note('c4'), 12)
         p1.insert(0, meter.TimeSignature('3/4'))
@@ -3703,7 +3705,9 @@ class Test(unittest.TestCase):
         self.assertEqual(mtsRepr.count('SET_TEMPO'), 100)
 
     def testMidiExportConductorD(self):
-        '''120 bpm and 4/4 are supplied by default.'''
+        '''
+        120 bpm and 4/4 are supplied by default.
+        '''
         s = stream.Stream()
         s.insert(note.Note())
         mts = streamHierarchyToMidiTracks(s)
@@ -3715,7 +3719,9 @@ class Test(unittest.TestCase):
         self.assertEqual(condTrkRepr.count('PITCH_BEND'), 0)
 
     def testMidiExportConductorE(self):
-        '''The conductor only gets the first element at an offset.'''
+        '''
+        The conductor only gets the first element at an offset.
+        '''
         from music21 import converter
 
         s = stream.Stream()
@@ -3735,7 +3741,9 @@ class Test(unittest.TestCase):
         self.assertEqual(len(keySignatures), 1)
 
     def testMidiExportConductorF(self):
-        '''Multiple meter changes'''
+        '''
+        Multiple meter changes
+        '''
         from music21 import converter
         from music21 import midi as midiModule
 

--- a/music21/musedata/__init__.py
+++ b/music21/musedata/__init__.py
@@ -72,7 +72,8 @@ class MuseDataRecord(prebase.ProtoM21Object):
         self._cache = {}
 
     def isRest(self):
-        '''Return a boolean if this record is a rest.
+        '''
+        Return a boolean if this record is a rest.
 
         >>> mdr = musedata.MuseDataRecord('D4     1        s     d  ]]')
         >>> mdr.isRest()
@@ -87,8 +88,8 @@ class MuseDataRecord(prebase.ProtoM21Object):
         return False
 
     def isTied(self):
-        '''Return a boolean if this record is tied.
-
+        '''
+        Return a boolean if this record is tied.
 
         >>> mdr = musedata.MuseDataRecord('D4     8-       h     d        -')
         >>> mdr.isTied()
@@ -177,8 +178,8 @@ class MuseDataRecord(prebase.ProtoM21Object):
         return ''.join(pStr)
 
     def _getAccidentalObject(self):
-        '''Return a music21 Accidental object for the representation.
-
+        '''
+        Return a music21 Accidental object for the representation.
 
         >>> mdr = musedata.MuseDataRecord('Ef4    1        s     d  ==')
         >>> mdr._getAccidentalObject()
@@ -346,8 +347,8 @@ class MuseDataRecord(prebase.ProtoM21Object):
 #            return data
 
     def getLyrics(self):
-        '''Return lyrics as a list.
-
+        '''
+        Return lyrics as a list.
 
         >>> mdr = musedata.MuseDataRecord('D4     2        e     u                    con-')
         >>> mdr.stage = 2
@@ -367,8 +368,8 @@ class MuseDataRecord(prebase.ProtoM21Object):
         return data
 
     def getBeams(self):
-        '''Return complete span of characters defining beams.
-
+        '''
+        Return complete span of characters defining beams.
 
         >>> mdr = musedata.MuseDataRecord('E2     1        s     u  =')
         >>> mdr.getBeams()
@@ -394,8 +395,8 @@ class MuseDataRecord(prebase.ProtoM21Object):
     # (), {}, []
 
     def _getAdditionalNotations(self):
-        '''Return an articulation object or None
-
+        '''
+        Return an articulation object or None
 
         >>> mdr = musedata.MuseDataRecord('C4    12        e     u  [      .p')
         >>> mdr._getAdditionalNotations()
@@ -429,8 +430,8 @@ class MuseDataRecord(prebase.ProtoM21Object):
         return data
 
     def getArticulationObjects(self):
-        '''Return a list of 0 or more music21 Articulation objects
-
+        '''
+        Return a list of 0 or more music21 Articulation objects
 
         >>> mdr = musedata.MuseDataRecord('C4    12        e     u  [      .p')
         >>> mdr.getArticulationObjects()
@@ -469,8 +470,8 @@ class MuseDataRecord(prebase.ProtoM21Object):
         return post
 
     def getExpressionObjects(self):
-        '''Return a list of 0 or more music21 Articulation objects
-
+        '''
+        Return a list of 0 or more music21 Articulation objects
 
         >>> mdr = musedata.MuseDataRecord('C4    12        e     u  [      t')
         >>> mdr.getExpressionObjects()
@@ -503,8 +504,8 @@ class MuseDataRecord(prebase.ProtoM21Object):
         return post
 
     def getDynamicObjects(self):
-        '''Return a list of 0 or more music21 Dynamic objects
-
+        '''
+        Return a list of 0 or more music21 Dynamic objects
 
         >>> mdr = musedata.MuseDataRecord('C5    12        e     u         ff')
         >>> mdr.getDynamicObjects()
@@ -669,7 +670,8 @@ class MuseDataMeasure(prebase.ProtoM21Object):
         return bl
 
     def getMeasureObject(self):
-        '''Return a configured music21 :class:`~music21.stream.Measure`.
+        '''
+        Return a configured music21 :class:`~music21.stream.Measure`.
         '''
         from music21 import stream
 
@@ -703,7 +705,8 @@ class MuseDataMeasure(prebase.ProtoM21Object):
         return False
 
     def hasVoices(self):
-        '''Return True of if this Measure defines one or more 'back' indication.
+        '''
+        Return True of if this Measure defines one or more 'back' indication.
 
         Note: this does not instantiate MuseDataRecord instances.
         '''
@@ -719,14 +722,16 @@ class MuseDataMeasure(prebase.ProtoM21Object):
         return MuseDataRecordIterator(self.src, self)
 
     def getRecords(self):
-        '''Return a lost of all records stored in this measure as MuseDataRecord.
+        '''
+        Return a list of all records stored in this measure as MuseDataRecord.
         '''
         return list(self)
 
 
 # ------------------------------------------------------------------------------
 class MuseDataMeasureIterator:
-    '''Create MuseDataMeasure objects on demand, in order
+    '''
+    Create MuseDataMeasure objects on demand, in order
     '''
 
     def __init__(self, src, boundaries, parent):
@@ -751,7 +756,8 @@ class MuseDataMeasureIterator:
 
 
 class MuseDataPart(prebase.ProtoM21Object):
-    '''A MuseData part is defined by collection of lines
+    '''
+    A MuseData part is defined by collection of lines
     '''
 
     def __init__(self, src=None, stage=None):
@@ -1209,7 +1215,8 @@ class MuseDataPart(prebase.ProtoM21Object):
             return post
 
     def getClefObject(self, voice=1):
-        '''Return a music21 clef object based on a two character clef definition.
+        '''
+        Return a music21 clef object based on a two character clef definition.
 
         >>> fp1 = (common.getSourceFilePath() / 'musedata' / 'testPrimitive'
         ...                    / 'test01' / '01.md')
@@ -1290,7 +1297,8 @@ class MuseDataPart(prebase.ProtoM21Object):
                 return int(raw)
 
     def getTranspositionIntervalObject(self):
-        '''If this part defines a transposition, return a corresponding Interval object.
+        '''
+        If this part defines a transposition, return a corresponding Interval object.
 
         >>> fp1 = (common.getSourceFilePath() / 'musedata' / 'testPrimitive'
         ...                    / 'test01' / '01.md')
@@ -1422,7 +1430,8 @@ class MuseDataPart(prebase.ProtoM21Object):
         return MuseDataMeasureIterator(self.src, self._measureBoundaries, self)
 
     def getMeasures(self):
-        '''Return a list of all measures stored in this part as MuseDataMeasure objects.
+        '''
+        Return a list of all measures stored in this part as MuseDataMeasure objects.
         '''
         return list(self)
 
@@ -1514,7 +1523,8 @@ class MuseDataFile(prebase.ProtoM21Object):
 
 # ------------------------------------------------------------------------------
 class MuseDataWork(prebase.ProtoM21Object):
-    '''A work might consist of one or more files.
+    '''
+    A work might consist of one or more files.
     '''
 
     def __init__(self):
@@ -1683,7 +1693,8 @@ class MuseDataDirectory(prebase.ProtoM21Object):
         return True
 
     def getPaths(self, group=None):
-        '''Return sorted paths for a group, or None
+        '''
+        Return sorted paths for a group, or None
         '''
         # environLocal.printDebug(['getPaths() called with self.paths', self.paths])
         return self.paths

--- a/music21/musedata/translate.py
+++ b/music21/musedata/translate.py
@@ -38,7 +38,8 @@ class MuseDataTranslateException(exceptions21.Music21Exception):
 
 
 def _musedataBeamToBeams(beamSymbol):
-    '''Given a musedata beam symbol, converter to a music21 Beams object representation.
+    '''
+    Given a musedata beam symbol, converter to a music21 Beams object representation.
 
     >>> from music21.musedata import translate
     >>> translate._musedataBeamToBeams('[[')
@@ -82,7 +83,8 @@ def _musedataBeamToBeams(beamSymbol):
 
 
 def _musedataRecordListToNoteOrChord(records, previousElement=None):
-    '''Given a list of MuseDataRecord objects, return a configured
+    '''
+    Given a list of MuseDataRecord objects, return a configured
     :class:`~music21.note.Note` or :class:`~music21.chord.Chord`.
 
     Optionally pass a previous element, which may be music21 Note, Chord, or Rest;
@@ -159,7 +161,8 @@ def _processPending(hasVoices, pendingRecords, eLast, m, vActive):
 
 
 def musedataPartToStreamPart(museDataPart, inputM21=None):
-    '''Translate a musedata part to a :class:`~music21.stream.Part`.
+    '''
+    Translate a musedata part to a :class:`~music21.stream.Part`.
     '''
     from music21 import stream
     from music21 import note

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -73,7 +73,8 @@ if t.TYPE_CHECKING:
 # ------------------------------------------------------------------------------
 
 def typeToMusicXMLType(value):
-    '''Convert a music21 type to a MusicXML type.
+    '''
+    Convert a music21 type to a MusicXML type.
 
     >>> musicxml.m21ToXml.typeToMusicXMLType('longa')
     'long'

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -1141,7 +1141,9 @@ class Test(unittest.TestCase):
         self.assertEqual(len(root.findall('part/measure/attributes/time')), 3)
 
     def testBackupAmount(self):
-        '''Regression test for chord members causing too-large backup amounts.'''
+        '''
+        Regression test for chord members causing too-large backup amounts.
+        '''
         from music21 import chord
         from music21 import defaults
         from music21 import layout
@@ -1158,7 +1160,9 @@ class Test(unittest.TestCase):
         )
 
     def testForwardRepeatMarks(self):
-        '''Regression test for losing forward repeat marks.'''
+        '''
+        Regression test for losing forward repeat marks.
+        '''
         from music21 import bar
         from music21 import layout
         from music21 import note

--- a/music21/musicxml/testFiles.py
+++ b/music21/musicxml/testFiles.py
@@ -16094,7 +16094,8 @@ ALL = [
 
 
 def get(contentRequest):
-    '''Get test material by type of content
+    '''
+    Get test material by type of content
 
     >>> from music21.musicxml.testFiles import get
 

--- a/music21/musicxml/test_m21ToXml.py
+++ b/music21/musicxml/test_m21ToXml.py
@@ -482,7 +482,9 @@ class Test(unittest.TestCase):
                     self.assertTrue(gotRightBarline)
 
     def testTextExpressionOffset(self):
-        '''Transfer element offset after calling getTextExpression().'''
+        '''
+        Transfer element offset after calling getTextExpression().
+        '''
         # https://github.com/cuthbertLab/music21/issues/624
         s = converter.parse('tinynotation: 4/4 c1')
         c = repeat.Coda()
@@ -755,7 +757,9 @@ class Test(unittest.TestCase):
         realizeDurationsAndAssertTags(m, forwardTag=False, offsetTag=False)
 
     def test_inexpressible_hidden_rests_become_forward_tags(self):
-        '''Express hidden rests with inexpressible durations as <forward> tags.'''
+        '''
+        Express hidden rests with inexpressible durations as <forward> tags.
+        '''
         m = stream.Measure()
         # 7 eighths in the space of 4 eighths, imported as 137/480
         # (137/480) * 7 = 1.9979, not 2.0

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -348,7 +348,9 @@ class Test(unittest.TestCase):
         # s.show()
 
     def testImportMetronomeMarksC(self):
-        '''Import tempo into only the first PartStaff'''
+        '''
+        Import tempo into only the first PartStaff
+        '''
         from music21 import corpus
         s = corpus.parse('demos/two-parts')
         self.assertEqual(len(s.parts.first()[tempo.MetronomeMark]), 1)

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1008,7 +1008,8 @@ class MusicXMLImporter(XMLParserBase):
 
     def xmlCreditToTextBox(self, mxCredit):
         # noinspection PyShadowingNames
-        '''Convert a MusicXML credit to a music21 TextBox
+        '''
+        Convert a MusicXML credit to a music21 TextBox
 
         >>> import xml.etree.ElementTree as ET
         >>> credit = ET.fromstring(

--- a/music21/note.py
+++ b/music21/note.py
@@ -2045,7 +2045,8 @@ class TestExternal(unittest.TestCase):
     show = True
 
     def testSingle(self):
-        '''Need to test direct meter creation w/o stream
+        '''
+        Need to test direct note creation w/o stream
         '''
         from music21 import note
         a = note.Note('D-3')

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -524,7 +524,8 @@ def _greedyEnharmonicsSearch(oldPitches, scoreFunc=_dissonanceScore):
 
 
 def simplifyMultipleEnharmonics(pitches, criterion=_dissonanceScore, keyContext=None):
-    r'''Tries to simplify the enharmonic spelling of a list of pitches, pitch-
+    r'''
+    Tries to simplify the enharmonic spelling of a list of pitches, pitch-
     or pitch-class numbers according to a given criterion.
 
     A function can be passed as an argument to `criterion`, that is tried to be
@@ -1490,7 +1491,8 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
 
     @property
     def fullName(self):
-        '''Return the most complete representation of this Accidental.
+        '''
+        Return the most complete representation of this Accidental.
 
         >>> a = pitch.Accidental('double-flat')
         >>> a.fullName
@@ -2690,7 +2692,8 @@ class Pitch(prebase.ProtoM21Object):
 
     @property
     def unicodeName(self) -> str:
-        '''Name presently returns pitch name and accidental without octave.
+        '''
+        Name presently returns pitch name and accidental without octave.
 
         >>> a = pitch.Pitch('G#')
         >>> a.unicodeName

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -112,7 +112,8 @@ class RepeatExpression(RepeatMark, expressions.Expression):
             return ''
 
     def getText(self):
-        '''Get the text used for this expression.
+        '''
+        Get the text used for this expression.
         '''
         return self._textExpression.content
 
@@ -140,7 +141,8 @@ class RepeatExpression(RepeatMark, expressions.Expression):
         return te
 
     def setTextExpression(self, value):
-        '''Directly set a TextExpression object.
+        '''
+        Directly set a TextExpression object.
         '''
         if not isinstance(value, expressions.TextExpression):
             raise RepeatExpressionException(
@@ -158,7 +160,8 @@ class RepeatExpression(RepeatMark, expressions.Expression):
             return copy.deepcopy(self._textExpression)
 
     def isValidText(self, value):
-        '''Return True or False if the supplied text could be used for this RepeatExpression.
+        '''
+        Return True or False if the supplied text could be used for this RepeatExpression.
         '''
         def stripText(s):
             # remove all spaces, punctuation, and make lower
@@ -229,8 +232,8 @@ class Segno(RepeatExpressionMarker):
 
 
 class Fine(RepeatExpressionMarker):
-    '''The fine word as placed in a score.
-
+    '''
+    The fine word as placed in a score.
 
     >>> rm = repeat.Fine()
     '''
@@ -994,12 +997,14 @@ class Expander:
             raise ExpanderException('no repeat command found')
 
     def _getRepeatExpressionCommand(self, streamObj):
-        '''Get the instance found in this stream; assumes that there is one.
+        '''
+        Get the instance found in this stream; assumes that there is one.
         '''
         return streamObj.flatten().getElementsByClass(RepeatExpressionCommand).first()
 
     def _daCapoIsCoherent(self):
-        '''Check of a DC statement is coherent.
+        '''
+        Check of a DC statement is coherent.
         '''
         # there can be only one da capo statement for the provided span
         sumDc = self._dcCount + self._dcafCount + self._dcacCount
@@ -1025,7 +1030,8 @@ class Expander:
         return False
 
     def _dalSegnoIsCoherent(self):
-        '''Check of a sa segno statement is coherent.
+        '''
+        Check of a sa segno statement is coherent.
         '''
         # there can be only one da segno statement for the provided span
         sumDs = (self._asCount
@@ -1148,7 +1154,8 @@ class Expander:
         return groups
 
     def _repeatBracketsAreCoherent(self):
-        '''Check if repeat brackets are coherent.
+        '''
+        Check if repeat brackets are coherent.
 
         This must be done for each group of brackets, not for the entire Stream.
         '''

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -4184,7 +4184,9 @@ class Test(unittest.TestCase):
             self.assertEqual(rn.figure, rn_out.figure, f'{aug6}: {rn_out}')
 
     def testSetFigureAgain(self):
-        '''Setting the figure again doesn't double the alterations'''
+        '''
+        Setting the figure again doesn't double the alterations
+        '''
         ger = RomanNumeral('Ger7')
         pitches_before = ger.pitches
         ger.figure = 'Ger7'

--- a/music21/romanText/__init__.py
+++ b/music21/romanText/__init__.py
@@ -11,7 +11,8 @@
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 
-'''Objects for processing Roman numeral analysis files, in formats defined and demonstrated by:
+'''
+Objects for processing Roman numeral analysis files, in formats defined and demonstrated by:
 Dmitri Tymoczko, Trevor De Clercq & David Temperley, and the DCMLab.
 '''
 from __future__ import annotations

--- a/music21/romanText/rtObjects.py
+++ b/music21/romanText/rtObjects.py
@@ -70,7 +70,8 @@ class RTFileException(exceptions21.Music21Exception):
 # ------------------------------------------------------------------------------
 
 class RTToken(prebase.ProtoM21Object):
-    '''Stores each linear, logical entity of a RomanText.
+    '''
+    Stores each linear, logical entity of a RomanText.
 
     A multi-pass parsing procedure is likely necessary, as RomanText permits
     variety of groupings and markings.
@@ -125,7 +126,8 @@ class RTToken(prebase.ProtoM21Object):
         return False
 
     def isForm(self):
-        '''Occasionally found in header.
+        '''
+        Occasionally found in header.
         '''
         return False
 
@@ -153,7 +155,8 @@ class RTToken(prebase.ProtoM21Object):
 
 
 class RTTagged(RTToken):
-    '''In romanText, some data elements are tags, that is a tag name, a colon,
+    '''
+    In romanText, some data elements are tags, that is a tag name, a colon,
     optional whitespace, and data. In non-RTTagged elements, there is just
     data.
 
@@ -187,7 +190,8 @@ class RTTagged(RTToken):
             self.data = src
 
     def isComposer(self):
-        '''True is the tag represents a composer.
+        '''
+        True is the tag represents a composer.
 
         >>> rth = romanText.rtObjects.RTTagged('Composer: Claudio Monteverdi')
         >>> rth.isComposer()
@@ -204,7 +208,8 @@ class RTTagged(RTToken):
         return False
 
     def isTitle(self):
-        '''True if tag represents a title, otherwise False.
+        '''
+        True if tag represents a title, otherwise False.
 
         >>> tag = romanText.rtObjects.RTTagged('Title: This is a title.')
         >>> tag.isTitle()
@@ -251,7 +256,8 @@ class RTTagged(RTToken):
         return False
 
     def isProofreader(self):
-        '''True if tag represents a proofreader, otherwise False.
+        '''
+        True if tag represents a proofreader, otherwise False.
 
         >>> tag = romanText.rtObjects.RTTagged('Proofreader: This is a proofreader.')
         >>> tag.isProofreader()
@@ -266,7 +272,8 @@ class RTTagged(RTToken):
         return False
 
     def isTimeSignature(self):
-        '''True if tag represents a time signature, otherwise False.
+        '''
+        True if tag represents a time signature, otherwise False.
 
         >>> tag = romanText.rtObjects.RTTagged('TimeSignature: This is a time signature.')
         >>> tag.isTimeSignature()
@@ -327,7 +334,8 @@ class RTTagged(RTToken):
             return False
 
     def isNote(self):
-        '''True if tag represents a note, otherwise False.
+        '''
+        True if tag represents a note, otherwise False.
 
         >>> tag = romanText.rtObjects.RTTagged('Note: This is a note.')
         >>> tag.isNote()
@@ -342,7 +350,8 @@ class RTTagged(RTToken):
         return False
 
     def isForm(self):
-        '''True if tag represents a form, otherwise False.
+        '''
+        True if tag represents a form, otherwise False.
 
         >>> tag = romanText.rtObjects.RTTagged('Form: This is a form.')
         >>> tag.isForm()
@@ -357,7 +366,8 @@ class RTTagged(RTToken):
         return False
 
     def isPedal(self):
-        '''True if tag represents a pedal, otherwise False.
+        '''
+        True if tag represents a pedal, otherwise False.
 
         >>> tag = romanText.rtObjects.RTTagged('Pedal: This is a pedal.')
         >>> tag.isPedal()
@@ -372,7 +382,8 @@ class RTTagged(RTToken):
         return False
 
     def isVersion(self):
-        '''True if tag defines the version of RomanText standard used,
+        '''
+        True if tag defines the version of RomanText standard used,
         otherwise False.
 
         Pieces without the tag are defined to conform to RomanText 1.0,
@@ -394,7 +405,8 @@ class RTTagged(RTToken):
             return False
 
     def isWork(self):
-        '''True if tag represents a work, otherwise False.
+        '''
+        True if tag represents a work, otherwise False.
 
         The "work" is not defined as a header tag, but is used to represent
         all tags, often placed after Composer, for the work or pieces designation.
@@ -425,7 +437,8 @@ class RTTagged(RTToken):
             return False
 
     def isMovement(self):
-        '''True if tag represents a movement, otherwise False.
+        '''
+        True if tag represents a movement, otherwise False.
 
         >>> tag = romanText.rtObjects.RTTagged('Movement: This is a movement.')
         >>> tag.isMovement()
@@ -465,7 +478,8 @@ class RTTagged(RTToken):
 
 
 class RTMeasure(RTToken):
-    '''In RomanText, measures are given one per line and always start with 'm'.
+    '''
+    In RomanText, measures are given one per line and always start with 'm'.
 
     For instance:
 
@@ -590,7 +604,8 @@ class RTMeasure(RTToken):
         return True
 
     def getCopyTarget(self):
-        '''If this measure defines a copy operation, return two lists defining
+        '''
+        If this measure defines a copy operation, return two lists defining
         the measures to copy; the second list has the repeat data.
 
         >>> rtm = romanText.rtObjects.RTMeasure('m35-36 = m29-30')
@@ -611,7 +626,8 @@ class RTMeasure(RTToken):
 
 
 class RTAtom(RTToken):
-    '''In RomanText, definitions of chords, phrases boundaries, open/close
+    '''
+    In RomanText, definitions of chords, phrases boundaries, open/close
     parenthesis, beat indicators, etc. appear within measures (RTMeasure
     objects). These individual elements will be called Atoms, as they are data
     that is not tagged.
@@ -641,7 +657,8 @@ class RTAtom(RTToken):
 
 
 class RTChord(RTAtom):
-    r'''An RTAtom subclass that defines a chord.  Also contains a reference to
+    r'''
+    An RTAtom subclass that defines a chord.  Also contains a reference to
     the container.
 
     >>> chordIV = romanText.rtObjects.RTChord('IV')
@@ -659,7 +676,8 @@ class RTChord(RTAtom):
 
 
 class RTNoChord(RTAtom):
-    r'''An RTAtom subclass that defines absence of a chord.  Also contains a
+    r'''
+    An RTAtom subclass that defines absence of a chord.  Also contains a
     reference to the container.
 
     >>> chordNC = romanText.rtObjects.RTNoChord('NC')
@@ -683,7 +701,8 @@ class RTNoChord(RTAtom):
 
 
 class RTBeat(RTAtom):
-    r'''An RTAtom subclass that defines a beat definition.  Also contains a
+    r'''
+    An RTAtom subclass that defines a beat definition.  Also contains a
     reference to the container.
 
     >>> beatFour = romanText.rtObjects.RTBeat('b4')
@@ -779,7 +798,8 @@ class RTBeat(RTAtom):
         return beat
 
     def getOffset(self, timeSignature):
-        '''Given a time signature, return the offset position specified by this
+        '''
+        Given a time signature, return the offset position specified by this
         beat.
 
         >>> rtb = romanText.rtObjects.RTBeat('b1.5')
@@ -818,7 +838,8 @@ class RTBeat(RTAtom):
 
 
 class RTKeyTypeAtom(RTAtom):
-    '''RTKeyTypeAtoms contain utility functions for all Key-type tokens, i.e.
+    '''
+    RTKeyTypeAtoms contain utility functions for all Key-type tokens, i.e.
     RTKey, RTAnalyticKey, but not KeySignature.
 
     >>> gMinor = romanText.rtObjects.RTKeyTypeAtom('g;:')
@@ -838,14 +859,16 @@ class RTKeyTypeAtom(RTAtom):
         return key.Key(myKey)
 
     def getKeySignature(self):
-        '''Get a KeySignature object.
+        '''
+        Get a KeySignature object.
         '''
         myKey = self.getKey()
         return key.KeySignature(myKey.sharps)
 
 
 class RTKey(RTKeyTypeAtom):
-    '''An RTKey(RTAtom) defines both a change in KeySignature and a change
+    '''
+    An RTKey(RTAtom) defines both a change in KeySignature and a change
     in the analyzed Key.
 
     They are defined by ";:" after the Key.
@@ -874,7 +897,8 @@ class RTKey(RTKeyTypeAtom):
 
 
 class RTAnalyticKey(RTKeyTypeAtom):
-    '''An RTAnalyticKey(RTKeyTypeAtom) only defines a change in the key
+    '''
+    An RTAnalyticKey(RTKeyTypeAtom) only defines a change in the key
     being analyzed.  It does not in itself create a :class:`~music21.key.Key`
     object.
 
@@ -1072,7 +1096,6 @@ class RTRepeatStop(RTRepeat):
 # ------------------------------------------------------------------------------
 
 class RTHandler:
-
     # divide elements of a character stream into rtObjects and handle
     # store in a list, and pass global information to components
     def __init__(self):
@@ -1083,13 +1106,13 @@ class RTHandler:
         self.currentLineNumber = 0
 
     def splitAtHeader(self, lines):
-        '''Divide string into header and non-header; this is done before
+        '''
+        Divide string into header and non-header; this is done before
         tokenization.
 
         >>> rth = romanText.rtObjects.RTHandler()
         >>> rth.splitAtHeader(['Title: s', 'Time Signature:', '', 'm1 g: i'])
         (['Title: s', 'Time Signature:', ''], ['m1 g: i'])
-
         '''
         # iterate over lines and find the first measure definition
         iStartBody = None
@@ -1104,7 +1127,8 @@ class RTHandler:
         return lines[:iStartBody], lines[iStartBody:]
 
     def tokenizeHeader(self, lines):
-        '''In the header, we only have :class:`~music21.romanText.base.RTTagged`
+        '''
+        In the header, we only have :class:`~music21.romanText.base.RTTagged`
         tokens. We can this process these all as the same class.
         '''
         post = []
@@ -1120,7 +1144,8 @@ class RTHandler:
         return post
 
     def tokenizeBody(self, lines):
-        '''In the body, we may have measure, time signature, or note
+        '''
+        In the body, we may have measure, time signature, or note
         declarations, as well as possible other tagged definitions.
         '''
         post = []
@@ -1153,7 +1178,8 @@ class RTHandler:
         return post
 
     def tokenizeAtoms(self, line, container=None):
-        '''Given a line of data stored in measure consisting only of Atoms,
+        '''
+        Given a line of data stored in measure consisting only of Atoms,
         tokenize and return a list.
 
         >>> rth = romanText.rtObjects.RTHandler()
@@ -1265,7 +1291,8 @@ class RTHandler:
         self.tokenize(src)
 
     def definesMovements(self, countRequired=2):
-        '''Return True if more than one movement is defined in a RT file.
+        '''
+        Return True if more than one movement is defined in a RT file.
 
         >>> rth = romanText.rtObjects.RTHandler()
         >>> rth.process('Movement: 1 \\n Movement: 2 \\n \\n m1')
@@ -1286,7 +1313,8 @@ class RTHandler:
         return False
 
     def definesMovement(self):
-        '''Return True if this handler has 1 or more movement.
+        '''
+        Return True if this handler has 1 or more movement.
 
         >>> rth = romanText.rtObjects.RTHandler()
         >>> rth.process('Movement: 1 \\n \\n m1')
@@ -1362,25 +1390,28 @@ class RTHandler:
     # --------------------------------------------------------------------------
     # access tokens
 
-    def _getTokens(self):
+    @property
+    def tokens(self):
+        '''
+        Get or set tokens for this Handler.
+        '''
         if not self._tokens:
             raise RTHandlerException('must process tokens before calling split')
         return self._tokens
 
-    def _setTokens(self, tokens):
-        '''Assign tokens to this Handler.
+    @tokens.setter
+    def tokens(self, tokens):
+        '''
+        Assign tokens to this Handler.
         '''
         self._tokens = tokens
-
-    tokens = property(_getTokens, _setTokens,
-                      doc='''Get or set tokens for this Handler.
-        ''')
 
     def __len__(self):
         return len(self._tokens)
 
     def __add__(self, other):
-        '''Return a new handler adding the tokens in both
+        '''
+        Return a new handler adding the tokens in both
         '''
         rth = self.__class__()  # will get the same class type
         rth.tokens = self._tokens + other._tokens
@@ -1427,7 +1458,8 @@ class RTFile(prebase.ProtoM21Object):
         self.filename = filename
 
     def openFileLike(self, fileLike):
-        '''Assign a file-like object, such as those provided by StringIO, as an
+        '''
+        Assign a file-like object, such as those provided by StringIO, as an
         open file object.
         '''
         self.file = fileLike  # already 'open'
@@ -1439,14 +1471,16 @@ class RTFile(prebase.ProtoM21Object):
         self.file.close()
 
     def read(self):
-        '''Read a file. Note that this calls readstr, which processes all tokens.
+        '''
+        Read a file. Note that this calls readstr, which processes all tokens.
 
         If `number` is given, a work number will be extracted if possible.
         '''
         return self.readstr(self.file.read())
 
     def readstr(self, strSrc):
-        '''Read a string and process all Tokens. Returns a ABCHandler instance.
+        '''
+        Read a string and process all Tokens. Returns a ABCHandler instance.
         '''
         handler = RTHandler()
         # return the handler instance

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -300,7 +300,8 @@ def _copyMultipleMeasures(rtMeasure: rtObjects.RTMeasure,
 
 
 def _getKeyAndPrefix(rtKeyOrString):
-    '''Given an RTKey specification, return the Key and a string prefix based
+    '''
+    Given an RTKey specification, return the Key and a string prefix based
     on the tonic:
 
     >>> romanText.translate._getKeyAndPrefix('c')
@@ -1165,7 +1166,8 @@ def fixPickupMeasure(partObject):
 
 
 def romanTextToStreamOpus(rtHandler, inputM21=None):
-    '''The main processing routine for RomanText objects that may or may not
+    '''
+    The main processing routine for RomanText objects that may or may not
     be multi movement.
 
     Takes in a romanText.rtObjects.RTFile() object, or a string as rtHandler.

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -541,7 +541,8 @@ class TsvHandler:
         self.tsvData = self._importTsv()  # converted to private
 
     def _get_heading_indices(self, header_row: list[str]) -> None:
-        '''Private method to get column name/column index correspondences.
+        '''
+        Private method to get column name/column index correspondences.
 
         Expected column indices (those in HEADERS, which correspond to TabChord
         attributes) are stored in self._head_indices. Others go in

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -128,7 +128,8 @@ class Scale(base.Music21Object):
 
     @property
     def isConcrete(self):
-        '''To be concrete, a Scale must have a defined tonic.
+        '''
+        To be concrete, a Scale must have a defined tonic.
         An abstract Scale is not Concrete, nor is a Concrete scale
         without a defined tonic.  Thus, is always false.
         '''
@@ -431,7 +432,8 @@ class AbstractScale(Scale):
         return self._net.degreeMaxUnique
 
     # def reverse(self):
-    #     '''Reverse all intervals in this scale.
+    #     '''
+    #     Reverse all intervals in this scale.
     #     '''
     #     pass
 
@@ -1641,8 +1643,9 @@ class ConcreteScale(Scale):
 
     # this needs to stay separate from getPitches; both are needed
     pitches = property(getPitches,
-                       doc='''Get a default pitch list from this scale.
-        ''')
+                       doc='''
+                           Get a default pitch list from this scale.
+                           ''')
 
     def getChord(
         self,
@@ -2707,7 +2710,8 @@ class DiatonicScale(ConcreteScale):
 # ------------------------------------------------------------------------------
 # diatonic scales and modes
 class MajorScale(DiatonicScale):
-    '''A Major Scale
+    '''
+    A Major Scale
 
     >>> sc = scale.MajorScale(pitch.Pitch('d'))
     >>> sc.pitchFromDegree(7).name
@@ -2725,7 +2729,8 @@ class MajorScale(DiatonicScale):
 
 
 class MinorScale(DiatonicScale):
-    '''A natural minor scale, or the Aeolian mode.
+    '''
+    A natural minor scale, or the Aeolian mode.
 
     >>> sc = scale.MinorScale(pitch.Pitch('g'))
     >>> [str(p) for p in sc.pitches]
@@ -2754,7 +2759,8 @@ class DorianScale(DiatonicScale):
 
 
 class PhrygianScale(DiatonicScale):
-    '''A Phrygian scale (E-E white key)
+    '''
+    A Phrygian scale (E-E white key)
 
     >>> sc = scale.PhrygianScale(pitch.Pitch('e'))
     >>> [str(p) for p in sc.pitches]
@@ -2788,7 +2794,8 @@ class LydianScale(DiatonicScale):
 
 
 class MixolydianScale(DiatonicScale):
-    '''A mixolydian scale
+    '''
+    A mixolydian scale
 
     >>> sc = scale.MixolydianScale(pitch.Pitch('g'))
     >>> [str(p) for p in sc.pitches]
@@ -2824,7 +2831,8 @@ class HypodorianScale(DiatonicScale):
 
 
 class HypophrygianScale(DiatonicScale):
-    '''A hypophrygian scale
+    '''
+    A hypophrygian scale
 
     >>> sc = scale.HypophrygianScale(pitch.Pitch('e'))
     >>> sc.abstract.octaveDuplicating
@@ -2845,7 +2853,8 @@ class HypophrygianScale(DiatonicScale):
 
 
 class HypolydianScale(DiatonicScale):
-    '''A hypolydian scale
+    '''
+    A hypolydian scale
 
     >>> sc = scale.HypolydianScale(pitch.Pitch('f'))
     >>> [str(p) for p in sc.pitches]
@@ -2861,7 +2870,8 @@ class HypolydianScale(DiatonicScale):
 
 
 class HypomixolydianScale(DiatonicScale):
-    '''A hypomixolydian scale
+    '''
+    A hypomixolydian scale
 
     >>> sc = scale.HypomixolydianScale(pitch.Pitch('g'))
     >>> [str(p) for p in sc.pitches]
@@ -2877,7 +2887,8 @@ class HypomixolydianScale(DiatonicScale):
 
 
 class LocrianScale(DiatonicScale):
-    '''A so-called "locrian" scale
+    '''
+    A so-called "locrian" scale
 
     >>> sc = scale.LocrianScale(pitch.Pitch('b'))
     >>> [str(p) for p in sc.pitches]
@@ -2895,7 +2906,8 @@ class LocrianScale(DiatonicScale):
 
 
 class HypolocrianScale(DiatonicScale):
-    '''A hypolocrian scale
+    '''
+    A hypolocrian scale
 
     >>> sc = scale.HypolocrianScale(pitch.Pitch('b'))
     >>> [str(p) for p in sc.pitches]
@@ -2913,7 +2925,8 @@ class HypolocrianScale(DiatonicScale):
 
 
 class HypoaeolianScale(DiatonicScale):
-    '''A hypoaeolian scale
+    '''
+    A hypoaeolian scale
 
     >>> sc = scale.HypoaeolianScale(pitch.Pitch('a'))
     >>> [str(p) for p in sc.pitches]
@@ -3105,8 +3118,8 @@ class ChromaticScale(ConcreteScale):
 
 
 class WholeToneScale(ConcreteScale):
-    '''A concrete whole-tone scale.
-
+    '''
+    A concrete whole-tone scale.
 
     >>> sc = scale.WholeToneScale('g2')
     >>> [str(p) for p in sc.pitches]

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -1091,7 +1091,8 @@ class IntervalNetwork:
             raise IntervalNetworkException(f'cannot filter by: {nodeId}')
 
     def getNext(self, nodeStart, direction):
-        '''Given a Node, get two lists, one of next Edges, and one of next Nodes,
+        '''
+        Given a Node, get two lists, one of next Edges, and one of next Nodes,
         searching all Edges to find all matches.
 
         There may be more than one possibility. If so, the caller must look
@@ -2030,8 +2031,8 @@ class IntervalNetwork:
         alteredDegrees=None,
         reverse=False,
     ) -> list[interval.Interval]:
-        '''Realize the sequence of intervals between the specified pitches, or the termini.
-
+        '''
+        Realize the sequence of intervals between the specified pitches, or the termini.
 
         >>> edgeList = ['M2', 'M2', 'm2', 'M2', 'M2', 'M2', 'm2']
         >>> net = scale.intervalNetwork.IntervalNetwork()

--- a/music21/scale/scala/__init__.py
+++ b/music21/scale/scala/__init__.py
@@ -408,7 +408,8 @@ class ScalaFile:
         self.fileName = os.path.basename(fp)
 
     def openFileLike(self, fileLike):
-        '''Assign a file-like object, such as those provided by StringIO, as an open file object.
+        '''
+        Assign a file-like object, such as those provided by StringIO, as an open file object.
         '''
         self.file = fileLike  # already 'open'
 
@@ -428,7 +429,8 @@ class ScalaFile:
         return self.readstr(self.file.read())
 
     def readstr(self, strSrc):
-        '''Read a string and process all Tokens. Returns a ABCHandler instance.
+        '''
+        Read a string and process all Tokens. Returns a ABCHandler instance.
         '''
         ss = ScalaData(strSrc, self.fileName)
         ss.parse()
@@ -522,7 +524,8 @@ def parse(target):
 
 def search(target):
     # noinspection SpellCheckingInspection
-    '''Search the scala archive for matches based on a string
+    '''
+    Search the scala archive for matches based on a string
 
     >>> mbiraScales = scale.scala.search('mbira')
     >>> mbiraScales

--- a/music21/scale/test_scale_main.py
+++ b/music21/scale/test_scale_main.py
@@ -905,7 +905,9 @@ class Test(unittest.TestCase):
             e.deriveRanked(['C4', 'E4', 'G4'], comparisonAttribute='name')
 
     def test_getPitches_multiple_times(self):
-        '''Worth testing because we found cached lists being mutated.'''
+        '''
+        Worth testing because we found cached lists being mutated.
+        '''
         c_maj = scale.MajorScale('C')
 
         for i in range(3):  # catch both even and odd states

--- a/music21/search/serial.py
+++ b/music21/search/serial.py
@@ -93,7 +93,9 @@ class ContiguousSegmentOfNotes(base.Music21Object):
 
     @property
     def startMeasureNumber(self):
-        '''The measure number on which the contiguous segment begins.'''
+        '''
+        The measure number on which the contiguous segment begins.
+        '''
         if self.segment:
             return self.segment[0].measureNumber
         else:
@@ -140,7 +142,8 @@ class ContiguousSegmentOfNotes(base.Music21Object):
 
     @property
     def originalCenteredTransformationsFromMatched(self):
-        '''The list of original-centered transformations taking a segment being
+        '''
+        The list of original-centered transformations taking a segment being
         searched for to a found segment, for example, in
         :func:`~music21.search.serial.findTransformedSegments`.
         For an explanation of the

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -1396,7 +1396,9 @@ class Test(unittest.TestCase):
         self.assertEqual(nonRows, [])
 
     def testExtractRowParts(self):
-        '''Was a problem in slices'''
+        '''
+        Was a problem in slices
+        '''
         aRow = getHistoricalRowByName('BergViolinConcerto')
         unused_aRow2 = aRow[0:3]
 

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -529,8 +529,8 @@ class Spanner(base.Music21Object):
         #    'id(new)', id(new)])
 
     def isFirst(self, spannedElement):
-        '''Given a spannedElement, is it first?
-
+        '''
+        Given a spannedElement, is it first?
 
         >>> n1 = note.Note('g')
         >>> n2 = note.Note('f#')
@@ -2331,7 +2331,8 @@ class Test(unittest.TestCase):
         self.assertTrue(sp3.hasSpannedElement(m5))
 
     def testOttavaShiftA(self):
-        '''Test basic octave shift creation and output, as well as passing
+        '''
+        Test basic octave shift creation and output, as well as passing
         objects through make measure calls.
         '''
         from music21 import stream
@@ -2384,7 +2385,8 @@ class Test(unittest.TestCase):
         self.assertEqual(raw.count('type="up"'), 1)
 
     def testOttavaShiftB(self):
-        '''Test a single note octave
+        '''
+        Test a single note octave
         '''
         from music21 import stream
         from music21 import note

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -4156,7 +4156,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             return None
 
     # def getElementAfterOffset(self, offset, classList=None):
-    #    '''Get element after a provided offset
+    #    '''
+    #    Get element after a provided offset
     #
     #    TODO: write this
     #    '''
@@ -4164,7 +4165,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     #
     #
     # def getElementBeforeElement(self, element, classList=None):
-    #    '''given an element, get the element before
+    #    '''
+    #    given an element, get the element before
     #
     #    TODO: write this
     #    '''
@@ -8107,7 +8109,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         return self._cache['HighestOffset']
 
     def _setHighestTime(self, value):
-        '''For internal use only.
+        '''
+        For internal use only.
         '''
         self._cache['HighestTime'] = value
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -135,7 +135,8 @@ class TestExternal(unittest.TestCase):
             score1.show('lily.png')
 
     def testMXOutput(self):
-        '''A simple test of adding notes to measures in a stream.
+        '''
+        A simple test of adding notes to measures in a stream.
         '''
         c = Stream()
         for dummy in range(4):
@@ -148,7 +149,8 @@ class TestExternal(unittest.TestCase):
             c.show()
 
     def testMxMeasures(self):
-        '''A test of the automatic partitioning of notes in a measure and the creation of ties.
+        '''
+        A test of the automatic partitioning of notes in a measure and the creation of ties.
         '''
 
         n = note.Note()
@@ -166,8 +168,8 @@ class TestExternal(unittest.TestCase):
             a.show()
 
     def testMultipartStreams(self):
-        '''Test the creation of multipart streams by simply having streams within streams.
-
+        '''
+        Test the creation of multipart streams by simply having streams within streams.
         '''
         q = Stream()
         r = Stream()
@@ -267,7 +269,8 @@ class TestExternal(unittest.TestCase):
             s.show()
 
     def testBeamsStream(self):
-        '''A test of beams applied to different time signatures.
+        '''
+        A test of beams applied to different time signatures.
         '''
         q = Stream()
         r = Stream()
@@ -593,7 +596,8 @@ class Test(unittest.TestCase):
         self.assertEqual(s.duration.quarterLength, Fraction(4, 9))
 
     def testMeasureStream(self):
-        '''An approach to setting TimeSignature measures in offsets and durations
+        '''
+        An approach to setting TimeSignature measures in offsets and durations
         '''
         a = meter.TimeSignature('3/4')
         b = meter.TimeSignature('5/4')
@@ -707,7 +711,8 @@ class Test(unittest.TestCase):
         self.assertEqual(r.activeSite, s)
 
     def testActiveSitesMultiple(self):
-        '''Test an object having multiple activeSites.
+        '''
+        Test an object having multiple activeSites.
         '''
         a = Stream()
         b = Stream()
@@ -783,7 +788,8 @@ class Test(unittest.TestCase):
         unused_mx = GEX.parse(s).decode('utf-8')
 
     def testMeasureAndTieCreation(self):
-        '''A test of the automatic partitioning of notes in a measure and the creation of ties.
+        '''
+        A test of the automatic partitioning of notes in a measure and the creation of ties.
         '''
 
         n = note.Note()
@@ -800,7 +806,8 @@ class Test(unittest.TestCase):
         unused_mx = GEX.parse(a).decode('utf-8')
 
     def testStreamCopy(self):
-        '''Test copying a stream
+        '''
+        Test copying a stream
         '''
         # import pdb; pdb.set_trace()
         # search activeSite from a measure within
@@ -832,7 +839,8 @@ class Test(unittest.TestCase):
             post.insert(aElement.offset, bElement)
 
     def testIteration(self):
-        '''This test was designed to illustrate a past problem with stream
+        '''
+        This test was designed to illustrate a past problem with stream
         Iterations.
         '''
         q = Stream()
@@ -896,10 +904,9 @@ class Test(unittest.TestCase):
         self.assertEqual(offsets, [0.0, 10.0, 3.0, 20.0, 40.0])
 
     def testElements(self):
-        '''Test basic Elements wrapping non music21 objects
         '''
-        # needed to do fully-qualified isinstance name checking music21 vs base
-
+        Test basic Elements wrapping non music21 objects
+        '''
         a = Stream()
         a.insert(50, music21.Music21Object())
         self.assertEqual(len(a), 1)
@@ -1370,7 +1377,8 @@ class Test(unittest.TestCase):
         self.assertEqual(l2, 3)
 
     def testStripTiesScore(self):
-        '''Test stripTies using the Score method
+        '''
+        Test stripTies using the Score method
         '''
         from music21.musicxml import testPrimitive
 
@@ -1772,7 +1780,8 @@ class Test(unittest.TestCase):
         self.assertEqual(list(post.keys()), correctMeasureOffsetMap)
 
     def testMusicXMLGenerationViaPropertyA(self):
-        '''Test output tests above just by calling the musicxml attribute
+        '''
+        Test output tests above just by calling the musicxml attribute
         '''
         a = ['c', 'g#', 'd-', 'f#', 'e', 'f'] * 4
 
@@ -1813,7 +1822,8 @@ class Test(unittest.TestCase):
         unused_mx = GEX.parse(p).decode('utf-8')
 
     def testMusicXMLGenerationViaPropertyB(self):
-        '''Test output tests above just by calling the musicxml attribute
+        '''
+        Test output tests above just by calling the musicxml attribute
         '''
         n = note.Note()
         n.quarterLength = 3
@@ -1830,7 +1840,8 @@ class Test(unittest.TestCase):
         unused_mx = GEX.parse(a).decode('utf-8')
 
     def testMusicXMLGenerationViaPropertyC(self):
-        '''Test output tests above just by calling the musicxml attribute
+        '''
+        Test output tests above just by calling the musicxml attribute
         '''
 
         a = ['c', 'g#', 'd-', 'f#', 'e', 'f'] * 4
@@ -1853,7 +1864,8 @@ class Test(unittest.TestCase):
         unused_mx = GEX.parse(p).decode('utf-8')
 
     def testContextNestedA(self):
-        '''Testing getting clefs from higher-level streams
+        '''
+        Testing getting clefs from higher-level streams
         '''
         s1 = Stream()
         s2 = Stream()
@@ -1911,7 +1923,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(post), 1)
 
     def testContextNestedB(self):
-        '''Testing getting clefs from higher-level streams
+        '''
+        Testing getting clefs from higher-level streams
         '''
         sInner = Stream()
         sInner.id = 'innerStream'
@@ -1957,7 +1970,8 @@ class Test(unittest.TestCase):
         # self.assertIsInstance(post, clef.AltoClef)
 
     def testContextNestedC(self):
-        '''Testing getting clefs from higher-level streams
+        '''
+        Testing getting clefs from higher-level streams
         '''
         from music21.common.enums import ElementSearch
 
@@ -2308,7 +2322,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(sPartitioned.getElementsByClass(Measure)), 1)
 
     def testMakeMeasuresWithBarlines(self):
-        '''Test makeMeasures with optional barline parameters.
+        '''
+        Test makeMeasures with optional barline parameters.
         '''
         s = Stream()
         s.repeatAppend(note.Note(quarterLength=0.5), 20)
@@ -2357,7 +2372,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s['Expression']), 1)
 
     def testRemove(self):
-        '''Test removing components from a Stream.
+        '''
+        Test removing components from a Stream.
         '''
         s = Stream()
         n1 = note.Note('g')
@@ -2398,7 +2414,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s.notes), 0)
 
     def testReplace(self):
-        '''Test replacing components from a Stream.
+        '''
+        Test replacing components from a Stream.
         '''
         s = Stream()
         n1 = note.Note('g')
@@ -2529,7 +2546,8 @@ class Test(unittest.TestCase):
         unused_s3Measures = s3.makeMeasures()
 
     def testBestTimeSignature(self):
-        '''Get a time signature based on components in a measure.
+        '''
+        Get a time signature based on components in a measure.
         '''
         m = Measure()
         for ql in [2, 3, 2]:
@@ -2559,7 +2577,8 @@ class Test(unittest.TestCase):
         self.assertEqual(ts.denominator, 16)
 
     def testGetKeySignatures(self):
-        '''Searching contexts for key signatures
+        '''
+        Searching contexts for key signatures
         '''
         s = Stream()
         ks1 = key.KeySignature(1)
@@ -2601,7 +2620,8 @@ class Test(unittest.TestCase):
         self.assertIs(post, ks1)
 
     def testGetKeySignaturesThreeMeasures(self):
-        '''Searching contexts for key signatures
+        '''
+        Searching contexts for key signatures
         '''
 
         ks1 = key.KeySignature(1)
@@ -2642,7 +2662,8 @@ class Test(unittest.TestCase):
         self.assertIs(post, ks1)
 
     def testMakeAccidentalsA(self):
-        '''Test accidental display setting
+        '''
+        Test accidental display setting
         '''
         s = Stream()
         n1 = note.Note('a#')
@@ -3208,7 +3229,8 @@ class Test(unittest.TestCase):
                     )
 
     def testScaleDurationsBasic(self):
-        '''Scale some durations, independent of offsets.
+        '''
+        Scale some durations, independent of offsets.
         '''
 
         def procCompare(s, scalar, match):
@@ -3284,7 +3306,8 @@ class Test(unittest.TestCase):
                     [1.5, 4.5, 6, 9, 0.75, 0.75, 1.5])
 
     def testAugmentOrDiminishHighestTimes(self):
-        '''Need to make sure that highest offset and time are properly updated
+        '''
+        Need to make sure that highest offset and time are properly updated
         '''
         src = corpus.parse('bach/bwv324.xml')
         # get some measures of the soprano; just get the notes
@@ -3311,7 +3334,8 @@ class Test(unittest.TestCase):
         self.assertEqual(ex.highestTime, 84.0)
 
     def testAugmentOrDiminishCorpus(self):
-        '''Extract phrases from the corpus and use for testing
+        '''
+        Extract phrases from the corpus and use for testing
         '''
         # first method: iterating through notes
         src = corpus.parse('bach/bwv324.xml')
@@ -3577,7 +3601,9 @@ class Test(unittest.TestCase):
         self.assertEqual(m2.rightBarline, b4)  # this is on elements
 
     def testMeasureLayout(self):
-        '''test both system layout and measure width'''
+        '''
+        test both system layout and measure width
+        '''
 
         # Note: Measure.layoutWidth is not currently read by musicxml
         s = Stream()
@@ -4125,7 +4151,8 @@ class Test(unittest.TestCase):
                 self.assertEqual(post.mode, matchArden[i][1])
 
     def testMakeTupletBracketsA(self):
-        '''Creating brackets
+        '''
+        Creating brackets
         '''
         from music21.stream import makeNotation
 
@@ -4161,7 +4188,8 @@ class Test(unittest.TestCase):
         # s.show()
 
     def testMakeTupletBracketsB(self):
-        '''Creating brackets
+        '''
+        Creating brackets
         '''
         from music21.stream import makeNotation
 
@@ -4268,7 +4296,8 @@ class Test(unittest.TestCase):
         # s.show()
 
     def testMakeNotationA(self):
-        '''This is a test of many make procedures
+        '''
+        This is a test of many make procedures
         '''
         def collectTupletType(s_inner):
             post = []
@@ -4313,7 +4342,8 @@ class Test(unittest.TestCase):
         # s.show()
 
     def testMakeNotationB(self):
-        '''Testing voices making routines within make notation
+        '''
+        Testing voices making routines within make notation
         '''
         from music21.instrument import Xylophone
         s = Stream()
@@ -4340,7 +4370,8 @@ class Test(unittest.TestCase):
         self.assertIsInstance(sPost.getInstruments(recurse=True)[0], Xylophone)
 
     def testMakeNotationC(self):
-        '''Test creating diverse, overlapping durations and notes
+        '''
+        Test creating diverse, overlapping durations and notes
         '''
         s = Stream()
         for dur in [0.5, 1.5, 3]:
@@ -4357,7 +4388,8 @@ class Test(unittest.TestCase):
         self.assertIsNotNone(sPost.flatten().notes[-1].tie)
 
     def testMakeNotationScoreA(self):
-        '''Test makeNotation on Score objects
+        '''
+        Test makeNotation on Score objects
         '''
         s = Score()
         p1 = Stream()
@@ -4383,7 +4415,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(post.flatten().getElementsByClass(clef.Clef)), 2)
 
     def testMakeNotationScoreB(self):
-        '''Test makeNotation on Score objects
+        '''
+        Test makeNotation on Score objects
         '''
         s = Score()
         p1 = Stream()
@@ -4411,7 +4444,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(post.flatten().getElementsByClass(clef.Clef)), 2)
 
     def testMakeNotationScoreC(self):
-        '''Test makeNotation on Score objects
+        '''
+        Test makeNotation on Score objects
         '''
         s = Score()
         p1 = Stream()
@@ -4872,7 +4906,8 @@ class Test(unittest.TestCase):
         self.assertEqual(m.number, 2)
 
     def testElementsHighestTimeA(self):
-        '''Test adding elements at the highest time position
+        '''
+        Test adding elements at the highest time position
         '''
         n1 = note.Note()
         n1.quarterLength = 30
@@ -5007,7 +5042,8 @@ class Test(unittest.TestCase):
             s.storeAtEnd(b2)
 
     def testElementsHighestTimeB(self):
-        '''Test adding elements at the highest time position
+        '''
+        Test adding elements at the highest time position
         '''
         n1 = note.Note()
         n1.quarterLength = 30
@@ -7854,7 +7890,8 @@ class Test(unittest.TestCase):
 
 
     def testSplitAtQuarterLengthB(self):
-        '''Test if recursive calls work over voices in a Measure
+        '''
+        Test if recursive calls work over voices in a Measure
         '''
         m1 = Measure()
         v1 = Voice()
@@ -7877,7 +7914,8 @@ class Test(unittest.TestCase):
         # sPost.show()
 
     def testSplitAtQuarterLengthC(self):
-        '''Test splitting a Score
+        '''
+        Test splitting a Score
         '''
         s = corpus.parse('bwv66.6')
         sLeft, sRight = s.splitAtQuarterLength(6)
@@ -7900,7 +7938,9 @@ class Test(unittest.TestCase):
         # sRight.show()
 
     def testGracesInStream(self):
-        '''testing grace notes'''
+        '''
+        testing grace notes
+        '''
         s = Measure()
         s.append(note.Note('G3'))
         self.assertEqual(s.highestTime, 1.0)
@@ -7986,7 +8026,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s[variant.Variant]), 2)
 
     def testActivateVariantsA(self):
-        '''This tests a single-measure variant
+        '''
+        This tests a single-measure variant
         '''
         s = Stream()
         s.repeatAppend(note.Note('d2'), 12)
@@ -8017,7 +8058,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s[variant.Variant]), 1)
 
     def testActivateVariantsB(self):
-        '''This tests two variants with different groups, each a single measure
+        '''
+        This tests two variants with different groups, each a single measure
         '''
         s = Stream()
         s.repeatAppend(note.Note('d2'), 12)
@@ -8066,7 +8108,8 @@ class Test(unittest.TestCase):
         self.assertEqual(str(match), "[['default'], ['default']]")
 
     def testActivateVariantsC(self):
-        '''This tests a two-measure variant
+        '''
+        This tests a two-measure variant
         '''
         s = Stream()
         s.repeatAppend(note.Note('d2'), 12)
@@ -8101,7 +8144,8 @@ class Test(unittest.TestCase):
         self.assertEqual(len(s[variant.Variant]), 1)
 
     def testActivateVariantsD(self):
-        '''This tests a note-level variant
+        '''
+        This tests a note-level variant
         '''
         s = Stream()
         s.repeatAppend(note.Note('d2'), 12)
@@ -8136,7 +8180,8 @@ class Test(unittest.TestCase):
         # variant part will not be matched
 
     def testActivateVariantsE(self):
-        '''This tests a note-level variant with miss-matched rhythms
+        '''
+        This tests a note-level variant with miss-matched rhythms
         '''
         s = Stream()
         s.repeatAppend(note.Note('d2'), 12)
@@ -8205,7 +8250,9 @@ class Test(unittest.TestCase):
         # s.show()
 
     def testActivateVariantsBySpanB(self):
-        '''test replacing 2 measures by a longer single measure'''
+        '''
+        test replacing 2 measures by a longer single measure
+        '''
         s = Stream()
         s.repeatAppend(note.Note('d2'), 16)
         s.makeMeasures(inPlace=True)
@@ -8328,11 +8375,15 @@ class Test(unittest.TestCase):
 
     @staticmethod
     def get_beams_from_stream(srcList):
-        '''Helper function to return beam list for all notes and rests in the stream.'''
+        '''
+        Helper function to return beam list for all notes and rests in the stream.
+        '''
         return [n.beams for n in srcList if isinstance(n, GeneralNote)]
 
     def test_makeBeams__all_quarters(self):
-        '''Test that for a measure full of quarters, there are no beams'''
+        '''
+        Test that for a measure full of quarters, there are no beams
+        '''
         m = Measure()
         m.timeSignature = meter.TimeSignature('4/4')
         m.repeatAppend(note.Note(quarterLength=1), 4)
@@ -8343,7 +8394,9 @@ class Test(unittest.TestCase):
         self.assertEqual([beam.Beams(), beam.Beams(), beam.Beams(), beam.Beams()], beams)
 
     def test_makeBeams__all_eighths(self):
-        '''Test a full measure full of eighth is grouped by beams into couples'''
+        '''
+        Test a full measure full of eighth is grouped by beams into couples
+        '''
         m = Measure()
         m.timeSignature = meter.TimeSignature('4/4')
         m.repeatAppend(note.Note(quarterLength=0.5), 8)
@@ -8372,7 +8425,9 @@ class Test(unittest.TestCase):
         self.assertEqual(second_note_beams, beams[7])
 
     def test_makeBeams__eighth_rests_and_eighth(self):
-        '''Test a full measure of 8th rest followed by 8th note'''
+        '''
+        Test a full measure of 8th rest followed by 8th note
+        '''
         m = Measure()
         m.timeSignature = meter.TimeSignature('4/4')
         for i in range(4):
@@ -8422,7 +8477,9 @@ class Test(unittest.TestCase):
         self.assertEqual(third_note_beams, beams[5])
 
     def test_makeBeams__1_e_n_a(self):
-        '''Test that 4 16th notes have proper beams across them all.'''
+        '''
+        Test that 4 16th notes have proper beams across them all.
+        '''
         m = Measure()
         m.timeSignature = meter.TimeSignature('1/4')
         m.repeatAppend(note.Note(quarterLength=0.25), 4)

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -136,7 +136,8 @@ class TempoIndication(base.Music21Object):
     #     # self.style.justify = 'left'  # creates a style object to share.
 
     def getSoundingMetronomeMark(self, found=None):
-        '''Get the appropriate MetronomeMark from any sort of TempoIndication, regardless of class.
+        '''
+        Get the appropriate MetronomeMark from any sort of TempoIndication, regardless of class.
         '''
         if found is None:
             found = self
@@ -437,7 +438,8 @@ class MetronomeMark(TempoIndication):
             return f'{self.text} {self.referent.fullName}={self.number}'
 
     def _updateTextFromNumber(self):
-        '''Update text if number is given and text is not defined
+        '''
+        Update text if number is given and text is not defined
         '''
         if self._tempoText is None and self._number is not None:
             # PyCharm inspection does not like using attributes on functions that become properties
@@ -448,7 +450,8 @@ class MetronomeMark(TempoIndication):
                 self.textImplicit = True
 
     def _updateNumberFromText(self):
-        '''Update number if text is given and number is not defined
+        '''
+        Update number if text is given and number is not defined
         '''
         if self._number is None and self._tempoText is not None:
             self._number = self._getDefaultNumber(self._tempoText)
@@ -786,7 +789,8 @@ class MetronomeMark(TempoIndication):
             raise MetronomeMarkException('cannot derive seconds as getQuarterBPM() returns None')
 
     def durationToSeconds(self, durationOrQuarterLength):
-        '''Given a duration specified as a :class:`~music21.duration.Duration` object or a
+        '''
+        Given a duration specified as a :class:`~music21.duration.Duration` object or a
         quarter length, return the resultant time in seconds at the tempo specified by
         this MetronomeMark.
 
@@ -1087,7 +1091,8 @@ class MetricModulation(TempoIndication):
     # --------------------------------------------------------------------------
     # high-level configuration methods
     def updateByContext(self):
-        '''Update this metric modulation based on the context,
+        '''
+        Update this metric modulation based on the context,
         or the surrounding MetronomeMarks or MetricModulations.
         The object needs to reside in a Stream for this to be effective.
         '''
@@ -1113,10 +1118,10 @@ class MetricModulation(TempoIndication):
             self._newMetronome.number = self._oldMetronome.number
 
     def setEqualityByReferent(self, side=None, referent=1.0):
-        '''Set the other side of the metric modulation to
+        '''
+        Set the other side of the metric modulation to
         an equality; side can be specified, or if one side
         is None, that side will be set.
-
 
         >>> mm1 = tempo.MetronomeMark(number=60, referent=1)
         >>> mmod1 = tempo.MetricModulation()
@@ -1542,10 +1547,11 @@ class Test(unittest.TestCase):
                          '<music21.tempo.MetronomeMark lento 16th=52>')
 
     def testSetReferentA(self):
-        '''Test setting referents directly via context searches.
         '''
-        from music21 import tempo
+        Test setting referents directly via context searches.
+        '''
         from music21 import stream
+        from music21 import tempo
         p = stream.Part()
         m1 = stream.Measure()
         m1.repeatAppend(note.Note(quarterLength=1), 4)

--- a/music21/test/testPerformance.py
+++ b/music21/test/testPerformance.py
@@ -33,7 +33,8 @@ environLocal = environment.Environment('test.testPerformance')
 class Test(unittest.TestCase):
 
     def runStreamIterationByIterator(self):
-        '''Stream iteration by iterator
+        '''
+        Stream iteration by iterator
         '''
         from music21 import note
         from music21 import stream
@@ -51,7 +52,8 @@ class Test(unittest.TestCase):
                 pass
 
     def runStreamIterationByElements(self):
-        '''Stream iteration by .elements access
+        '''
+        Stream iteration by .elements access
         '''
         from music21 import note
         from music21 import stream
@@ -69,7 +71,8 @@ class Test(unittest.TestCase):
                 pass
 
     def runGetElementsByClassType(self):
-        '''Getting elements by class type
+        '''
+        Getting elements by class type
         '''
         from music21 import note
         from music21 import stream
@@ -88,7 +91,8 @@ class Test(unittest.TestCase):
             self.assertEqual(len(post), 1500)
 
     def runGetElementsByClassString(self):
-        '''Getting elements by string
+        '''
+        Getting elements by string
         '''
         from music21 import note
         from music21 import stream
@@ -107,12 +111,14 @@ class Test(unittest.TestCase):
             self.assertEqual(len(post), 1500)
 
     def runParseBeethoven(self):
-        '''Loading file: beethoven/opus59no2/movement3
+        '''
+        Loading file: beethoven/opus59no2/movement3
         '''
         junk = corpus.parse('beethoven/opus59no2/movement3', forceSource=True)
 
     def runMusicxmlOutPartsBeethoven(self):
-        '''Loading file and rendering musicxml output for each part: beethoven/opus59no2/movement3
+        '''
+        Loading file and rendering musicxml output for each part: beethoven/opus59no2/movement3
         '''
         x = corpus.parse('beethoven/opus59no2/movement3', forceSource=True)
         # problem: doing each part is much faster than the whole score
@@ -128,12 +134,14 @@ class Test(unittest.TestCase):
         junk = GEX().parse(x)
 
     def runParseHaydn(self):
-        '''Loading file: haydn/opus74no1/movement3
+        '''
+        Loading file: haydn/opus74no1/movement3
         '''
         junk = corpus.parse('haydn/opus74no1/movement3', forceSource=True)
 
     def runParseRobertSchumann(self):
-        '''Loading file: schumann_robert/opus41no1/movement2
+        '''
+        Loading file: schumann_robert/opus41no1/movement2
         '''
         junk = corpus.parse('schumann_robert/opus41no1/movement2', forceSource=True)
 
@@ -151,7 +159,8 @@ class Test(unittest.TestCase):
         junk = GEX().parse(x)
 
     def runCreateTimeSignatures(self):
-        '''Creating 500 TimeSignature objects
+        '''
+        Creating 500 TimeSignature objects
         '''
         from music21 import meter
         tsStr = ['4/4', '4/4', '4/4', '3/4', '3/4', '2/4', '2/4', '2/2',
@@ -186,12 +195,14 @@ class Test(unittest.TestCase):
             p.transpose('p5', inPlace=True)
 
     def runParseABC(self):
-        '''Creating loading a large multiple work abc file (han1)
+        '''
+        Creating loading a large multiple work abc file (han1)
         '''
         dummy = corpus.parse('essenFolksong/han1')
 
     def runGetElementsByContext(self):
-        '''Test getting elements by context from a Stream
+        '''
+        Test getting elements by context from a Stream
         '''
         from music21 import stream
         from music21 import clef
@@ -223,7 +234,8 @@ class Test(unittest.TestCase):
                     assert post is not None
 
     def runGetElementsByPrevious(self):
-        '''Test getting elements by using the previous method
+        '''
+        Test getting elements by using the previous method
         '''
         from music21 import stream
         from music21 import clef
@@ -255,7 +267,8 @@ class Test(unittest.TestCase):
                     assert post is not None
 
     def runParseMonteverdiRNText(self):
-        '''Loading file: beethoven/opus59no2/movement3
+        '''
+        Loading file: beethoven/opus59no2/movement3
         '''
         unused = corpus.parse('monteverdi/madrigal.5.3.rntxt', forceSource=True)
 

--- a/music21/test/test_base.py
+++ b/music21/test/test_base.py
@@ -230,7 +230,8 @@ class Test(unittest.TestCase):
         self.assertIsInstance(post, clef.BassClef)
 
     def testSitesMeasures(self):
-        '''Can a measure determine the last Clef used?
+        '''
+        Can a measure determine the last Clef used?
         '''
         a = corpus.parse('bach/bwv324.xml')
         measures = a.parts[0].getElementsByClass(stream.Measure).stream()  # measures of first part
@@ -291,7 +292,8 @@ class Test(unittest.TestCase):
         self.assertTrue(isinstance(post, clef.AltoClef), post)
 
     def testBeatAccess(self):
-        '''Test getting beat data from various Music21Objects.
+        '''
+        Test getting beat data from various Music21Objects.
         '''
         s = corpus.parse('bach/bwv66.6.xml')
         p1 = s.parts['#Soprano']
@@ -381,7 +383,8 @@ class Test(unittest.TestCase):
         self.assertEqual([1.0, 0.25, 0.5, 0.25, 1.0, 0.25, 0.5, 0.25, 1.0, 0.25, 0.5, 0.25], match)
 
     def testMeasureNumberAccess(self):
-        '''Test getting measure number data from various Music21Objects.
+        '''
+        Test getting measure number data from various Music21Objects.
         '''
         s = corpus.parse('bach/bwv66.6.xml')
         p1 = s.parts['#Soprano']

--- a/music21/test/test_expressions.py
+++ b/music21/test/test_expressions.py
@@ -119,7 +119,8 @@ class Test(unittest.TestCase):
 
 
     def testTrillExtensionA(self):
-        '''Test basic wave line creation and output, as well as passing
+        '''
+        Test basic wave line creation and output, as well as passing
         objects through make measure calls.
         '''
         s = stream.Stream()

--- a/music21/test/test_pitch.py
+++ b/music21/test/test_pitch.py
@@ -43,7 +43,8 @@ class Test(unittest.TestCase):
         self.assertEqual(b.octave, 3)
 
     def testAccidentalImport(self):
-        '''Test that we are getting the properly set accidentals
+        '''
+        Test that we are getting the properly set accidentals
         '''
         s = corpus.parse('bwv438.xml')
         tenorMeasures = s.parts[2].getElementsByClass(stream.Measure)
@@ -59,7 +60,8 @@ class Test(unittest.TestCase):
         self.assertTrue(pAltered.accidental.displayStatus)
 
     def testUpdateAccidentalDisplaySimple(self):
-        '''Test updating accidental display.
+        '''
+        Test updating accidental display.
         '''
         past = [Pitch('A#3'), Pitch('C#'), Pitch('C')]
 
@@ -77,7 +79,8 @@ class Test(unittest.TestCase):
         self.assertEqual(b.accidental.name, 'natural')
 
     def testUpdateAccidentalDisplaySeries(self):
-        '''Test updating accidental display.
+        '''
+        Test updating accidental display.
         '''
         def proc(_pList, past):
             for p in _pList:
@@ -182,7 +185,8 @@ class Test(unittest.TestCase):
         compare(pList, result)
 
     def testUpdateAccidentalDisplaySeriesKeySignature(self):
-        '''Test updating accidental display against a KeySignature
+        '''
+        Test updating accidental display against a KeySignature
         '''
         def proc(_pList, past, alteredPitches):
             for p in _pList:

--- a/music21/test/test_repeat.py
+++ b/music21/test/test_repeat.py
@@ -130,7 +130,8 @@ class Test(unittest.TestCase):
                           'D4', 'D4', 'D4', 'D4', 'F4', 'F4', 'F4', 'F4'])
 
     def testRepeatCoherenceC(self):
-        '''Using da capo/dal segno
+        '''
+        Using da capo/dal segno
         '''
         # no repeats
         s = stream.Part()
@@ -1321,7 +1322,8 @@ class Test(unittest.TestCase):
         # self.assertTrue(ex._repeatBracketsAreCoherent())
 
     def testRepeatEndingsE(self):
-        '''Expanding two endings (1, 2, then 3) without a start repeat
+        '''
+        Expanding two endings (1, 2, then 3) without a start repeat
         '''
         p = stream.Part()
         m1 = stream.Measure()
@@ -1354,7 +1356,8 @@ class Test(unittest.TestCase):
         self.assertEqual(post[0]['measureIndices'], [1, 2, 3])
 
     def testRepeatEndingsF(self):
-        '''Two sets of two endings (1, 2, then 3) without a start repeat
+        '''
+        Two sets of two endings (1, 2, then 3) without a start repeat
         '''
         p = stream.Part()
         m1 = stream.Measure()
@@ -1406,7 +1409,8 @@ class Test(unittest.TestCase):
         self.assertEqual(post[1]['measureIndices'], [5, 6, 7])
 
     def testRepeatEndingsG(self):
-        '''Two sets of two endings (1, 2, then 3) without a start repeat
+        '''
+        Two sets of two endings (1, 2, then 3) without a start repeat
         '''
         p = stream.Part()
         m1 = stream.Measure()
@@ -1445,7 +1449,8 @@ class Test(unittest.TestCase):
         # post.show()
 
     def testRepeatEndingsH(self):
-        '''Two sets of two endings (1, 2, then 3) without a start repeat
+        '''
+        Two sets of two endings (1, 2, then 3) without a start repeat
         '''
         p = stream.Part()
         m1 = stream.Measure(number=1)
@@ -1488,7 +1493,8 @@ class Test(unittest.TestCase):
                          ['C', 'D', 'E', 'C', 'D', 'E', 'C', 'F', 'C', 'G', 'A', 'B', 'C'])
 
     def testRepeatEndingsI(self):
-        '''Two sets of two endings (1, 2, then 3) without a start repeat
+        '''
+        Two sets of two endings (1, 2, then 3) without a start repeat
         '''
         p = stream.Part()
         m1 = stream.Measure(number=1)
@@ -1542,7 +1548,8 @@ class Test(unittest.TestCase):
                           'G', 'A', 'G', 'A', 'G', 'B', 'G', 'C'])
 
     def testRepeatEndingsJ(self):
-        '''Two sets of two endings (1, 2, then 3) without a start repeat
+        '''
+        Two sets of two endings (1, 2, then 3) without a start repeat
         '''
         p = stream.Part()
         m1 = stream.Measure(number=1)

--- a/music21/test/timeGraphs.py
+++ b/music21/test/timeGraphs.py
@@ -22,7 +22,8 @@ import music21
 
 
 class Test:
-    '''Base class for timed tests that need music21 imported
+    '''
+    Base class for timed tests that need music21 imported
     '''
 
 

--- a/music21/text.py
+++ b/music21/text.py
@@ -327,18 +327,10 @@ class TextBox(base.Music21Object):
             return ''
 
 
-    def _getContent(self):
-        return self._content
-
-    def _setContent(self, value):
-        if not isinstance(value, str):
-            self._content = str(value)
-        else:
-            self._content = value
-
-    content = property(_getContent, _setContent,
-        doc='''Get or set the content.
-
+    @property
+    def content(self):
+        '''
+        Get or set the content.
 
         >>> te = text.TextBox('Con fuoco')
         >>> te.content
@@ -346,19 +338,20 @@ class TextBox(base.Music21Object):
         >>> te.style.justify = 'center'
         >>> te.style.justify
         'center'
+        '''
+        return self._content
 
-        ''')
+    @content.setter
+    def content(self, value):
+        if not isinstance(value, str):
+            self._content = str(value)
+        else:
+            self._content = value
 
-    def _getPage(self):
-        return self._page
-
-    def _setPage(self, value):
-        if value is not None:
-            self._page = int(value)  # must be an integer
-        # do not set otherwise
-
-    page = property(_getPage, _setPage,
-        doc='''Get or set the page number. The first page (page 1) is the default.
+    @property
+    def page(self):
+        '''
+        Get or set the page number. The first page (page 1) is the default.
 
         >>> te = text.TextBox('Great Score')
         >>> te.content
@@ -368,20 +361,50 @@ class TextBox(base.Music21Object):
         >>> te.page = 2
         >>> te.page
         2
-        ''')
+        '''
+        return self._page
+
+    @page.setter
+    def page(self, value):
+        if value is not None:
+            self._page = int(value)  # must be an integer
+        # do not set otherwise
 
 
 # ------------------------------------------------------------------------------
+_stored_trigrams = {}
+
+
 class LanguageDetector:
+    # noinspection SpellCheckingInspection
     '''
-    Attempts to detect language on the basis of trigrams
+    Attempts to detect language on the basis of trigrams.
 
-    uses code from
-    https://code.activestate.com/recipes/326576-language-detection-using-character-trigrams/
-    unknown author.  No license given.
+    >>> ld = text.LanguageDetector()
+    >>> ld.mostLikelyLanguage('Guten Morgen Frau Wieck. Ich bin Robert.')
+    'de'
 
-    See Trigram docs below.
+    Note that accuracy improves with longer texts, and that the trigrams are
+    case sensitive.  Putting "Morgen" in lowercase evaluates the text as Dutch.
+
+    Supported languages are currently:
+
+    >>> text.LanguageDetector.languageLong
+    {'en': 'English',
+     'fr': 'French',
+     'it': 'Italian',
+     'de': 'German',
+     'cn': 'Chinese',
+     'la': 'Latin',
+     'nl': 'Dutch'}
+
+    See also, documentation for :class:`~music21.text.Trigram`.
     '''
+    # uses code from
+    # https://code.activestate.com/recipes/326576-language-detection-using-character-trigrams/
+    # Previously unattributed w/o license given, now attributed to
+    # Douglas Bagnall under the BSD-compatible PSF (Python) license.
+
     languageCodes = ['en', 'fr', 'it', 'de', 'cn', 'la', 'nl']
     languageLong = {
         'en': 'English',
@@ -392,26 +415,37 @@ class LanguageDetector:
         'la': 'Latin',
         'nl': 'Dutch',
     }
+    @classmethod
+    def readExcerpts(cls):
+        '''
+        Read the stored trigrams once and store them for later.
 
-    def __init__(self, text=None):
-        self.text = text
-        self.trigrams = {}
-        self.readExcerpts()
-
-    def readExcerpts(self):
-        for languageCode in self.languageCodes:
+        Called on first LanguageDectector read.
+        '''
+        for languageCode in cls.languageCodes:
             thisExcerpt = (common.getSourceFilePath() / 'languageExcerpts'
                             / 'trainingData' / (languageCode + '.txt'))
 
             with thisExcerpt.open(encoding='utf-8') as f:
                 excerptWords = f.read().split()
-                self.trigrams[languageCode] = Trigram(excerptWords)
+                _stored_trigrams[languageCode] = Trigram(excerptWords)
+        return _stored_trigrams.copy()
 
-    def mostLikelyLanguage(self, excerpt):
+
+    def __init__(self, text=None):
+        self.text = text
+        self.trigrams = _stored_trigrams.copy() or LanguageDetector.readExcerpts()
+
+    def mostLikelyLanguage(self, excerpt: str) -> str | None:
         # noinspection SpellCheckingInspection
         '''
-        returns the code of the most likely language for a passage, works on
-        unicode or ascii. current languages: en, fr, de, it, cn, or None
+        Returns the code of the most likely language for a passage, works on
+        unicode or ascii. Current languages are:
+
+        >>> text.LanguageDetector.languageCodes
+        ['en', 'fr', 'it', 'de', 'cn', 'la', 'nl']
+
+        or None if no language is detected.
 
         >>> ld = text.LanguageDetector()
         >>> ld.mostLikelyLanguage('Hello there, how are you doing today? '

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -2565,7 +2565,8 @@ class Test(unittest.TestCase):
 
 
     def testVariantGroupA(self):
-        '''Variant groups are used to distinguish
+        '''
+        Variant groups are used to distinguish
         '''
         v1 = Variant()
         v1.groups.append('alt-a')

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -673,7 +673,8 @@ class VoiceLeadingQuartet(base.Music21Object):
                 and self.hIntervals[0].direction == interval.Direction.DESCENDING)
 
     def antiParallelMotion(self, simpleName=None) -> bool:
-        '''Returns True if the simple interval before is the same as the simple
+        '''
+        Returns True if the simple interval before is the same as the simple
         interval after and the motion is contrary. if simpleName is
         specified as an Interval object or a string then it only returns
         true if the simpleName of both intervals is the same as simpleName
@@ -1812,8 +1813,9 @@ class VerticalityNTuplet(base.Music21Object):
 
 
 class VerticalityTriplet(VerticalityNTuplet):
-    '''a collection of three Verticalities'''
-
+    '''
+    a collection of three Verticalities
+    '''
     def __init__(self, listOfVerticalities, **keywords):
         super().__init__(listOfVerticalities, **keywords)
 
@@ -1915,7 +1917,8 @@ class VerticalityTriplet(VerticalityNTuplet):
 
 
 class NNoteLinearSegment(base.Music21Object):
-    '''a list of n notes strung together in a sequence
+    '''
+    a list of n notes strung together in a sequence
     noteList = [note1, note2, note3, ..., note-n ] Once this
     object is created with a noteList, the noteList may not
     be changed

--- a/music21/volume.py
+++ b/music21/volume.py
@@ -143,8 +143,8 @@ class Volume(prebase.ProtoM21Object, SlottedObjectMixin):
                                                  ] = True,
                        baseLevel=0.5,
                        clip=True):
-        '''Return the realized as rounded and formatted string value. Useful for testing.
-
+        '''
+        Return the realized as rounded and formatted string value. Useful for testing.
 
         >>> v = volume.Volume(velocity=64)
         >>> v.getRealizedStr()


### PR DESCRIPTION
Doc strings are now required to be in my favorite format: 
```
    '''
    Begins on a new line, and ends with an empty triple-single-quotes
    '''
```

Improve the speed of LanguageDetector by caching trigrams.