### PR TITLE
Start 9.6 beta - update requirements.dev

### DIFF
--- a/dist/dist.py
+++ b/dist/dist.py
@@ -93,25 +93,22 @@ so allocate time (2 min on M4).  Start working on the announcement while it's ru
 
         [pypi]
         username:__token__
-        password:pypi-the_gibberish_generated_in_create_api_token_at_the_bottom_of_account_settings
+        password:pypi-API_TOKEN
 
-    The "password" is under "Account Settings" -> "API Token" -> "Options" -> "View Unique
-    Identifier" -- the Copy button doesn't work at least on Mac.
-    (or you can use the "password" field in the [pypi] section, but that's not recommended)')
+    The "password" is the API token you've just created -- if you lose the file you
+    will also lose the API token. and have to create it again.  This is all very
+    poorly documented.  This is Not the "Unique identifier" that you see in the
+    "API Tokens" tab on the "Your Account" page -- super confusing.
 
-    FYI -- PyPI is apparently uninterested in having contributions from smaller projects
-    which haven't been following their internal security discussions for years.  All of this
-    is super mysterious and not well documented.  sigh.  But they did mail out USB sticks to
-    the top 1% of projects in Python!
+20. Delete the two .tar.gz files and .whl file in dist. (and the docs)
 
-20. Delete the two .tar.gz files and .whl file in dist.
-
-21. For starting a new major release create a GitHub branch for the old one.
+21. For starting a new major release create a GitHub branch to preserve the old one
+    for patches, etc. esp. during beta releases.
 
 22. Immediately increment the number in _version.py and run tests on it here
     to prepare for next release.
 
-23. Announce on the blog, to the list, and twitter.
+23. Announce on the blog and to the list.
 '''
 import os
 import shutil

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ Changing this number invalidates old pickles -- do it if the old pickles create 
 '''
 from __future__ import annotations
 
-__version__ = '9.5.0'
+__version__ = '9.6.0b1'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -27,7 +27,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'9.5.0'
+'9.6.0b1'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 wheel
-astroid>=3.2.0
-pylint>=2.16.0
+pylint>=3.2.0
 flake8<7.0.0
 flake8-quotes>=3.3.2
 hatchling
@@ -17,3 +16,5 @@ nbval
 pytest
 docutils
 types-requests
+twine
+hatch


### PR DESCRIPTION
Update version for 9.6 beta development

Change the dev requirements to match what Jacob Walls had suggested but that I forgot to do (remove astroid and pin pylint to 3.2 or higher.

Update last couple parts of dist.py