### PR TITLE
Avoid calling hyphenToCamelCase twice per note

### DIFF
--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -3160,8 +3160,8 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
             if mxPitch is None:  # whoops!!!!
                 return p
 
-        seta(p, mxPitch, 'step')
-        seta(p, mxPitch, 'octave', transform=int)
+        seta(p, mxPitch, 'step', 'step')
+        seta(p, mxPitch, 'octave', 'octave', transform=int)
         mxAlter = mxPitch.find('alter')
         accAlter = None
         if alterText := strippedText(mxAlter):


### PR DESCRIPTION
`hyphenToCamelCase` from common.stringTools.py currently gets called twice for every note in a piece when importing an xml file. This can be avoided by passing an `attributeName` argument when using the `_setAttributeFromTagText` method to set the step and octave properties of notes.

With this change, when importing a file like:
`score = corpus.parse('joplin/maple_leaf_rag.mxl', forceSource=True)`
`_setAttributeFromTagText` goes from being called over 30k times to about 120 times. Since all the string manipulation in hyphenToCamelCase has no impact on one-word strings, all these avoided calls were unnecessary.
