### PR TITLE
Lowercase some RomanNumeral figures created with integers

### DIFF
--- a/.github/workflows/pythonpylint.yml
+++ b/.github/workflows/pythonpylint.yml
@@ -63,7 +63,7 @@ jobs:
                   cache: 'pip'
             - name: Install mypy
               run: |
-                  python -m pip install mypy
+                  python -m pip install mypy==0.982
             - name: Install dependencies
               run: |
                   python -m pip install -r requirements.txt

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2268,8 +2268,20 @@ class RomanNumeral(harmony.Harmony):
         self.scaleCardinality: int = 7
 
         if isinstance(figure, int):
-            self.caseMatters = False
             figure = common.toRoman(figure)
+            if self.caseMatters:
+                mode = ''
+                if isinstance(keyOrScale, key.Key):
+                    mode = keyOrScale.mode
+                elif isinstance(keyOrScale, scale.DiatonicScale):
+                    mode = keyOrScale.type
+                elif isinstance(keyOrScale, str) and keyOrScale:
+                    mode = 'major' if keyOrScale[0].isupper() else 'minor'
+                if (
+                    (mode == 'major' and figure in ('II', 'III', 'VI', 'VII'))
+                    or (mode == 'minor' and figure in ('I', 'II', 'IV', 'V'))
+                ):
+                    figure = figure.lower()
 
         # immediately fix low-preference figures
         if isinstance(figure, str):
@@ -4388,6 +4400,24 @@ class Test(unittest.TestCase):
         self.assertEqual(rn.seventh.name, 'A-')
         rn = RomanNumeral('bVII7', 'C', seventhMinor=Minor67Default.CAUTIONARY)
         self.assertEqual(rn.seventh.name, 'A')
+
+    def test_int_figure_case_matters(self):
+        '''https://github.com/cuthbertLab/music21/issues/1450'''
+        minorKeyObj = key.Key("c")
+        rn = RomanNumeral(2, minorKeyObj)
+        self.assertEqual(rn.figure, 'ii')
+        rn = RomanNumeral(2, minorKeyObj, caseMatters=False)
+        self.assertEqual(rn.figure, 'II')
+
+        rn = RomanNumeral(4, 'c')
+        self.assertEqual(rn.figure, 'iv')
+
+        rn = RomanNumeral(6, scale.MajorScale('c'))
+        self.assertEqual(rn.figure, 'vi')
+
+        # Major still works
+        rn = RomanNumeral(4, 'C')
+        self.assertEqual(rn.figure, 'IV')
 
 
 class TestExternal(unittest.TestCase):

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -4402,8 +4402,10 @@ class Test(unittest.TestCase):
         self.assertEqual(rn.seventh.name, 'A')
 
     def test_int_figure_case_matters(self):
-        '''https://github.com/cuthbertLab/music21/issues/1450'''
-        minorKeyObj = key.Key("c")
+        '''
+        Fix for https://github.com/cuthbertLab/music21/issues/1450
+        '''
+        minorKeyObj = key.Key('c')
         rn = RomanNumeral(2, minorKeyObj)
         self.assertEqual(rn.figure, 'ii')
         rn = RomanNumeral(2, minorKeyObj, caseMatters=False)


### PR DESCRIPTION
Closes #1450

Previously, RomanNumerals created with integer figures were always uppercase, even when `caseMatters` was True.

Now, certain figures are lowercased according to the mode.

***

cc/ @MarkGotham would you be willing to review?

I didn't use structural pattern matching per this comment:
https://github.com/cuthbertLab/music21/blob/d77f4059a6943aa43b0dea388faa2bf2b8257c6c/music21/midi/translate.py#L1281-L1283