### PR TITLE
fix jupyter/colab MIDI

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -478,26 +478,28 @@ class ConverterIPython(SubConverter):
             load_require_script = ''
             if inGoogleColabNotebook():
                 load_require_script = '''
-                    <script src="//cuthbertLab.github.io/music21j/ext/require/require.js"
+                    <script
+                    src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"
                     ></script>
                 '''
 
+            utf_binary = binaryBase64.decode('utf-8')
             # noinspection PyTypeChecker
             display(HTML('''
                 <div id="''' + outputId + '''"></div>
-                <link rel="stylesheet" href="//cuthbertLab.github.io/music21j/css/m21.css"
-                    type="text/css" />
+                <link rel="stylesheet" href="https://cuthbertLab.github.io/music21j/css/m21.css">
                 ''' + load_require_script + '''
                 <script>
                 require.config({
-                    paths: {'music21': '//cuthbertLab.github.io/music21j/src/music21'}
+                    paths: {
+                        'music21': 'https://cuthbertLab.github.io/music21j/releases/music21.debug',
+                    }
                 });
-                require(['music21'], function() {
-                               mp = new music21.miditools.MidiPlayer();
-                               mp.addPlayer("#''' + outputId + '''");
-                               mp.base64Load("data:audio/midi;base64,'''
-                                + binaryBase64.decode('utf-8') + '''");
-                        });
+                require(['music21'], function(music21) {
+                    mp = new music21.miditools.MidiPlayer();
+                    mp.addPlayer("#''' + outputId + '''");
+                    mp.base64Load("data:audio/midi;base64,''' + utf_binary + '''");
+                });
                 </script>'''))
 
 


### PR DESCRIPTION
A recent update to music21j on github.io broke MIDI output in Jupyter notebooks in music21.  This will fix it.

Backport to v8