### PR TITLE
Avoid creating duplicative ChordStepModifications

### DIFF
--- a/music21/base.py
+++ b/music21/base.py
@@ -2425,7 +2425,7 @@ class Music21Object(prebase.ProtoM21Object):
         A reference to the most-recent object used to
         contain this object. In most cases, this will be a
         Stream or Stream sub-class. In most cases, an object's
-        activeSite attribute is automatically set when an the
+        activeSite attribute is automatically set when the
         object is attached to a Stream.
 
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -581,11 +581,11 @@ class ChordStepModification(prebase.ProtoM21Object):
 
     # INITIALIZER #
 
-    def __init__(self, modType=None, degree=None, intervalObj=None):
-        self._modType = None  # add, alter, subtract
-        self._interval = None  # alteration of degree, alter ints in mxl
-        self._degree = None  # the degree number, where 3 is the third
-        # use properties if defined
+    def __init__(self, modType=None, degree=None, intervalObj=interval.Interval('P1')):
+        self._modType: str | None = None  # add, alter, subtract
+        self._interval: interval.Interval | None = None  # alteration of degree, alter ints in mxl
+        self._degree: int | None = None  # the degree number, where 3 is the third
+        # use properties if defined: runs certain type conversions
         if modType is not None:
             self.modType = modType
         if degree is not None:

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1632,7 +1632,9 @@ class ChordSymbol(Harmony):
 
         return list(c.pitches)
 
-    def _adjustPitchesForChordStepModifications(self, pitches):
+    def _adjustPitchesForChordStepModifications(
+        self, pitches: t.Iterable[pitch.Pitch]
+    ) -> list[pitch.Pitch]:
         '''
         degree-value element: indicates degree in chord, positive integers only
 
@@ -1796,7 +1798,7 @@ class ChordSymbol(Harmony):
             elif chordStepModification.modType == 'alter':
                 typeAlter(chordStepModification)
 
-        return tuple(pitches)
+        return pitches
 
     def _parseAddAlterSubtract(self, remaining: str, modType: str) -> str:
         '''
@@ -2120,7 +2122,7 @@ class ChordSymbol(Harmony):
             self.inversion(None, transposeOnSet=False)
             inversionNum = None
 
-        pitches = list(self._adjustPitchesForChordStepModifications(pitches))
+        pitches = self._adjustPitchesForChordStepModifications(pitches)
 
         if inversionNum not in (0, None):
             for p in pitches[0:inversionNum]:

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -504,7 +504,8 @@ class Harmony(chord.Chord):
             raise HarmonyException(
                 f'cannot add this object as a degree: {degree}')
 
-        self.chordStepModifications.append(degree)
+        if degree not in self.chordStepModifications:
+            self.chordStepModifications.append(degree)
         if updatePitches:
             self._updatePitches()
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -598,9 +598,9 @@ class ChordStepModification(prebase.ProtoM21Object):
 
     # INITIALIZER #
 
-    def __init__(self, modType=None, degree=None, intervalObj=interval.Interval('P1')):
+    def __init__(self, modType=None, degree=None, intervalObj=None):
         self._modType: str | None = None  # add, alter, subtract
-        self._interval: interval.Interval | None = None  # alteration of degree, alter ints in mxl
+        self._interval: interval.Interval  # alteration of degree, alter ints in mxl
         self._degree: int | None = None  # the degree number, where 3 is the third
         # use properties if defined: runs certain type conversions
         if modType is not None:
@@ -609,6 +609,8 @@ class ChordStepModification(prebase.ProtoM21Object):
             self.degree = degree
         if intervalObj is not None:
             self.interval = intervalObj
+        else:
+            self.interval = interval.Interval('P1')
 
     # SPECIAL METHODS #
 

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -323,6 +323,22 @@ class Harmony(chord.Chord):
         >>> h.bass(note.Note('E'))
         >>> h.figure
         'CM'
+
+        OMIT_FROM_DOCS
+
+        Fixed storing deduced figures by avoiding duplicate chordStepModifications:
+
+        >>> h = harmony.ChordSymbol('CM7omit5')
+        >>> h.addChordStepModification(harmony.ChordStepModification(modType='add', degree=4))
+        >>> h.findFigure()
+        'Cmaj7 subtract 5 add 4'
+
+        >>> h.figure
+        'CM7omit5'
+
+        >>> h.figure = h.findFigure()
+        >>> h.figure
+        'Cmaj7 subtract 5 add 4'
         '''
         if self._figure is None:
             return self.findFigure()

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -563,7 +563,8 @@ class ChordStepModification(prebase.ProtoM21Object):
 
     >>> hd = harmony.ChordStepModification('add', 4)
     >>> hd
-    <music21.harmony.ChordStepModification modType=add degree=4 interval=None>
+    <music21.harmony.ChordStepModification modType=add
+        degree=4 interval=<music21.interval.Interval P1>>
 
     >>> hd = harmony.ChordStepModification('alter', 3, 1)
     >>> hd


### PR DESCRIPTION
Fixes #1500 by not creating duplicative ChordStepModifications.

Also:
- Avoid unnecessary casting to tuple and back in `_adjustPitchesForChordStepModifications()`
- Default ChordStepModification.interval to perfect unison to avoid None != Interval('P1')