### PR TITLE
Fix #1685: Harmony parsing errors with doubled characters

### DIFF
--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -3162,6 +3162,12 @@ class Test(unittest.TestCase):
 
         self.assertEqual(ch1.pitches, ch2.pitches)
 
+    def testDoubledCharacters(self):
+        ch1 = ChordSymbol('Co omit5')
+        ch2 = ChordSymbol('Cdim omit5')
+
+        self.assertEqual(ch1.pitches, ch2.pitches)
+
     def x_testPower(self):
         '''
         power chords should not have inversions

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -1890,7 +1890,7 @@ class ChordSymbol(Harmony):
             for charString in getAbbreviationListGivenChordType(chordKind):
                 if sH == charString:
                     self.chordKind = chordKind
-                    return originalsH.replace(charString, '')
+                    return originalsH[len(sH):]
         return originalsH
 
     def _hasPitchAboveC4(self, pitches):


### PR DESCRIPTION
Fixes #1685.
Corrects parsing error for harmony strings and adds regression test for #1685.