### PR TITLE
Verticality.makeElement unpitched aware

### DIFF
--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -875,7 +875,7 @@ class Verticality(prebase.ProtoM21Object):
                 continue
             el = timeSpan.element
             if isinstance(el, chord.ChordBase):
-                firstNoteElement: note.Note|None = None
+                firstNoteElement: note.Note | None = None
                 for subEl in el:
                     if isinstance(subEl, note.Note):
                         firstNoteElement = subEl


### PR DESCRIPTION
Make Verticality.makeElement aware of unpitched objects.

Supersedes #1652 -- which pointed out an important bug but didn't put the onus on type-safety on the calling attribute.