### PR TITLE
SoundParser to a separate file

### DIFF
--- a/music21/musicxml/helpers.py
+++ b/music21/musicxml/helpers.py
@@ -12,9 +12,20 @@
 from __future__ import annotations
 
 import copy
+import typing as t
 from xml.etree.ElementTree import tostring as et_tostring
 
+from music21 import common
 from music21 import meter
+from music21.musicxml import xmlObjects
+from music21 import prebase
+
+if t.TYPE_CHECKING:
+    from collections.abc import Callable
+    import xml.etree.ElementTree as ET
+
+    from music21.base import Music21Object
+
 
 def dumpString(obj, *, noCopy=False) -> str:
     r'''
@@ -193,6 +204,200 @@ def isFullMeasureRest(r: 'music21.note.Rest') -> bool:
         if tsContext and tsContext.barDuration.quarterLength == r.duration.quarterLength:
             isFullMeasure = True
     return isFullMeasure
+
+
+def synchronizeIdsToM21(element: ET.Element, m21Object: Music21Object):
+    '''
+    MusicXML 3.1 defines the id attribute
+    (%optional-unique-id)
+    on many elements which is perfect for setting as .id on
+    a music21 element.
+
+    <fermata id="hello"><id>bye</id></fermata>
+
+    >>> from xml.etree.ElementTree import fromstring as El
+    >>> e = El('<fermata id="fermata1"/>')
+    >>> f = expressions.Fermata()
+    >>> musicxml.helpers.synchronizeIdsToM21(e, f)
+    >>> f.id
+    'fermata1'
+
+    Does not change the id if the id is not specified:
+
+    >>> e = El('<fermata />')
+    >>> f = expressions.Fermata()
+    >>> f.id = 'doNotOverwrite'
+    >>> musicxml.helpers.synchronizeIdsToM21(e, f)
+    >>> f.id
+    'doNotOverwrite'
+    '''
+    newId = element.get('id', None)
+    if not newId:
+        return
+    m21Object.id = newId
+
+def synchronizeIdsToXML(
+    element: ET.Element,
+    m21Object: prebase.ProtoM21Object | None
+) -> None:
+    # noinspection PyTypeChecker
+    '''
+    MusicXML 3.1 defines the id attribute (entity: %optional-unique-id)
+    on many elements which is perfect for getting from .id on
+    a music21 element.
+
+    >>> from xml.etree.ElementTree import fromstring as El
+    >>> e = El('<fermata />')
+    >>> f = expressions.Fermata()
+    >>> f.id = 'fermata1'
+    >>> musicxml.helpers.synchronizeIdsToXML(e, f)
+    >>> e.get('id')
+    'fermata1'
+
+    Does not set attr: id if el.id is not valid or default:
+
+    >>> e = El('<fermata />')
+    >>> f = expressions.Fermata()
+    >>> musicxml.helpers.synchronizeIdsToXML(e, f)
+    >>> e.get('id', None) is None
+    True
+    >>> f.id = '123456'  # invalid for MusicXML id
+    >>> musicxml.helpers.synchronizeIdsToXML(e, f)
+    >>> e.get('id', None) is None
+    True
+
+    None can be passed in instead of a m21object.
+
+    >>> e = El('<fermata />')
+    >>> musicxml.helpers.synchronizeIdsToXML(e, None)
+    >>> e.get('id', 'no idea')
+    'no idea'
+    '''
+    # had to suppress type-checking because of spurious error on
+    #    e.get('id', 'no idea')
+    if not isinstance(m21Object, prebase.ProtoM21Object):
+        return
+    if not hasattr(m21Object, 'id'):
+        return
+
+    m21Id = m21Object.id  # type: ignore
+
+    if m21Id is None:
+        return
+
+    if not xmlObjects.isValidXSDID(m21Id):
+        return
+    element.set('id', m21Id)
+
+
+
+def setM21AttributeFromAttribute(
+    m21El: t.Any,
+    xmlEl: ET.Element,
+    xmlAttributeName: str,
+    attributeName: str | None = None,
+    transform: Callable[[str], t.Any] | None = None,
+) -> None:
+    '''
+    If xmlEl has at least one element of tag==tag with some text. If
+    it does, set the attribute either with the same name (with "foo-bar" changed to
+    "fooBar") or with attributeName to the text contents.
+
+    Pass a function or lambda function as transform to transform the value before setting it
+
+    >>> from xml.etree.ElementTree import fromstring as El
+    >>> e = El('<page-layout new-page="yes" page-number="4" />')
+
+    >>> setb = musicxml.helpers.setM21AttributeFromAttribute
+    >>> pl = layout.PageLayout()
+    >>> setb(pl, e, 'page-number')
+    >>> pl.pageNumber
+    '4'
+
+    >>> setb(pl, e, 'new-page', 'isNew')
+    >>> pl.isNew
+    'yes'
+
+
+    Transform the pageNumber value to an int.
+
+    >>> setb(pl, e, 'page-number', transform=int)
+    >>> pl.pageNumber
+    4
+
+    More complex...
+
+    >>> convBool = musicxml.xmlObjects.yesNoToBoolean
+    >>> setb(pl, e, 'new-page', 'isNew', transform=convBool)
+    >>> pl.isNew
+    True
+    '''
+    value = xmlEl.get(xmlAttributeName)  # find first
+    if value is None:
+        return
+
+    if transform is not None:
+        value = transform(value)
+
+    if attributeName is None:
+        attributeName = common.hyphenToCamelCase(xmlAttributeName)
+    setattr(m21El, attributeName, value)
+
+
+def setXMLAttributeFromAttribute(
+    m21El: t.Any,
+    xmlEl: ET.Element,
+    xmlAttributeName: str,
+    attributeName: str | None = None,
+    transform: Callable[[t.Any], t.Any] | None = None
+):
+    '''
+    If m21El has at least one element of tag==tag with some text. If
+    it does, set the attribute either with the same name (with "foo-bar" changed to
+    "fooBar") or with attributeName to the text contents.
+
+    Pass a function or lambda function as transform to transform the value before setting it
+
+    >>> from xml.etree.ElementTree import fromstring as El
+    >>> e = El('<page-layout/>')
+
+    >>> setb = musicxml.helpers.setXMLAttributeFromAttribute
+    >>> pl = layout.PageLayout()
+    >>> pl.pageNumber = 4
+    >>> pl.isNew = True
+
+    >>> setb(pl, e, 'page-number')
+    >>> e.get('page-number')
+    '4'
+
+    >>> XB = musicxml.m21ToXml.XMLExporterBase()
+    >>> XB.dump(e)
+    <page-layout page-number="4" />
+
+    >>> setb(pl, e, 'new-page', 'isNew')
+    >>> e.get('new-page')
+    'True'
+
+
+    Transform the isNew value to 'yes'.
+
+    >>> convBool = musicxml.xmlObjects.booleanToYesNo
+    >>> setb(pl, e, 'new-page', 'isNew', transform=convBool)
+    >>> e.get('new-page')
+    'yes'
+    '''
+    if attributeName is None:
+        attributeName = common.hyphenToCamelCase(xmlAttributeName)
+
+    value = getattr(m21El, attributeName, None)
+    if value is None:
+        return
+
+    if transform is not None:
+        value = transform(value)
+
+    xmlEl.set(xmlAttributeName, str(value))
+
 
 
 if __name__ == '__main__':

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -16,20 +16,115 @@ Pulled out because xmlToM21 is getting way too big.
 '''
 from __future__ import annotations
 
+import typing as t
+import xml.etree.ElementTree as ET
+import warnings
+
+from music21 import common
+from music21 import duration
+from music21 import tempo
+
+from music21.musicxml import helpers
+
+if t.TYPE_CHECKING:
+    from music21.musicxml.xmlToM21 import MeasureParser
+
+
 class SoundTagMixin:
-    pass
-
-    def soundTagParser(self, mxSound):
+    '''
+    This Mixin is applied to MeasureParser -- it is moved
+    out from there because there is still a lot to write
+    here and xmlToM21.py is getting too big.
+    '''
+    def xmlSound(self, mxSound: ET.Element) -> None:
         '''
-        Returns a list of objects that represent the sound tag.
+        Convert a <sound> tag to one or more relevant objects
+        (presently just MetronomeMark),
+        and add it or them to the core and staffReference.
         '''
-        soundObjs = []
-        # pylint: disable=unused-variable
-        tempoNum = mxSound.get('tempo')  # @UnusedVariable
-        dynamicsNum = mxSound.get('dynamics')  # @UnusedVariable
+        if t.TYPE_CHECKING:
+            assert isinstance(self, MeasureParser) and isinstance(self, SoundTagMixin)
 
+        # offset is out of order because we need to know it before direction-type
+        offsetDirection = self.xmlToOffset(mxSound)
+        totalOffset = offsetDirection + self.offsetMeasureNote
+
+        staffKey = self.getStaffNumber(mxSound)
+
+        self.setSound(mxSound,
+                      None,
+                      staffKey,
+                      totalOffset)
+
+    def setSound(
+        self,
+        mxSound: ET.Element,
+        mxDir: ET.Element | None,
+        staffKey: int,
+        totalOffset: float
+    ) -> None:
+        '''
+        Takes a <sound> tag and creates objects from it.
+        Presently only handles <sound tempo='x'> events and inserts them as MetronomeMarks.
+        If the <sound> tag is a child of a <direction> tag, the direction information
+        is used to set the placement of the MetronomeMark.
+        '''
+        if t.TYPE_CHECKING:
+            assert isinstance(self, MeasureParser) and isinstance(self, SoundTagMixin)
+        # TODO: coda
+        # TODO: dacapo
+        # TODO: dalsegno
+        # TODO: damper-pedal
+        # TODO: divisions
+        # TODO: dynamics
+        # TODO: fine
+        # TODO: forward-repeat
+        # TODO: id
+        # TODO: pizzicato
+        # TODO: segno
+        # TODO: soft-pedal
+        # TODO: sostenuto-pedal
+        # TODO: time-only
+        # TODO: tocoda
         # TODO: musicxml4: swing: straight or first/second/swing-type, swing-style
         # TODO: musicxml4: instrument-change: instrument-sound, solo or ensemble or none
         #                                     virtual-instrument
+        if 'tempo' in mxSound.attrib:
+            self.setSoundTempo(mxSound, mxDir, staffKey, totalOffset)
 
-        return soundObjs
+
+    def setSoundTempo(
+        self,
+        mxSound: ET.Element,
+        mxDir: ET.Element | None,
+        staffKey: int,
+        totalOffset: float
+    ) -> None:
+        '''
+        Add a metronome mark from the tempo attribute of a <sound> tag.
+        '''
+        if t.TYPE_CHECKING:
+            assert isinstance(self, MeasureParser) and isinstance(self, SoundTagMixin)
+
+        qpm = common.numToIntOrFloat(float(mxSound.get('tempo', 0)))
+        if qpm == 0:
+            warnings.warn('0 qpm tempo tag found, skipping.')
+            return
+        mm = tempo.MetronomeMark(referent=duration.Duration(type='quarter'),
+                                 number=None,
+                                 numberSounding=qpm,
+                                 )
+        helpers.synchronizeIdsToM21(mxSound, mm)
+        self.setPrintObject(mxSound, mm)
+        self.setPosition(mxSound, mm)
+        if mxDir is not None:
+            helpers.setM21AttributeFromAttribute(
+                mm, mxDir, 'placement', 'placement'
+            )
+            self.setEditorial(mxDir, mm)
+        self.insertCoreAndRef(totalOffset, staffKey, mm)
+
+
+if __name__ == '__main__':
+    import music21
+    music21.mainTest()  # doctests only

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -56,7 +56,12 @@ from music21 import text  # for text boxes
 from music21 import tie
 
 from music21.musicxml import xmlObjects
+from music21.musicxml import helpers
+from music21.musicxml.xmlSoundParser import SoundTagMixin
 from music21.musicxml.xmlObjects import MusicXMLImportException, MusicXMLWarning
+
+synchronizeIds = helpers.synchronizeIdsToM21
+setAttributeFromAttribute = helpers.setM21AttributeFromAttribute
 
 if t.TYPE_CHECKING:
     from music21 import base
@@ -183,54 +188,6 @@ def _floatOrIntStr(strObj):
         return strObj
 
 
-def _setAttributeFromAttribute(m21El, xmlEl, xmlAttributeName,
-                               attributeName=None, transform=None):
-    '''
-    If xmlEl has at least one element of tag==tag with some text. If
-    it does, set the attribute either with the same name (with "foo-bar" changed to
-    "fooBar") or with attributeName to the text contents.
-
-    Pass a function or lambda function as transform to transform the value before setting it
-
-    >>> from xml.etree.ElementTree import fromstring as El
-    >>> e = El('<page-layout new-page="yes" page-number="4" />')
-
-    >>> setb = musicxml.xmlToM21._setAttributeFromAttribute
-    >>> pl = layout.PageLayout()
-    >>> setb(pl, e, 'page-number')
-    >>> pl.pageNumber
-    '4'
-
-    >>> setb(pl, e, 'new-page', 'isNew')
-    >>> pl.isNew
-    'yes'
-
-
-    Transform the pageNumber value to an int.
-
-    >>> setb(pl, e, 'page-number', transform=int)
-    >>> pl.pageNumber
-    4
-
-    More complex...
-
-    >>> convBool = musicxml.xmlObjects.yesNoToBoolean
-    >>> setb(pl, e, 'new-page', 'isNew', transform=convBool)
-    >>> pl.isNew
-    True
-    '''
-    value = xmlEl.get(xmlAttributeName)  # find first
-    if value is None:
-        return
-
-    if transform is not None:
-        value = transform(value)
-
-    if attributeName is None:
-        attributeName = common.hyphenToCamelCase(xmlAttributeName)
-    setattr(m21El, attributeName, value)
-
-
 def _setAttributeFromTagText(m21El, xmlEl, tag, attributeName=None, *, transform=None):
     '''
     If xmlEl has at least one element of tag==tag with some text. If
@@ -296,36 +253,6 @@ def _addMetadataItemFromTagText(m21md: metadata.Metadata, xmlEl, tag, mdUniqueNa
         return
 
     m21md.add(mdUniqueName, value)
-
-def _synchronizeIds(element, m21Object):
-    '''
-    MusicXML 3.1 defines the id attribute
-    (%optional-unique-id)
-    on many elements which is perfect for setting as .id on
-    a music21 element.
-
-    <fermata id="hello"><id>bye</id></fermata>
-
-    >>> from xml.etree.ElementTree import fromstring as El
-    >>> e = El('<fermata id="fermata1"/>')
-    >>> f = expressions.Fermata()
-    >>> musicxml.xmlToM21._synchronizeIds(e, f)
-    >>> f.id
-    'fermata1'
-
-    Does not change the id if the id is not specified:
-
-    >>> e = El('<fermata />')
-    >>> f = expressions.Fermata()
-    >>> f.id = 'doNotOverwrite'
-    >>> musicxml.xmlToM21._synchronizeIds(e, f)
-    >>> f.id
-    'doNotOverwrite'
-    '''
-    newId = element.get('id', None)
-    if not newId:
-        return
-    m21Object.id = newId
 
 
 # ------------------------------------------------------------------------------
@@ -656,7 +583,7 @@ class XMLParserBase:
         else:
             pageLayout = inputM21
 
-        setb = _setAttributeFromAttribute
+        setb = setAttributeFromAttribute
         setb(pageLayout, mxPrint, 'new-page', 'isNew', transform=xmlObjects.yesNoToBoolean)
         setb(pageLayout, mxPrint, 'page-number', transform=int)
 
@@ -723,7 +650,7 @@ class XMLParserBase:
         else:
             systemLayout = inputM21
 
-        setb = _setAttributeFromAttribute
+        setb = setAttributeFromAttribute
         setb(systemLayout, mxPrint, 'new-system', 'isNew', xmlObjects.yesNoToBoolean)
 
         # mxSystemLayout = mxPrint.get('systemLayout')
@@ -2358,7 +2285,7 @@ class PartParser(XMLParserBase):
 
 
 # -----------------------------------------------------------------------------
-class MeasureParser(XMLParserBase):
+class MeasureParser(SoundTagMixin, XMLParserBase):
     '''
     parser to work with a single <measure> tag.
 
@@ -2401,6 +2328,7 @@ class MeasureParser(XMLParserBase):
         'link': None,
         'bookmark': None,
         # Note: <print> is handled separately...
+        # <sound> and xmlSound are found in xmlSoundParser.py
     }
     def __init__(self,
                  mxMeasure: ET.Element | None = None,
@@ -2863,7 +2791,7 @@ class MeasureParser(XMLParserBase):
     def xmlToChord(self, mxNoteList: list[ET.Element]) -> chord.ChordBase:
         # noinspection PyShadowingNames
         '''
-        Given an a list of mxNotes, fill the necessary parameters
+        Given a list of mxNotes, fill the necessary parameters
 
         >>> from xml.etree.ElementTree import fromstring as EL
         >>> MP = musicxml.xmlToM21.MeasureParser()
@@ -3901,7 +3829,7 @@ class MeasureParser(XMLParserBase):
         tag = mxObj.tag
         if tag in xmlObjects.TECHNICAL_MARKS:
             tech = xmlObjects.TECHNICAL_MARKS[tag]()
-            _synchronizeIds(mxObj, tech)
+            synchronizeIds(mxObj, tech)
             if tag == 'fingering':
                 self.handleFingering(tech, mxObj)
             if tag in ('handbell', 'other-technical') and strippedText(mxObj):
@@ -4011,7 +3939,7 @@ class MeasureParser(XMLParserBase):
         tag = mxObj.tag
         if tag in xmlObjects.ARTICULATION_MARKS:
             articulationObj = xmlObjects.ARTICULATION_MARKS[tag]()
-            _synchronizeIds(mxObj, articulationObj)
+            synchronizeIds(mxObj, articulationObj)
 
             self.setPrintStyle(mxObj, articulationObj)
             self.setPlacement(mxObj, articulationObj)
@@ -4246,7 +4174,7 @@ class MeasureParser(XMLParserBase):
             idFound = mxObj.get('number')
             if mxType in ('up', 'down'):
                 sp = spanner.Ottava()
-                # MusicXML pitches are encoded at sounding octaves
+                # MusicXML's pitches are encoded at sounding octaves
                 # Thus, set non-transposing
                 sp.transposing = False
                 if mxType == 'up':
@@ -4316,7 +4244,7 @@ class MeasureParser(XMLParserBase):
 
                 # TODO: attr bend-sound on <slide> only
                 self.setPrintStyle(mxObj, gliss)
-                _synchronizeIds(mxObj, gliss)
+                synchronizeIds(mxObj, gliss)
 
     def xmlToTremolo(self, mxTremolo, n):
         '''
@@ -4378,7 +4306,7 @@ class MeasureParser(XMLParserBase):
             su.completeStatus = True
             # only add after complete
         elif mxObj.get('type') == 'start':
-            _synchronizeIds(mxObj, su)
+            synchronizeIds(mxObj, su)
 
         return su
 
@@ -4446,7 +4374,7 @@ class MeasureParser(XMLParserBase):
             mxTiedList = mxNotations.findall('tied')
             if mxTiedList:
                 firstTied = mxTiedList[0]
-                _synchronizeIds(firstTied, tieObj)
+                synchronizeIds(firstTied, tieObj)
 
                 tieStyle = firstTied.get('line-type')
                 if tieStyle is not None and tieStyle != 'wavy':  # do not support wavy...
@@ -5269,10 +5197,14 @@ class MeasureParser(XMLParserBase):
         # avoiding doubled metronomes.
         if not metronome_added:
             for mxSound in mxDirection.findall('sound'):
+                if 'tempo' not in mxSound.attrib:
+                    continue
+                # setSoundTempo is defined in xmlSoundParser.py
                 self.setSound(mxSound,
                               mxDirection,
                               staffKey,
                               totalOffset)
+                break
 
         # TODO: musicxml 4:listening
 
@@ -5323,7 +5255,7 @@ class MeasureParser(XMLParserBase):
             else:
                 rm = repeat.Coda()
 
-            _synchronizeIds(mxDir, rm)
+            synchronizeIds(mxDir, rm)
             self.setPosition(mxDir, rm)
             self.insertCoreAndRef(totalOffset, staffKey, rm)
             self.setEditorial(mxDirection, rm)
@@ -5331,22 +5263,22 @@ class MeasureParser(XMLParserBase):
         elif tag == 'metronome':
             mm = self.xmlToTempoIndication(mxDir)
             # SAX was offsetMeasureNote; bug? should be totalOffset???
-            _setAttributeFromAttribute(mm, mxDirection, 'placement', 'placement')
+            setAttributeFromAttribute(mm, mxDirection, 'placement', 'placement')
             self.insertCoreAndRef(totalOffset, staffKey, mm)
             self.setEditorial(mxDirection, mm)
 
         elif tag == 'rehearsal':
-            rm = self.xmlToRehearsalMark(mxDir)
-            self.setStyleAttributes(mxDirection, rm, 'placement')
-            self.insertCoreAndRef(totalOffset, staffKey, rm)
-            self.setEditorial(mxDirection, rm)
+            rm_gen = self.xmlToRehearsalMark(mxDir)
+            self.setStyleAttributes(mxDirection, rm_gen, 'placement')
+            self.insertCoreAndRef(totalOffset, staffKey, rm_gen)
+            self.setEditorial(mxDirection, rm_gen)
 
         elif tag == 'words':
             textExpression = self.xmlToTextExpression(mxDir)
             # environLocal.printDebug(['got TextExpression object', repr(te)])
             # offset here is a combination of the current position
             # (offsetMeasureNote) and the direction's offset
-            _setAttributeFromAttribute(textExpression, mxDirection, 'placement', 'placement')
+            setAttributeFromAttribute(textExpression, mxDirection, 'placement', 'placement')
 
             repeatExpression = textExpression.getRepeatExpression()
             if repeatExpression is not None:
@@ -5376,75 +5308,12 @@ class MeasureParser(XMLParserBase):
 
         d = dynamics.Dynamic(m21DynamicText)
 
-        _synchronizeIds(mxDyn, d)
-        _setAttributeFromAttribute(d, mxDirection, 'placement', 'placement')
+        synchronizeIds(mxDyn, d)
+        setAttributeFromAttribute(d, mxDirection, 'placement', 'placement')
 
         self.insertCoreAndRef(totalOffset, staffKey, d)
         self.setPosition(mxDir, d)
         self.setEditorial(mxDirection, d)
-
-    def xmlSound(self, mxSound: ET.Element):
-        '''
-        Convert a <sound> tag to a relevant object (presently just MetronomeMark),
-        and add it to the core and staffReference.
-        '''
-        # offset is out of order because we need to know it before direction-type
-        offsetDirection = self.xmlToOffset(mxSound)
-        totalOffset = offsetDirection + self.offsetMeasureNote
-
-        staffKey = self.getStaffNumber(mxSound)
-
-        self.setSound(mxSound,
-                      None,
-                      staffKey,
-                      totalOffset)
-
-    def setSound(
-        self,
-        mxSound: ET.Element,
-        mxDir: ET.Element | None,
-        staffKey: int,
-        totalOffset: float
-    ):
-        '''
-        Takes a <sound> tag and creates objects from it.
-        Presently only handles <sound tempo='x'> events and inserts them as MetronomeMarks.
-        If the <sound> tag is a child of a <direction> tag, the direction information
-        is used to set the placement of the MetronomeMark.
-        '''
-        # TODO: move to xmlSoundParser.py where is should have been.
-
-        # TODO: coda
-        # TODO: dacapo
-        # TODO: dalsegno
-        # TODO: damper-pedal
-        # TODO: divisions
-        # TODO: dynamics
-        # TODO: fine
-        # TODO: forward-repeat
-        # TODO: id
-        # TODO: pizzicato
-        # TODO: segno
-        # TODO: soft-pedal
-        # TODO: sostenuto-pedal
-        # TODO: time-only
-        # TODO: tocoda
-        if 'tempo' in mxSound.attrib:
-            qpm = common.numToIntOrFloat(float(mxSound.get('tempo', 0)))
-            if qpm == 0:
-                warnings.warn('0 qpm tempo tag found, skipping.')
-                return
-            mm = tempo.MetronomeMark(referent=duration.Duration(type='quarter'),
-                                     number=None,
-                                     numberSounding=qpm,
-                                     )
-            _synchronizeIds(mxSound, mm)
-            self.setPrintObject(mxSound, mm)
-            self.setPosition(mxSound, mm)
-            if mxDir is not None:
-                _setAttributeFromAttribute(mm, mxDir, 'placement', 'placement')
-                self.setEditorial(mxDir, mm)
-            self.insertCoreAndRef(totalOffset, staffKey, mm)
 
     def xmlToTextExpression(self, mxWords):
         # noinspection PyShadowingNames
@@ -5561,7 +5430,7 @@ class MeasureParser(XMLParserBase):
             if paren == 'yes':
                 mm.parentheses = True
 
-        _synchronizeIds(mxMetronome, mm)
+        synchronizeIds(mxMetronome, mm)
 
         self.setPrintObject(mxMetronome, mm)  # new in 4.0 -- do not output until we output 4.0
         self.setPosition(mxMetronome, mm)
@@ -5741,7 +5610,7 @@ class MeasureParser(XMLParserBase):
         else:
             post = interval.Interval('P1')  # guaranteed to return an interval object.
 
-        _synchronizeIds(mxTranspose, post)
+        synchronizeIds(mxTranspose, post)
 
         return post
 
@@ -6210,9 +6079,6 @@ class MeasureParser(XMLParserBase):
         if mxStaffType is not None:
             try:
                 xmlText: str = mxStaffType.text.strip()
-                # inspection bug: https://youtrack.jetbrains.com/issue/PY-42287
-                # remove "no inspection..." when issue is closed
-                # noinspection PyArgumentList
                 stl.staffType = stream.enums.StaffType(xmlText)
             except ValueError:
                 warnings.warn(

--- a/music21/noteworthy/binaryTranslate.py
+++ b/music21/noteworthy/binaryTranslate.py
@@ -601,7 +601,9 @@ class NWCStaff:
         dumpObjects = []
 
         # default to first midi instrument
-        instruName = self.instrumentName.decode('latin_1') if self.instrumentName else 'Acoustic Grand Piano'
+        instruName = (self.instrumentName.decode('latin_1')
+                      if self.instrumentName
+                      else 'Acoustic Grand Piano')
         label = self.label.decode('latin_1') if self.label else instruName
 
         staffString = '|AddStaff|Name:' + label


### PR DESCRIPTION
Going in the opposite direction as #1599 -- move MusicXML `<sound>` tag parsing to a separate file along with several helpers to helpers.py -- both m21ToXML and xmlToM21 are getting huge! so anything to try to make these files more manageable is the right direction.

While fixing mypy errors, noticed a bunch of warnings that things that were typed were not being checked in noteworthy/binaryTranslate.py -- checked these and fixed.  (TODO: make the contents of untyped functions are not checked become an error in CI)