### PR TITLE
Minimize gaps produced by quantization algorithm

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ Changing this number invalidates old pickles -- do it if the old pickles create 
 '''
 from __future__ import annotations
 
-__version__ = '9.0.0a9'
+__version__ = '9.0.0a10'
 
 
 def get_version_tuple(vv):

--- a/music21/base.py
+++ b/music21/base.py
@@ -27,7 +27,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'9.0.0a9'
+'9.0.0a10'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2065,7 +2065,7 @@ def midiTrackToStream(
         singleN.editorial.midiTickStart = notes[0][0][0]
         s.coreInsert(o, singleN)
 
-    s.coreElementsChanged()
+    s.sort(force=True)  # will also run coreElementsChanged()
     # quantize to nearest 16th
     if quantizePost:
         s.quantize(quarterLengthDivisors=quarterLengthDivisors,

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9385,11 +9385,12 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         def findNextElementNotCoincident(
             useStream: Stream,
             startIndex: int,
+            startOffset: OffsetQL,
         ) -> tuple[base.Music21Object | None, BestQuantizationMatch | None]:
             for next_el in useStream._elements[startIndex:]:
                 next_offset = useStream.elementOffset(next_el)
                 look_ahead_result = bestMatch(float(next_offset), quarterLengthDivisors)
-                if look_ahead_result.match > o:
+                if look_ahead_result.match > startOffset:
                     return next_el, look_ahead_result
             return None, None
 
@@ -9427,8 +9428,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                     zeroAllowed = not isinstance(e, note.NotRest) or e.duration.isGrace
                     if processOffsets and originallySorted:
                         next_element, look_ahead_result = (
-                            findNextElementNotCoincident(useStream, i + 1)
-                        )
+                            findNextElementNotCoincident(
+                                useStream=useStream, startIndex=i + 1, startOffset=o))
                         if next_element is not None and look_ahead_result is not None:
                             gapToFill = opFrac(look_ahead_result.match - e.offset)
                             d_matchTuple = bestMatch(

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -25,7 +25,6 @@ from collections import deque, namedtuple, OrderedDict
 from collections.abc import Collection, Iterable, Sequence
 import copy
 from fractions import Fraction
-import heapq
 import itertools
 import math
 from math import isclose

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -2344,7 +2344,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         updateIsFlat = False
         if element.isStream:
             updateIsFlat = True
-        self.coreElementsChanged(updateIsFlat=updateIsFlat)
+        self.coreElementsChanged(updateIsFlat=updateIsFlat, clearIsSorted=not ignoreSort)
         if ignoreSort is False:
             self.isSorted = storeSorted
 
@@ -9431,7 +9431,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                         )
                         if next_element is not None and look_ahead_result is not None:
                             gapToFill = opFrac(look_ahead_result.match - e.offset)
-                            d_matchTuple = bestMatch(float(ql), quarterLengthDivisors, zeroAllowed, gapToFill)
+                            d_matchTuple = bestMatch(
+                                float(ql), quarterLengthDivisors, zeroAllowed, gapToFill)
                         else:
                             d_matchTuple = bestMatch(float(ql), quarterLengthDivisors, zeroAllowed)
                     else:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -25,6 +25,7 @@ from collections import deque, namedtuple, OrderedDict
 from collections.abc import Collection, Iterable, Sequence
 import copy
 from fractions import Fraction
+import heapq
 import itertools
 import math
 from math import isclose
@@ -9395,8 +9396,13 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         # this presently is not trying to avoid overlaps that
         # result from quantization; this may be necessary
 
-        def bestMatch(target, divisors, zeroAllowed=True, gapToFill=0.0):
-            found = []
+        def bestMatch(
+            target, 
+            divisors, 
+            zeroAllowed=True, 
+            gapToFill=0.0
+        ) -> BestQuantizationMatch:
+            found: list[BestQuantizationMatch] = []
             for div in divisors:
                 tick = 1 / div  # divisor expressed as QL, e.g. 0.25
                 match, error, signedErrorInner = common.nearestMultiple(target, tick)
@@ -9412,8 +9418,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                 found.append(
                     BestQuantizationMatch(
                         remainingGap, error, tick, match, signedErrorInner, div))
-            # get first, and leave out the error
-            bestMatchTuple = sorted(found)[0]
+            # get smallest remainingGap, error, tick
+            bestMatchTuple = min(found)
             return bestMatchTuple
 
         def findNextElementNotCoincident(

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -9396,9 +9396,9 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         # result from quantization; this may be necessary
 
         def bestMatch(
-            target, 
-            divisors, 
-            zeroAllowed=True, 
+            target,
+            divisors,
+            zeroAllowed=True,
             gapToFill=0.0
         ) -> BestQuantizationMatch:
             found: list[BestQuantizationMatch] = []

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -2344,7 +2344,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         updateIsFlat = False
         if element.isStream:
             updateIsFlat = True
-        self.coreElementsChanged(updateIsFlat=updateIsFlat, clearIsSorted=not ignoreSort)
+        self.coreElementsChanged(updateIsFlat=updateIsFlat)
         if ignoreSort is False:
             self.isSorted = storeSorted
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -4026,7 +4026,7 @@ class Test(unittest.TestCase):
             for i in range(len(srcDur)):
                 n = note.Note()
                 n.quarterLength = srcDur[i]
-                s.insert(srcOffset[i], n)
+                s.insert(srcOffset[i], n, ignoreSort=True)
 
             s.quantize(divList, processOffsets=True, processDurations=True, inPlace=True)
 
@@ -4070,6 +4070,18 @@ class Test(unittest.TestCase):
                     [F('1/3'), F('1/3'), F('1/3'), 0.25, 0.25],
 
                     [8, 6])  # snap to 0.125 and 0.1666666
+
+        # User-reported example: contains overlap
+        # Smarter parsing in v.9, as long as stream is sorted
+        # https://github.com/cuthbertLab/music21/issues/1536
+        procCompare([2.016, 2.026, 2.333, 2.646, 3.0, 3.323, 3.651],
+                    [0.123, 0.656, 0.104, 0.094, 0.146, 0.099, 0.141],
+
+                    [2, 2, F('7/3'), F('8/3'), 3.0, F('10/3'), F('11/3')],
+                    [F('1/3'), F('2/3'), F('1/3'), F('1/3'),
+                     F('1/3'), F('1/3'), 0.25],
+
+                    [4, 3])
 
     def testQuantizeMinimumDuration(self):
         '''

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -4071,8 +4071,8 @@ class Test(unittest.TestCase):
 
                     [8, 6])  # snap to 0.125 and 0.1666666
 
-        # User-reported example: contains overlap
-        # Smarter parsing in v.9, as long as stream is sorted
+        # User-reported example: contains overlap and tiny gaps
+        # Parsing with fewer gaps in v.9, as long as stream is sorted
         # https://github.com/cuthbertLab/music21/issues/1536
         procCompare([2.016, 2.026, 2.333, 2.646, 3.0, 3.323, 3.651],
                     [0.123, 0.656, 0.104, 0.094, 0.146, 0.099, 0.141],

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -4026,7 +4026,9 @@ class Test(unittest.TestCase):
             for i in range(len(srcDur)):
                 n = note.Note()
                 n.quarterLength = srcDur[i]
-                s.insert(srcOffset[i], n, ignoreSort=True)
+                s.insert(srcOffset[i], n)
+            # Must be sorted for quantizing to work optimally.
+            s.sort()
 
             s.quantize(divList, processOffsets=True, processDurations=True, inPlace=True)
 

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -4742,7 +4742,7 @@ class Test(unittest.TestCase):
         '''A sorted stream does not become unsorted when ignoreSort=True.'''
         s = Stream()
         s.repeatAppend(note.Note(), 4)
-        s.insert(1, tempo.MetronomeMark(), ignoreSort=True)
+        s.insert(4, tempo.MetronomeMark(), ignoreSort=True)
         self.assertTrue(s.isSorted)
 
     def testMakeChordsBuiltA(self):

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -4740,13 +4740,6 @@ class Test(unittest.TestCase):
         self.assertEqual([(0.0, 2), (0.0, 30), (5.0, 25), (8.0, 10), (10.0, 2),
                           (15.0, 10), (20.0, 2), (22.0, 1.0)], match)
 
-    def testInsertIgnoreSort(self):
-        '''A sorted stream does not become unsorted when ignoreSort=True.'''
-        s = Stream()
-        s.repeatAppend(note.Note(), 4)
-        s.insert(4, tempo.MetronomeMark(), ignoreSort=True)
-        self.assertTrue(s.isSorted)
-
     def testMakeChordsBuiltA(self):
         # test with equal durations
         pitchCol = [('C2', 'A2'),

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -4738,6 +4738,13 @@ class Test(unittest.TestCase):
         self.assertEqual([(0.0, 2), (0.0, 30), (5.0, 25), (8.0, 10), (10.0, 2),
                           (15.0, 10), (20.0, 2), (22.0, 1.0)], match)
 
+    def testInsertIgnoreSort(self):
+        '''A sorted stream does not become unsorted when ignoreSort=True.'''
+        s = Stream()
+        s.repeatAppend(note.Note(), 4)
+        s.insert(1, tempo.MetronomeMark(), ignoreSort=True)
+        self.assertTrue(s.isSorted)
+
     def testMakeChordsBuiltA(self):
         # test with equal durations
         pitchCol = [('C2', 'A2'),


### PR DESCRIPTION
Fixes #1536 by improving the algorithm that "looks ahead" to minimize gaps when quantizing durations from its first draft in #1062, as long as the stream is sorted first.

Looking ahead was the right idea, but using the same divisor was not right, because in a passage of triplets, on beats, you have a tie between divisors (for calculating offsets). For the screenshotted example below, that means the last triplet-eighths of a beat were quantized as sixteenths (because there was a tie for the "best divisor" for the quantization of the offset at the X.0 beat).

This refactor solves the reported issue and also includes a simpler way of achieving #641's requirement of nonzero durations on non-grace notes.

- This also uncovered some infelicities with Stream.insert(ignoreSort=True), adding an explicit test.
- Now streams parsed from MIDI are explicitly sorted.

**Before**
<img width="917" alt="Screenshot 2023-03-25 at 5 53 43 PM" src="https://user-images.githubusercontent.com/38668450/227744077-09f79382-059e-43f5-abb1-beca1fce9db2.png">


**After**
<img width="910" alt="Screenshot 2023-03-25 at 5 53 19 PM" src="https://user-images.githubusercontent.com/38668450/227744076-382abb9d-0e1a-4f6e-a852-f0e1784fad46.png">

