### PR TITLE
Fix #1382: Simplify ChordBase duration creation

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -138,25 +138,17 @@ class ChordBase(note.NotRest):
         # if provided.
 
         super().__init__(**keywords)
-
-        # inherit Duration object from GeneralNote
-        # keep it here in case we have no notes
-        durationKeyword = None
-        if 'duration' in keywords:
-            durationKeyword = keywords['duration']
-
-        durationKeyword = self._add_core_or_init(notes, useDuration=durationKeyword)
-
-        if durationKeyword is not None:
-            self.duration = durationKeyword
-        elif 'type' in keywords or 'quarterLength' in keywords:  # dots dont cut it
-            self.duration = Duration(**keywords)
-
+        # Normally, we inherit Duration object from GeneralNote
+        # It is overridden here in case no chord duration is specified
+        if not any(k in keywords for k in ('duration', 'type', 'quarterLength')):
+            self._add_core_or_init(notes, useDuration=None)
+        else:
+            self._add_core_or_init(notes, useDuration=self.duration)
 
     def __eq__(self, other):
         if not super().__eq__(other):
             return False
-        if not len(self.notes) == len(other.notes):
+        if len(self.notes) != len(other.notes):
             return False
         return True
 
@@ -237,13 +229,13 @@ class ChordBase(note.NotRest):
             elif isinstance(n, ChordBase):
                 for newNote in n._notes:
                     self._notes.append(copy.deepcopy(newNote))
-                if quickDuration is True:
+                if quickDuration:
                     self.duration = n.duration
                     useDuration = None
                     quickDuration = False
             elif isinstance(n, note.NotRest):
                 self._notes.append(n)
-                if quickDuration is True:
+                if quickDuration:
                     self.duration = n.duration
                     useDuration = None
                     quickDuration = False


### PR DESCRIPTION
Fixes #1382. Had a look at the mentioned thread and found that the duration code can indeed be simplified a bit.
Chords basically have two ways of setting their duration.
Either the duration is specified explicitly in the keywords of the constructor (via `duration`, `type`, or `quarterLength`), or it must be inferred from the notes contained in the chord (via `_add_core_or_init`).
  
