### PR TITLE
substitute deprecation for removal: converter.py

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,27 @@
+# Read the Docs configuration file for music21
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: documentation/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/music21/common/misc.py
+++ b/music21/common/misc.py
@@ -225,7 +225,7 @@ def runningInNotebook() -> bool:
         return False
 
 
-@deprecated
+@deprecated('v9', 'v10', 'use runningInNotebook() instead')
 def runningUnderIPython() -> bool:  # pragma: no cover
     '''
     DEPRECATED in v9: use runningInNotebook() instead

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -425,7 +425,7 @@ def registerSubConverter(newSubConverter: type[subConverters.SubConverter]) -> N
     '''
     _registeredSubConverters.appendleft(newSubConverter)
 
-@common.deprecated
+@common.deprecated('v9', 'v10', 'use unregisterSubconverter with capital C')
 def registerSubconverter(
     newSubConverter: type[subConverters.SubConverter]
 ) -> None:  # pragma: no cover
@@ -488,7 +488,7 @@ def unregisterSubConverter(
                 f'Could not remove {removeSubConverter!r} from registered subConverters')
 
 
-@common.deprecated
+@common.deprecated('v9', 'v10', 'use unregisterSubConverter with capital C')
 def unregisterSubconverter(
     newSubConverter: type[subConverters.SubConverter]
 ) -> None:  # pragma: no cover
@@ -807,6 +807,13 @@ class Converter:
 
     # -----------------------------------------------------------------------#
     # SubConverters
+    @common.deprecated('v9', 'v10', 'use subConvertersList with capital C')
+    def subconvertersList(
+        self,
+        converterType: t.Literal['any', 'input', 'output'] = 'any'
+    ) -> list[type[subConverters.SubConverter]]:  # pragma: no cover
+        return self.subConvertersList(converterType)
+
     @staticmethod
     def subConvertersList(
         converterType: t.Literal['any', 'input', 'output'] = 'any'
@@ -938,6 +945,10 @@ class Converter:
 
         return filteredSubConvertersList
 
+    @common.deprecated('v9', 'v10', 'use defaultSubConverters with capital C')
+    def defaultSubconverters(self) -> list[type[subConverters.SubConverter]]:  # pragma: no cover
+        return self.defaultSubConverters()
+
     @staticmethod
     def defaultSubConverters() -> list[type[subConverters.SubConverter]]:
         '''
@@ -981,6 +992,12 @@ class Converter:
                     and issubclass(possibleSubConverter, subConverters.SubConverter)):
                 defaultSubConverters.append(possibleSubConverter)
         return defaultSubConverters
+
+    @common.deprecated('v9', 'v10', 'use getSubConverterFormats with capital C')
+    def getSubconverterFormats(
+        self
+    ) -> dict[str, type[subConverters.SubConverter]]:  # pragma: no cover
+        return self.getSubConverterFormats()
 
     @staticmethod
     def getSubConverterFormats() -> dict[str, type[subConverters.SubConverter]]:
@@ -1054,6 +1071,10 @@ class Converter:
             raise ConverterException(f'no converter available for format: {converterFormat}')
         subConverterClass = scf[converterFormat]
         return subConverterClass()
+
+    @common.deprecated('v9', 'v10', 'use setSubConverterFromFormat with capital C')
+    def setSubconverterFromFormat(self, converterFormat: str):  # pragma: no cover
+        self.setSubConverterFromFormat(converterFormat)
 
     def setSubConverterFromFormat(self, converterFormat: str):
         '''


### PR DESCRIPTION
Converter.subconvertersList, Converter.defaultSubconverters , Converter.getSubconverterFormats, and setSubconverterFromFormat are all restored.

Note that most of these have been converted in their newer capital-C form to also be callable from the Class (staticmethods) -- this has not been added to the old forms which behave like before.

also keep taking every opportunity to see what readthedocs.io wants...