### PR TITLE
Cache result of findGaps() on gapless streams

### DIFF
--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -10543,6 +10543,11 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         * Changed in v7: gapStream is filled with rests instead of Music21Objects
         '''
         if 'findGaps' in self._cache and self._cache['findGaps'] is not None:
+            if self._cache['findGaps'] is False:
+                # We are using False to represent the None that would be
+                # returned by calling findGaps() on a gapless stream, because
+                # None is music21's convention for forcing cache misses.
+                return None
             return self._cache['findGaps']
 
         gapStream = self.cloneEmpty(derivationMethod='findGaps')
@@ -10565,6 +10570,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         gapStream.sort()
 
         if not gapStream:
+            self._cache['findGaps'] = False
             return None
         else:
             self._cache['findGaps'] = gapStream


### PR DESCRIPTION
This approach uses False to distinguish "no gaps" from "force a cache miss" (None), although this has to then be converted back to None for cache hits.

An alternative would be to rewrite the cache (there aren't that many keys) to just delete keys when intending to force cache misses.

Another alternative would be to break BC and have findGaps() return something else, like an empty stream that would still test False.

Closes #1514