### PR TITLE
Avoid altering score on write

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -465,7 +465,7 @@ class GeneralObjectExporter:
     def fromGeneralObject(self, obj: prebase.ProtoM21Object):
         '''
         Converts any Music21Object (or a duration or a pitch) to something that
-        can be passed to ScoreExporter()
+        can be passed to :class:`ScoreExporter`.
 
         >>> GEX = musicxml.m21ToXml.GeneralObjectExporter()
         >>> s = GEX.fromGeneralObject(duration.Duration(3.0))
@@ -491,6 +491,8 @@ class GeneralObjectExporter:
         >>> outStr = out.decode('utf-8')  # now is string
         >>> '<note print-object="no" print-spacing="yes">' in outStr
         True
+        >>> len(v[note.Rest])  # original stream unchanged
+        0
         '''
         classes = obj.classes
         outObj = None

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -520,7 +520,8 @@ class GeneralObjectExporter:
         '''
         Runs :meth:`~music21.stream.Score.makeNotation` on the copy.
         '''
-        sc.makeNotation(inPlace=True)
+        if self.makeNotation:
+            sc.makeNotation(inPlace=True)
         if not sc.isWellFormedNotation():
             warnings.warn(f'{sc} is not well-formed; see isWellFormedNotation()',
                 category=MusicXMLWarning)
@@ -532,7 +533,7 @@ class GeneralObjectExporter:
         From a part, put it in a new score.
         '''
         if p.isFlat:
-            p = p.makeMeasures()
+            p.makeMeasures(inPlace=True)
         # p.makeImmutable()  # impossible, we haven't made notation yet.
         s = stream.Score()
         s.insert(0, p)


### PR DESCRIPTION
We copy the score object early to avoid modifying it when calling `.write("musicxml", *)`
See #1557

@jacobtylerwalls 