### PR TITLE
WIP: Instantiation w/ **keywords tests

### DIFF
--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -3408,6 +3408,9 @@ class ABCFile(prebase.ProtoM21Object):
 
 # ------------------------------------------------------------------------------
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
     def testTokenization(self):
         from music21.abcFormat import testFiles

--- a/music21/alpha/analysis/fixer.py
+++ b/music21/alpha/analysis/fixer.py
@@ -504,6 +504,10 @@ class TurnFixer(OrnamentFixer):
         super().__init__(changes, midiStream, omrStream, recognizer)
 
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
+
     def measuresEqual(self, m1, m2):
         '''
         Returns a tuple of (True/False, reason)

--- a/music21/alpha/analysis/hasher.py
+++ b/music21/alpha/analysis/hasher.py
@@ -585,6 +585,9 @@ class NoteHash(tuple):
 
 
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
     def _approximatelyEqual(self, a, b, sig_fig=2):
         '''

--- a/music21/alpha/analysis/ornamentRecognizer.py
+++ b/music21/alpha/analysis/ornamentRecognizer.py
@@ -262,6 +262,10 @@ class _TestCondition:
         self.isInverted = isInverted
 
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
+
     def testRecognizeTurn(self):
         # set up experiment
         testConditions = []

--- a/music21/alpha/analysis/search.py
+++ b/music21/alpha/analysis/search.py
@@ -251,6 +251,9 @@ def findConsecutiveScale(source, targetScale, degreesRequired=5,
 
 # ------------------------------------------------------------------------------
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
     def testFindConsecutiveScaleA(self):
         sc = scale.MajorScale('a4')

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -1413,6 +1413,9 @@ def analysisClassFromMethodName(method: str) -> type[DiscreteAnalysis] | None:
 
 
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
     def testKeyAnalysisKrumhansl(self):
         from music21 import converter

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -891,6 +891,9 @@ class PartReduction:
 
 # ------------------------------------------------------------------------------
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
     def testExtractionA(self):
         from music21 import analysis

--- a/music21/analysis/transposition.py
+++ b/music21/analysis/transposition.py
@@ -191,6 +191,9 @@ class TranspositionChecker:
 
 # ------------------------------------------------------------------------------
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
     def testConstructTranspositionChecker(self):
         p = [pitch.Pitch('D#')]

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -363,6 +363,9 @@ class TestMockProcessor:
 
 
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
     def testBasic(self):
         from music21 import corpus

--- a/music21/articulations.py
+++ b/music21/articulations.py
@@ -662,6 +662,9 @@ class HandbellIndication(TechnicalIndication):
 
 # ------------------------------------------------------------------------------
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
     def testBasic(self):
         a = FretBend()

--- a/music21/bar.py
+++ b/music21/bar.py
@@ -375,6 +375,9 @@ class Repeat(repeat.RepeatMark, Barline):
 
 # ------------------------------------------------------------------------------
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
     def testSortOrder(self):
         from music21 import stream

--- a/music21/base.py
+++ b/music21/base.py
@@ -483,16 +483,19 @@ class Music21Object(prebase.ProtoM21Object):
             ignoreAttributes = ignoreAttributes | defaultIgnoreSet
 
         # call class to get a new, empty instance
-        # TODO: this creates an extra duration object for notes... optimize...
-        if '_duration' in ignoreAttributes and self._duration is not None:
-            d = self._duration
-            clientStore = d.client
-            d.client = None
-            newDuration = copy.deepcopy(d, memo)
-            d.client = clientStore
-            new = self.__class__(duration=newDuration)
-        else:
-            new = self.__class__()
+        try:
+            if '_duration' in ignoreAttributes and self._duration is not None:
+                # prevent creating an extra Duration.  deepcopy on Duration is optimized
+                d = self._duration
+                clientStore = d.client
+                d.client = None
+                newDuration = copy.deepcopy(d, memo)
+                d.client = clientStore
+                new = self.__class__(duration=newDuration)
+            else:
+                new = self.__class__()
+        except TypeError:
+            return common.defaultDeepcopy(self, memo)
 
         if '_derivation' in ignoreAttributes:
             # was: keep the old ancestor but need to update the client

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -702,7 +702,9 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
 
 
 class Test(unittest.TestCase):
-    pass
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
 
 # -----------------------------------------------------------------------------

--- a/music21/braille/objects.py
+++ b/music21/braille/objects.py
@@ -79,7 +79,9 @@ class BrailleExplicitNoteExtraSmaller(BrailleExplicitNoteLength):
 
 # ------------------------------------------------------------------------------
 class Test(unittest.TestCase):
-    pass
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
 
 if __name__ == '__main__':

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -1279,7 +1279,6 @@ def getIndex(featureString, extractorType=None):
 class Test(unittest.TestCase):
 
     def testStreamFormsA(self):
-
         from music21 import features
         self.maxDiff = None
 

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -685,7 +685,6 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         Insert the Global Events (GlobalReferenceLines and GlobalCommentLines) into an appropriate
         place in the outer Stream.
 
-
         Run after self.spineCollection.createMusic21Streams().
         Is run automatically by self.parse().
         uses self.spineCollection.getOffsetsAndPrioritiesByPosition()
@@ -737,31 +736,31 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         if appendList:
             self.stream.coreElementsChanged()
 
-#     @property
-#     def stream(self):
-#         if self._storedStream is not None:
-#             return self._storedStream
-#         if self.parsedLines is False:
-#             self.parse()
-#
-#         if self.spineCollection is None:
-#             raise HumdrumException('parsing got no spine collections!')
-#         elif self.spineCollection.spines is None:
-#             raise HumdrumException('not a single spine in your data... um, not my problem! ' +
-#                                    '(well, maybe it is...file a bug report if you ' +
-#                                    'have doubled checked your data)')
-#         elif self.spineCollection.spines[0].stream is None:
-#             raise HumdrumException('okay, you got at least one spine, but it ain\'t got ' +
-#                                    'a stream in it; (check your data or file a bug report)')
-#         else:
-#             masterStream = stream.Score()
-#             for thisSpine in self.spineCollection:
-#                 thisSpine.stream.id = 'spine_' + str(thisSpine.id)
-#             for thisSpine in self.spineCollection:
-#                 if thisSpine.parentSpine is None and thisSpine.spineType == 'kern':
-#                     masterStream.insert(thisSpine.stream)
-#             self._storedStream = masterStream
-#             return masterStream
+    # @property
+    # def stream(self):
+    #     if self._storedStream is not None:
+    #         return self._storedStream
+    #     if self.parsedLines is False:
+    #         self.parse()
+    #
+    #     if self.spineCollection is None:
+    #         raise HumdrumException('parsing got no spine collections!')
+    #     elif self.spineCollection.spines is None:
+    #         raise HumdrumException('not a single spine in your data... um, not my problem! ' +
+    #                                '(well, maybe it is...file a bug report if you ' +
+    #                                'have doubled checked your data)')
+    #     elif self.spineCollection.spines[0].stream is None:
+    #         raise HumdrumException('okay, you got at least one spine, but it ain\'t got ' +
+    #                                'a stream in it; (check your data or file a bug report)')
+    #     else:
+    #         masterStream = stream.Score()
+    #         for thisSpine in self.spineCollection:
+    #             thisSpine.stream.id = 'spine_' + str(thisSpine.id)
+    #         for thisSpine in self.spineCollection:
+    #             if thisSpine.parentSpine is None and thisSpine.spineType == 'kern':
+    #                 masterStream.insert(thisSpine.stream)
+    #         self._storedStream = masterStream
+    #         return masterStream
 
     def parseMetadata(self, s=None):
         '''
@@ -2499,7 +2498,6 @@ def kernTandemToObject(tandem):
 
     This method converts them to music21 objects.
 
-
     >>> m = humdrum.spineParser.kernTandemToObject('*M3/1')
     >>> m
     <music21.meter.TimeSignature 3/1>
@@ -2619,8 +2617,8 @@ def kernTandemToObject(tandem):
 
 
 class MiscTandem(base.Music21Object):
-    def __init__(self, tandem=''):
-        super().__init__()
+    def __init__(self, tandem='', **keywords):
+        super().__init__(**keywords)
         self.tandem = tandem
 
     def _reprInternal(self):
@@ -2631,16 +2629,14 @@ class SpineComment(base.Music21Object):
     '''
     A Music21Object that represents a comment in a single spine.
 
-
     >>> sc = humdrum.spineParser.SpineComment('! this is a spine comment')
     >>> sc
     <music21.humdrum.spineParser.SpineComment 'this is a spine comment'>
     >>> sc.comment
     'this is a spine comment'
     '''
-
-    def __init__(self, comment=''):
-        super().__init__()
+    def __init__(self, comment='', **keywords):
+        super().__init__(**keywords)
         commentPart = re.sub(r'^!+\s?', '', comment)
         self.comment = commentPart
 
@@ -2652,16 +2648,14 @@ class GlobalComment(base.Music21Object):
     '''
     A Music21Object that represents a comment for the whole score
 
-
     >>> sc = humdrum.spineParser.GlobalComment('!! this is a global comment')
     >>> sc
     <music21.humdrum.spineParser.GlobalComment 'this is a global comment'>
     >>> sc.comment
     'this is a global comment'
     '''
-
-    def __init__(self, comment=''):
-        super().__init__()
+    def __init__(self, comment='', **keywords):
+        super().__init__(**keywords)
         commentPart = re.sub(r'^!!+\s?', '', comment)
         commentPart = commentPart.strip()
         self.comment = commentPart
@@ -2713,8 +2707,8 @@ class GlobalReference(base.Music21Object):
     False
     '''
 
-    def __init__(self, codeOrAll='', valueOrNone=None):
-        super().__init__()
+    def __init__(self, codeOrAll='', valueOrNone=None, **keywords):
+        super().__init__(**keywords)
         codeOrAll = re.sub(r'^!!!+', '', codeOrAll)
         codeOrAll = codeOrAll.strip()
         if valueOrNone is None and ':' in codeOrAll:
@@ -2816,7 +2810,7 @@ class GlobalReference(base.Music21Object):
         'EED': 'electronicEditor',  # electronic editor
         'ENC': 'electronicEncoder',  # electronic encoder (person)
         'END': '',  # encoding date
-        'EMD': '',  # electronic document modification description (one per modificiation)
+        'EMD': '',  # electronic document modification description (one per modification)
         'EEV': '',  # electronic edition version
         'EFL': '',  # file number e.g. '1/4' for one of four
         'EST': '',  # encoding status (free form, normally eliminated prior to distribution)
@@ -2864,6 +2858,9 @@ class GlobalReference(base.Music21Object):
 
 
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
     def testLoadMazurka(self):
         # hf1 = HumdrumFile('d:/web/eclipse/music21misc/mazurka06-2.krn')
@@ -2871,22 +2868,22 @@ class Test(unittest.TestCase):
         hf1 = HumdrumDataCollection(testFiles.mazurka6)
         hf1.parse()
 
-    #    hf1 = HumdrumFile('d:/web/eclipse/music21misc/ojibway.krn')
-    #    for thisEventCollection in hf1.eventCollections:
-    #        ev = thisEventCollection.getSpineEvent(0).contents
-    #        if ev is not None:
-    #            print(ev)
-    #        else:
-    #            print('NONE')
-
-    #    for mySpine in hf1.spineCollection:
-    #        print('\n\n***NEW SPINE: No. ' + str(mySpine.id) + ' parentSpine: '
-    #            + str(mySpine.parentSpine) + ' childSpines: ' + str(mySpine.childSpines))
-    #        print(mySpine.spineType)
-    #        for childSpinesSpine in mySpine.childSpinesSpines():
-    #            print(str(childSpinesSpine.id) + ' *** testing spineCollection code ***')
-    #        for thisEvent in mySpine:
-    #            print(thisEvent.contents)
+       # hf1 = HumdrumFile('d:/web/eclipse/music21misc/ojibway.krn')
+       # for thisEventCollection in hf1.eventCollections:
+       #     ev = thisEventCollection.getSpineEvent(0).contents
+       #     if ev is not None:
+       #         print(ev)
+       #     else:
+       #         print('NONE')
+       #
+       # for mySpine in hf1.spineCollection:
+       #     print('\n\n***NEW SPINE: No. ' + str(mySpine.id) + ' parentSpine: '
+       #         + str(mySpine.parentSpine) + ' childSpines: ' + str(mySpine.childSpines))
+       #     print(mySpine.spineType)
+       #     for childSpinesSpine in mySpine.childSpinesSpines():
+       #         print(str(childSpinesSpine.id) + ' *** testing spineCollection code ***')
+       #     for thisEvent in mySpine:
+       #         print(thisEvent.contents)
         spine5 = hf1.spineCollection.getSpineById(5)
         self.assertEqual(spine5.id, 5)
         self.assertEqual(spine5.parentSpine.id, 1)

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -283,6 +283,10 @@ del t
 
 
 class Test(unittest.TestCase):
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
+
     def test_reprInternal(self):
         from music21.base import Music21Object
         b = Music21Object()

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -167,8 +167,8 @@ class RomanTextUnprocessedToken(base.ElementWrapper):
 
 
 class RomanTextUnprocessedMetadata(base.Music21Object):
-    def __init__(self, tag='', data=''):
-        super().__init__()
+    def __init__(self, tag='', data='', **keywords):
+        super().__init__(**keywords)
         self.tag = tag
         self.data = data
 

--- a/music21/search/serial.py
+++ b/music21/search/serial.py
@@ -76,8 +76,8 @@ class ContiguousSegmentOfNotes(base.Music21Object):
     _DOC_ORDER = ['startMeasureNumber', 'startOffset', 'zeroCenteredTransformationsFromMatched',
                   'originalCenteredTransformationsFromMatched']
 
-    def __init__(self, segment=None, containerStream=None, partNumber=0):
-        super().__init__()
+    def __init__(self, segment=None, containerStream=None, partNumber=0, **keywords):
+        super().__init__(**keywords)
         self.segment = segment
         self.containerStream = containerStream
         self.partNumber = partNumber

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -1892,6 +1892,10 @@ class Test(unittest.TestCase):
         from music21.musicxml.m21ToXml import GeneralObjectExporter
         self.GEX = GeneralObjectExporter()
 
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
+
     def xmlStr(self, obj):
         xmlBytes = self.GEX.parse(obj)
         return xmlBytes.decode('utf-8')

--- a/music21/test/commonTest.py
+++ b/music21/test/commonTest.py
@@ -50,7 +50,9 @@ def testCopyAll(testInstance: unittest.TestCase, globals_: typing.Dict[str, typi
 
         try:  # see if obj can be made w/o args
             instance = obj()
-        except TypeError:
+        except TypeError as te:
+            if issubclass(obj, music21.base.Music21Object):
+                raise TypeError('Define Music21Objects to be instantiated without initial args')
             continue
 
         try:

--- a/music21/tie.py
+++ b/music21/tie.py
@@ -147,7 +147,9 @@ class Tie(prebase.ProtoM21Object, SlottedObjectMixin):
 
 
 class Test(unittest.TestCase):
-    pass
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
 
 
 # ------------------------------------------------------------------------------

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -2530,6 +2530,10 @@ class Test(unittest.TestCase):
         out += ']'
         return out
 
+    def testCopyAndDeepcopy(self):
+        from music21.test.commonTest import testCopyAll
+        testCopyAll(self, globals())
+
     def testBasicA(self):
         o = Variant()
         o.append(note.Note('G3', quarterLength=2.0))

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -1426,8 +1426,10 @@ class Verticality(base.Music21Object):
             in a single part)''',
     }
 
-    def __init__(self, contentDict: dict, **keywords):
+    def __init__(self, contentDict: dict | None = None, **keywords):
         super().__init__(**keywords)
+        if contentDict is None:
+            contentDict = {}
         for partNum, element in contentDict.items():
             if not isinstance(element, list):
                 contentDict[partNum] = [element]
@@ -1793,7 +1795,7 @@ class VerticalityNTuplet(base.Music21Object):
     motion and music theory elements such as passing tones
     '''
 
-    def __init__(self, listOfVerticalities=None, **keywords):
+    def __init__(self, listOfVerticalities=(), **keywords):
         super().__init__(**keywords)
 
         self.verticalities = listOfVerticalities
@@ -1816,11 +1818,12 @@ class VerticalityTriplet(VerticalityNTuplet):
     '''
     a collection of three Verticalities
     '''
-    def __init__(self, listOfVerticalities=None, **keywords):
+    def __init__(self, listOfVerticalities=(), **keywords):
         super().__init__(listOfVerticalities, **keywords)
 
         self.tnlsDict = {}  # defaultdict(int)  # Three Note Linear Segments
-        self._calcTNLS()
+        if len(listOfVerticalities):
+            self._calcTNLS()
 
     def _calcTNLS(self):
         '''
@@ -1928,7 +1931,7 @@ class NNoteLinearSegment(base.Music21Object):
     [<music21.note.Note A>, <music21.note.Note C>, <music21.note.Note D>]
     '''
 
-    def __init__(self, noteList=None, **keywords):
+    def __init__(self, noteList=(), **keywords):
         super().__init__(**keywords)
         self._noteList = []
         for value in noteList:
@@ -2040,7 +2043,7 @@ class ThreeNoteLinearSegment(NNoteLinearSegment):
                   'couldBeDiatonicNeighborTone',
                   'couldBeChromaticNeighborTone']
 
-    def __init__(self, noteListOrN1=None, n2=None, n3=None, **keywords):
+    def __init__(self, noteListOrN1=(), n2=None, n3=None, **keywords):
         if common.isIterable(noteListOrN1):
             super().__init__(noteListOrN1, **keywords)
         else:
@@ -2320,7 +2323,7 @@ class NChordLinearSegmentException(exceptions21.Music21Exception):
 
 
 class NObjectLinearSegment(base.Music21Object):
-    def __init__(self, objectList=None, **keywords):
+    def __init__(self, objectList=(), **keywords):
         super().__init__(**keywords)
         self.objectList = objectList
 
@@ -2329,7 +2332,7 @@ class NObjectLinearSegment(base.Music21Object):
 
 
 class NChordLinearSegment(NObjectLinearSegment):
-    def __init__(self, chordList=None, **keywords):
+    def __init__(self, chordList=(), **keywords):
         super().__init__(chordList, **keywords)
         self._chordList = []
         for value in chordList:
@@ -2369,6 +2372,11 @@ class NChordLinearSegment(NObjectLinearSegment):
 
 class TwoChordLinearSegment(NChordLinearSegment):
     def __init__(self, chordList=None, chord2=None, **keywords):
+        if chordList is None and chord2 is None:
+            # to make it so all objects can be instantiated w/o initial args
+            from music21 import chord
+            chordList = chord.Chord()
+            chord2 = chord.Chord()
         if isinstance(chordList, (list, tuple)):
             if len(chordList) != 2:  # pragma: no cover
                 raise ValueError(

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -1793,7 +1793,7 @@ class VerticalityNTuplet(base.Music21Object):
     motion and music theory elements such as passing tones
     '''
 
-    def __init__(self, listOfVerticalities, **keywords):
+    def __init__(self, listOfVerticalities=None, **keywords):
         super().__init__(**keywords)
 
         self.verticalities = listOfVerticalities
@@ -1816,7 +1816,7 @@ class VerticalityTriplet(VerticalityNTuplet):
     '''
     a collection of three Verticalities
     '''
-    def __init__(self, listOfVerticalities, **keywords):
+    def __init__(self, listOfVerticalities=None, **keywords):
         super().__init__(listOfVerticalities, **keywords)
 
         self.tnlsDict = {}  # defaultdict(int)  # Three Note Linear Segments
@@ -1928,7 +1928,7 @@ class NNoteLinearSegment(base.Music21Object):
     [<music21.note.Note A>, <music21.note.Note C>, <music21.note.Note D>]
     '''
 
-    def __init__(self, noteList, **keywords):
+    def __init__(self, noteList=None, **keywords):
         super().__init__(**keywords)
         self._noteList = []
         for value in noteList:
@@ -2320,7 +2320,7 @@ class NChordLinearSegmentException(exceptions21.Music21Exception):
 
 
 class NObjectLinearSegment(base.Music21Object):
-    def __init__(self, objectList, **keywords):
+    def __init__(self, objectList=None, **keywords):
         super().__init__(**keywords)
         self.objectList = objectList
 
@@ -2329,7 +2329,7 @@ class NObjectLinearSegment(base.Music21Object):
 
 
 class NChordLinearSegment(NObjectLinearSegment):
-    def __init__(self, chordList, **keywords):
+    def __init__(self, chordList=None, **keywords):
         super().__init__(chordList, **keywords)
         self._chordList = []
         for value in chordList:
@@ -2368,7 +2368,7 @@ class NChordLinearSegment(NObjectLinearSegment):
         return f'chordList={self.chordList}'
 
 class TwoChordLinearSegment(NChordLinearSegment):
-    def __init__(self, chordList, chord2=None, **keywords):
+    def __init__(self, chordList=None, chord2=None, **keywords):
         if isinstance(chordList, (list, tuple)):
             if len(chordList) != 2:  # pragma: no cover
                 raise ValueError(
@@ -2404,7 +2404,6 @@ class TwoChordLinearSegment(NChordLinearSegment):
 # ------------------------------------------------------------------------------
 
 class Test(unittest.TestCase):
-
     def testInstantiateEmptyObject(self):
         '''
         test instantiating an empty VoiceLeadingQuartet


### PR DESCRIPTION
TEMPORARILY Restoring an old requirement for Music21Objects that require them to be instantiable without ().

I think that this is the wrong approach now that I'm working on it, and will probably close in favor of a `__new__` based deepcopy rather than `__init__` based.