### PR TITLE
Fix pylint recommendations

### DIFF
--- a/music21/analysis/reduceChords.py
+++ b/music21/analysis/reduceChords.py
@@ -384,7 +384,7 @@ class ChordReducer:
                             )
                             print(msg)
                             # raise ChordReducerException(msg)
-                        offset = min(offset, previousTimespan.endTime)
+                        offset = max(offset, previousTimespan.endTime)
                     scoreTree.removeTimespan(group[0])
                     subtree.removeTimespan(group[0])
                     newTimespan = group[0].new(offset=offset)

--- a/music21/analysis/reduceChords.py
+++ b/music21/analysis/reduceChords.py
@@ -384,8 +384,7 @@ class ChordReducer:
                             )
                             print(msg)
                             # raise ChordReducerException(msg)
-                        if offset < previousTimespan.endTime:
-                            offset = previousTimespan.endTime
+                        offset = min(offset, previousTimespan.endTime)
                     scoreTree.removeTimespan(group[0])
                     subtree.removeTimespan(group[0])
                     newTimespan = group[0].new(offset=offset)
@@ -542,8 +541,7 @@ class ChordReducer:
             measureObject.flatten().notes,
             weightAlgorithm,
         )
-        if maximumNumberOfChords > len(chordWeights):
-            maximumNumberOfChords = len(chordWeights)
+        maximumNumberOfChords = min(maximumNumberOfChords, len(chordWeights))
         sortedChordWeights = sorted(
             chordWeights,
             key=chordWeights.get,

--- a/music21/analysis/reduceChordsOld.py
+++ b/music21/analysis/reduceChordsOld.py
@@ -79,15 +79,14 @@ class ChordReducer:
         4.0
         '''
         from music21 import note
-        if measureObj.isFlat is False:
+        if not measureObj.isFlat:
             mObj = measureObj.flatten().notes.stream()
         else:
             mObj = measureObj.notes.stream()
 
         chordWeights = self.computeMeasureChordWeights(mObj, weightAlgorithm)
 
-        if numChords > len(chordWeights):
-            numChords = len(chordWeights)
+        numChords = min(numChords, len(chordWeights))
 
         maxNChords = sorted(chordWeights, key=chordWeights.get, reverse=True)[:numChords]
         if not maxNChords:

--- a/music21/analysis/reduceChordsOld.py
+++ b/music21/analysis/reduceChordsOld.py
@@ -79,7 +79,7 @@ class ChordReducer:
         4.0
         '''
         from music21 import note
-        if not measureObj.isFlat:
+        if measureObj.isFlat is False:
             mObj = measureObj.flatten().notes.stream()
         else:
             mObj = measureObj.notes.stream()

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -193,10 +193,8 @@ class WindowedAnalysis:
         elif windowType == 'noOverlap':
             start = 0
             end = start + windowSize
-            i = 0
-            while True:
-                if end >= len(self._windowedStream):
-                    end = len(self._windowedStream)
+            for i in range(windowCount):
+                end = min(end, len(self._windowedStream))
 
                 current = stream.Stream()
                 for j in range(start, end):
@@ -210,9 +208,6 @@ class WindowedAnalysis:
 
                 start = end
                 end = start + windowSize
-                i += 1
-                if i >= windowCount:
-                    break
 
         elif windowType == 'adjacentAverage':
             # first get overlapping windows

--- a/music21/braille/text.py
+++ b/music21/braille/text.py
@@ -599,7 +599,10 @@ class BrailleTextLine(prebase.ProtoM21Object):
         '''
         searchLocation = max(self.highestUsedLocation, self.textLocation)
         addSpaceAmount = 1 if addSpace else 0
-        return (searchLocation + len(text) + addSpaceAmount) <= self.lineLength
+        if (searchLocation + len(text) + addSpaceAmount) > self.lineLength:
+            return False
+        else:
+            return True
 
     def canInsert(self, textLocation, text):
         '''

--- a/music21/braille/text.py
+++ b/music21/braille/text.py
@@ -336,8 +336,7 @@ class BrailleText(prebase.ProtoM21Object):
                 if self.allLines[i].isHeading:
                     break
                 lineLength = self.allLines[i].textLocation
-                if lineLength > maxLineLength:
-                    maxLineLength = lineLength
+                maxLineLength = max(maxLineLength, lineLength)
             for j in range(indexStart, indexFinal):
                 brailleTextLine = self.allLines[j]
                 lineStrToCenter = str(brailleTextLine)
@@ -565,12 +564,10 @@ class BrailleTextLine(prebase.ProtoM21Object):
         '''
         if not self.canInsert(textLocation, text):
             raise BrailleTextException('Text cannot be inserted at specified location.')
-        self.textLocation = textLocation
-        for char in list(text):
-            self.allChars[self.textLocation] = char
-            self.textLocation += 1
-        if self.textLocation > self.highestUsedLocation:
-            self.highestUsedLocation = self.textLocation
+        for i, char in enumerate(text, start=textLocation):
+            self.allChars[i] = char
+        self.textLocation = textLocation + len(text)
+        self.highestUsedLocation = max(self.highestUsedLocation, self.textLocation)
 
     def canAppend(self, text, addSpace=True):
         '''
@@ -600,15 +597,9 @@ class BrailleTextLine(prebase.ProtoM21Object):
         >>> btl.canAppend('1234', addSpace=False)
         False
         '''
-        if self.highestUsedLocation > self.textLocation:
-            searchLocation = self.highestUsedLocation
-        else:
-            searchLocation = self.textLocation
+        searchLocation = max(self.highestUsedLocation, self.textLocation)
         addSpaceAmount = 1 if addSpace else 0
-        if (searchLocation + len(text) + addSpaceAmount) > self.lineLength:
-            return False
-        else:
-            return True
+        return (searchLocation + len(text) + addSpaceAmount) <= self.lineLength
 
     def canInsert(self, textLocation, text):
         '''

--- a/music21/common/objects.py
+++ b/music21/common/objects.py
@@ -67,8 +67,7 @@ class RelativeCounter(collections.Counter):
 
     def __iter__(self):
         sortedKeys = sorted(super().__iter__(), key=lambda x: self[x], reverse=True)
-        for k in sortedKeys:
-            yield k
+        yield from sortedKeys
 
     def items(self):
         for k in self:

--- a/music21/features/jSymbolic.py
+++ b/music21/features/jSymbolic.py
@@ -3016,8 +3016,7 @@ class MaximumNumberOfIndependentVoicesFeature(featuresModule.FeatureExtractor):
             for p in c.pitches:
                 for gSub in p.groups:
                     g.append(gSub)  # add to temporary group; will act as a set
-            if len(g) > found:
-                found = len(g)
+            found = max(found, len(g))
         self.feature.vector[0] = found
 
 

--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -186,10 +186,7 @@ def addLyricsToBassNote(bassNote, notationString=None):
     n = notation.Notation(notationString)
     if not n.figureStrings:
         return
-    maxLength = 0
-    for fs in n.figureStrings:
-        if len(fs) > maxLength:
-            maxLength = len(fs)
+    maxLength = max([len(fs) for fs in n.figureStrings])
     for fs in n.figureStrings:
         spacesInFront = ''
         for i in range(maxLength - len(fs)):

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -401,8 +401,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                 self.eventList.append(GlobalCommentLine(self.parsePositionInStream, line))
             else:
                 thisLine = SpineLine(self.parsePositionInStream, line)
-                if thisLine.numSpines > self.maxSpines:
-                    self.maxSpines = thisLine.numSpines
+                self.maxSpines = max(self.maxSpines, thisLine.numSpines)
                 self.eventList.append(thisLine)
             self.parsePositionInStream += 1
         self.fileLength = self.parsePositionInStream

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1551,8 +1551,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
             else:
                 innerStream.transferOffsetToElements()
                 ht = innerStream.highestTime
-            if ht > self.highestTime:
-                self.highestTime = ht
+            self.highestTime = max(self.highestTime, ht)
         self.refStreamOrTimeRange = [0.0, self.highestTime]
         self.parts = list(s.parts)
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1967,8 +1967,7 @@ class PartParser(XMLParserBase):
 
         self.lastMeasureParser = measureParser
 
-        if measureParser.staves > self.maxStaves:
-            self.maxStaves = measureParser.staves
+        self.maxStaves = max(self.maxStaves, measureParser.staves)
 
         if measureParser.transposition is not None:
             self.updateTransposition(measureParser.transposition)

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -828,8 +828,8 @@ class IntervalNetwork:
         for n in self.nodes.values():
             if x is None:
                 x = n.degree
-            if n.degree < x:
-                x = n.degree
+            else:
+                x = min(x, n.degree)
         return x
 
     @property
@@ -847,8 +847,8 @@ class IntervalNetwork:
         for n in self.nodes.values():
             if x is None:
                 x = n.degree
-            if n.degree > x:
-                x = n.degree
+            else:
+                x = max(x, n.degree)
         return x
 
     @property
@@ -870,8 +870,8 @@ class IntervalNetwork:
                 continue
             if x is None:
                 x = n.degree
-            if n.degree > x:
-                x = n.degree
+            else:
+                x = max(x, n.degree)
         return x
 
     @property

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -2828,8 +2828,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                 o = insertList[i]
                 e = insertList[i + 1]
                 qL = e.duration.quarterLength
-                if o + qL > highestTimeInsert:
-                    highestTimeInsert = o + qL
+                highestTimeInsert = max(highestTimeInsert, o + qL)
                 if lowestOffsetInsert is None or o < lowestOffsetInsert:
                     lowestOffsetInsert = o
                 i += 2
@@ -8425,8 +8424,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             for e in self._elements:
                 candidateOffset = (self.elementOffset(e)
                                    + e.duration.quarterLength)
-                if candidateOffset > highestTimeSoFar:
-                    highestTimeSoFar = candidateOffset
+                highestTimeSoFar = max(highestTimeSoFar, candidateOffset)
             self._cache['HighestTime'] = opFrac(highestTimeSoFar)
         return self._cache['HighestTime']
 
@@ -11183,10 +11181,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         # environLocal.printDebug(['makeVoices(): olDict', olDict])
         # find the max necessary voices by finding the max number
         # of elements in each group; these may not all be necessary
-        maxVoiceCount = 1
-        for group in olDict.values():
-            if len(group) > maxVoiceCount:
-                maxVoiceCount = len(group)
+        maxVoiceCount = max([len(group) for group in olDict.values()] + [1])
         if maxVoiceCount == 1:  # nothing to do here
             if not inPlace:
                 return returnObj

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -508,8 +508,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
     def __reversed__(self):
         me = self.matchingElements()
         me.reverse()
-        for item in me:
-            yield item
+        yield from me
 
     def clone(self: StreamIteratorType) -> StreamIteratorType:
         '''

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -523,8 +523,7 @@ def makeMeasures(
             refStreamHighestTime = refStreamOrTimeRange.highestTime
         else:  # assume it's a list
             refStreamHighestTime = max(refStreamOrTimeRange)
-        if refStreamHighestTime > oMax:
-            oMax = refStreamHighestTime
+        oMax = max(oMax, refStreamHighestTime)
 
     # create a stream of measures to contain the offsets range defined
     # create as many measures as needed to fit in oMax

--- a/music21/test/treeYield.py
+++ b/music21/test/treeYield.py
@@ -66,16 +66,14 @@ class TreeYielder:  # pragma: no cover
                 dictTuple = ('dict', keyX)
                 self.stackVals.append(dictTuple)
                 x = obj[keyX]
-                for z in self.run(x, memo=memo):
-                    yield z
+                yield from self.run(x, memo=memo)
                 self.stackVals.pop()
 
         elif tObj in [list, tuple]:
             for i, x in enumerate(obj):
                 listTuple = ('listLike', i)
                 self.stackVals.append(listTuple)
-                for z in self.run(x, memo=memo):
-                    yield z
+                yield from self.run(x, memo=memo)
                 self.stackVals.pop()
 
         else:  # objects or uncaught types...
@@ -95,8 +93,7 @@ class TreeYielder:  # pragma: no cover
                 objTuple = ('getattr', x)
                 self.stackVals.append(objTuple)
                 try:
-                    for z in self.run(gotValue, memo=memo):
-                        yield z
+                    yield from self.run(gotValue, memo=memo)
                 except RuntimeError:
                     raise ValueError(f'Maximum recursion on:\n{self.currentLevel()}')
                 self.stackVals.pop()

--- a/music21/tree/core.py
+++ b/music21/tree/core.py
@@ -519,12 +519,10 @@ class AVLTree(prebase.ProtoM21Object):
         def recurse(node):
             if node is not None:
                 if node.leftChild is not None:
-                    for n in recurse(node.leftChild):
-                        yield n
+                    yield from recurse(node.leftChild)
                 yield node
                 if node.rightChild is not None:
-                    for n in recurse(node.rightChild):
-                        yield n
+                    yield from recurse(node.rightChild)
         return recurse(self.rootNode)
 
     def populateFromSortedList(self, listOfTuples):

--- a/music21/tree/node.py
+++ b/music21/tree/node.py
@@ -273,18 +273,14 @@ class ElementNode(core.AVLNode):
         leftChild = self.leftChild
         if leftChild:
             leftChild.updateEndTimes()
-            if leftChild.endTimeLow < endTimeLow:
-                endTimeLow = leftChild.endTimeLow
-            if endTimeHigh < leftChild.endTimeHigh:
-                endTimeHigh = leftChild.endTimeHigh
+            endTimeLow = min(endTimeLow, leftChild.endTimeLow)
+            endTimeHigh = max(endTimeHigh, leftChild.endTimeHigh)
 
         rightChild = self.rightChild
         if rightChild:
             rightChild.updateEndTimes()
-            if rightChild.endTimeLow < endTimeLow:
-                endTimeLow = rightChild.endTimeLow
-            if endTimeHigh < rightChild.endTimeHigh:
-                endTimeHigh = rightChild.endTimeHigh
+            endTimeLow = min(endTimeLow, rightChild.endTimeLow)
+            endTimeHigh = max(endTimeHigh, rightChild.endTimeHigh)
         self.endTimeLow = endTimeLow
         self.endTimeHigh = endTimeHigh
 
@@ -515,18 +511,14 @@ class OffsetNode(ElementNode):
         leftChild = self.leftChild
         if leftChild:
             leftChild.updateEndTimes()
-            if leftChild.endTimeLow < endTimeLow:
-                endTimeLow = leftChild.endTimeLow
-            if endTimeHigh < leftChild.endTimeHigh:
-                endTimeHigh = leftChild.endTimeHigh
+            endTimeLow = min(endTimeLow, leftChild.endTimeLow)
+            endTimeHigh = max(endTimeHigh, leftChild.endTimeHigh)
 
         rightChild = self.rightChild
         if rightChild:
             rightChild.updateEndTimes()
-            if rightChild.endTimeLow < endTimeLow:
-                endTimeLow = rightChild.endTimeLow
-            if endTimeHigh < rightChild.endTimeHigh:
-                endTimeHigh = rightChild.endTimeHigh
+            endTimeLow = min(endTimeLow, rightChild.endTimeLow)
+            endTimeHigh = max(endTimeHigh, rightChild.endTimeHigh)
         self.endTimeLow = endTimeLow
         self.endTimeHigh = endTimeHigh
 

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -1554,11 +1554,7 @@ class Verticality(base.Music21Object):
         >>> vs1.getShortestDuration()
         1.0
         '''
-        leastQuarterLength = self.objects[0].quarterLength
-        for obj in self.objects:
-            if obj.quarterLength < leastQuarterLength:
-                leastQuarterLength = obj.quarterLength
-        return leastQuarterLength
+        return min([obj.quarterLength for obj in self.objects])
 
     def getLongestDuration(self):
         '''
@@ -1574,11 +1570,7 @@ class Verticality(base.Music21Object):
         >>> vs1.getLongestDuration()
         4.0
         '''
-        longestQuarterLength = self.objects[0].quarterLength
-        for obj in self.objects:
-            if obj.quarterLength > longestQuarterLength:
-                longestQuarterLength = obj.quarterLength
-        return longestQuarterLength
+        return max([obj.quarterLength for obj in self.objects])
 
     def changeDurationOfAllObjects(self, newQuarterLength):
         '''


### PR DESCRIPTION
Pylint now recommends using `yield from` and the use of `min/max` to simplify if statements.