### PR TITLE
Remove useless Pylint disables

### DIFF
--- a/documentation/docbuild/make.py
+++ b/documentation/docbuild/make.py
@@ -128,12 +128,12 @@ class DocBuilder:
 
         if sphinx_new:
             # noinspection PyPackageRequirements
-            import sphinx.cmd.build  # pylint: disable=import-error
+            import sphinx.cmd.build
             sphinx_main_command = sphinx.cmd.build.main
         else:
             sphinx_main_command = sphinx.main  # pylint: disable=no-member
 
-        try:  # pylint: disable=assignment-from-no-return
+        try:
             returnCode = sphinx_main_command(sphinxOptions)
         except SystemExit:
             returnCode = 0

--- a/documentation/nbvalNotebook.py
+++ b/documentation/nbvalNotebook.py
@@ -13,9 +13,9 @@ import sys
 import subprocess
 
 # noinspection PyPackageRequirements
-import pytest  # pylint: disable=unused-import,import-error
+import pytest  # pylint: disable=unused-import
 # noinspection PyPackageRequirements
-import nbval  # pylint: disable=unused-import,import-error
+import nbval  # pylint: disable=unused-import
 
 from music21 import environment
 from music21 import common

--- a/documentation/testDocumentation.py
+++ b/documentation/testDocumentation.py
@@ -23,9 +23,9 @@ import sys
 import time
 
 # noinspection PyPackageRequirements
-from docutils.core import publish_doctree  # pylint: disable=import-error
+from docutils.core import publish_doctree
 # noinspection PyPackageRequirements
-import docutils.nodes  # pylint: disable=import-error
+import docutils.nodes
 
 
 import nbvalNotebook  # TODO: make into a package and import with .nbvalNotebook

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -1685,7 +1685,7 @@ class ABCNote(ABCToken):
             ql = activeDefaultQuarterLength * int(numStr)
 
         if self.brokenRhythmMarker is not None:
-            symbol, direction = self.brokenRhythmMarker  # pylint: disable=unpacking-non-sequence
+            symbol, direction = self.brokenRhythmMarker
             if symbol == '>':
                 modPair = (1.5, 0.5)
             elif symbol == '<':

--- a/music21/abcFormat/testFiles.py
+++ b/music21/abcFormat/testFiles.py
@@ -9,10 +9,6 @@ from __future__ import annotations
 
 import unittest
 
-# some lines must be this long, because of sources.
-# pylint: disable=line-too-long
-
-
 # abc standard
 # http://abcnotation.com/abc2mtex/abc.txt
 from music21 import environment

--- a/music21/audioSearch/__init__.py
+++ b/music21/audioSearch/__init__.py
@@ -154,7 +154,7 @@ def autocorrelationFunction(recordedSignal, recordSampleRateIn):
     correlation = correlation[lengthCorrelation:]
     difference = numpy.diff(correlation)  # Calculates the difference between slots
     positiveDifferences = numpy.where(difference > 0)[0]
-    if len(positiveDifferences) == 0:  # pylint: disable=len-as-condition
+    if len(positiveDifferences) == 0:
         finalResult = 10  # Rest
     else:
         beginning = positiveDifferences[0]

--- a/music21/base.py
+++ b/music21/base.py
@@ -61,7 +61,7 @@ from music21 import environment
 from music21 import exceptions21
 from music21 import prebase
 from music21.sites import Sites, SitesException, WEAKREF_ACTIVE
-from music21.style import Style  # pylint: disable=unused-import
+from music21.style import Style
 from music21.sorting import SortTuple, ZeroSortTupleLow, ZeroSortTupleHigh
 # needed for temporal manipulations; not music21 objects
 from music21 import tie
@@ -165,7 +165,7 @@ class _SplitTuple(tuple):
         # noinspection PyTypeChecker
         return super(_SplitTuple, cls).__new__(cls, tuple(tupEls))
 
-    def __init__(self, tupEls):  # pylint: disable=super-init-not-called
+    def __init__(self, tupEls):
         self.spannerList = []
 
 # -----------------------------------------------------------------------------
@@ -673,7 +673,7 @@ class Music21Object(prebase.ProtoM21Object):
 
     def __setstate__(self, state: dict[str, t.Any]):
         # defining self.__dict__ upon initialization currently breaks everything
-        object.__setattr__(self, '__dict__', state)  # pylint: disable=attribute-defined-outside-init
+        object.__setattr__(self, '__dict__', state)
 
     def _reprInternal(self) -> str:
         '''
@@ -3200,7 +3200,7 @@ class Music21Object(prebase.ProtoM21Object):
         for listType in ('expressions', 'articulations'):
             if hasattr(e, listType):
                 temp = getattr(e, listType)
-                setattr(e, listType, [])  # pylint: disable=attribute-defined-outside-init
+                setattr(e, listType, [])
                 setattr(eRemain, listType, [])
                 for thisExpression in temp:  # using thisExpression as a shortcut for expr or art.
                     if hasattr(thisExpression, 'splitClient'):  # special method (see Trill)

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -177,7 +177,7 @@ class ChordBase(note.NotRest):
         # after copying, if a Volume exists, it is linked to the old object
         # look at _volume so as not to create object if not already there
         # noinspection PyProtectedMember
-        for n in new._notes:  # pylint: disable=no-member
+        for n in new._notes:
             n._chordAttached = new
             # if .volume is called, a new Volume obj will be created
             if n.hasVolumeInformation():

--- a/music21/common/__init__.py
+++ b/music21/common/__init__.py
@@ -40,7 +40,6 @@ __all__ = [
 
 from music21 import defaults
 from music21 import exceptions21
-# pylint: disable=wildcard-import
 from music21.common.classTools import *  # including isNum, isListLike
 from music21.common.decorators import *  # gives the deprecated decorator
 from music21.common.enums import *

--- a/music21/common/enums.py
+++ b/music21/common/enums.py
@@ -74,8 +74,6 @@ class BooleanEnum(Enum):
         else:
             return False
 
-    # pylint having Enum problems with classes as usual.
-    # pylint: disable=comparison-with-callable
     def __eq__(self, other):
         if isinstance(other, self.__class__):
             return super().__eq__(other)

--- a/music21/common/fileTools.py
+++ b/music21/common/fileTools.py
@@ -65,7 +65,7 @@ def readPickleGzip(filePath: str | pathlib.Path) -> t.Any:
         try:
             uncompressed = pickledFile.read()
             newMdb = pickle.loads(uncompressed)
-        except Exception as e:  # pylint: disable=broad-exception-caught
+        except Exception as e:
             # pickle exceptions cannot be caught directly
             # because they might come from pickle or _pickle and the latter cannot
             # be caught.

--- a/music21/common/parallel.py
+++ b/music21/common/parallel.py
@@ -104,8 +104,6 @@ def runParallel(iterable, parallelFunction, *,
     >>> outputs
     [99, 11, 123]
     '''
-    # multiprocessing has trouble with introspection
-    # pylint: disable=not-callable
     numCpus = cpus()
 
     if numCpus == 1 or multiprocessing.current_process().daemon:

--- a/music21/common/types.py
+++ b/music21/common/types.py
@@ -17,7 +17,7 @@ import typing as t
 from music21.common.enums import OffsetSpecial
 
 if t.TYPE_CHECKING:
-    import music21  # pylint: disable=unused-import
+    import music21
 
 DocOrder = list[str | Callable]
 OffsetQL = float | Fraction

--- a/music21/configure.py
+++ b/music21/configure.py
@@ -546,10 +546,10 @@ class Dialog:
         else:
             try:
                 self._performAction(simulate=simulate)
-            except DialogException:  # pylint: disable=catching-non-exception
+            except DialogException:
                 # in some cases, the action selected requires exciting the
                 # configuration assistant
-                # pylint: disable=raising-non-exception,raise-missing-from
+                # pylint: disable=raise-missing-from
                 raise DialogException('perform action raised a dialog exception')
 
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1427,7 +1427,7 @@ class Test(unittest.TestCase):
         it was exported from
         the "sibmei" plug-in for Sibelius).
         '''
-        from unittest import mock  # pylint: disable=no-name-in-module
+        from unittest import mock
         with mock.patch('music21.mei.MeiToM21Converter') as mockConv:
             testPath = common.getSourceFilePath() / 'mei' / 'test' / 'notes_in_utf16.mei'
             testConverter = ConverterMEI()
@@ -1438,7 +1438,7 @@ class Test(unittest.TestCase):
         '''
         For the sake of completeness, this is the same as testImportMei3() but with a UTF-8 file.
         '''
-        from unittest import mock  # pylint: disable=no-name-in-module
+        from unittest import mock
         with mock.patch('music21.mei.MeiToM21Converter') as mockConv:
             testPath = common.getSourceFilePath() / 'mei' / 'test' / 'notes_in_utf8.mei'
             testConverter = ConverterMEI()

--- a/music21/corpus/corpora.py
+++ b/music21/corpus/corpora.py
@@ -742,7 +742,7 @@ class LocalCorpus(Corpus):
             self._name = None
         elif name in ('core', 'virtual'):
             raise CorpusException(f'The name {name!r} is reserved.')
-        else:  # pylint: disable=no-else-raise  # false positive.
+        else:
             self._name = name
 
     # SPECIAL METHODS #

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -49,7 +49,7 @@ def etIndent(elem, level=0, spaces=2):
     indent an elementTree element for printing
     '''
     i = '\n' + level * spaces * ' '
-    if len(elem):  # pylint: disable=len-as-condition
+    if len(elem):
         if not elem.text or not elem.text.strip():
             elem.text = i + spaces * ' '
         if not elem.tail or not elem.tail.strip():

--- a/music21/exceptions21.py
+++ b/music21/exceptions21.py
@@ -35,7 +35,7 @@ class StreamException(Music21Exception):
     pass
 
 class ImmutableStreamException(StreamException):
-    def __init__(self, msg='An immutable Stream cannot be changed'):  # pylint: disable=useless-super-delegation
+    def __init__(self, msg='An immutable Stream cannot be changed'):
         super().__init__(msg)
 
 

--- a/music21/features/__init__.py
+++ b/music21/features/__init__.py
@@ -12,8 +12,7 @@ from __future__ import annotations
 
 __all__ = ['base', 'outputFormats', 'jSymbolic', 'native']
 
-# __init__ can wildcard import base; it's how it is designed.
-from music21.features.base import *  # pylint: disable=wildcard-import
+from music21.features.base import *
 
 from music21.features import base
 from music21.features import outputFormats
@@ -21,6 +20,5 @@ from music21.features import outputFormats
 from music21.features import jSymbolic
 from music21.features import native
 
-# pylint: disable=redefined-builtin
 __doc__ = base.__doc__
 

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -891,7 +891,7 @@ class WindowedAnalysis(primitives.GraphColorGrid, PlotStreamMixin):
         if not self.processorClass:
             return None
         if not self._processor:
-            self._processor = self.processorClass(self.streamObj)  # pylint: disable=not-callable
+            self._processor = self.processorClass(self.streamObj)
         return self._processor
 
     def run(self, *, callProcess: bool = True, **keywords):

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1277,7 +1277,6 @@ class HumdrumSpine(prebase.ProtoM21Object):
             elif eventC.startswith('!'):
                 thisObject = SpineComment(eventC)
             else:
-                # pylint: disable=attribute-defined-outside-init
                 thisObject = base.ElementWrapper(event)
                 thisObject.humdrumPosition = event.position
 
@@ -1335,7 +1334,6 @@ class KernSpine(HumdrumSpine):
                     thisObject = self.processNoteEvent(eventC)
 
                 if thisObject is not None:
-                    # pylint: disable=attribute-defined-outside-init
                     thisObject.humdrumPosition = event.position
                     thisObject.priority = event.position
                     self.stream.coreAppend(thisObject)

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -3676,7 +3676,7 @@ class Interval(IntervalBase):
         if p and p._client:
             return p._client
         elif p:
-            from music21 import note  # pylint: disable=redefined-outer-name
+            from music21 import note
             return note.Note(pitch=p)
 
     @noteStart.setter
@@ -3696,7 +3696,7 @@ class Interval(IntervalBase):
         if p and p._client:
             return p._client
         elif p:
-            from music21 import note  # pylint: disable=redefined-outer-name
+            from music21 import note
             return note.Note(pitch=p)
 
     @noteEnd.setter

--- a/music21/lily/lilyObjects.py
+++ b/music21/lily/lilyObjects.py
@@ -8,8 +8,6 @@
 # Copyright:    Copyright © 2007-2012 Michael Scott Asato Cuthbert
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
-# pylint: disable=too-many-function-args
-# unfortunately the way this was originally set up the previous line is needed
 '''
 music21 translates to Lilypond format and if Lilypond is installed on the
 local computer, can automatically generate .pdf, .png, and .svg versions
@@ -2265,7 +2263,6 @@ class Test(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    # pylint: disable=ungrouped-imports
     import music21
     music21.mainTest(Test)
 

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -2667,7 +2667,6 @@ class TestExternal(unittest.TestCase):
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':
-    # pylint: disable=ungrouped-imports
     import music21
     music21.mainTest(Test)  # , TestExternal)
     # music21.mainTest(TestExternal, 'noDocTest')

--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -309,7 +309,7 @@ class MeiToM21Converter:
             if isinstance(self.documentRoot, ElementTree):
                 # pylint warns that :class:`Element` doesn't have a getroot() method, which is
                 # true enough, but...
-                self.documentRoot = self.documentRoot.getroot()  # pylint: disable=maybe-no-member
+                self.documentRoot = self.documentRoot.getroot()
 
             if f'{MEI_NS}mei' != self.documentRoot.tag:
                 raise MeiElementError(_WRONG_ROOT_ELEMENT.format(self.documentRoot.tag))
@@ -419,7 +419,7 @@ def makeDuration(
     0.5
     '''
     returnDuration = duration.Duration(base)
-    returnDuration.dots = dots  # pylint: disable=assigning-non-slot
+    returnDuration.dots = dots
     return returnDuration
 
 
@@ -1521,7 +1521,7 @@ def _guessTuplets(theLayer):
 
 # Element-Based Converter Functions
 # -----------------------------------------------------------------------------
-def scoreDefFromElement(elem, slurBundle=None):  # pylint: disable=unused-argument
+def scoreDefFromElement(elem, slurBundle=None):
     '''
     <scoreDef> Container for score meta-information.
 
@@ -1694,7 +1694,7 @@ def staffGrpFromElement(elem, slurBundle=None, staffDefDict=None):
     return staffDefDict
 
 
-def staffDefFromElement(elem, slurBundle=None):  # pylint: disable=unused-argument
+def staffDefFromElement(elem, slurBundle=None):
     '''
     <staffDef> Container for staff meta-information.
 

--- a/music21/mei/test_base.py
+++ b/music21/mei/test_base.py
@@ -22,11 +22,6 @@ from __future__ import annotations
 # if we mock many things, this may be triggered
 # pylint: disable=too-many-arguments
 
-# pylint is bad at guessing types in these tests---reasonably so
-# pylint: disable=maybe-no-member
-
-# pylint: disable=ungrouped-imports
-# pylint: disable=import-error
 import unittest
 
 # To have working MagicMock objects, we can't use cElementTree even though it would be faster.
@@ -36,7 +31,7 @@ from xml.etree import ElementTree as ETree
 
 from collections import defaultdict
 from fractions import Fraction
-from unittest import mock  # pylint: disable=no-name-in-module
+from unittest import mock
 
 from music21 import articulations
 from music21 import bar

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -2420,7 +2420,6 @@ class Metadata(base.Music21Object):
 
         if valueType is int:
             # noinspection PyBroadException
-            # pylint: disable=bare-except
             try:
                 return int(value)
             except:

--- a/music21/metadata/caching.py
+++ b/music21/metadata/caching.py
@@ -377,7 +377,7 @@ class JobProcessor:
 # -----------------------------------------------------------------------------
 
 
-class WorkerProcess(multiprocessing.Process):  # pylint: disable=inherit-non-class
+class WorkerProcess(multiprocessing.Process):
     '''
     A worker process for use by the multithreaded metadata-caching job
     processor.

--- a/music21/metadata/primitives.py
+++ b/music21/metadata/primitives.py
@@ -399,7 +399,6 @@ class Date(prebase.ProtoM21Object):
         Traceback (most recent call last):
         TypeError: ...argument 'day' (pos 3)...
         '''
-        # pylint: disable=no-value-for-parameter
         post = []
         # order here is order for datetime
         # TODO: need defaults for incomplete times.

--- a/music21/midi/__init__.py
+++ b/music21/midi/__init__.py
@@ -352,8 +352,7 @@ class _ContainsEnum(IntEnum):
 
     @classmethod
     def hasValue(cls, val):
-        # https://github.com/PyCQA/pylint/issues/3941
-        return val in cls._value2member_map_  # pylint: disable=no-member
+        return val in cls._value2member_map_
 
 
 class ChannelVoiceMessages(_ContainsEnum):

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6959,7 +6959,6 @@ class MeasureExporter(XMLExporterBase):
         if mxMeasureStyle is not None:
             mxAttributes.append(mxMeasureStyle)
 
-        # pylint: disable=len-as-condition
         if len(mxAttributes) > 0 or mxAttributes.attrib:
             self.xmlRoot.append(mxAttributes)
         return mxAttributes

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -788,7 +788,6 @@ class XMLParserBase:
             staffLayout.staffNumber = staffNumber
 
         if hasattr(self, 'staffLayoutObjects') and hasattr(self, 'offsetMeasureNote'):
-            # pylint: disable=no-member
             staffLayoutKey = ((staffNumber or 1), self.offsetMeasureNote)
             self.staffLayoutObjects[staffLayoutKey] = staffLayout
 
@@ -863,7 +862,6 @@ class MusicXMLImporter(XMLParserBase):
         self.xmlRootToScore(self.xmlRoot, self.stream)
 
     def parseXMLText(self):
-        # pylint: disable=undefined-variable
         if isinstance(self.xmlText, bytes):
             self.xmlText = self.xmlText.decode('utf-8')
         sio = io.StringIO(self.xmlText)
@@ -2031,7 +2029,7 @@ class PartParser(XMLParserBase):
             e.measureNumber = str(measureParser.measureNumber)
             e.partName = self.stream.partName
             raise e
-        except Exception as e:  # pylint: disable=broad-exception-caught
+        except Exception as e:
             warnings.warn(
                 f'The following exception took place in m. {measureParser.measureNumber} in '
                 + f'part {self.stream.partName}.',
@@ -2933,13 +2931,13 @@ class MeasureParser(XMLParserBase):
             for sp in ss:
                 sp.replaceSpannedElement(n, c)
             for art in n.articulations:
-                if type(art) in seenArticulations:  # pylint: disable=unidiomatic-typecheck
+                if type(art) in seenArticulations:
                     continue
                 c.articulations.append(art)
                 if not isinstance(art, articulations.Fingering):
                     seenArticulations.add(type(art))
             for exp in n.expressions:
-                if type(exp) in seenExpressions:  # pylint: disable=unidiomatic-typecheck
+                if type(exp) in seenExpressions:
                     continue
                 c.expressions.append(exp)
                 seenExpressions.add(type(exp))

--- a/music21/note.py
+++ b/music21/note.py
@@ -1590,7 +1590,7 @@ class Note(NotRest):
         '''
         new = self._deepcopySubclassable(memo)
         # noinspection PyProtectedMember
-        new.pitch._client = new  # pylint: disable=no-member
+        new.pitch._client = new
         return new
 
     # --------------------------------------------------------------------------

--- a/music21/romanText/rtObjects.py
+++ b/music21/romanText/rtObjects.py
@@ -946,7 +946,7 @@ class RTOpenParens(RTAtom):
     <music21.romanText.rtObjects.RTOpenParens '('>
     '''
 
-    def __init__(self, src='(', container=None):  # pylint: disable=useless-super-delegation
+    def __init__(self, src='(', container=None):
         super().__init__(src, container)
 
 
@@ -958,7 +958,7 @@ class RTCloseParens(RTAtom):
     <music21.romanText.rtObjects.RTCloseParens ')'>
     '''
 
-    def __init__(self, src=')', container=None):  # pylint: disable=useless-super-delegation
+    def __init__(self, src=')', container=None):
         super().__init__(src, container)
 
 
@@ -1033,7 +1033,7 @@ class RTPhraseBoundary(RTPhraseMarker):
     <music21.romanText.rtObjects.RTPhraseBoundary '||'>
     '''
 
-    def __init__(self, src='||', container=None):  # pylint: disable=useless-super-delegation
+    def __init__(self, src='||', container=None):
         super().__init__(src, container)
 
 
@@ -1044,7 +1044,7 @@ class RTEllisonStart(RTPhraseMarker):
     <music21.romanText.rtObjects.RTEllisonStart '|*'>
     '''
 
-    def __init__(self, src='|*', container=None):  # pylint: disable=useless-super-delegation
+    def __init__(self, src='|*', container=None):
         super().__init__(src, container)
 
 
@@ -1055,7 +1055,7 @@ class RTEllisonStop(RTPhraseMarker):
     <music21.romanText.rtObjects.RTEllisonStop '*|'>
     '''
 
-    def __init__(self, src='*|', container=None):  # pylint: disable=useless-super-delegation
+    def __init__(self, src='*|', container=None):
         super().__init__(src, container)
 
 
@@ -1074,7 +1074,7 @@ class RTRepeatStart(RTRepeat):
     <music21.romanText.rtObjects.RTRepeatStart ...'||:'>
     '''
 
-    def __init__(self, src='||:', container=None):  # pylint: disable=useless-super-delegation
+    def __init__(self, src='||:', container=None):
         super().__init__(src, container)
 
 
@@ -1085,7 +1085,7 @@ class RTRepeatStop(RTRepeat):
     <music21.romanText.rtObjects.RTRepeatStop ...':||'>
     '''
 
-    def __init__(self, src=':||', container=None):  # pylint: disable=useless-super-delegation
+    def __init__(self, src=':||', container=None):
         super().__init__(src, container)
 
 

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -381,7 +381,7 @@ class PartTranslator:
         for token in tokens:
             try:
                 self.translateOneLineToken(token)
-            except Exception:  # pylint: disable=broad-exception-caught
+            except Exception:
                 tracebackMessage = traceback.format_exc()
                 raise RomanTextTranslateException(
                     f'At line {token.lineNumber} for token {token}, '

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -2338,7 +2338,7 @@ class IntervalNetwork:
             n = self.nodes[nId]
             if n.degree not in degreeCount:
                 degreeCount[n.degree] = 0
-            g.node[nId]['pos'] = (degreeCount[n.degree], n.degree)  # pylint: disable=no-member
+            g.node[nId]['pos'] = (degreeCount[n.degree], n.degree)
             degreeCount[n.degree] += 1
         environLocal.printDebug(['got degree count', degreeCount])
         return g

--- a/music21/search/__init__.py
+++ b/music21/search/__init__.py
@@ -39,5 +39,4 @@ from music21.search import lyrics
 from music21.search import segment
 from music21.search import serial
 
-# __init__ can wildcard import base; it's how it is designed.
-from music21.search.base import *  # pylint: disable=wildcard-import
+from music21.search.base import *

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -1364,8 +1364,6 @@ class Test(unittest.TestCase):
                          ['D', 'C#', 'A', 'B-', 'F', 'E-', 'E', 'C', 'G#', 'G', 'F#', 'B'])
         s37 = getHistoricalRowByName('SchoenbergOp37').matrix()
         r0 = s37[0]
-        # r0 is in fact an iterable object
-        # pylint: disable=not-an-iterable
         self.assertEqual([e.name for e in r0],
                          ['C', 'B', 'G', 'G#', 'E-', 'C#', 'D', 'B-', 'F#', 'F', 'E', 'A'])
 

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -955,7 +955,7 @@ class Sites(common.SlottedObjectMixin):
             del self.siteDict[siteId]
             # environLocal.printDebug(['removed site w/o exception:', siteId,
             #    'self.siteDict.keys()', self.siteDict.keys()])
-        except Exception as e:  # pylint: disable=broad-exception-caught
+        except Exception as e:
             raise SitesException(
                 'an entry for this object '
                 + f'({site}) is not stored in this Sites object'

--- a/music21/test/multiprocessTest.py
+++ b/music21/test/multiprocessTest.py
@@ -151,7 +151,6 @@ def mainPoolRunner(testGroup=('test',), restoreEnvironmentDefaults=False, leaveO
     pathsToRun = modGather.modulePaths  # [30:60]
     # print(pathsToRun)
 
-    # pylint: disable=not-callable
     with multiprocessing.Pool(processes=poolSize) as pool:
 
         # imap returns the results as they are completed.

--- a/music21/test/test_note.py
+++ b/music21/test/test_note.py
@@ -46,7 +46,7 @@ class Test(unittest.TestCase):
         self.assertEqual(matchStr, outStr)
         i = 0
         for thisNote in note1.splitAtDurations():
-            matchSub = matchStr.split('\n')[i]  # pylint: disable=use-maxsplit-arg
+            matchSub = matchStr.split('\n')[i]
             conv = LilypondConverter()
             conv.appendM21ObjectToContext(thisNote)
             outStr = str(conv.context).replace(' ', '').strip()

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -870,7 +870,7 @@ class Verticality(prebase.ProtoM21Object):
                 continue
             el = timeSpan.element
             if isinstance(el, chord.Chord):
-                if len(el) == 0:  # pylint: disable=len-as-condition
+                if len(el) == 0:
                     continue
 
                 if el.articulations or el.expressions:
@@ -894,7 +894,6 @@ class Verticality(prebase.ProtoM21Object):
         seenArticulations = set()
         seenExpressions = set()
 
-        # pylint: disable=unidiomatic-typecheck
         for n in sorted(notesToAdd.values(), key=lambda x: x.pitch.ps):
             c.add(n)
             if gatherArticulations:

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -191,7 +191,7 @@ class VoiceLeadingQuartet(base.Music21Object):
         if isinstance(keyValue, str):
             try:
                 keyValue = key.Key(key.convertKeyStringToMusic21KeyString(keyValue))
-            except Exception as e:  # pragma: no cover  # pylint: disable=broad-exception-caught
+            except Exception as e:  # pragma: no cover
                 raise VoiceLeadingQuartetException(
                     f'got a key signature string that is not supported: {keyValue}'
                 ) from e
@@ -200,7 +200,7 @@ class VoiceLeadingQuartet(base.Music21Object):
                 isKey = (isinstance(keyValue, key.Key))
                 if isKey is False:
                     raise AttributeError
-            except AttributeError:  # pragma: no cover  # pylint: disable=raise-missing-from
+            except AttributeError:  # pragma: no cover
                 raise VoiceLeadingQuartetException(
                     'got a key signature that is not a string or music21 Key '
                     + f'object: {keyValue}'
@@ -225,7 +225,7 @@ class VoiceLeadingQuartet(base.Music21Object):
                     n.duration.quarterLength = 0.0
                     n.pitch = value
                     setattr(self, which, n)
-            except Exception as e:  # pragma: no cover  # pylint: disable=broad-exception-caught
+            except Exception as e:  # pragma: no cover
                 raise VoiceLeadingQuartetException(
                     f'not a valid note specification: {value!r}'
                 ) from e

--- a/music21/volpiano.py
+++ b/music21/volpiano.py
@@ -298,7 +298,7 @@ def toPart(volpianoText, *, breaksToLayout=False):
 
     if continuousNumberOfBreakTokens > 0:
         breakClass = classByNumBreakTokens[continuousNumberOfBreakTokens]
-        breakToken = breakClass()  # pylint: disable=not-callable
+        breakToken = breakClass()
         currentMeasure.append(breakToken)
 
     if m:


### PR DESCRIPTION
Not the most substantial PR, but it's nice to remove useless pylint disables every once in a while.

Found this with the `--enable=useless-suppression` argument.