### PR TITLE
Store "numbered ending" within barline

### DIFF
--- a/music21/bar.py
+++ b/music21/bar.py
@@ -129,6 +129,8 @@ class Barline(base.Music21Object):
     classSortOrder = -5
 
     equalityAttributes = ('type', 'pause', 'location')
+    
+    numberedEnding = None
 
     def __init__(self,
                  type=None,  # pylint: disable=redefined-builtin
@@ -156,6 +158,9 @@ class Barline(base.Music21Object):
 
     def _setType(self, value):
         self._type = standardizeBarType(value)
+
+    def setNumberedEnding(self, value):
+        self.numberedEnding = value
 
     type = property(_getType, _setType,
         doc='''

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4825,6 +4825,7 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
         # barline objects also store ending objects, that mark begin
         # and end of repeat bracket designations
         mxEndingObj = mxBarline.find('ending')
+        barline.setNumberedEnding(mxEndingObj)
         if mxEndingObj is not None:
             # TODO: musicxml 4: system="yes/no" -- does this apply to whole system?
 


### PR DESCRIPTION
When parsing musicxml files which contain numbered endings, it would be nice to be able to access them within the "Measure" object.
I believe one reasonable way to do this would be to store the numbered ending in the Barline
object, be it a "Repeat" or not. Then it is easily accessed by the "numberedEnding" field.
