### PR TITLE
Remove TYPE_CHECKING workaround for Pylint

### DIFF
--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -60,7 +60,6 @@ from collections.abc import Sequence
 import io
 import re
 import typing as t
-from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 
 from music21 import common
@@ -70,7 +69,7 @@ from music21 import prebase
 
 from music21.abcFormat import translate
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import bar
     from music21 import clef
     from music21 import duration
@@ -1635,7 +1634,7 @@ class ABCNote(ABCToken):
         # assume we have a complete fraction
         elif '/' in numStr:
             nStr, dStr = numStr.split('/')
-            if TYPE_CHECKING:
+            if t.TYPE_CHECKING:
                 assert nStr is not None
                 assert dStr is not None
             n = int(nStr.strip())

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 from collections import OrderedDict
 from collections.abc import Iterable, Sequence
 import typing as t
-from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 
 from music21 import environment
@@ -39,7 +38,7 @@ from music21 import key
 from music21 import pitch
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
 
 

--- a/music21/articulations.py
+++ b/music21/articulations.py
@@ -77,7 +77,6 @@ A longer test showing the utility of the module:
 from __future__ import annotations
 
 import typing as t
-from typing import TYPE_CHECKING  # Pylint bug
 import unittest
 
 from music21 import base
@@ -86,7 +85,7 @@ from music21.common.classTools import tempAttribute
 from music21 import environment
 from music21 import style
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import interval
 
 

--- a/music21/base.py
+++ b/music21/base.py
@@ -44,7 +44,6 @@ import functools
 from importlib.util import find_spec
 import typing as t
 from typing import overload  # Pycharm can't do alias
-from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 import warnings
 import weakref
@@ -67,7 +66,7 @@ from music21.sorting import SortTuple, ZeroSortTupleLow, ZeroSortTupleHigh
 # needed for temporal manipulations; not music21 objects
 from music21 import tie
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     import fractions
     from io import IOBase
     import pathlib
@@ -2749,7 +2748,7 @@ class Music21Object(prebase.ProtoM21Object):
             self._duration = Duration(0)
 
         d_out = self._duration
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert d_out is not None
 
         return d_out

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -75,7 +75,7 @@ To get rid of beams on a note do:
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING  # pylint bug
+import typing as t
 import unittest
 
 from music21 import exceptions21
@@ -86,7 +86,7 @@ from music21 import style
 from music21.common.objects import EqualSlottedObjectMixin
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import base
 
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -21,7 +21,6 @@ from collections.abc import Iterable, Sequence
 import copy
 import typing as t
 from typing import overload  # pycharm bug
-from typing import TYPE_CHECKING  # pylint bug
 import unittest
 
 from music21 import beam
@@ -41,7 +40,7 @@ from music21.chord import tables
 from music21.chord import tools
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
 
 
@@ -470,7 +469,7 @@ class ChordBase(note.NotRest):
         if velocities:  # avoid division by zero error
             self._volume.velocity = int(round(sum(velocities) / len(velocities)))
 
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert self._volume is not None
         return self._volume
 
@@ -487,7 +486,7 @@ class ChordBase(note.NotRest):
             note.NotRest._setVolume(self, expr, setClient=False)
         elif common.isNum(expr):
             vol = self._getVolume()
-            if TYPE_CHECKING:
+            if t.TYPE_CHECKING:
                 assert isinstance(expr, (int, float))
 
             if expr < 1:  # assume a scalar
@@ -4042,7 +4041,7 @@ class Chord(ChordBase):
         if inPlace is True:
             c2 = self
 
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             from music21.stream import Stream
             assert isinstance(c2, Stream)
         # startOctave = c2.bass().octave
@@ -5009,7 +5008,7 @@ class Chord(ChordBase):
             self._duration = pitchZeroDuration
 
         d_out = self._duration
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert isinstance(d_out, Duration)
         return d_out
 

--- a/music21/chord/tools.py
+++ b/music21/chord/tools.py
@@ -14,10 +14,9 @@ enough to go in the music21 core library.
 '''
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import typing as t
 
-
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import chord
     from music21 import pitch
 

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -19,7 +19,7 @@ within :class:`~music21.stream.Measure` objects.
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING  # pylint needs no alias
+import typing as t
 import unittest
 
 from music21 import base
@@ -29,7 +29,7 @@ from music21 import pitch
 from music21 import style
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
 
 
@@ -879,7 +879,7 @@ def clefFromString(clefString, octaveShift=0) -> Clef:
             clefObj.line = lineNum
         else:
             ClefType = line_list[lineNum]
-            if TYPE_CHECKING:
+            if t.TYPE_CHECKING:
                 assert ClefType is not None
                 assert issubclass(ClefType, PitchClef)
             clefObj = ClefType()

--- a/music21/common/types.py
+++ b/music21/common/types.py
@@ -13,11 +13,10 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable
 from fractions import Fraction
 import typing as t
-from typing import TYPE_CHECKING
 
 from music21.common.enums import OffsetSpecial
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     import music21  # pylint: disable=unused-import
 
 DocOrder = list[str | Callable]

--- a/music21/corpus/manager.py
+++ b/music21/corpus/manager.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 import pathlib
 import os
-from typing import TYPE_CHECKING
+import typing as t
 
 from music21 import common
 from music21 import converter
@@ -33,7 +33,7 @@ from music21 import metadata
 from music21.corpus import corpora
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21.metadata import bundles
     from music21 import stream
 

--- a/music21/derivation.py
+++ b/music21/derivation.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 import functools
-from typing import TYPE_CHECKING  # Pylint bug
+import typing as t
 import unittest
 
 from music21 import common
@@ -27,7 +27,7 @@ from music21.common.objects import SlottedObjectMixin
 from music21 import environment
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import base
 
 

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -55,7 +55,6 @@ from functools import lru_cache
 import io
 from math import inf, isnan
 import typing as t
-from typing import TYPE_CHECKING  # pylint bug
 import unittest
 
 from music21 import common
@@ -68,7 +67,7 @@ from music21 import exceptions21
 from music21 import prebase
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import base
     from music21 import note
     from music21 import stream
@@ -3524,7 +3523,7 @@ class TupletFixer:
             currentTupletDuration = opFrac(currentTupletDuration + n.duration.quarterLength)
             thisTup = n.duration.tuplets[0]
             tupDurationActual = thisTup.durationActual
-            if TYPE_CHECKING:
+            if t.TYPE_CHECKING:
                 assert tupDurationActual is not None
 
             thisTupType = tupDurationActual.type

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import copy
 import string
-from typing import TYPE_CHECKING  # pylint needs no alias
+import typing as t
 
 from music21 import base
 from music21 import common
@@ -37,7 +37,7 @@ from music21 import spanner
 from music21 import style
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import note
 
 

--- a/music21/graph/__init__.py
+++ b/music21/graph/__init__.py
@@ -45,7 +45,6 @@ __all__ = [
 ]
 
 import typing as t
-from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 
 from music21 import common
@@ -58,7 +57,7 @@ from music21.graph import primitives
 from music21.graph import utilities
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
 
 

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -28,7 +28,6 @@ from collections.abc import Iterable
 import importlib
 import unittest
 import typing as t
-from typing import TYPE_CHECKING  # must be imported separately
 
 from music21 import base
 from music21 import common
@@ -39,7 +38,7 @@ from music21 import note
 from music21 import pitch
 from music21.tree.trees import OffsetTree
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
 
 environLocal = environment.Environment('instrument')

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -27,7 +27,6 @@ import enum
 import math
 import re
 import typing as t
-from typing import TYPE_CHECKING  # pylint needs no alias
 
 from music21 import base
 from music21 import common
@@ -37,7 +36,7 @@ from music21 import environment
 from music21 import exceptions21
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import key
     from music21 import note
     from music21 import pitch
@@ -3072,7 +3071,7 @@ class Interval(IntervalBase):
 
         # both self.diatonic and self.chromatic can still both be None if an
         # empty Interval class is being created, such as in deepcopy
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert diatonic is not None
             assert chromatic is not None
 

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -21,7 +21,6 @@ import copy
 import fractions
 from math import gcd
 import typing as t
-from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 
 from music21 import base
@@ -40,7 +39,7 @@ from music21.meter.core import MeterSequence
 
 environLocal = environment.Environment('meter')
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
 
 # this is just a placeholder so that .beamSequence, etc. do not need to

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -19,7 +19,6 @@ from collections.abc import Sequence
 import copy
 import math
 import typing as t
-from typing import TYPE_CHECKING
 import unittest
 import warnings
 
@@ -43,7 +42,7 @@ from music21 import tempo
 from music21.midi.percussion import MIDIPercussionException, PercussionMapper
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import base
     from music21 import midi
 
@@ -2084,7 +2083,7 @@ def midiTrackToStream(
         ts_iter = conductorPart['TimeSignature']
         if ts_iter:
             meterStream = ts_iter.stream()
-            if TYPE_CHECKING:
+            if t.TYPE_CHECKING:
                 assert meterStream is not None
 
             # Supply any missing time signature at the start

--- a/music21/note.py
+++ b/music21/note.py
@@ -21,7 +21,6 @@ from collections.abc import Iterable, Sequence
 import copy
 import typing as t
 from typing import overload  # PyCharm bug
-from typing import TYPE_CHECKING  # PyLint bug
 import unittest
 
 from music21 import base
@@ -39,7 +38,7 @@ from music21 import style
 from music21 import tie
 from music21 import volume
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import articulations
     from music21 import chord
     from music21 import instrument
@@ -1015,7 +1014,7 @@ class NotRest(GeneralNote):
                               *,
                               ignoreAttributes: set[str] | None = None) -> _NotRestType:
         new = super()._deepcopySubclassable(memo, ignoreAttributes={'_chordAttached'})
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             new = t.cast(_NotRestType, new)
         # let the chord restore _chordAttached
 
@@ -1227,7 +1226,7 @@ class NotRest(GeneralNote):
                 self._volume = volume.Volume(client=forceClient)
 
         volume_out = self._volume
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert volume_out is not None
 
         return volume_out

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -23,7 +23,6 @@ import copy
 import itertools
 import math
 import typing as t
-from typing import TYPE_CHECKING  # pylint needs no alias
 from typing import overload  # Pycharm can't use an alias
 import unittest
 
@@ -38,7 +37,7 @@ from music21 import interval
 from music21 import prebase
 from music21 import style
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import note
 
 PitchType = t.TypeVar('PitchType', bound='Pitch')

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import copy
 import string
-from typing import TYPE_CHECKING  # pylint needs no alias
+import typing as t
 
 from music21 import environment
 from music21 import exceptions21
@@ -30,7 +30,7 @@ from music21 import spanner
 from music21 import style
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
 
 

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -18,7 +18,6 @@ import collections
 from collections.abc import Generator, MutableMapping
 import typing as t
 from typing import overload  # for some reason does not work in PyCharm if not directly imported
-from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 import weakref
 
@@ -27,7 +26,7 @@ from music21 import exceptions21
 from music21 import prebase
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
 
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -32,7 +32,6 @@ import os
 import pathlib
 import typing as t
 from typing import overload  # pycharm bug disallows alias
-from typing import TYPE_CHECKING  # pylint bug
 import unittest
 import warnings
 
@@ -69,7 +68,7 @@ from music21.stream import filters
 from music21.stream.enums import GivenElementsBehavior, RecursionType
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import pitch
     from music21 import spanner
 

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import copy
 from fractions import Fraction
-from typing import TYPE_CHECKING  # pylint needs no alias
+import typing as t
 import unittest
 
 from music21.base import Music21Object
@@ -38,7 +38,7 @@ from music21.exceptions21 import StreamException, ImmutableStreamException
 from music21.stream.iterator import StreamIterator, RecursiveIterator
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21.stream import Stream
 
 
@@ -546,7 +546,7 @@ class StreamCore(Music21Object):
         >>> scoreTree
         <ElementTree {20} (0.0 <0.-25...> to 8.0) <music21.stream.Score exampleScore>>
         '''
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert isinstance(self, Stream)
         hashedAttributes = hash((tuple(classList or ()),
                                   flatten,

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -20,7 +20,6 @@ from collections.abc import Callable, Iterable, Sequence
 import copy
 import typing as t
 from typing import overload  # PyCharm can't use alias
-from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 import warnings
 
@@ -35,7 +34,7 @@ from music21 import base   # just for typing. (but in a bound, so keep here)
 
 from music21.sites import SitesException
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
 
 T = t.TypeVar('T')
@@ -753,7 +752,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
                     if f(e, self) is False:
                         return False
                 except TypeError:  # one element filters are acceptable.
-                    if TYPE_CHECKING:
+                    if t.TYPE_CHECKING:
                         assert isinstance(f, filters.StreamFilter)
                     if f(e) is False:
                         return False
@@ -1840,7 +1839,7 @@ class RecursiveIterator(StreamIterator, Sequence[M21ObjType]):
             # in a recursive filter, the stream does not need to match the filter,
             # only the internal elements.
             if e.isStream:
-                if TYPE_CHECKING:
+                if t.TYPE_CHECKING:
                     assert isinstance(e, stream.Stream)
 
                 childRecursiveIterator: RecursiveIterator[M21ObjType] = RecursiveIterator(

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from collections.abc import Iterable, Generator
 import copy
 import typing as t
-from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 
 from music21 import beam
@@ -36,7 +35,7 @@ from music21.common.types import StreamType, OffsetQL
 from music21.exceptions21 import StreamException
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
     from music21.stream.iterator import StreamIterator
 

--- a/music21/style.py
+++ b/music21/style.py
@@ -15,7 +15,7 @@ etc. such that precise positioning information, layout, size, etc. can be specif
 '''
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import typing as t
 import unittest
 
 from music21 import common
@@ -23,7 +23,7 @@ from music21 import exceptions21
 from music21.prebase import ProtoM21Object
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import editorial
 
 

--- a/music21/tablature.py
+++ b/music21/tablature.py
@@ -17,7 +17,7 @@ Chord from FretBoard Object with tuning.
 '''
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import typing as t
 import unittest
 
 from music21 import common
@@ -27,7 +27,7 @@ from music21 import pitch
 from music21 import prebase
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import duration
 
 

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import typing as t
-from typing import TYPE_CHECKING  # pylint needs no alias
 import unittest
 
 from music21.base import Music21Object
@@ -28,7 +27,7 @@ from music21.tree import spans
 from music21.tree import timespanTree
 from music21.tree import trees
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21 import stream
 
 

--- a/music21/tree/timespanTree.py
+++ b/music21/tree/timespanTree.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from collections.abc import Generator, Iterable
 import itertools
 import random
-from typing import TYPE_CHECKING
+import typing as t
 import unittest
 
 import more_itertools
@@ -33,7 +33,7 @@ from music21.tree import spans
 from music21.tree import trees
 
 
-if TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from music21.tree.verticality import VerticalitySequence
 
 

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -36,7 +36,7 @@ The list of objects included here are:
 from __future__ import annotations
 
 import enum
-from typing import TYPE_CHECKING  # pylint bug; does not arise here though.
+import typing as t
 import unittest
 
 from music21 import base
@@ -535,7 +535,7 @@ class VoiceLeadingQuartet(base.Music21Object):
         vInt1 = self.vIntervals[1]
         vInt1_generic = vInt1.generic
 
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert vInt0_generic is not None
             assert vInt1_generic is not None
 
@@ -1134,7 +1134,7 @@ class VoiceLeadingQuartet(base.Music21Object):
 
         firstHarmony = self.vIntervals[0].simpleName
         secondGeneric = self.vIntervals[1].generic
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert secondGeneric is not None
         secondHarmony = secondGeneric.simpleUndirected
 
@@ -1202,7 +1202,7 @@ class VoiceLeadingQuartet(base.Music21Object):
 
         hInt0_generic = self.hIntervals[0].generic
         hInt1_generic = self.hIntervals[1].generic
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert hInt0_generic is not None
             assert hInt1_generic is not None
 
@@ -1263,7 +1263,7 @@ class VoiceLeadingQuartet(base.Music21Object):
         v1ns = v1.noteStart
         v1ne = v1.noteEnd
 
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert v0ns is not None and v0ne is not None
             assert v1ns is not None and v1ne is not None
 
@@ -1318,7 +1318,7 @@ class VoiceLeadingQuartet(base.Music21Object):
 
         vInt0_generic = self.vIntervals[0].generic
         vInt1_generic = self.vIntervals[1].generic
-        if TYPE_CHECKING:
+        if t.TYPE_CHECKING:
             assert vInt0_generic is not None
             assert vInt1_generic is not None
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pylint
+pylint>=2.15.4
 flake8
 flake8-quotes
 hatchling
@@ -8,7 +8,6 @@ coveralls
 scipy
 sphinx
 python-Levenshtein
-setuptools
 coverage
 nbconvert
 jupyter


### PR DESCRIPTION
Pylint 2.15.4 to the rescue!  Thanks @jacobtylerwalls and others!