### PR TITLE
Roman Numerals: Don't substitute `d` for `0` in `add10`

### DIFF
--- a/music21/roman.py
+++ b/music21/roman.py
@@ -4349,6 +4349,10 @@ class Test(unittest.TestCase):
         self.assertEqual([p.name for p in rn.pitches], ['B', 'D', 'F', 'A-'])
         rn = roman.RomanNumeral('vii/07', 'c')
         self.assertEqual([p.name for p in rn.pitches], ['B', 'D', 'F', 'A'])
+        # However, when there is a '10' somewhere in the figure, don't replace
+        #   the 0 (this occurs in DCML corpora)
+        rn = roman.RomanNumeral('V7[add10]', 'c')
+        self.assertEqual([p.name for p in rn.pitches], ['G', 'B-', 'B', 'D', 'F'])
 
     def testIII7(self):
         c = chord.Chord(['E4', 'G4', 'B4', 'D5'])

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2415,7 +2415,7 @@ class RomanNumeral(harmony.Harmony):
 
         # immediately fix low-preference figures
         if isinstance(figure, str):
-            figure = figure.replace('0', 'o')  # viio7
+            figure = re.sub(r'(?<!\d)0', 'o', figure)  # viio7 (but don't alter 10.)
             figure = figure.replace('º', 'o')
             figure = figure.replace('°', 'o')
             # /o is just a shorthand for ø -- so it should not be stored.


### PR DESCRIPTION
`add10` annotations (which occur when converting some DCML files) were causing a bug because the 0 was being converted to `o`, leading to parsing exceptions.

This PR updates the replace logic for `0` so as not to match this case, and adds a test case to the unit test.