### PR TITLE
Pre-equality: rem hash

### DIFF
--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -1580,7 +1580,7 @@ class Test(unittest.TestCase):
         s2.repeatAppend(note.Note('c#'), 2)
         k = s2.analyze('key')
         # Ensure all pitch classes are present
-        self.assertEqual(len(set(k.alternateInterpretations)), 23)
+        self.assertEqual(len(k.alternateInterpretations), 23)
 
 
 # define presented order in documentation

--- a/music21/base.py
+++ b/music21/base.py
@@ -265,6 +265,8 @@ class Groups(list):  # no need to inherit from slotted object
 
 
 # -----------------------------------------------------------------------------
+_EQUALITY_SENTINEL_SELF = object()
+_EQUALITY_SENTINEL_OTHER = object()
 
 
 class Music21Object(prebase.ProtoM21Object):
@@ -306,6 +308,8 @@ class Music21Object(prebase.ProtoM21Object):
     isStream = False
 
     _styleClass: type[Style] = Style
+
+    equalityAttributes = ('duration',)
 
     # define order for presenting names in documentation; use strings
     _DOC_ORDER: list[str] = []
@@ -401,6 +405,12 @@ class Music21Object(prebase.ProtoM21Object):
             self.duration.quarterLength = quarterLength
         elif duration is not None:
             self.duration = duration
+
+    # def __eq__(self, other):
+    #     '''
+    #     Two music21 objects are
+    #     '''
+
 
     @property
     def id(self) -> int | str:

--- a/music21/key.py
+++ b/music21/key.py
@@ -363,10 +363,6 @@ class KeySignature(base.Music21Object):
         self._alteredPitches: list[pitch.Pitch] | None = None
         self.accidentalsApplyOnlyToOctave = False
 
-    def __hash__(self):
-        hashTuple = (self._sharps, tuple(self._alteredPitches), self.accidentalsApplyOnlyToOctave)
-        return hash(hashTuple)
-
     # --------------------------------------------------------------------------
 
     def _strDescription(self):
@@ -992,10 +988,6 @@ class Key(KeySignature, scale.DiatonicScale):
 
         # store an ordered list of alternative Key objects
         self.alternateInterpretations: list[Key] = []
-
-    def __hash__(self):
-        hashTuple = (self.tonic, self.mode)
-        return hash(hashTuple)
 
     def _reprInternal(self):
         return 'of ' + str(self)

--- a/music21/note.py
+++ b/music21/note.py
@@ -614,8 +614,7 @@ class GeneralNote(base.Music21Object):
         they have the same articulation and expression classes (in any order),
         and their ties are equal.
         '''
-
-        if other is None or not isinstance(other, GeneralNote):
+        if not isinstance(other, GeneralNote):
             return NotImplemented
         # checks type, dots, tuplets, quarterLength, uses Pitch.__eq__
         if self.duration != other.duration:
@@ -1519,7 +1518,7 @@ class Note(NotRest):
         >>> n1 == 5
         False
         '''
-        if other is None or not isinstance(other, Note):
+        if not isinstance(other, type(self)):
             return NotImplemented
 
         # checks pitch.octave, pitch.accidental, uses Pitch.__eq__

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -947,7 +947,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         >>> a == c
         False
         '''
-        if other is None or not isinstance(other, Accidental):
+        if not isinstance(other, Accidental):
             return False
         if self.name == other.name:
             return True

--- a/music21/tie.py
+++ b/music21/tie.py
@@ -136,7 +136,7 @@ class Tie(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> t2 == None
         False
         '''
-        if other is None or not isinstance(other, Tie):
+        if not isinstance(other, type(self)):
             return False
         elif self.type == other.type:
             return True


### PR DESCRIPTION
This is a cleanup PR that prepares for implementing #1458.  I want to get this part right before putting in a commit that might break things.

Key and KeySignature were the only Music21Objects that implemented __hash__ -- they should not be hashable, since they are mutable, like all M21 objects. 