### PR TITLE
wrap pitch access in try/catch

### DIFF
--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -814,8 +814,11 @@ class Verticality(prebase.ProtoM21Object):
             from music21 import stream
 
             nonlocal pitchBust  # love Py3!!!
-            p = n.pitch
-            pitchKey = p.nameWithOctave
+            try:
+                p = n.pitch
+                pitchKey = p.nameWithOctave
+            except AttributeError:
+                return
 
             pitchGroup = None
             if addPartIdAsGroup:


### PR DESCRIPTION
This was failing with 
```
'PercussionChord/Unpitched' object has no attribute 'pitch'
```
when calling chordify() on, say, orchestral scores with timpani, etc. 