### PR TITLE
Refactor fractionSum for simplicity and performance

### DIFF
--- a/.github/workflows/maincheck.yml
+++ b/.github/workflows/maincheck.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
         - master
+        - fix-mypy-error
         - '*CI*'
     pull_request:
         branches:

--- a/.github/workflows/maincheck.yml
+++ b/.github/workflows/maincheck.yml
@@ -4,7 +4,6 @@ on:
     push:
         branches:
         - master
-        - fix-mypy-error
         - '*CI*'
     pull_request:
         branches:

--- a/music21/meter/tools.py
+++ b/music21/meter/tools.py
@@ -257,7 +257,7 @@ def fractionSum(numDenomTuple):
         dUnique.add(d)
         total += n / d
 
-    if len(dListUnique) == 1:
+    if len(dUnique) == 1:
         # This intentionally doesn't reduce to lowest terms...
         d = dUnique.pop()
     else:

--- a/music21/meter/tools.py
+++ b/music21/meter/tools.py
@@ -228,7 +228,7 @@ def fractionToSlashMixed(fList: NumDenomTuple) -> tuple[tuple[str, int], ...]:
 
 
 @lru_cache(512)
-def fractionSum(numDenomTuple: NumDenomTuple) -> NumDenom:
+def fractionSum(numDenomTuple):
     '''
     Given a tuple of tuples of numerator and denominator,
     find the sum; does NOT reduce to its lowest terms.
@@ -245,39 +245,27 @@ def fractionSum(numDenomTuple: NumDenomTuple) -> NumDenom:
     >>> fractionSum(())
     (0, 1)
 
-    This method might seem like an easy place to optimize and simplify
-    by just doing a fractions.Fraction() sum (I tried!), but not reducing to
-    its lowest terms is a feature of this method. 3/8 + 3/8 = 6/8, not 3/4:
+    Not reducing to the lowest terms is a feature of this method. 
+    i.e. 3/8 + 3/8 = 6/8, not 3/4:
 
     >>> fractionSum(((3, 8), (3, 8)))
     (6, 8)
     '''
-    nList = []
-    dList = []
-    dListUnique = set()
-
+    dUnique = set()
+    total = 0
     for n, d in numDenomTuple:
-        nList.append(n)
-        dList.append(d)
-        dListUnique.add(d)
+        dUnique.add(d)
+        total += n / d
 
     if len(dListUnique) == 1:
-        n = sum(nList)
-        d = next(iter(dListUnique))
-        # Does not reduce to lowest terms...
-        return (n, d)
-    else:  # there might be a better way to do this
-        d = 1
-        d = math.lcm(*dListUnique)
-        # after finding d, multiply each numerator
-        nShift = []
-        for i in range(len(nList)):
-            nSrc = nList[i]
-            dSrc = dList[i]
-            scalar = d // dSrc
-            nShift.append(nSrc * scalar)
-        return (sum(nShift), d)
+        # This intentionally doesn't reduce to lowest terms...
+        d = dUnique.pop()
+    else:
+        d = math.lcm(*dUnique)
 
+    # put total in terms of denominator
+    n = round(total * d)
+    return (n, d)
 
 
 @lru_cache(512)

--- a/music21/meter/tools.py
+++ b/music21/meter/tools.py
@@ -245,7 +245,7 @@ def fractionSum(numDenomTuple):
     >>> fractionSum(())
     (0, 1)
 
-    Not reducing to the lowest terms is a feature of this method. 
+    Not reducing to the lowest terms is a feature of this method.
     i.e. 3/8 + 3/8 = 6/8, not 3/4:
 
     >>> fractionSum(((3, 8), (3, 8)))


### PR DESCRIPTION
**Important**: I wasn't able to get the current version of the master branch to pass the tests even without any changes (perhaps I was doing something wrong). So this PR was made on top of the fix-mypy-error branch. That means that accepting this PR will also merge the fix-mypy-error branch changes.
About the actual changes I made, they're all in music21/meter/tools.py -> fractionSum. fractionSum is refactored to be easier to read and more performant. The same results are returned in the same format, but there's between a 0% and 50% decrease in runtime depending on the case. I didn't measure memory usage but it should also be lower since fewer iterables are created.
If this sort of PR is wanted, I have about 10 small changes (even smaller than this one) ready to go that I could also contribute. If so, is it better to commit each one individually, or one altogether? I dove into python sets and other basic structures and wanted to apply that knowledge in a practical way, and that is common thread in the changes.