### PR TITLE
Improve measure numbers on ClercqTemperley

### DIFF
--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -970,6 +970,7 @@ class Converter:
         ('abc', <class 'music21.converter.subConverters.ConverterABC'>)
         ('braille', <class 'music21.converter.subConverters.ConverterBraille'>)
         ('capella', <class 'music21.converter.subConverters.ConverterCapella'>)
+        ('clercqtemperley', <class 'music21.converter.subConverters.ConverterClercqTemperley'>)
         ('cttxt', <class 'music21.converter.subConverters.ConverterClercqTemperley'>)
         ('har', <class 'music21.converter.subConverters.ConverterClercqTemperley'>)
         ('humdrum', <class 'music21.converter.subConverters.ConverterHumdrum'>)

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1397,8 +1397,8 @@ class ConverterClercqTemperley(SubConverter):
     Wrapper for parsing harmonic definitions in Trevor de Clercq and
     David Temperley's format.
     '''
-    registerFormats = ('cttxt', 'har')
-    registerInputExtensions = ('cttxt', 'har')
+    registerFormats = ('cttxt', 'har', 'clercqTemperley')
+    registerInputExtensions = ('cttxt', 'har', 'clercqTemperley')
 
     def parseData(self, strData: str | pathlib.Path, number=None):
         from music21.romanText import clercqTemperley

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1400,10 +1400,10 @@ class ConverterClercqTemperley(SubConverter):
     registerFormats = ('cttxt', 'har')
     registerInputExtensions = ('cttxt', 'har')
 
-    def parseData(self, strData, number=None):
+    def parseData(self, strData: str | pathlib.Path, number=None):
         from music21.romanText import clercqTemperley
         ctSong = clercqTemperley.CTSong(strData)
-        self.stream = ctSong.toScore()
+        self.stream = ctSong.toPart()
 
     def parseFile(self,
                   filePath: pathlib.Path | str,


### PR DESCRIPTION
de Clercq / Temperley files were being exported with all measure numbers set to 0.  Now they are properly numbered.

Deprecate `toScore` in CT parsing, add `toPart` since the format currently returns a Part object.  (this should be changed to a Score object instead to fit w/ RomanText parsing, but not done now).

Typing improvements for the converter.