### PR TITLE
Speed up hasElement by 2x

### DIFF
--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1434,7 +1434,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             if hasattr(other, attr):
                 setattr(self, attr, getattr(other, attr))
 
-    def hasElement(self, obj):
+    def hasElement(self, obj: base.Music21Object) -> bool:
         '''
         Return True if an element, provided as an argument, is contained in
         this Stream.
@@ -1449,8 +1449,16 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> s.hasElement(n1)
         True
         '''
-        objId = id(obj)
-        return self.coreHasElementByMemoryLocation(objId)
+        if id(obj) in self._offsetDict:
+            return True
+
+        for e in self._elements:
+            if e is obj:  # pragma: no cover
+                return True
+        for e in self._endElements:
+            if e is obj:  # pragma: no cover
+                return True
+        return False
 
     def hasElementOfClass(self, className, forceFlat=False):
         '''

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -335,32 +335,6 @@ class StreamCore(Music21Object):
             post.setDerivationMethod(methodName, recurse=True)
         return post
 
-    def coreHasElementByMemoryLocation(self, objId: int) -> bool:
-        '''
-        NB -- a "core" stream method that is not necessary for most users. use hasElement(obj)
-
-        Return True if an element object id, provided as an argument, is contained in this Stream.
-
-        >>> s = stream.Stream()
-        >>> n1 = note.Note('g')
-        >>> n2 = note.Note('g#')
-        >>> s.append(n1)
-        >>> s.coreHasElementByMemoryLocation(id(n1))
-        True
-        >>> s.coreHasElementByMemoryLocation(id(n2))
-        False
-        '''
-        if objId in self._offsetDict:
-            return True
-
-        for e in self._elements:
-            if id(e) == objId:  # pragma: no cover
-                return True
-        for e in self._endElements:
-            if id(e) == objId:  # pragma: no cover
-                return True
-        return False
-
     def coreGetElementByMemoryLocation(self, objId):
         '''
         NB -- a "core" stream method that is not necessary for most users.


### PR DESCRIPTION
Instead of comparing the result of the `id` function between objects, we can use the built-in `is` operator to achieve the same in half the time. `coreHasElementByMemoryLocation` was only used this one time and can therefore be removed as well.