### PR TITLE
Better errors on pitch creation

### DIFF
--- a/dist/dist.py
+++ b/dist/dist.py
@@ -28,6 +28,10 @@ so allocate time.  Start working on the announcement while it's running.
 
 
 4. run test/warningMultiprocessTest.py for lowest and highest Py version -- fix all warnings!
+4b. run `from music21.test import treeYield
+    and then run `treeYield.find_all_non_hashable_m21objects()` and check that the set returned is
+    empty.  Note -- it will print a bunch of module names, but only the final set matters.
+    Then do the same for `treeYield.find_all_non_default_instantiation_m21objects()`.
 5. commit and wait for results on GitHub Actions
      (normally not necessary, because it's slower and mostly duplicates multiprocessTest,
      but should be done before making a release).
@@ -64,10 +68,10 @@ so allocate time.  Start working on the announcement while it's running.
 18. Push tags: git push --tags  (or git push upstream --tags if not on main branch)
 
 19. Create a new release on GitHub and upload the TWO non-wheel files created here and docs.
-    Drag in this order: .tar.gz, documentation, no-corpus.tar.gz
+    Drag in this order: .tar.gz, -docs.zip, no-corpus.tar.gz
 
     Finish this before doing the next step, even though it looks like it could be done in parallel.
-
+    
 20. Upload the new file to PyPI with "twine upload music21-7.3.5a2.tar.gz", and same for the
     whl file (but NOT no corpus) [*]
 

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ Changing this number invalidates old pickles -- do it if the old pickles create 
 '''
 from __future__ import annotations
 
-__version__ = '9.1.0'
+__version__ = '9.2.0b1'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -27,7 +27,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'9.1.0'
+'9.2.0b1'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -2781,15 +2781,23 @@ class Pitch(prebase.ProtoM21Object):
         Set name, which may be provided with or without octave values. C4 or D-3
         are both accepted.
         '''
-        usrStr = usrStr.strip()
+        try:
+            usrStr = usrStr.strip()
+        except AttributeError:
+            raise ValueError(f'Argument to name, {usrStr!r}, must be a string, not {type(usrStr)}.')
+
         # extract any numbers that may be octave designations
         octFound: list[str] = []
         octNot: list[str] = []
 
+        foundNonOctave = False
         for char in usrStr:
             if char in '0123456789':
+                if not foundNonOctave:
+                    raise ValueError(f'Cannot have octave given before pitch name in {usrStr!r}.')
                 octFound.append(char)
             else:
+                foundNonOctave = True
                 octNot.append(char)
         usrStr = ''.join(octNot)
         octFoundStr = ''.join(octFound)

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -920,7 +920,7 @@ class IntervalNetwork:
 
         If `equateTermini` is True, the terminals will be given the same degree.
         '''
-        post = OrderedDict()
+        post: OrderedDict[Terminus | int, int] = OrderedDict()
         for nId, n in self.nodes.items():
             if equateTermini:
                 if nId == Terminus.HIGH:

--- a/music21/test/test_pitch.py
+++ b/music21/test/test_pitch.py
@@ -44,7 +44,7 @@ class Test(unittest.TestCase):
 
     def testNameSetting(self):
         with self.assertRaisesRegex(ValueError,
-                                    "Cannot have octave given before pitch name in '8D-4'\."):
+                                    r"Cannot have octave given before pitch name in '8D-4'\."):
             p = Pitch('8D-4')
         with self.assertRaises(ValueError):
             p = Pitch('23')

--- a/music21/test/test_pitch.py
+++ b/music21/test/test_pitch.py
@@ -42,6 +42,22 @@ class Test(unittest.TestCase):
         b = Pitch('B#3')
         self.assertEqual(b.octave, 3)
 
+    def testNameSetting(self):
+        with self.assertRaisesRegex(ValueError,
+                                    "Cannot have octave given before pitch name in '8D-4'\."):
+            p = Pitch('8D-4')
+        with self.assertRaises(ValueError):
+            p = Pitch('23')
+        p = Pitch(23)
+        self.assertEqual(p.midi, 23)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Argument to name, 32, must be a string, not <class 'int'>."
+        ):
+            p.name = 32
+
+
+
     def testAccidentalImport(self):
         '''
         Test that we are getting the properly set accidentals

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ pylint>=2.16.0
 flake8<6.0.0
 flake8-quotes
 hatchling
-mypy>=0.990
+mypy>=1.4.0
 coveralls
 scipy
 sphinx


### PR DESCRIPTION
Better errors are now given on invalid pitch creation like '60' (string) instead of 60 (int).

Tightens up a bug discovered by @vanderstel  (private communication) where Pitch('2D#5') was allowed and created a D# in octave 25.

(unrelated tiny dist.py improvements added here -- notes from release of 9.0 -- change version to 9.2 beta