### PR TITLE
Correct diminished and half-diminished 11th chord types

### DIFF
--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -94,8 +94,8 @@ CHORD_TYPES = collections.OrderedDict([
     ('minor-11th', ['1,-3,5,-7,9,11', ['m11', 'min11']]),  # Y
     ('augmented-major-11th', ['1,3,#5,7,9,11', ['+M11', 'augmaj11']]),  # N
     ('augmented-11th', ['1,3,#5,-7,9,11', ['+11', 'aug11']]),  # N
-    ('half-diminished-11th', ['1,-3,-5,-7,-9,11', ['ø11']]),  # N
-    ('diminished-11th', ['1,-3,-5,--7,-9,-11', ['o11', 'dim11']]),  # N
+    ('half-diminished-11th', ['1,-3,-5,-7,9,11', ['ø11']]),  # N
+    ('diminished-11th', ['1,-3,-5,--7,9,11', ['o11', 'dim11']]),  # N
 
     # thirteenths
     ('major-13th', ['1,3,5,7,9,11,13', ['M13', 'Maj13']]),  # Y
@@ -920,11 +920,11 @@ def chordSymbolFigureFromChord(inChord: chord.Chord, includeChordType=False):
     >>> harmony.chordSymbolFigureFromChord(c, True)
     ('F+11', 'augmented-11th')
 
-    >>> c = chord.Chord(['G3', 'B-3', 'D-4', 'F4', 'A-3', 'C4'])
+    >>> c = chord.Chord(['G3', 'B-3', 'D-4', 'F4', 'A3', 'C4'])
     >>> harmony.chordSymbolFigureFromChord(c, True)
     ('Gø11', 'half-diminished-11th')
 
-    >>> c = chord.Chord(['E-3', 'G-3', 'B--3', 'D--4', 'F-3', 'A--3'])
+    >>> c = chord.Chord(['E-3', 'G-3', 'B--3', 'D--4', 'F3', 'A-3'])
     >>> harmony.chordSymbolFigureFromChord(c, True)
     ('E-o11', 'diminished-11th')
 


### PR DESCRIPTION
The following 11th chord types were inconsistent with 9th and 13th chords and with common usage AFAICT:
- half-diminished 11th: was using a diminished 9th
- diminished 11ths: was using a diminished 9ths and diminished 11th

My understanding is that diminshed/half-diminished refers to the sevenths--everything else needs to be given with "flat/sharp-11" if wanted, see `half-diminished-minor-ninth` earlier in this file.