### PR TITLE
Don't set status byte on Meta Message (Fix #1574)

### DIFF
--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -891,8 +891,9 @@ class MidiEvent(prebase.ProtoM21Object):
             midiBytes = rsb + midiBytes
             byte0 = midiBytes[0]
         else:
-            # store last status byte
-            self.lastStatusByte = midiBytes[0]
+            if midiBytes[0] != 0xff:
+                # store last status byte, unless it's a meta message
+                self.lastStatusByte = midiBytes[0]
 
         msgType: int = byte0 & 0xF0  # bitwise and to derive message type w/o channel
 

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -890,10 +890,9 @@ class MidiEvent(prebase.ProtoM21Object):
             # and process as before
             midiBytes = rsb + midiBytes
             byte0 = midiBytes[0]
-        else:
-            if midiBytes[0] != 0xff:
-                # store last status byte, unless it's a meta message
-                self.lastStatusByte = midiBytes[0]
+        elif midiBytes[0] != 0xff:
+            # store last status byte, unless it's a meta message
+            self.lastStatusByte = midiBytes[0]
 
         msgType: int = byte0 & 0xF0  # bitwise and to derive message type w/o channel
 


### PR DESCRIPTION
Fixes #1574
When loading a MIDI file, messages can set a (running) status byte. However, meta messages don't set the status byte. 

This leads to problem on several MIDI files, for example 8584aaa73eb54bae39708da8be5e6282.mid from the lakh dataset.

It could be argued that the `!= 0xff` check is too conservative as running status is only applicable for messages in the range `0x8n - 0xEn`, the proposal is this way to be aligned with other python midi libraries:
https://github.com/mido/mido/blob/bff6bf2a8711e33782de5661ed5ccdffb0bb1688/mido/midifiles/midifiles.py#L204-L206 

