### PR TITLE
Fix MIDI parsing with unknown meta message

### DIFF
--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -918,8 +918,8 @@ class MidiEvent(prebase.ProtoM21Object):
             if MetaEvents.hasValue(byte1):
                 self.type = MetaEvents(byte1)
             else:
-                environLocal.printDebug([f'unknown meta event: FF {byte1:02X}'])
-                sys.stdout.flush()
+                # environLocal.printDebug([f'unknown meta event: FF {byte1:02X}'])
+                # sys.stdout.flush()
                 self.type = MetaEvents.UNKNOWN
             length, midiBytesAfterLength = getVariableLengthNumber(midiBytes[2:])
             self.data = midiBytesAfterLength[:length]
@@ -1987,6 +1987,13 @@ class Test(unittest.TestCase):
                             if e.type == ChannelVoiceMessages.POLYPHONIC_KEY_PRESSURE][0]
         self.assertEqual(pressureEventRead.parameter1, 60)
         self.assertEqual(pressureEventRead.parameter2, 90)
+
+    def testReadUnknownMetaMessage(self):
+        mt = MidiTrack()
+        mt.processDataToEvents(b'\x00\xff\x08\x06DUMMY\x00\x00\xff\n\x05Myut\x00'
+                               + b'\x00\xffX\x04\x03\x01\x12\x01')
+        self.assertEqual(len(mt.events), 6)
+        self.assertEqual(mt.events[3].type, MetaEvents.UNKNOWN)
 
 
 # ------------------------------------------------------------------------------

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -400,6 +400,7 @@ class MetaEvents(_ContainsEnum):
     TIME_SIGNATURE = 0x58
     KEY_SIGNATURE = 0x59
     SEQUENCER_SPECIFIC_META_EVENT = 0x7F
+    UNKNOWN = 0xFF  # Container for any unknown code
 
 
 class SysExEvents(_ContainsEnum):

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -915,11 +915,12 @@ class MidiEvent(prebase.ProtoM21Object):
 
         # SEQUENCE_TRACK_NAME and other MetaEvents are here
         elif byte0 == METAEVENT_MARKER:  # 0xFF
-            if not MetaEvents.hasValue(byte1):
+            if MetaEvents.hasValue(byte1):
+                self.type = MetaEvents(byte1)
+            else:
                 environLocal.printDebug([f'unknown meta event: FF {byte1:02X}'])
                 sys.stdout.flush()
-                raise MidiException(f'Unknown midi event type: FF {byte1:02X}')
-            self.type = MetaEvents(byte1)
+                self.type = MetaEvents.UNKNOWN
             length, midiBytesAfterLength = getVariableLengthNumber(midiBytes[2:])
             self.data = midiBytesAfterLength[:length]
             # return remainder


### PR DESCRIPTION
The MIDI standard defines a few different types of MetaMessage depending
on their byte code.
However, many MIDI files "in the wild" contain invalid or unknown codes.
This issue occurs on e.g. 00c6b7becb462c02d7a18c44585543ba.mid from the lakh dataset.
Music21 presently discards the message and moves forward after just
the time delta event. This results in (silently) producing incorrect MIDI.
Other well-known parsers, such as mido, parse these meta messages as normal and
assign them an unknown code, which yields a more robust parser and gives correct behavior.
Let me know what you think!

False:
```python3
<DeltaTime (empty) track=0, channel=None>
<MidiEvent PROGRAM_NAME, track=0, channel=None, data=b'DUMMY\x00'>
<DeltaTime t=16266, track=0, channel=None>
<MidiEvent LYRIC, track=0, channel=None, data=b'yut\x00\x00\xffX\x04\x03\x01\x12\x01'>
```
Corrected:
```python3
<DeltaTime (empty) track=0, channel=None>
<MidiEvent PROGRAM_NAME, track=0, channel=None, data=b'DUMMY\x00'>
<DeltaTime (empty) track=0, channel=None>
<MidiEvent UNKNOWN, track=0, channel=None, data=b'Myut\x00'>
<DeltaTime (empty) track=0, channel=None>
<MidiEvent TIME_SIGNATURE, track=0, channel=None, data=b'\x04\x02\x18\x08'>
```