### PR TITLE
Fix ugly MusicXML durations & offsets

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ Changing this number invalidates old pickles -- do it if the old pickles create 
 '''
 from __future__ import annotations
 
-__version__ = '9.2.0b1'
+__version__ = '9.2.0b2'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -27,7 +27,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'9.2.0b1'
+'9.2.0b2'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -1504,6 +1504,34 @@ class Test(unittest.TestCase):
         m = s[stream.Measure].first()
         self.assertIs(m.showNumber, stream.enums.ShowNumber.NEVER)
 
+     def testAdjustTimeAttributesFromMeasure(self):
+        # Ignore import artifacts:
+        d = duration.Duration(3 + 3/480)
+        m = stream.Measure([meter.TimeSignature('6/8'), note.Note(duration=d)])
+        PP = PartParser()
+        PP.lastMeasureOffset = 21.0
+        PP.setLastMeasureInfo(m)
+        with self.assertWarns(MusicXMLWarning):
+            PP.adjustTimeAttributesFromMeasure(m)
+        self.assertEqual(PP.lastMeasureOffset, 24.0)
+
+        # Keep 'round' overful measures and extremely overful measures, as they were
+        # likely intentional.
+        d = duration.Duration(3.125)
+        m = stream.Measure([meter.TimeSignature('6/8'), note.Note(duration=d)])
+        PP = PartParser()
+        PP.lastMeasureOffset = 21.0
+        PP.setLastMeasureInfo(m)
+        PP.adjustTimeAttributesFromMeasure(m)
+        self.assertEqual(PP.lastMeasureOffset, 24.125)
+
+        d = duration.Duration(4.0)
+        m = stream.Measure([meter.TimeSignature('6/8'), note.Note(duration=d)])
+        PP = PartParser()
+        PP.lastMeasureOffset = 21.0
+        PP.setLastMeasureInfo(m)
+        PP.adjustTimeAttributesFromMeasure(m)
+        self.assertEqual(PP.lastMeasureOffset, 25.0)
 
 if __name__ == '__main__':
     import music21

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -56,12 +56,12 @@ class Test(unittest.TestCase):
         mxScorePart = self.EL('<score-part><part-name>Elec.</part-name></score-part>')
         mxPart = self.EL('<part><measure><note><type>thirty-tooth</type></note></measure></part>')
 
-        PP = PartParser(mxPart=mxPart, mxScorePart=mxScorePart)
-        PP.partId = '1'
+        pp = PartParser(mxPart=mxPart, mxScorePart=mxScorePart)
+        pp.partId = '1'
 
         msg = 'In part (Elec.), measure (0): found unknown MusicXML type: thirty-tooth'
         with self.assertRaises(MusicXMLImportException) as error:
-            PP.parse()
+            pp.parse()
         self.assertEqual(str(error.exception), msg)
 
     def testBarRepeatConversion(self):
@@ -1478,9 +1478,9 @@ class Test(unittest.TestCase):
         </score-part>
         '''
 
-        PP = PartParser()
+        pp = PartParser()
         mxScorePart = EL(scorePart)
-        tmb = PP.getDefaultInstrument(mxScorePart)
+        tmb = pp.getDefaultInstrument(mxScorePart)
         self.assertIsInstance(tmb, instrument.Tambourine)
         self.assertEqual(tmb.percMapPitch, 54)  # 1-indexed
 
@@ -1488,11 +1488,11 @@ class Test(unittest.TestCase):
         scorePart = scorePart.replace('Tambourine', 'Cabasa')
         scorePart = scorePart.replace('Tamb.', 'Cab.')
         scorePart = scorePart.replace('55', '70')  # 1-indexed
-        PP = PartParser()
+        pp = PartParser()
         mxScorePart = EL(scorePart)
         msg = '69 does not map to a valid instrument!'
         with self.assertWarnsRegex(MusicXMLWarning, msg):
-            unp = PP.getDefaultInstrument(mxScorePart)
+            unp = pp.getDefaultInstrument(mxScorePart)
         self.assertIsInstance(unp, instrument.UnpitchedPercussion)
         self.assertEqual(unp.percMapPitch, 69)
 
@@ -1508,30 +1508,30 @@ class Test(unittest.TestCase):
         # Ignore import artifacts:
         d = duration.Duration(3 + 3 / 480)
         m = stream.Measure([meter.TimeSignature('6/8'), note.Note(duration=d)])
-        PP = PartParser()
-        PP.lastMeasureOffset = 21.0
-        PP.setLastMeasureInfo(m)
+        pp = PartParser()
+        pp.lastMeasureOffset = 21.0
+        pp.setLastMeasureInfo(m)
         with self.assertWarns(MusicXMLWarning):
-            PP.adjustTimeAttributesFromMeasure(m)
-        self.assertEqual(PP.lastMeasureOffset, 24.0)
+            pp.adjustTimeAttributesFromMeasure(m)
+        self.assertEqual(pp.lastMeasureOffset, 24.0)
 
         # Keep 'round' overful measures and extremely overful measures, as they were
         # likely intentional.
         d = duration.Duration(3.125)
         m = stream.Measure([meter.TimeSignature('6/8'), note.Note(duration=d)])
-        PP = PartParser()
-        PP.lastMeasureOffset = 21.0
-        PP.setLastMeasureInfo(m)
-        PP.adjustTimeAttributesFromMeasure(m)
-        self.assertEqual(PP.lastMeasureOffset, 24.125)
+        pp = PartParser()
+        pp.lastMeasureOffset = 21.0
+        pp.setLastMeasureInfo(m)
+        pp.adjustTimeAttributesFromMeasure(m)
+        self.assertEqual(pp.lastMeasureOffset, 24.125)
 
         d = duration.Duration(4.0)
         m = stream.Measure([meter.TimeSignature('6/8'), note.Note(duration=d)])
-        PP = PartParser()
-        PP.lastMeasureOffset = 21.0
-        PP.setLastMeasureInfo(m)
-        PP.adjustTimeAttributesFromMeasure(m)
-        self.assertEqual(PP.lastMeasureOffset, 25.0)
+        pp = PartParser()
+        pp.lastMeasureOffset = 21.0
+        pp.setLastMeasureInfo(m)
+        pp.adjustTimeAttributesFromMeasure(m)
+        self.assertEqual(pp.lastMeasureOffset, 25.0)
 
 
 if __name__ == '__main__':

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -1504,9 +1504,9 @@ class Test(unittest.TestCase):
         m = s[stream.Measure].first()
         self.assertIs(m.showNumber, stream.enums.ShowNumber.NEVER)
 
-     def testAdjustTimeAttributesFromMeasure(self):
+    def testAdjustTimeAttributesFromMeasure(self):
         # Ignore import artifacts:
-        d = duration.Duration(3 + 3/480)
+        d = duration.Duration(3 + 3 / 480)
         m = stream.Measure([meter.TimeSignature('6/8'), note.Note(duration=d)])
         PP = PartParser()
         PP.lastMeasureOffset = 21.0
@@ -1532,6 +1532,7 @@ class Test(unittest.TestCase):
         PP.setLastMeasureInfo(m)
         PP.adjustTimeAttributesFromMeasure(m)
         self.assertEqual(PP.lastMeasureOffset, 25.0)
+
 
 if __name__ == '__main__':
     import music21

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2200,14 +2200,15 @@ class PartParser(XMLParserBase):
             # otherwise it was likely the result of malformed MusicXML.
             if (diff > 0.5
                   or nearestMultiple(diff, 0.0625)[1] < tol
-                  or nearestMultiple(diff, opFrac(1 / 12))[1] < tol):
+                  or nearestMultiple(diff, 1 / 12)[1] < tol):
                 mOffsetShift = mHighestTime
             else:
                 mOffsetShift = lastTimeSignatureQuarterLength
                 warnings.warn(
-                    f"Warning: measure {m.number} in part {self.stream.partName}"
-                    f"is overfull: {mHighestTime} > {lastTimeSignatureQuarterLength},"
-                    f"assuming {mOffsetShift} is correct."
+                    f'Warning: measure {m.number} in part {self.stream.partName}'
+                    f'is overfull: {mHighestTime} > {lastTimeSignatureQuarterLength},'
+                    f'assuming {mOffsetShift} is correct.',
+                    MusicXMLWarning
                 )
         elif (mHighestTime == 0.0
               and not m.recurse().notesAndRests.getElementsNotOfClass('Harmony')

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2198,15 +2198,17 @@ class PartParser(XMLParserBase):
             tol = 1e-6
             # If the measure is overfull by a "round" amount, assume that it was intended
             # otherwise it was likely the result of malformed MusicXML.
-            if (diff > 0.5 
-                  or nearestMultiple(diff, 0.0625)[1] < tol 
-                  or nearestMultiple(diff, opFrac(1/12))[1] < tol):
+            if (diff > 0.5
+                  or nearestMultiple(diff, 0.0625)[1] < tol
+                  or nearestMultiple(diff, opFrac(1 / 12))[1] < tol):
                 mOffsetShift = mHighestTime
             else:
                 mOffsetShift = lastTimeSignatureQuarterLength
-                warnings.warn(f"""Warning: measure {m.number} in part {self.stream.partName}
-                    is overfull: {mHighestTime} > {lastTimeSignatureQuarterLength}, 
-                    assuming {mOffsetShift} is correct.""")
+                warnings.warn(
+                    f"Warning: measure {m.number} in part {self.stream.partName}"
+                    f"is overfull: {mHighestTime} > {lastTimeSignatureQuarterLength},"
+                    f"assuming {mOffsetShift} is correct."
+                )
         elif (mHighestTime == 0.0
               and not m.recurse().notesAndRests.getElementsNotOfClass('Harmony')
               ):

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1625,10 +1625,10 @@ class PartParser(XMLParserBase):
         ...     + '</midi-instrument>'
         ...     + '</score-part>')
         >>> from xml.etree.ElementTree import fromstring as EL
-        >>> PP = musicxml.xmlToM21.PartParser()
+        >>> pp = musicxml.xmlToM21.PartParser()
 
         >>> mxScorePart = EL(scorePart)
-        >>> i = PP.getDefaultInstrument(mxScorePart)
+        >>> i = pp.getDefaultInstrument(mxScorePart)
         >>> i
         <music21.instrument.Instrument ': Instrument 4'>
         >>> i.instrumentName
@@ -1647,10 +1647,10 @@ class PartParser(XMLParserBase):
         ...     + '</midi-instrument>'
         ...     + '</score-part>')
         >>> from xml.etree.ElementTree import fromstring as EL
-        >>> PP = musicxml.xmlToM21.PartParser()
+        >>> pp = musicxml.xmlToM21.PartParser()
 
         >>> mxScorePart = EL(scorePart)
-        >>> i = PP.getDefaultInstrument(mxScorePart)
+        >>> i = pp.getDefaultInstrument(mxScorePart)
         >>> i
         <music21.instrument.Trumpet ': C Trumpet'>
         >>> i.instrumentName
@@ -2067,15 +2067,15 @@ class PartParser(XMLParserBase):
         Also sets self.lastTimeSignature from the timeSignature found in
         the measure, if any.
 
-        >>> PP = musicxml.xmlToM21.PartParser()
+        >>> pp = musicxml.xmlToM21.PartParser()
 
         Here are the defaults:
 
-        >>> PP.lastMeasureNumber
+        >>> pp.lastMeasureNumber
         0
-        >>> PP.lastNumberSuffix is None
+        >>> pp.lastNumberSuffix is None
         True
-        >>> PP.lastTimeSignature is None
+        >>> pp.lastTimeSignature is None
         True
 
         After setLastMeasureInfo:
@@ -2084,15 +2084,15 @@ class PartParser(XMLParserBase):
         >>> m.numberSuffix = 'b'
         >>> ts38 = meter.TimeSignature('3/8')
         >>> m.timeSignature = ts38
-        >>> PP.setLastMeasureInfo(m)
+        >>> pp.setLastMeasureInfo(m)
 
-        >>> PP.lastMeasureNumber
+        >>> pp.lastMeasureNumber
         4
-        >>> PP.lastNumberSuffix
+        >>> pp.lastNumberSuffix
         'b'
-        >>> PP.lastTimeSignature
+        >>> pp.lastTimeSignature
         <music21.meter.TimeSignature 3/8>
-        >>> PP.lastTimeSignature is ts38
+        >>> pp.lastTimeSignature is ts38
         True
 
         Note that if there was no timeSignature defined in m,
@@ -2101,10 +2101,10 @@ class PartParser(XMLParserBase):
         after the first measure there's going to be routines
         that need some sort of time signature:
 
-        >>> PP2 = musicxml.xmlToM21.PartParser()
+        >>> pp2 = musicxml.xmlToM21.PartParser()
         >>> m2 = stream.Measure(number=2)
-        >>> PP2.setLastMeasureInfo(m2)
-        >>> PP2.lastTimeSignature
+        >>> pp2.setLastMeasureInfo(m2)
+        >>> pp2.lastTimeSignature
         <music21.meter.TimeSignature 4/4>
 
 
@@ -2112,14 +2112,14 @@ class PartParser(XMLParserBase):
         to unnumbered measures, if a measure has the same number
         as the lastMeasureNumber, the lastNumberSuffix is not updated:
 
-        >>> PP3 = musicxml.xmlToM21.PartParser()
-        >>> PP3.lastMeasureNumber = 10
-        >>> PP3.lastNumberSuffix = 'X1'
+        >>> pp3 = musicxml.xmlToM21.PartParser()
+        >>> pp3.lastMeasureNumber = 10
+        >>> pp3.lastNumberSuffix = 'X1'
 
         >>> m10 = stream.Measure(number=10)
         >>> m10.numberSuffix = 'X2'
-        >>> PP3.setLastMeasureInfo(m10)
-        >>> PP3.lastNumberSuffix
+        >>> pp3.setLastMeasureInfo(m10)
+        >>> pp3.lastNumberSuffix
         'X1'
         '''
         if m.number == self.lastMeasureNumber:
@@ -2157,22 +2157,22 @@ class PartParser(XMLParserBase):
         >>> m = stream.Measure([meter.TimeSignature('4/4'), harmony.ChordSymbol('C7')])
         >>> m.highestTime
         0.0
-        >>> PP = musicxml.xmlToM21.PartParser()
-        >>> PP.setLastMeasureInfo(m)
-        >>> PP.adjustTimeAttributesFromMeasure(m)
+        >>> pp = musicxml.xmlToM21.PartParser()
+        >>> pp.setLastMeasureInfo(m)
+        >>> pp.adjustTimeAttributesFromMeasure(m)
         >>> m.highestTime
         4.0
-        >>> PP.lastMeasureWasShort
+        >>> pp.lastMeasureWasShort
         False
 
         Incomplete final measure:
 
         >>> m = stream.Measure([meter.TimeSignature('6/8'), note.Note(), note.Note()])
         >>> m.offset = 24.0
-        >>> PP = musicxml.xmlToM21.PartParser()
-        >>> PP.lastMeasureOffset = 21.0
-        >>> PP.setLastMeasureInfo(m)
-        >>> PP.adjustTimeAttributesFromMeasure(m)
+        >>> pp = musicxml.xmlToM21.PartParser()
+        >>> pp.lastMeasureOffset = 21.0
+        >>> pp.setLastMeasureInfo(m)
+        >>> pp.adjustTimeAttributesFromMeasure(m)
         >>> m.paddingRight
         1.0
         '''
@@ -2254,39 +2254,39 @@ class PartParser(XMLParserBase):
         '''
         If there is an active MultiMeasureRestSpanner, add the Rest, r, to it:
 
-        >>> PP = musicxml.xmlToM21.PartParser()
+        >>> pp = musicxml.xmlToM21.PartParser()
         >>> mmrSpanner = spanner.MultiMeasureRest()
         >>> mmrSpanner
         <music21.spanner.MultiMeasureRest 0 measures>
 
-        >>> PP.activeMultiMeasureRestSpanner = mmrSpanner
-        >>> PP.multiMeasureRestsToCapture = 2
+        >>> pp.activeMultiMeasureRestSpanner = mmrSpanner
+        >>> pp.multiMeasureRestsToCapture = 2
         >>> r1 = note.Rest(type='whole', id='r1')
-        >>> PP.applyMultiMeasureRest(r1)
-        >>> PP.multiMeasureRestsToCapture
+        >>> pp.applyMultiMeasureRest(r1)
+        >>> pp.multiMeasureRestsToCapture
         1
-        >>> PP.activeMultiMeasureRestSpanner
+        >>> pp.activeMultiMeasureRestSpanner
         <music21.spanner.MultiMeasureRest 1 measure>
 
-        >>> PP.activeMultiMeasureRestSpanner is mmrSpanner
+        >>> pp.activeMultiMeasureRestSpanner is mmrSpanner
         True
-        >>> PP.stream.show('text')  # Nothing...
+        >>> pp.stream.show('text')  # Nothing...
 
         >>> r2 = note.Rest(type='whole', id='r2')
-        >>> PP.applyMultiMeasureRest(r2)
-        >>> PP.multiMeasureRestsToCapture
+        >>> pp.applyMultiMeasureRest(r2)
+        >>> pp.multiMeasureRestsToCapture
         0
-        >>> PP.activeMultiMeasureRestSpanner is None
+        >>> pp.activeMultiMeasureRestSpanner is None
         True
 
         # spanner added to stream
 
-        >>> PP.stream.show('text')
+        >>> pp.stream.show('text')
         {0.0} <music21.spanner.MultiMeasureRest 2 measures>
 
         >>> r3 = note.Rest(type='whole', id='r3')
-        >>> PP.applyMultiMeasureRest(r3)
-        >>> PP.stream.show('text')
+        >>> pp.applyMultiMeasureRest(r3)
+        >>> pp.stream.show('text')
         {0.0} <music21.spanner.MultiMeasureRest 2 measures>
 
         '''


### PR DESCRIPTION
We all know the ugly offsets (3875/480, 161/180, etc.) that happen after importing some musicXML files.
This usually occurs because the file contains tuplets with strange durations that cannot be represented exactly using integer `<duration>` tags in musicXML. For this reason, rounding errors can accumulate and lead to over/underfull measures.
Currently, if a measure is overfull, music21 just accepts that as a fact and increases the duration of the measure, shifting all following objects and resulting in them having very odd offsets. 

This proposal deals with this by automatically detecting such cases, warning the user, and fixing them. 
The change only affects behavior if the measure duration resulting from the contained notes differs from the duration dictated by the time signature by less than 0.5 and is a very ugly duration. 
In my testing, this fixes the vast majority of imports without breaking anything else.

Let me know what you think!