### PR TITLE
Remove byte order mark from corpus.virtual

### DIFF
--- a/music21/corpus/virtual.py
+++ b/music21/corpus/virtual.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 # Name:         corpus/virtual.py
 # Purpose:      Access to the Virtual corpus collection


### PR DESCRIPTION
Was playing with [this tool](https://github.com/carljm/compfinder) and wondered why it couldn't parse the AST for `corpus.virtual`. Answer: it has a [byte order mark](https://www.freecodecamp.org/news/a-quick-tale-about-feff-the-invisible-character-cd25cd4630e7/).