### PR TITLE
Add 'fa up' notehead type

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4247,6 +4247,7 @@ class Chord(ChordBase):
         'diamond'
         'do'
         'fa'
+        'fa up'
         'inverted triangle'
         'la'
         'left triangle'

--- a/music21/note.py
+++ b/music21/note.py
@@ -59,6 +59,7 @@ noteheadTypeNames = (
     'diamond',
     'do',
     'fa',
+    'fa up',
     'inverted triangle',
     'la',
     'left triangle',
@@ -1132,7 +1133,7 @@ class NotRest(GeneralNote):
 
         >>> note.noteheadTypeNames
         ('arrow down', 'arrow up', 'back slashed', 'circle dot', 'circle-x', 'circled', 'cluster',
-         'cross', 'diamond', 'do', 'fa', 'inverted triangle', 'la', 'left triangle',
+         'cross', 'diamond', 'do', 'fa', 'fa up', 'inverted triangle', 'la', 'left triangle',
          'mi', 'none', 'normal', 'other', 're', 'rectangle', 'slash', 'slashed', 'so',
          'square', 'ti', 'triangle', 'x')
         >>> n = note.Note()


### PR DESCRIPTION
This PR adds the 'fa up' notehead type, which is included in the official [MusicXML spec](https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/notehead-value/).
While it is rarely used, it should still be included as it currently leads to import errors for MusicXML files that use it. 