### PR TITLE
TSV converter bug fix: don't add 'd' prefix to 2-digit added tones like `[add13]`

### DIFF
--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -261,7 +261,7 @@ class TabChordBase(abc.ABC):
                     self.extra.get('chord_type', '') == 'Mm7'
                     and self.numeral != 'V'
                 ):
-                    # However, we need to make sure not to match [add13] and 
+                    # However, we need to make sure not to match [add13] and
                     # the like, otherwise we will end up with [addd13]
                     self.chord = re.sub(
                         r'''
@@ -881,7 +881,7 @@ class M21toTSV:
                 # We replace the "d" annotation for Mm7 chords on degrees other than
                 #   V because it is not used by the DCML standard
                 # NB: slightly different from DCML: no key.
-                thisEntry.chord = thisRN.figure.replace('d', '', 1)  
+                thisEntry.chord = thisRN.figure.replace('d', '', 1)
                 thisEntry.pedal = None
                 thisEntry.numeral = thisRN.romanNumeral
                 thisEntry.form = getForm(thisRN)

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -260,8 +260,15 @@ class TabChordBase(abc.ABC):
                     self.extra.get('chord_type', '') == 'Mm7'
                     and self.numeral != 'V'
                 ):
-                    # we need to make sure not to match [add4] and the like
-                    self.chord = re.sub(r'(\d+)(?!])', r'd\1', self.chord)
+                    # we need to make sure not to match [add13] and the like
+                    self.chord = re.sub(
+                        r'''
+                            (\d+)  # match one or more digits
+                            (?![\]\d])  # without a digit or a ']' to the right
+                        ''',
+                        r'd\1', 
+                        self.chord, 
+                        flags=re.VERBOSE)
 
         # Local - relative and figure
         if isMinor(self.local_key):

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -878,7 +878,10 @@ class M21toTSV:
                     relativeroot = characterSwaps(
                         relativeroot, isMinor(local_key), direction='m21-DCML'
                     )
-                thisEntry.chord = thisRN.figure  # NB: slightly different from DCML: no key.
+                # We replace the "d" annotation for Mm7 chords on degrees other than
+                #   V because it is not used by the DCML standard
+                # NB: slightly different from DCML: no key.
+                thisEntry.chord = thisRN.figure.replace('d', '', 1)  
                 thisEntry.pedal = None
                 thisEntry.numeral = thisRN.romanNumeral
                 thisEntry.form = getForm(thisRN)

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -256,18 +256,20 @@ class TabChordBase(abc.ABC):
             if self.dcml_version == 2:
                 self.chord = self.chord.replace('%', 'ø')
                 self.chord = handleAddedTones(self.chord)
+                # prefix figures for Mm7 chords on degrees other than 'V' with 'd'
                 if (
                     self.extra.get('chord_type', '') == 'Mm7'
                     and self.numeral != 'V'
                 ):
-                    # we need to make sure not to match [add13] and the like
+                    # However, we need to make sure not to match [add13] and 
+                    # the like, otherwise we will end up with [addd13]
                     self.chord = re.sub(
                         r'''
                             (\d+)  # match one or more digits
                             (?![\]\d])  # without a digit or a ']' to the right
                         ''',
-                        r'd\1', 
-                        self.chord, 
+                        r'd\1',
+                        self.chord,
                         flags=re.VERBOSE)
 
         # Local - relative and figure

--- a/music21/romanText/tsvEg_v2major.tsv
+++ b/music21/romanText/tsvEg_v2major.tsv
@@ -10,4 +10,7 @@ mc	mn	mc_onset	mn_onset	timesig	staff	voice	volta	label	globalkey	localkey	pedal
 99	99	1/2	1/2	3/4	4	1		Ger6/vi	C	V		Ger6/vi	Ger	vii	o	65	b3	V/vi			Ger	0	0	-1, 3, 0, 9		9	-1
 121	121	0	0	3/4	4	1		V/vi	C	i		V/vi		V				vi			M	0	1	-3, 1, -2		-3	-3
 125	124	1/16	1/16	2/4	4	1		Fr6	F	vi		Fr6	Fr	V		43	b5	V			Fr	0	1	-4, 0, 2, 6		2	-4
-142	141	0	0	4/4				#VII+/vi	C	I		#VII+/vi		#VII	+			vi			+	0	0				
+141	140	0	0	4/4				#VII+/vi	C	I		#VII+/vi		#VII	+			vi			+	0	0				
+142	141	0	0	4/4				VI43	G	iii		VI43		VI		43		vi			Mm7	0	0				
+143	142	0	0	4/4				VI43(13)	G	iii		VI43(13)		VI		43	13	vi			Mm7	0	0				
+144	143	0	0	4/4				V13	G	I		V13		V		13					Mm7	0	0				


### PR DESCRIPTION
The regex to add `d` to Mm7 chords on degrees other than 5 was giving false positives for cases like `[add13]`, where it would match the `1`, resulting in `[addd13]`. This PR fixes that bug.

I added 2 test cases to `tsvEg_v2major.tsv` and discovered that there was another bug where the `d` syntax (e.g., for `IVd7`) was not being removed when converting from Music21 to DCML tsv, although it is not used in the latter standard. So I also added a fix for that.