### PR TITLE
Upgrade flake8 to v6

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
 wheel
 pylint>=2.16.0
-flake8<6.0.0
-flake8-quotes
+flake8<7.0.0
+flake8-quotes>=3.3.2
 hatchling
 mypy>=0.990
 coveralls


### PR DESCRIPTION
Flake8-quotes now has a compatible version which is what we were waiting for.

Now no versions are pinned to less-than-highest.