### PR TITLE
Mini-optimization to updateEndTimes

### DIFF
--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -241,9 +241,8 @@ def asTree(
             if classList and element.classSet.isdisjoint(classList):
                 continue
 
-            endTime = flatOffset + element.duration.quarterLength
-
             if useTimespans:
+                endTime = flatOffset + element.duration.quarterLength
                 pitchedTimespan = spans.PitchedTimespan(
                     element=element,
                     parentage=tuple(reversed(currentParentage)),

--- a/music21/tree/node.py
+++ b/music21/tree/node.py
@@ -260,14 +260,13 @@ class ElementNode(core.AVLNode):
 
         Returns None.
         '''
-        pos = self.position
-        if isinstance(pos, SortTuple):
-            pos = pos.offset
-
         try:
             endTimeLow = self.payload.endTime
             endTimeHigh = endTimeLow
         except AttributeError:  # elements do not have endTimes. do NOT mix elements and timespans.
+            pos = self.position
+            if isinstance(pos, SortTuple):
+                pos = pos.offset
             endTimeLow = pos + self.payload.duration.quarterLength
             endTimeHigh = endTimeLow
 


### PR DESCRIPTION
Very slightly improves the performance of `updateEndTimes` which is called millions of times in some tree-related tasks.
Does not affect functionality. Same for `recurseGetTreeByClass`.