### PR TITLE
Speed up __contains__ by 2x and deprecate hasElement

### DIFF
--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -286,12 +286,12 @@ class ScoreReduction:
             return
 
         removalIndices = []
-        if m.hasElement(n):
+        if n in m:
             offset = n.getOffsetBySite(m)
         else:  # it is in a Voice
             offset = 0.0
             for v in m.voices:
-                if v.hasElement(n):
+                if n in v:
                     offset = n.getOffsetBySite(v)
 
 

--- a/music21/base.py
+++ b/music21/base.py
@@ -1256,7 +1256,7 @@ class Music21Object(prebase.ProtoM21Object):
             # of the site does not actually have this Music21Object in
             # its elements list, it is an orphan and should be removed
             # note: this permits non-site context Streams to continue
-            if s.isStream and not s.hasElement(self):
+            if s.isStream and not self in s:
                 if excludeStorageStreams:
                     # only get those that are not Storage Streams
                     if ('SpannerStorage' not in s.classes

--- a/music21/base.py
+++ b/music21/base.py
@@ -1256,7 +1256,7 @@ class Music21Object(prebase.ProtoM21Object):
             # of the site does not actually have this Music21Object in
             # its elements list, it is an orphan and should be removed
             # note: this permits non-site context Streams to continue
-            if s.isStream and not self in s:
+            if s.isStream and self not in s:
                 if excludeStorageStreams:
                     # only get those that are not Storage Streams
                     if ('SpannerStorage' not in s.classes

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -1193,8 +1193,8 @@ class Test(unittest.TestCase):
         sf.setupSerializationScaffold()
 
         # test safety
-        self.assertTrue(s2.hasElement(n1))
-        self.assertTrue(s1.hasElement(n1))
+        self.assertTrue(n1 in s2)
+        self.assertTrue(n1 in s1)
 
     def testJSONPickleSpanner(self):
         from music21 import converter

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -783,7 +783,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         except IndexError:
             return None
 
-    def __contains__(self, el):
+    def __contains__(self, el: base.Music21Object) -> bool:
         '''
         Returns True if `el` is in the stream (compared with Identity) and False otherwise.
 
@@ -811,8 +811,11 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> nC2 in s.elements
         True
         '''
-        return (any(sEl is el for sEl in self._elements)
-                or any(sEl is el for sEl in self._endElements))
+        # Should be the fastest implementation of this naive check, compare with
+        # https://stackoverflow.com/questions/44802682/python-any-unexpected-performance
+        return (id(el) in self._offsetDict
+                or any(True for sEl in self._elements if sEl is el)
+                or any(True for sEl in self._endElements if sEl is el))
 
     @property
     def elements(self) -> tuple[M21ObjType, ...]:
@@ -1433,7 +1436,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                      'definesExplicitPageBreaks', '_atSoundingPitch', '_mutable'):
             if hasattr(other, attr):
                 setattr(self, attr, getattr(other, attr))
-
+                
+    @deprecated('v10', 'v11', 'use `obj in stream` instead')
     def hasElement(self, obj: base.Music21Object) -> bool:
         '''
         Return True if an element, provided as an argument, is contained in
@@ -1449,16 +1453,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> s.hasElement(n1)
         True
         '''
-        if id(obj) in self._offsetDict:
-            return True
-
-        for e in self._elements:
-            if e is obj:  # pragma: no cover
-                return True
-        for e in self._endElements:
-            if e is obj:  # pragma: no cover
-                return True
-        return False
+        return obj in self
 
     def hasElementOfClass(self, className, forceFlat=False):
         '''

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1436,8 +1436,9 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                      'definesExplicitPageBreaks', '_atSoundingPitch', '_mutable'):
             if hasattr(other, attr):
                 setattr(self, attr, getattr(other, attr))
-                
-    @deprecated('v10', 'v11', 'use `obj in stream` instead')
+
+    @common.deprecated('v10', 'v11', 'Use `el in stream` instead of '
+                       '`stream.hasElement(el)`')
     def hasElement(self, obj: base.Music21Object) -> bool:
         '''
         Return True if an element, provided as an argument, is contained in
@@ -2008,7 +2009,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         # must manually add elements to new Stream
         for e in self._elements:
             # environLocal.printDebug(['deepcopy()', e, 'old', old, 'id(old)', id(old),
-            #     'new', new, 'id(new)', id(new), 'old.hasElement(e)', old.hasElement(e),
+            #     'new', new, 'id(new)', id(new), 'e in old', e in old,
             #     'e.activeSite', e.activeSite, 'e.getSites()', e.getSites(), 'e.getSiteIds()',
             #     e.getSiteIds()], format='block')
             #

--- a/music21/test/test_base.py
+++ b/music21/test/test_base.py
@@ -570,14 +570,14 @@ class Test(unittest.TestCase):
         n2 = copy.deepcopy(n1)
         self.assertEqual(id(n2.derivation.origin), id(n1))
 
-    def testHasElement(self):
+    def testContains(self):
         n1 = note.Note()
         s1 = stream.Stream()
         s1.append(n1)
         s2 = copy.deepcopy(s1)
         n2 = s2[0]  # this is a new instance; not the same as n1
-        self.assertFalse(s2.hasElement(n1))
-        self.assertTrue(s2.hasElement(n2))
+        self.assertFalse(n1 in s2)
+        self.assertTrue(n2 in s2)
 
         self.assertFalse(s1 in n2.sites)
         self.assertTrue(s2 in n2.sites)
@@ -622,7 +622,7 @@ class Test(unittest.TestCase):
             s.insert(i, el)
 
         for ew in storage:
-            self.assertTrue(s.hasElement(ew))
+            self.assertTrue(ew in s)
 
         match = [e.getOffsetBySite(s) for e in storage]
         self.assertEqual(match, [0.0, 1.0])
@@ -648,7 +648,7 @@ class Test(unittest.TestCase):
             s.insert(i, el)
 
         for ew in storage:
-            self.assertTrue(s.hasElement(ew))
+            self.assertTrue(ew in s)
 
         matchOffset = []
         matchBeatStrength = []


### PR DESCRIPTION
Follow up to #1621.
I am aware of the dev sabbatical, just opening the PR now so I don't forget about it later...

Proposal:
`hasElement` has identical functionality to `__contains__`. Since the Zen of Python teaches us that "There should be one-- and preferably only one --obvious way to do it.", I propose deprecating `hasElement` in favor of the more concise and pythonic `__contains__`.
In addition, I have  optimized the speed of the function by adding the fast `offsetDict` check to `__contains__`, and after stumbling on [this discussion](https://stackoverflow.com/questions/44802682/python-any-unexpected-performance), and changing the calls to `any`, the changes resulted in about a 2x speed-up on my machine, which is significant since the contains check is used a lot throughout the package.
For `self._elements` with fewer than 200 elements, this would be slightly faster (10%) still:

```python3
if len(self._elements) > 200:
    return any(True for x in self._elements if x is obj)
for el in self._elements:
    if el is obj:
        return True
return False
```

Since the absolute time spent in `__contains__` is dominated by checks with large `self._elements`, I think the trade-off favors the more readable variant over this slightly faster, optimized version. Let me know what you think!
Here's a comparison graph vs the speed of `hasElement` before #1621:
![Figure_1](https://github.com/cuthbertLab/music21/assets/35711942/41f439bc-f140-44dc-b434-c5f6e221efbd)

I have also removed all uses of `hasElement` in the music21 codebase since the method would be deprecated.



