### PR TITLE
In conversion from musicXML, allow multiple {Fret/String}Indications for chord.

### DIFF
--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2873,7 +2873,9 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
                 if type(art) in seenArticulations:
                     continue
                 c.articulations.append(art)
-                if not isinstance(art, (articulations.Fingering, articulations.StringIndication, articulations.FretIndication)):
+                if not isinstance(art, (articulations.Fingering,
+                                        articulations.StringIndication,
+                                        articulations.FretIndication)):
                     seenArticulations.add(type(art))
             for exp in n.expressions:
                 if type(exp) in seenExpressions:

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2873,7 +2873,7 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
                 if type(art) in seenArticulations:
                     continue
                 c.articulations.append(art)
-                if not isinstance(art, articulations.Fingering):
+                if not isinstance(art, (articulations.Fingering, articulations.StringIndication, articulations.FretIndication)):
                     seenArticulations.add(type(art))
             for exp in n.expressions:
                 if type(exp) in seenExpressions:


### PR DESCRIPTION
Currently, it's not possible to access frets and string information in guitar tablatures for chords after conversion from musicXML, because StringIndication and FretIndication objects are stored in chord.articulation property only for a single (lowest) note of a chord.

E.g., when running the attached example with very simple musicXML, expected:

`<music21.chord.Chord D3 A3 D4 F4 A4>
[<music21.articulations.FretIndication 5>, <music21.articulations.StringIndication 5>, <music21.articulations.FretIndication 7>, <music21.articulations.StringIndication 4>, <music21.articulations.FretIndication 7>, <music21.articulations.StringIndication 3>, <music21.articulations.FretIndication 6>, <music21.articulations.StringIndication 2>, <music21.articulations.FretIndication 5>, <music21.articulations.StringIndication 1>]`

 but have only:
`<music21.chord.Chord D3 A3 D4 F4 A4>
[<music21.articulations.FretIndication 5>, <music21.articulations.StringIndication 5>]`

[chord_test.zip](https://github.com/cuthbertLab/music21/files/13663827/chord_test.zip)

Suggested fix is following already established path, i.e., similar to excluding articulations.Fingering from articulations uniqueness check.