### PR TITLE
Speed up Duration deepcopy

### DIFF
--- a/music21/duration.py
+++ b/music21/duration.py
@@ -1807,7 +1807,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         Don't copy client when creating
         '''
         if self._componentsNeedUpdating:
-            self._updateComponents()
+            return common.defaultDeepcopy(self, memo, ignoreAttributes={'client'})
 
         if (len(self._components) == 1
                 and self._dotGroups == (0,)


### PR DESCRIPTION
Instead of updating the components during deepcopy (which is expensive), we can defer this update until it is actually needed and just copy the object for now. This speeds up tasks that use derivations (e.g. `quantize`) by up to 30% on my machine. 