### PR TITLE
Fix #1653: Correct scale caching mechanism.

### DIFF
--- a/music21/roman.py
+++ b/music21/roman.py
@@ -3489,10 +3489,11 @@ class RomanNumeral(harmony.Harmony):
             elif 'Scale' in keyClasses:
                 # Need unique 'hash' for each scale. Names is not enough as there are
                 # multiple scales with the same name but different pitches.
+                scaleHash = keyOrScale.name
                 if getattr(keyOrScale, 'isConcrete', False):
-                    scaleHash = "_".join([p.nameWithOctave for p in keyOrScale.pitches])
-                else:
-                    scaleHash = keyOrScale.name
+                    scaleHash += "_".join(
+                        [p.nameWithOctave for p in keyOrScale.pitches]
+                    )
                 if scaleHash in _scaleCache:
                     keyOrScale = _scaleCache[scaleHash]
                 else:

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -3491,7 +3491,7 @@ class RomanNumeral(harmony.Harmony):
                 # multiple scales with the same name but different pitches.
                 scaleHash = keyOrScale.name
                 if getattr(keyOrScale, 'isConcrete', False):
-                    scaleHash += "_".join(
+                    scaleHash += '_'.join(
                         [p.nameWithOctave for p in keyOrScale.pitches]
                     )
                 if scaleHash in _scaleCache:

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -2488,10 +2488,10 @@ class RomanNumeral(harmony.Harmony):
         if not isinstance(self._figure, str):  # pragma: no cover
             raise RomanNumeralException(f'got a non-string figure: {self._figure!r}')
 
-        if not self.useImpliedScale:
-            useScale = self._scale
-        else:
+        if self.useImpliedScale:
             useScale = self.impliedScale
+        else:
+            useScale = self._scale
 
         (workingFigure, useScale) = self._correctForSecondaryRomanNumeral(useScale)
 
@@ -3487,10 +3487,16 @@ class RomanNumeral(harmony.Harmony):
                     # store for later
                     _keyCache[keyOrScale.tonicPitchNameWithCase] = keyOrScale
             elif 'Scale' in keyClasses:
-                if keyOrScale.name in _scaleCache:
-                    keyOrScale = _scaleCache[keyOrScale.name]
+                # Need unique 'hash' for each scale. Names is not enough as there are
+                # multiple scales with the same name but different pitches.
+                if getattr(keyOrScale, 'isConcrete', False):
+                    scaleHash = "_".join([p.nameWithOctave for p in keyOrScale.pitches])
                 else:
-                    _scaleCache[keyOrScale.name] = keyOrScale
+                    scaleHash = keyOrScale.name
+                if scaleHash in _scaleCache:
+                    keyOrScale = _scaleCache[scaleHash]
+                else:
+                    _scaleCache[scaleHash] = keyOrScale
             else:
                 raise RomanNumeralException(
                     f'Cannot get a key from this object {keyOrScale!r}, send only '
@@ -4552,6 +4558,14 @@ class Test(unittest.TestCase):
         # Major still works
         rn = RomanNumeral(4, 'C')
         self.assertEqual(rn.figure, 'IV')
+
+    def test_scale_caching(self):
+        mcs = scale.ConcreteScale('c', pitches=('C', 'D', 'E', 'F', 'G', 'A', 'B'))
+        rn = mcs.romanNumeral('IV7')
+        self.assertEqual([p.unicodeName for p in rn.pitches], ['F', 'A', 'C', 'E'])
+        mcs = scale.ConcreteScale('c', pitches=('C', 'D', 'E-', 'F', 'G', 'A', 'B'))
+        rn = mcs.romanNumeral('IV7')
+        self.assertEqual([p.unicodeName for p in rn.pitches], ['F', 'A', 'C', 'E♭'])
 
 
 class TestExternal(unittest.TestCase):


### PR DESCRIPTION
Fixes #1653: We cannot use the name of a `ConcreteScale` to cache the scales as there are sometimes different scales with the same name but different pitches. Using the pitch list and names now to be more precise and avoid collisions.
Also adds a regression test. (and a small unrelated simplification).