### PR TITLE
horns typically hunt in pairs

### DIFF
--- a/music21/languageExcerpts/instrumentLookup.py
+++ b/music21/languageExcerpts/instrumentLookup.py
@@ -228,6 +228,7 @@ englishToClassName = {
     'hi-hat': 'HiHatCymbal',
     'hi-hat cymbal': 'HiHatCymbal',
     'horn': 'Horn',
+    'horns': 'Horn',
     'jingle bells': 'SleighBells',
     'kalimba': 'Kalimba',
     'kettle drums': 'Timpani',


### PR DESCRIPTION
This small change is needed for a lot of orchestral scores with part names like "Horns 1 and 2 in Eb"