### PR TITLE
Export stem styles on notes with implicit stem directions

### DIFF
--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4103,17 +4103,26 @@ class MeasureExporter(XMLExporterBase):
             n = t.cast(note.NotRest, n)
             stemDirection = n.stemDirection
 
-        if stemDirection is not None:
+        if stem_has_style := (chordOrN.hasStyleInformation
+                                and isinstance(chordOrN.style, style.NoteStyle)
+                                and chordOrN.style.stemStyle is not None):
+            note_style = chordOrN.style
+
+        if stemDirection is not None or stem_has_style:
             mxStem = SubElement(mxNote, 'stem')
-            sdText = stemDirection
+            if stemDirection is None:
+                if closest_clef := chordOrN.getContextByClass(clef.Clef):
+                    sdText = closest_clef.getStemDirectionForPitches(chordOrN.pitches)
+                else:
+                    sdText = 'up'
+            else:
+                sdText = stemDirection
             if sdText == 'noStem':
                 sdText = 'none'
             mxStem.text = sdText
-            if (chordOrN.hasStyleInformation
-                    and isinstance(chordOrN.style, style.NoteStyle)
-                    and chordOrN.style.stemStyle is not None):
-                self.setColor(mxStem, chordOrN.style.stemStyle)
-                self.setPosition(mxStem, chordOrN.style.stemStyle)
+            if stem_has_style:
+                self.setColor(mxStem, note_style.stemStyle)
+                self.setPosition(mxStem, note_style.stemStyle)
 
         # end Stem
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4103,12 +4103,13 @@ class MeasureExporter(XMLExporterBase):
             n = t.cast(note.NotRest, n)
             stemDirection = n.stemDirection
 
-        if stem_has_style := (chordOrN.hasStyleInformation
-                                and isinstance(chordOrN.style, style.NoteStyle)
-                                and chordOrN.style.stemStyle is not None):
-            note_style = chordOrN.style
+        stem_style = None
+        if (chordOrN.hasStyleInformation
+                and isinstance(chordOrN.style, style.NoteStyle)
+                and chordOrN.style.stemStyle is not None):
+            stem_style = chordOrN.style.stemStyle
 
-        if stemDirection is not None or stem_has_style:
+        if stemDirection is not None or stem_style:
             mxStem = SubElement(mxNote, 'stem')
             if stemDirection is None:
                 if closest_clef := chordOrN.getContextByClass(clef.Clef):
@@ -4120,9 +4121,9 @@ class MeasureExporter(XMLExporterBase):
             if sdText == 'noStem':
                 sdText = 'none'
             mxStem.text = sdText
-            if stem_has_style:
-                self.setColor(mxStem, note_style.stemStyle)
-                self.setPosition(mxStem, note_style.stemStyle)
+            if stem_style:
+                self.setColor(mxStem, stem_style)
+                self.setPosition(mxStem, stem_style)
 
         # end Stem
 

--- a/music21/musicxml/test_m21ToXml.py
+++ b/music21/musicxml/test_m21ToXml.py
@@ -27,6 +27,7 @@ from music21 import note
 from music21 import repeat
 from music21 import spanner
 from music21 import stream
+from music21 import style
 from music21 import tempo
 
 from music21.musicxml import helpers
@@ -921,6 +922,13 @@ class Test(unittest.TestCase):
         self.assertIn('<rest', xmlOut)
         self.assertNotIn('<forward>', xmlOut)
 
+    def test_stem_style_without_direction(self):
+        one_note_tune = converter.parse('tinyNotation: 2/4 c2')
+        half_note = one_note_tune.recurse().notes.first()
+        half_note.style.stemStyle = style.Style()
+        half_note.style.stemStyle.color = 'red'
+        xmlOut = GeneralObjectExporter().parse(one_note_tune).decode('utf-8')
+        self.assertIn('<stem color="#FF0000">up</stem>', xmlOut)
 
 
 class TestExternal(unittest.TestCase):


### PR DESCRIPTION
**Before**
Stem styles were only exported if a stemDirection was explicit.

**Now**
If a stem has style information, the stem direction is calculated and the stem element is written with style info.

Fixes #1724