### PR TITLE
Set ABC version from I:abc-version information

### DIFF
--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -2033,7 +2033,7 @@ class ABCHandler:
 
     @staticmethod
     def returnAbcVersionFromMatch(verMats: re.Match) -> tuple[int, int, int]:
-        '''
+        r'''
         Given a match from a regular expression return the parsed ABC version
 
         >>> import re
@@ -2198,7 +2198,6 @@ class ABCHandler:
         accidentalized: dict[str, str] = {}
         accidental: str = ''
         abcPitch: str = ''  # ABC substring defining any pitch within the current token
-        self.isFirstComment = True
 
         while self.pos < self.srcLen - 1:
             self.pos += 1

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -757,7 +757,9 @@ class Test(unittest.TestCase):
         from music21.abcFormat import translate
 
         af = abcFormat.ABCFile()
+        self.assertEqual(af.abcVersion, (1, 3, 0))
         ah = af.readstr(directiveCarryOctave)
+        self.assertEqual(ah.abcVersion, (2, 1, 0))
         s = translate.abcToStreamScore(ah)
         notes = s.flatten().getElementsByClass(note.Note)
         gSharp = notes[1]

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -295,7 +295,7 @@ def parseABCNote(
     Parse an ABCNote object and add it to the destination stream.
     '''
     from music21 import abcFormat
-    
+
     n: note.GeneralNote
     cs: harmony.ChordSymbol | harmony.NoChord
 

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -53,7 +53,11 @@ _abcArticulationsToM21 = {
 }
 
 
-def abcToStreamPart(abcHandler, inputM21=None, spannerBundle=None):
+def abcToStreamPart(
+    abcHandler: abc.ABCHandler,
+    inputM21: stream.Part | None = None,
+    spannerBundle: spanner.SpannerBundle | None = None
+) -> stream.Part:
     '''
     Handler conversion of a single Part of a Score with multiple Parts.
     Results are added into the provided inputM21 object
@@ -234,7 +238,12 @@ def abcToStreamPart(abcHandler, inputM21=None, spannerBundle=None):
     return p
 
 
-def parseTokens(mh, dst, p, useMeasures):
+def parseTokens(
+    mh: abc.ABCHandler,
+    dst: stream.Measure | stream.Part,
+    p: stream.Part,
+    useMeasures: bool
+) -> tuple[int, bool]:
     '''
     parses all the tokens in a measure or part.
     '''
@@ -401,7 +410,16 @@ def abcToStreamScore(abcHandler, inputM21=None):
     titleCount = 0
     for t in abcHandler.tokens:
         if isinstance(t, abcFormat.ABCMetadata):
-            if t.isTitle():
+            if t.isVersion():
+                v = t.data.replace('abc-version', '').strip()
+                try:
+                    abcHandler.abcVersion = abcHandler.returnAbcVersionFromMatch(
+                        re.match(r'(\d+).(\d+).?(\d+)?', v)
+                    )
+                except AttributeError:
+                    pass
+
+            elif t.isTitle():
                 if titleCount == 0:  # first
                     md.add('title', t.data)
                     # environLocal.printDebug(['got metadata title', t.data])

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -280,11 +280,11 @@ def parseTokens(
                         dst.coreAppend(ts)
             elif t.isKey():
                 ks = t.getKeySignatureObject()
-                if ks is not None:
-                    if useMeasures:  # assume at start of measures
-                        dst.keySignature = ks
-                    else:
-                        dst.coreAppend(ks)
+                if ks is not None and useMeasures:
+                    # assume at start of measures
+                    dst.keySignature = ks
+                elif ks is not None:
+                    dst.coreAppend(ks)
                 # check for clef information sometimes stored in key
                 clefObj, transposition = t.getClefObject()
                 if clefObj is not None and transposition is not None:

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -294,6 +294,8 @@ def parseABCNote(
     '''
     Parse an ABCNote object and add it to the destination stream.
     '''
+    from music21 import abcFormat
+    
     n: note.GeneralNote
     cs: harmony.ChordSymbol | harmony.NoChord
 

--- a/music21/defaults.py
+++ b/music21/defaults.py
@@ -108,6 +108,10 @@ multiMeasureRestMaxSymbols = 11
 # and rewritten on thaw, etc.
 minIdNumberToConsiderMemoryLocation = 100_000_001
 
+
+# abc files without any version information parse as this version
+abcVersionDefault = (1, 3, 0)
+
 # ----------------------------------------------------------------||||||||||||--
 
 

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -40,6 +40,7 @@ from music21.meter.core import MeterSequence
 environLocal = environment.Environment('meter')
 
 if t.TYPE_CHECKING:
+    from music21.common.types import OffsetQL
     from music21 import stream
 
 # this is just a placeholder so that .beamSequence, etc. do not need to
@@ -1595,7 +1596,7 @@ class TimeSignature(TimeSignatureBase):
             # create a new object; it will not be linked
             self.displaySequence = MeterSequence(value, partitionRequest)
 
-    def getAccent(self, qLenPos: float) -> bool:
+    def getAccent(self, qLenPos: OffsetQL) -> bool:
         '''
         Return True or False if the qLenPos is at the start of an accent
         division.

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -242,7 +242,7 @@ class Spanner(base.Music21Object):
         self.idLocal: str | None = None
         # after all spannedElements have been gathered, setting complete
         # will mark that all parts have been gathered.
-        self.completeStatus = False
+        self.completeStatus: bool = False
 
         # data for fill:
 


### PR DESCRIPTION
Previously only `%abc-2.1` on the first line was enough to set the version number.  Now `I:abc-version 2.1` can be set anywhere.

Note that unlike the 2.1 format, the version Information header affects everything from that point forward within one song.  The last version does take effect, but different versions may be given within the same file and the one in effect at that moment will carry forward.

Added lots of typing and fixed some bugs.