### PR TITLE
Translate "implicit" attribute of MusicXML measures

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -402,7 +402,7 @@ class GeneralObjectExporter:
           <!--=========================== Part 1 ===========================-->
           <part id="...">
             <!--========================= Measure 1 ==========================-->
-            <measure number="1">
+            <measure implicit="no" number="1">
               <attributes>
                 <divisions>10080</divisions>
                 <time>
@@ -1724,7 +1724,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         >>> SX.dump(SX.partExporterList[0].xmlRoot)
         <part id="...">
           <!--========================= Measure 1 ==========================-->
-          <measure number="1">...</measure>
+          <measure implicit="no" number="1">...</measure>
         </part>
         >>> del SX.partExporterList[:]  # for garbage collection
         '''
@@ -7016,15 +7016,15 @@ class MeasureExporter(XMLExporterBase):
     def setMxAttributes(self):
         '''
         sets the attributes (x=y) for a measure,
-        that is, number, and layoutWidth
+        that is, number, implicit, and layoutWidth
 
         Does not create the <attributes> tag. That's elsewhere...
-
         '''
         m = self.stream
         if hasattr(m, 'measureNumberWithSuffix'):
             self.xmlRoot.set('number', m.measureNumberWithSuffix())
-        # TODO: attr: implicit
+        _setAttributeFromAttribute(
+            m, self.xmlRoot, 'implicit', 'numberImplicit', xmlObjects.booleanToYesNo)
         # TODO: attr: non-controlling
         if hasattr(m, 'layoutWidth') and m.layoutWidth is not None:
             _setAttributeFromAttribute(m, self.xmlRoot, 'width', 'layoutWidth')

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -7024,7 +7024,8 @@ class MeasureExporter(XMLExporterBase):
         if hasattr(m, 'measureNumberWithSuffix'):
             self.xmlRoot.set('number', m.measureNumberWithSuffix())
         _setAttributeFromAttribute(
-            m, self.xmlRoot, 'implicit', 'numberImplicit', xmlObjects.booleanToYesNo)
+            m, self.xmlRoot, 'implicit', 'showNumber',
+            lambda showNum: xmlObjects.booleanToYesNo(showNum is stream.enums.ShowNumber.NEVER))
         # TODO: attr: non-controlling
         if hasattr(m, 'layoutWidth') and m.layoutWidth is not None:
             _setAttributeFromAttribute(m, self.xmlRoot, 'width', 'layoutWidth')

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -297,7 +297,7 @@ class PartStaffExporterMixin:
         >>> root = SX.parse()
         >>> m1 = root.find('part/measure')
         >>> SX.dump(m1)
-        <measure number="1">
+        <measure implicit="no" number="1">
         ...
           <note>
             <pitch>
@@ -479,7 +479,7 @@ class PartStaffExporterMixin:
         >>> root = SX.parse()
         >>> m1 = root.find('part/measure')
         >>> SX.dump(m1)
-        <measure number="1">
+        <measure implicit="no" number="1">
           <attributes>
             <divisions>10080</divisions>
             <key number="1">
@@ -513,7 +513,7 @@ class PartStaffExporterMixin:
         >>> root = SX.parse()
         >>> m1 = root.find('part/measure')
         >>> SX.dump(m1)
-        <measure number="1">
+        <measure implicit="no" number="1">
             <attributes>
             <divisions>10080</divisions>
             <key>

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -1458,6 +1458,14 @@ class Test(unittest.TestCase):
         self.assertIsInstance(unp, instrument.UnpitchedPercussion)
         self.assertEqual(unp.percMapPitch, 69)
 
+    def testImportImplicitMeasureNumber(self):
+        from music21 import converter
+
+        xml_dir = common.getSourceFilePath() / 'musicxml' / 'lilypondTestSuite'
+        s = converter.parse(xml_dir / '46d-PickupMeasure-ImplicitMeasures.xml')
+        m = s[stream.Measure].first()
+        self.assertIs(m.numberImplicit, True)
+
 
 if __name__ == '__main__':
     import music21

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -1464,7 +1464,7 @@ class Test(unittest.TestCase):
         xml_dir = common.getSourceFilePath() / 'musicxml' / 'lilypondTestSuite'
         s = converter.parse(xml_dir / '46d-PickupMeasure-ImplicitMeasures.xml')
         m = s[stream.Measure].first()
-        self.assertIs(m.numberImplicit, True)
+        self.assertIs(m.showNumber, stream.enums.ShowNumber.NEVER)
 
 
 if __name__ == '__main__':

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -5346,10 +5346,12 @@ class MeasureParser(XMLParserBase):
 
         calls parseMeasureNumbers(), and gets the width from the width tag.
 
-        # TODO: implicit
         # TODO: non-controlling
         # may need to do a format/unit conversion?
         '''
+        implicit = self.mxMeasure.get('implicit')
+        self.stream.numberImplicit = xmlObjects.yesNoToBoolean(implicit)
+
         self.parseMeasureNumbers()
         width = self.mxMeasure.get('width')
         if width is not None:

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -5350,7 +5350,10 @@ class MeasureParser(XMLParserBase):
         # may need to do a format/unit conversion?
         '''
         implicit = self.mxMeasure.get('implicit')
-        self.stream.numberImplicit = xmlObjects.yesNoToBoolean(implicit)
+        if xmlObjects.yesNoToBoolean(implicit):
+            self.stream.showNumber = stream.enums.ShowNumber.NEVER
+        else:
+            self.stream.showNumber = stream.enums.ShowNumber.DEFAULT
 
         self.parseMeasureNumbers()
         width = self.mxMeasure.get('width')

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -65,7 +65,7 @@ from music21.stream import makeNotation
 from music21.stream import streamStatus
 from music21.stream import iterator
 from music21.stream import filters
-from music21.stream.enums import GivenElementsBehavior, RecursionType
+from music21.stream.enums import GivenElementsBehavior, RecursionType, ShowNumber
 
 
 if t.TYPE_CHECKING:
@@ -12845,7 +12845,7 @@ class Measure(Stream):
                 self.numberSuffix = suffix
         else:
             self.number = number
-        self.showNumber = False
+        self.showNumber = ShowNumber.DEFAULT
         # we can request layout width, using the same units used
         # in layout.py for systems; most musicxml readers do not support this
         # on input

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -12790,6 +12790,8 @@ class Measure(Stream):
             prefixes to measure numbers.  In music21 (like most measure
             numbering systems), these
             numbers appear as suffixes.''',
+        'numberImplicit': '''
+            Boolean describing if the measure number should not be displayed.''',
         'layoutWidth': '''
             A suggestion for layout width, though most rendering systems do not support
             this designation. Use :class:`~music21.layout.SystemLayout`
@@ -12843,6 +12845,7 @@ class Measure(Stream):
                 self.numberSuffix = suffix
         else:
             self.number = number
+        self.numberImplicit = False
         # we can request layout width, using the same units used
         # in layout.py for systems; most musicxml readers do not support this
         # on input
@@ -12874,7 +12877,7 @@ class Measure(Stream):
         ...
         <part id="...">
             <!--========================= Measure 4 ==========================-->
-            <measure number="4A">
+            <measure implicit="no" number="4A">
         ...
 
         Test round tripping:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -12790,8 +12790,8 @@ class Measure(Stream):
             prefixes to measure numbers.  In music21 (like most measure
             numbering systems), these
             numbers appear as suffixes.''',
-        'numberImplicit': '''
-            Boolean describing if the measure number should not be displayed.''',
+        'showNumber': '''
+            Enum describing if the measure number should be displayed.''',
         'layoutWidth': '''
             A suggestion for layout width, though most rendering systems do not support
             this designation. Use :class:`~music21.layout.SystemLayout`
@@ -12845,7 +12845,7 @@ class Measure(Stream):
                 self.numberSuffix = suffix
         else:
             self.number = number
-        self.numberImplicit = False
+        self.showNumber = False
         # we can request layout width, using the same units used
         # in layout.py for systems; most musicxml readers do not support this
         # on input

--- a/music21/stream/enums.py
+++ b/music21/stream/enums.py
@@ -55,6 +55,12 @@ class RecursionType(StrEnum):
     ELEMENTS_ONLY = 'elementsOnly'
 
 
+class ShowNumber(StrEnum):
+    DEFAULT = 'default'
+    ALWAYS = 'always'
+    NEVER = 'never'
+
+
 if __name__ == '__main__':
     from music21 import mainTest
     mainTest()


### PR DESCRIPTION
Requested at https://groups.google.com/g/music21list/c/vMaz9wJVPyc.

Used `numberImplicit` to rhyme with attributes on MetronomeMark.