### PR TITLE
check if HOME directory is writeable in getSettingsPath

### DIFF
--- a/music21/environment.py
+++ b/music21/environment.py
@@ -642,7 +642,7 @@ class _EnvironmentCore:
             return directory / 'music21-settings.xml'
         elif platform in ['nix', 'darwin']:
             # might not exist if running as nobody in a webserver...
-            if 'HOME' in os.environ:
+            if 'HOME' in os.environ and os.access(os.environ['HOME'], os.W_OK):
                 directory = pathlib.Path(os.environ['HOME'])
             else:
                 directory = pathlib.Path('/tmp/')


### PR DESCRIPTION
I came across this problem when running a script on a compute cluster where the home dir exists, but is mounted read-only when running on the actual compute node.

In this case we should store the .music21rc file in /tmp.