### PR TITLE
updated location of Musescore in Windows to match updated installer

### DIFF
--- a/music21/environment.py
+++ b/music21/environment.py
@@ -400,10 +400,10 @@ class _EnvironmentCore:
             for name, value in [
                 ('lilypondPath', 'lilypond'),
                 ('musicxmlPath',
-                 common.cleanpath(r'%PROGRAMFILES%\MuseScore 3\MuseScore.exe')
+                 common.cleanpath(r'%PROGRAMFILES%\MuseScore 3\bin\MuseScore3.exe')
                  ),
                 ('musescoreDirectPNGPath',
-                 common.cleanpath(r'%PROGRAMFILES%\MuseScore 3\MuseScore.exe')
+                 common.cleanpath(r'%PROGRAMFILES%\MuseScore 3\bin\MuseScore3.exe')
                  ),
             ]:
                 self[name] = value  # use for key checking


### PR DESCRIPTION
I've been working in music21 and had to override `musicxmlPath` in order for it to find my fresh install of Musescore. I have not yet tested my edit to see if it functions correctly, as it seems that this could break existing music21 setups and wanted to open the discussion before going further on this effort. I have time set aside Sunday to test this edit, and will report back at that time unless we have conversation come up before then. 

This could break existing music21 setups where the default works on a user's computer that has a Musescore installation in the old location, but is important for people who are installing music21 for the first time. Music21 has built in assumptions about an old version of Musescore, meaning that a new installation of music21 today is not set up to use a new installation of Musescore on Windows. I am open to your feedback on this topic as a new user of and prospective contributor to music21!

I am participating in hacktoberfest this year and hope this is a useful pull request. If you agree, please consider applying the `hacktoberfest-accepted` label to this pull request so I can get credit. This is my first professional pull request! @elementc is my mentor. Please feel free to let either of us know if there are things we should be doing differently when working with this project. 