### PR TITLE
Synchronize Measure IDs on Musicxml out

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -3143,6 +3143,9 @@ class MeasureExporter(XMLExporterBase):
         self.xmlRoot = Element('measure')
         self.currentDivisions = defaults.divisionsPerQuarter
 
+        # Adding ids to measure in the MusicXML export
+        _synchronizeIds (self.xmlRoot, self.stream)
+
         # TODO: allow for mid-measure transposition changes.
         self.transpositionInterval = None
         self.mxTranspose = None

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -3144,7 +3144,7 @@ class MeasureExporter(XMLExporterBase):
         self.currentDivisions = defaults.divisionsPerQuarter
 
         # Adding ids to measure in the MusicXML export
-        _synchronizeIds (self.xmlRoot, self.stream)
+        _synchronizeIds(self.xmlRoot, self.stream)
 
         # TODO: allow for mid-measure transposition changes.
         self.transpositionInterval = None

--- a/music21/musicxml/test_m21ToXml.py
+++ b/music21/musicxml/test_m21ToXml.py
@@ -378,6 +378,19 @@ class Test(unittest.TestCase):
         )
         self.assertEqual(len(tree.findall('.//measure/note/instrument')), 6)
 
+    def testExportIdOfMeasure(self):
+        ''' Check that id of measure are exported
+            as attributes of the <measure> eelement in MusicXML
+        '''
+        measure = stream.Measure(id="test", number=1)
+        measure.append(note.Note(type='whole'))
+        s = stream.Score(measure)
+        scEx = ScoreExporter(s)
+        tree = scEx.parse()
+
+        for measure_xml in tree.findall('.//measure'):
+            self.assertTrue("id" in measure_xml.attrib)
+
     def testMidiInstrumentNoName(self):
         i = instrument.Instrument()
         i.midiProgram = 42

--- a/music21/musicxml/test_m21ToXml.py
+++ b/music21/musicxml/test_m21ToXml.py
@@ -382,14 +382,15 @@ class Test(unittest.TestCase):
         ''' Check that id of measure are exported
             as attributes of the <measure> eelement in MusicXML
         '''
-        measure = stream.Measure(id="test", number=1)
+        measure = stream.Measure(id='test', number=1)
         measure.append(note.Note(type='whole'))
         s = stream.Score(measure)
         scEx = ScoreExporter(s)
         tree = scEx.parse()
 
         for measure_xml in tree.findall('.//measure'):
-            self.assertTrue("id" in measure_xml.attrib)
+            self.assertTrue('id' in measure_xml.attrib)
+            self.assertEqual(measure_xml.get('id'), 'test')
 
     def testMidiInstrumentNoName(self):
         i = instrument.Instrument()


### PR DESCRIPTION
Adding IDs to measures in MusicXML files. I added a call to _synchronizeIds(), just as it works already for other elements (eg, notes).