### PR TITLE
speed up sortTuple for streams

### DIFF
--- a/music21/base.py
+++ b/music21/base.py
@@ -2725,10 +2725,8 @@ class Music21Object(prebase.ProtoM21Object):
             offset = t.cast(OffsetQL, foundOffset)
             atEnd = 0
 
-        if self.duration.isGrace:
-            isNotGrace = 0
-        else:
-            isNotGrace = 1
+        # avoids expensive duration computation for streams, which can never be grace notes
+        isNotGrace = 1 if self.isStream or not self.duration.isGrace else 0
 
         if self.sites.hasSiteId(id(useSite)):
             insertIndex = self.sites.siteDict[id(useSite)].globalSiteIndex


### PR DESCRIPTION
This avoids the computation of the duration attribute when creating a stream's `sortTuple`, which is expensive as it requires iterating over all elements to compute `highestTime`.
Yields significant speedups on tasks that require sorting (12% overall for a simple load + quantize benchmark on my machine).