### PR TITLE
Python 3.12 Compatibility

### DIFF
--- a/.github/workflows/maincheck.yml
+++ b/.github/workflows/maincheck.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.10.6", "3.10", "3.11"]  # "3.10" must be in quotes to not have it eval to 3.1
+                python-version: ["3.10", "3.11", "3.12"]  # "3.10" must be in quotes to not have it eval to 3.1
         steps:
         - uses: actions/setup-python@v4
           with:
@@ -27,7 +27,7 @@ jobs:
         - name: Run Main Test script
           run: python -c 'from music21.test.testSingleCoreAll import ciMain as ci; ci()'
         - name: Coveralls
-          if: ${{ matrix.python-version == '3.10.6' }}
+          if: ${{ matrix.python-version == '3.11' }}
           env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               COVERALLS_SERVICE_NAME: github
@@ -40,7 +40,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: '3.10'
+                  python-version: '3.11'
                   cache: 'pip'
             - name: Install dependencies
               run: |
@@ -63,7 +63,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: '3.10'
+                  python-version: '3.11'
                   cache: 'pip'
             - name: Install dependencies
               run: |
@@ -83,7 +83,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: '3.10'
+                  python-version: '3.11'
                   cache: 'pip'
             - name: Install dependencies
               run: |

--- a/music21/__init__.py
+++ b/music21/__init__.py
@@ -52,7 +52,7 @@ if sys.version_info < minPythonVersion:
     If you have the wrong version there are several options for getting
     the right one.
 
-    - 1. (Best) Upgrade to Python 3, latest (currently 3.10).
+    - 1. (Best) Upgrade to Python 3, latest (currently 3.12).
 
          The great features there will more
          than make up for the headache of downloading

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -2037,12 +2037,12 @@ class ABCHandler:
         Given a match from a regular expression return the parsed ABC version
 
         >>> import re
-        >>> match = re.match('(\d+).(\d+).(\d+)', '2.3.4')
+        >>> match = re.match(r'(\d+).(\d+).(\d+)', '2.3.4')
         >>> ah = abcFormat.ABCHandler()
         >>> ah.returnAbcVersionFromMatch(match)
         (2, 3, 4)
 
-        >>> match = re.match('(\d+).(\d+).?(\d?)', '1.7')
+        >>> match = re.match(r'(\d+).(\d+).?(\d?)', '1.7')
         >>> ah.returnAbcVersionFromMatch(match)
         (1, 7, 0)
         '''

--- a/music21/audioSearch/recording.py
+++ b/music21/audioSearch/recording.py
@@ -92,7 +92,7 @@ def samplesFromRecording(seconds=10.0, storeFile=True,
         # write recording to disk
         data = b''.join(storedWaveSampleList)
         try:
-            # wave.open does not take a path-like object as of 3.10
+            # wave.open does not take a path-like object as of 3.12
             wf = wave.open(waveFilename, 'wb')
             wf.setnchannels(recordChannels)
             wf.setsampwidth(p_audio.get_sample_size(recordFormat))

--- a/music21/common/stringTools.py
+++ b/music21/common/stringTools.py
@@ -470,7 +470,7 @@ def parenthesesMatch(
         i += 1
 
     if len(stack) > 1:
-        raise ValueError(f'Opening {open!r} at index {stack[1].start-1} was never closed')
+        raise ValueError(f'Opening {open!r} at index {stack[1].start - 1} was never closed')
 
     return mainMatch.nested
 

--- a/music21/humdrum/questions.py
+++ b/music21/humdrum/questions.py
@@ -9,7 +9,7 @@ _DOC_IGNORE_MODULE_OR_PACKAGE = True
 # from music21 import common
 # from music21 import *  # doing this because it will simplify the examples
 
-# note: this are temporarily commented out until they work
+# note: these are temporarily commented out until they work
 # add optional show argument to mask output for automated testing
 
 
@@ -218,16 +218,16 @@ class Test(unittest.TestCase):
     #     else:
     #         return 'dips win'
 
-    def xtest009(self):
-        '''
-        Are lower pitches likely to be shorter and higher pitches likely to be longer?
-        '''
-        partStream = music21.converter.parse('dichterliebe1.xml')
-        unused_noteStream = partStream['notes']
-        # unused_table = analysis.correlate(noteStream, 'pitchSpace', 'duration')
-
-        # we must examine and interpolate the table in order to distinguish
-        # trends
+    # def xtest009(self):
+    #     '''
+    #     Are lower pitches likely to be shorter and higher pitches likely to be longer?
+    #     '''
+    #     partStream = music21.converter.parse('dichterliebe1.xml')
+    #     unused_noteStream = partStream['notes']
+    #     # unused_table = analysis.correlate(noteStream, 'pitchSpace', 'duration')
+    #
+    #     # we must examine and interpolate the table in order to distinguish
+    #     # trends
 
     # def xtest010(self):
     #     '''
@@ -271,22 +271,22 @@ class Test(unittest.TestCase):
     #     '''
     #     pass
 
-    def xtest015(self):
-        '''
-        Calculate harmonic intervals ignoring unisons.
-        '''
-        from collections import defaultdict
-        score1 = music21.converter.parse('dichterliebe1.xml')
-        monoScore = score1.chordsToNotes()    # returns a new Stream
-        unused_notePairs = monoScore.getAllSimultaneousNotes()
-        # returns a list of Tuples intervals = interval.generateFromNotePairs(notePairs)
-        intervals2 = defaultdict(lambda: 0)
-        for thisInt in intervals2:
-            if thisInt.name != 'P1':
-                intervals2[thisInt.name] += 1
-
-        for key in intervals2.keys().sort(key='simpleName'):
-            print(key, intervals2[key])
+    # def xtest015(self):
+    #     '''
+    #     Calculate harmonic intervals ignoring unisons.
+    #     '''
+    #     from collections import defaultdict
+    #     score1 = music21.converter.parse('dichterliebe1.xml')
+    #     monoScore = score1.chordsToNotes()    # returns a new Stream
+    #     unused_notePairs = monoScore.getAllSimultaneousNotes()
+    #     # returns a list of Tuples intervals = interval.generateFromNotePairs(notePairs)
+    #     intervals2 = defaultdict(lambda: 0)
+    #     for thisInt in intervals2:
+    #         if thisInt.name != 'P1':
+    #             intervals2[thisInt.name] += 1
+    #
+    #     for key in intervals2.keys().sort(key='simpleName'):
+    #         print(key, intervals2[key])
 
     def test016(self):
         '''

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -56,7 +56,7 @@ In the v8 implementation, contributor roles are treated the same as other
 non-contributor metadata.  Music21 includes a list of supported property terms,
 which are pulled from Dublin Core (namespace = 'dcterms'), MARC Relator codes
 (namespace = 'marcrel'), and Humdrum (namespace = 'humdrum').  Each property
-term is assigned a unique name (e.g. 'composer', 'alternativeTitle', etc).
+term is assigned a unique name (e.g. 'composer', 'alternativeTitle', etc.).
 
 Each metadata property can be specified by 'uniqueName' or by 'namespace:name'.
 For example: `md['composer']` and `md['marcrel:CMP']` are equivalent, as are
@@ -649,7 +649,7 @@ class Metadata(base.Music21Object):
         skipNonContributors is True, only contributor metadata will be returned.  If both
         of these are True, the returned Tuple will be empty. If returnPrimitives is False
         (default), values are all converted to str.  If returnPrimitives is True, the values
-        will retain their original ValueType (e.g. Text, Contributor, Copyright, etc).  If
+        will retain their original ValueType (e.g. Text, Contributor, Copyright, etc.).  If
         returnSorted is False, the returned Tuple will not be sorted by uniqueName (the
         default behavior is to sort).
 
@@ -1770,7 +1770,7 @@ class Metadata(base.Music21Object):
                 return str(values[0])
             if len(values) == 2:
                 return str(values[0]) + ' and ' + str(values[1])
-            return str(values[0]) + f' and {len(values)-1} others'
+            return str(values[0]) + f' and {len(values) - 1} others'
 
         if self._namespaceNameNeedsArticleNormalization(namespaceName):
             output: str = ''

--- a/music21/metadata/primitives.py
+++ b/music21/metadata/primitives.py
@@ -408,7 +408,7 @@ class Date(prebase.ProtoM21Object):
             if value is None:
                 break
             post.append(int(value))
-        return datetime.datetime(*post)
+        return datetime.datetime(*post)  # pylint: disable=no-value-for-parameter
 
     @property
     def hasTime(self):
@@ -824,7 +824,7 @@ class DateSelection(DatePrimitive):
 
 
 # This was enhanced in music21 v8 to add an optional encoding scheme (e.g. URI, DCMIPoint,
-# etc) as well as whether the text is translated, or in the original language.
+# etc.) as well as whether the text is translated, or in the original language.
 class Text(prebase.ProtoM21Object):
     r'''
     One unit of text data: a title, a name, or some other text data. Store the

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -941,7 +941,7 @@ class Test(unittest.TestCase):
           <step>D</step>
           <octave>5</octave>
         </pitch>
-        <duration>{defaults.divisionsPerQuarter * 0.5 * (2/3) * (2/3)}</duration>
+        <duration>{defaults.divisionsPerQuarter * 0.5 * (2 / 3) * (2 / 3)}</duration>
         <voice>1</voice>
         <type>eighth</type>
         <time-modification>

--- a/music21/note.py
+++ b/music21/note.py
@@ -1053,7 +1053,7 @@ class NotRest(GeneralNote):
 
         >>> import copy
         >>> n = note.NotRest()
-        >>> n.volume = volume.Volume(50)
+        >>> n.volume = volume.Volume(velocity=50)
         >>> m = copy.deepcopy(n)
         >>> m.volume.client is m
         True
@@ -1485,7 +1485,7 @@ class Note(NotRest):
     >>> highE <= otherHighE
     True
 
-    Notice you cannot compare Notes w/ ints or anything that does not a have a
+    Notice you cannot compare Notes w/ ints or anything that does not have a
     `.pitch` attribute.
 
     >>> highE < 50
@@ -1830,8 +1830,10 @@ class Unpitched(NotRest):
     >>> unp.displayStep = 'G'
     >>> unp.pitch
     Traceback (most recent call last):
-    AttributeError: 'Unpitched' object has no attribute 'pitch'
+    AttributeError: 'Unpitched' object has no attribute 'pitch...
     '''
+    # TODO: when Python 3.12 is minimum version.  Change AttributeError to read:
+    #        AttributeError: 'Unpitched' object has no attribute 'pitch'. Did you mean: 'pitches'?
 
     equalityAttributes = ('displayStep', 'displayOctave')
 

--- a/music21/scale/test_intervalNetwork.py
+++ b/music21/scale/test_intervalNetwork.py
@@ -10,6 +10,7 @@
 # ------------------------------------------------------------------------------
 from __future__ import annotations
 
+import sys
 import unittest
 
 from music21 import common
@@ -361,13 +362,19 @@ class Test(unittest.TestCase):
 
         net = IntervalNetwork()
         net.fillArbitrary(nodes, edges)
-        self.assertTrue(common.whitespaceEqual(str(net.edges),
-                                               '''
-            OrderedDict([(0, <music21.scale.intervalNetwork.Edge Direction.BI m2
-                                [(Terminus.LOW, 0), (0, Terminus.LOW)]>),
-                         (1, <music21.scale.intervalNetwork.Edge Direction.BI M3
-                                [(0, Terminus.HIGH), (Terminus.HIGH, 0)]>)])'''
-                                               ),
+        match = '''
+            OrderedDict({0: <music21.scale.intervalNetwork.Edge Direction.BI m2
+                                [(Terminus.LOW, 0), (0, Terminus.LOW)]>,
+                         1: <music21.scale.intervalNetwork.Edge Direction.BI M3
+                                [(0, Terminus.HIGH), (Terminus.HIGH, 0)]>})'''
+        if sys.version_info < (3, 12):
+            match = '''
+                OrderedDict([(0, <music21.scale.intervalNetwork.Edge Direction.BI m2
+                                    [(Terminus.LOW, 0), (0, Terminus.LOW)]>),
+                             (1, <music21.scale.intervalNetwork.Edge Direction.BI M3
+                                    [(0, Terminus.HIGH), (Terminus.HIGH, 0)]>)])'''
+
+        self.assertTrue(common.whitespaceEqual(str(net.edges), match),
                         str(net.edges))
 
         self.assertEqual(net.degreeMax, 3)

--- a/music21/test/coverageM21.py
+++ b/music21/test/coverageM21.py
@@ -40,12 +40,12 @@ def getCoverage(overrideVersion=False):
     # (The odds of a failure on the middle version are low if
     # the newest and oldest are passing)
     #
-    # Note the .minor == 10 -- that makes it only run on 3.10.6
+    # Note the .minor == 11 -- that makes it only run on 3.11
     #
     # When changing the version, be sure also to change
     # .github/maincheck.yml's line:
-    #           if: ${{ matrix.python-version == '3.10' }}
-    if overrideVersion or (sys.version_info.minor == 10 and sys.version_info.micro == 6):
+    #           if: ${{ matrix.python-version == '3.11' }}
+    if overrideVersion or sys.version_info.minor == 11:
         try:
             # noinspection PyPackageRequirements
             import coverage  # type: ignore

--- a/music21/test/testLint.py
+++ b/music21/test/testLint.py
@@ -22,7 +22,7 @@ try:
     # noinspection PyPackageRequirements
     from pylint.lint import Run as pylintRun  # type: ignore
 except ImportError:
-    pylintRun = None
+    pylintRun = None  # type: ignore
 
 
 # see feature list here:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Artistic Software",
     "Topic :: Multimedia :: Sound/Audio",
     "Topic :: Multimedia :: Sound/Audio :: Conversion",


### PR DESCRIPTION
Make music21 test suite fully compatible with Python 3.12 -- because the basic functionality of music21 works without change in music21, I'm not going to break sabbatical to do a new release for this, but all code tests going forward should also run on 3.12.

Minimum version remains 3.10.

Move coverage, flake8, and pylint to 3.11 -- keeping with general music21 policy to test these things on the middle version of Python supported, so that changes in run-time from oldest to newest versions can be observed.  (The middle version has more things its doing so it's always the slowest).

Thanks to @jacobtylerwalls for the fix in advance for the new OrderedDict syntax.