### PR TITLE
midi.translate improvements

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -50,7 +50,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '9.6.0b4'
+__version__ = '9.6.0b5'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/alpha/analysis/aligner.py
+++ b/music21/alpha/analysis/aligner.py
@@ -862,7 +862,7 @@ class StreamAligner:
             raise AlignmentTracebackException('Traceback of best alignment did not end properly')
 
         self.changesCount = Counter(elem[2] for elem in self.changes)
-        self.similarityScore = float(self.changesCount[ChangeOps.NoChange]) / len(self.changes)
+        self.similarityScore = self.changesCount[ChangeOps.NoChange] / len(self.changes)
 
     def showChanges(self, show=False):
         '''

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -407,7 +407,7 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
             # environLocal.printDebug(['added likely key', likelyKeys[pc]])
         return likelyKeys
 
-    def _getDifference(self, keyResults, pcDistribution, weightType) -> None|list[int|float]:
+    def _getDifference(self, keyResults, pcDistribution, weightType) -> None|list[float]:
         '''
         Takes in a list of numerical probable key results and returns the
         difference of the top two keys.
@@ -416,14 +416,14 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
         if keyResults is None:
             return None
 
-        solution: list[int|float] = [0.0] * 12
+        solution: list[float] = [0.0] * 12
         top = [0.0] * 12
         bottomRight = [0.0] * 12
         bottomLeft = [0.0] * 12
 
         toneWeights = self.getWeights(weightType)
-        profileAverage = float(sum(toneWeights)) / len(toneWeights)
-        histogramAverage = float(sum(pcDistribution)) / len(pcDistribution)
+        profileAverage = sum(toneWeights) / len(toneWeights)
+        histogramAverage = sum(pcDistribution) / len(pcDistribution)
 
         for i in range(len(solution)):
             for j in range(len(toneWeights)):
@@ -437,9 +437,9 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
                     pcDistribution[j] - histogramAverage) ** 2)
 
                 if bottomRight[i] == 0 or bottomLeft[i] == 0:
-                    solution[i] = 0
+                    solution[i] = 0.0
                 else:
-                    solution[i] = float(top[i]) / ((bottomRight[i] * bottomLeft[i]) ** 0.5)
+                    solution[i] = float(top[i] / ((bottomRight[i] * bottomLeft[i]) ** 0.5))
         return solution
 
     def solutionLegend(self, compress=False):

--- a/music21/base.py
+++ b/music21/base.py
@@ -27,7 +27,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'9.6.0b4'
+'9.6.0b5'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -147,8 +147,11 @@ MAX_ELEMENTS_IN_SEGMENT = 48  # 8 measures of 6 notes, etc. each
 
 _ThreeDigitNumber = namedtuple('_ThreeDigitNumber', ['hundreds', 'tens', 'ones'])
 
-SegmentKey = namedtuple('SegmentKey', ['measure', 'ordinal', 'affinity', 'hand'])
-SegmentKey.__new__.__defaults__ = (0, 0, None, None)
+class SegmentKey(t.NamedTuple):
+    measure: int = 0
+    ordinal: int = 0
+    affinity: Affinity|None = None
+    hand: str|None = None
 
 
 # ------------------------------------------------------------------------------

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -79,6 +79,7 @@ class SubConverter:
 
     def __init__(self, **keywords) -> None:
         self._stream: stream.Score|stream.Part|stream.Opus = stream.Score()
+        # TODO: unify keywords so that they are used by both parseFile and parseData
         self.keywords: dict[str, t.Any] = keywords
 
     def parseData(self, dataString, number: int|None = None):
@@ -1023,7 +1024,11 @@ class ConverterMidi(SubConverter):
     registerInputExtensions = ('mid', 'midi')
     registerOutputExtensions = ('mid',)
 
-    def parseData(self, strData, number=None):
+    def __init__(self, *, encoding='utf-8', **keywords):
+        self.encoding = encoding
+        super().__init__(**keywords)
+
+    def parseData(self, strData, number=None, *, encoding: str = ''):
         '''
         Get MIDI data from a binary string representation.
 
@@ -1033,13 +1038,22 @@ class ConverterMidi(SubConverter):
         `quantizePost` controls whether to quantize the output. (Default: True)
         `quarterLengthDivisors` allows for overriding the default quantization units
         in defaults.quantizationQuarterLengthDivisors. (Default: (4, 3)).
+
+        If encoding is not provided use the encoding of the Converter
+        (default "utf-8")
         '''
         from music21.midi import translate as midiTranslate
-        self.stream = midiTranslate.midiStringToStream(strData, **self.keywords)
+        self.stream = midiTranslate.midiStringToStream(
+            strData,
+            encoding=encoding or self.encoding,
+            **self.keywords
+        )
 
     def parseFile(self,
                   filePath: pathlib.Path|str,
                   number: int|None = None,
+                  *,
+                  encoding: str = '',
                   **keywords):
         '''
         Get MIDI data from a file path.
@@ -1050,9 +1064,17 @@ class ConverterMidi(SubConverter):
         `quantizePost` controls whether to quantize the output. (Default: True)
         `quarterLengthDivisors` allows for overriding the default quantization units
         in defaults.quantizationQuarterLengthDivisors. (Default: (4, 3)).
+
+        If encoding is not provided use the encoding of the Converter
+        (default "utf-8")
         '''
         from music21.midi import translate as midiTranslate
-        midiTranslate.midiFilePathToStream(filePath, inputM21=self.stream, **keywords)
+        midiTranslate.midiFilePathToStream(
+            filePath,
+            inputM21=self.stream,
+            encoding=encoding or self.encoding,
+            **keywords
+        )
 
     def write(self,
               obj,

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -176,26 +176,29 @@ class ScoreLayout(LayoutBase):
         if staffLayoutList is not None:
             self.staffLayoutList = staffLayoutList
 
-    def tenthsToMillimeters(self, tenths):
+    def tenthsToMillimeters(self, tenths: int|float) -> int|float:
         '''
         given the scalingMillimeters and scalingTenths,
         return the value in millimeters of a number of
         musicxml "tenths" where a tenth is a tenth of the distance
-        from one staff line to another
+        from one staff line to another.
 
         returns 0.0 if either of scalingMillimeters or scalingTenths
         is undefined.
 
-
         >>> sl = layout.ScoreLayout(scalingMillimeters=2.0, scalingTenths=10)
-        >>> print(sl.tenthsToMillimeters(10))
+        >>> sl.tenthsToMillimeters(10)
         2.0
-        >>> print(sl.tenthsToMillimeters(17))  # printing to round
+
+        Numbers are rounded to a maximum of 6 digits (but because they are floats,
+        there may be inaccuracies.
+
+        >>> sl.tenthsToMillimeters(17)
         3.4
         '''
         if self.scalingMillimeters is None or self.scalingTenths is None:
             return 0.0
-        millimetersPerTenth = float(self.scalingMillimeters) / self.scalingTenths
+        millimetersPerTenth = self.scalingMillimeters / self.scalingTenths
         return round(millimetersPerTenth * tenths, 6)
 
 

--- a/music21/midi/base.py
+++ b/music21/midi/base.py
@@ -1283,6 +1283,9 @@ class MidiEvent(prebase.ProtoM21Object):
         >>> me2.channel = 12
         >>> me1.matchedNoteOff(me2)
         False
+
+        Note that this method is no longer used in MIDI Parsing
+        because it is inefficient.
         '''
         if self.isNoteOn() and other.isNoteOff():
             if self.pitch == other.pitch and self.channel == other.channel:

--- a/music21/midi/tests.py
+++ b/music21/midi/tests.py
@@ -331,7 +331,7 @@ class Test(unittest.TestCase):
         # dealing with midi files that use running status compression
         s = converter.parse(fp, forceSource=True)
         self.assertEqual(len(s.parts), 2)
-        self.assertEqual(len(s.parts[0].recurse().notes), 704)
+        self.assertEqual(len(s.parts[0].recurse().notes), 702)
         self.assertEqual(len(s.parts[1].recurse().notes), 856)
 
         # for n in s.parts[0].notes:
@@ -1561,7 +1561,7 @@ class Test(unittest.TestCase):
 
         for filename, encoding, lyricFact in testCases:
             fp = common.getSourceFilePath() / 'midi' / 'testPrimitive' / filename
-            s = converter.parse(fp, encoding_type=encoding)
+            s = converter.parse(fp, encoding=encoding)
             for (n, l) in zip(s.flatten().notes, lyricFact):
                 self.assertEqual(n.lyric, l)
 

--- a/music21/midi/tests.py
+++ b/music21/midi/tests.py
@@ -329,7 +329,7 @@ class Test(unittest.TestCase):
         fp = dirLib / 'test09.mid'
         # a simple file created in athenacl
         # dealing with midi files that use running status compression
-        s = converter.parse(fp, forceSource=True)
+        s = converter.parse(fp)
         self.assertEqual(len(s.parts), 2)
         self.assertEqual(len(s.parts[0].recurse().notes), 702)
         self.assertEqual(len(s.parts[1].recurse().notes), 856)

--- a/music21/midi/tests.py
+++ b/music21/midi/tests.py
@@ -23,12 +23,20 @@ from music21.midi.base import (
     MidiFile,
 )
 from music21.midi.translate import (
+    TimedNoteEvent,
+    TranslateWarning,
+    channelInstrumentData,
+    conductorStream,
+    getMetaEvents,
     midiAsciiStringToBinaryString,
-    noteToMidiEvents,
+    midiEventsToInstrument,
     midiEventsToNote,
-    streamHierarchyToMidiTracks, midiFileToStream, conductorStream,
-    streamToMidiFile, prepareStreamForMidi, midiEventsToInstrument, getMetaEvents,
-    TranslateWarning, channelInstrumentData, packetStorageFromSubstreamList,
+    midiFileToStream,
+    noteToMidiEvents,
+    packetStorageFromSubstreamList,
+    prepareStreamForMidi,
+    streamHierarchyToMidiTracks,
+    streamToMidiFile,
     updatePacketStorageWithChannelInfo,
 )
 from music21.musicxml import testPrimitive
@@ -403,8 +411,7 @@ class Test(unittest.TestCase):
         self.assertIsInstance(eventList[3], MidiEvent)
 
         # translate eventList back to a note
-        n2 = midiEventsToNote(((eventList[0].time, eventList[1]),
-                               (eventList[2].time, eventList[2])))
+        n2 = midiEventsToNote(TimedNoteEvent(eventList[0].time, eventList[2].time, eventList[1]))
         self.assertEqual(n2.pitch.nameWithOctave, 'A4')
         self.assertEqual(n2.quarterLength, 2.0)
 

--- a/music21/midi/tests.py
+++ b/music21/midi/tests.py
@@ -329,7 +329,7 @@ class Test(unittest.TestCase):
         fp = dirLib / 'test09.mid'
         # a simple file created in athenacl
         # dealing with midi files that use running status compression
-        s = converter.parse(fp)
+        s = converter.parse(fp, forceSource=True)
         self.assertEqual(len(s.parts), 2)
         self.assertEqual(len(s.parts[0].recurse().notes), 704)
         self.assertEqual(len(s.parts[1].recurse().notes), 856)

--- a/music21/midi/tests.py
+++ b/music21/midi/tests.py
@@ -1538,23 +1538,24 @@ class Test(unittest.TestCase):
 
     def testMidiImportLyrics(self):
         lyricFactZh = ['明', '山', '涌', '水', '郁', '郁', '葱', '', '葱',
-                        '钟', '灵', '毓', '秀', '海', '天', '', '东',
-                        '济', '济', '多', '士', '四', '方', '所', '', '崇',
-                        '早', '', '育', '', '文', '明', '', '种']
+                       '钟', '灵', '毓', '秀', '海', '天', '', '东',
+                       '济', '济', '多', '士', '四', '方', '所', '', '崇',
+                       '早', '', '育', '', '文', '明', '', '种']
         lyricFactKo = ['빛', '날', '세', '라', '영', '웅', '열', '', '사',
-                        '만', '세', '불', '망', '하', '실', '', '이',
-                        '옛', '적', '이', '나', '지', '금', '이', '', '나',
-                        '항', '상', '앙', '모', '합', '니', '', '다']
+                       '만', '세', '불', '망', '하', '실', '', '이',
+                       '옛', '적', '이', '나', '지', '금', '이', '', '나',
+                       '항', '상', '앙', '모', '합', '니', '', '다']
         testCases = [
             ('test18.mid', 'utf-8', lyricFactZh),
             ('test19.mid', 'gbk', lyricFactZh),
             ('test20.mid', 'utf-8', lyricFactKo),
             ('test21.mid', 'euc-kr', lyricFactKo),
         ]
-        for (filename, encoding, lyricFact) in testCases:
+
+        for filename, encoding, lyricFact in testCases:
             fp = common.getSourceFilePath() / 'midi' / 'testPrimitive' / filename
             s = converter.parse(fp, encoding_type=encoding)
-            for (n, l) in zip(s.flat.notes, lyricFact):
+            for (n, l) in zip(s.flatten().notes, lyricFact):
                 self.assertEqual(n.lyric, l)
 
 

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2234,8 +2234,6 @@ def prepareStreamForMidi(s) -> stream.Stream:
         {0.0} <music21.stream.Measure 1 offset=0.0>
             {0.0} <music21.note.Note C>
     '''
-    from music21 import volume
-
     if s[stream.Measure]:
         s = s.expandRepeats()  # makes a deep copy
     else:

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -1877,7 +1877,13 @@ def getNotesFromEvents(
             awaitingNoteOn[event.pitch, event.channel] = time
         elif event.isNoteOn():
             try:
-                offTime = awaitingNoteOn.pop((event.pitch, event.channel))
+                # we had .pop() instead of .get() which would be quite a bit
+                # better to have, but there are a number of cases, including the
+                # test09 midi set where there are multiple note ons at the same
+                # point with multiple note offs at the same time point for the
+                # same pitch and channel.  Better to have the notes turned off
+                # from some previous note off event then to lose it.
+                offTime = awaitingNoteOn.get((event.pitch, event.channel))
                 notes.append(TimedNoteEvent(time, offTime, event))
             except KeyError:  # pragma: no cover
                 pass
@@ -1885,7 +1891,8 @@ def getNotesFromEvents(
                 #     f' cannot find note off for pitch {event.pitch} and channel {event.channel}'
                 # )
 
-    # could raise a warning on note offs without a note on.
+    # could also raise a warning on note offs without a note on.
+    print(len(notes))
     return notes[::-1]  # back to increasing order.
 
 

--- a/music21/text.py
+++ b/music21/text.py
@@ -589,12 +589,13 @@ class Trigram:
         thisLength = total ** 0.5
         self._length = thisLength
 
-    def similarity(self, other):
+    def similarity(self, other: Trigram) -> float:
         '''
         returns a number between 0 and 1 indicating similarity between
         two trigrams.
-        1 means an identical ratio of trigrams;
-        0 means no trigrams in common.
+
+        1.0 means an identical ratio of trigrams;
+        0.0 means no trigrams in common.
         '''
         if not isinstance(other, Trigram):
             raise TypeError("can't compare Trigram with non-Trigram")
@@ -612,14 +613,14 @@ class Trigram:
         # environLocal.warn([self.length, 'self'])
         # environLocal.warn([other.length, 'other'])
 
-        return float(total) / (self.length * other.length)
+        return float(total / (self.length * other.length))
 
-    def __sub__(self, other):
+    def __sub__(self, other: Trigram) -> float:
         '''
-        indicates difference between trigram sets; 1 is entirely
-        different, 0 is entirely the same.
+        indicates difference between trigram sets; 1.0 is entirely
+        different, 0.0 is entirely the same.
         '''
-        return 1 - self.similarity(other)
+        return 1.0 - self.similarity(other)
 
     def makeWords(self, count):
         '''


### PR DESCRIPTION
Followup from #1769 gave me an opportunity to find places to improve midi translate.  Pinging @oxygen-dioxide since some changes took place since then

* Change `getNotesFromEvents()` from potentially O(n^2) to O(n) while retaining sort order.

* Pass encoding to parsing of instrument names in addition to lyrics (renamed "encoding_type" to "encoding" -- missed in prior review)

* create TimingNoteEvent which is a typed NamedTuple that keeps track of when a MidiEvent NoteOn started, stopped, and what the NoteOn event was.  Replaced the old tuple of tuples.

* Faster gathering of Chords (remove potential O(n^2) search).

* Remove unused special case for single-note streams.

* opFrac many offsets and durations in MIDI for absolutely correct tuplets, etc.

* Misc: Update braille.translate SegmentKey to typing.NamedTuple

* Misc: Search code for places where we were still casting to float for Python 2 division!

* Misc: Add typing to text/Trigram and some layout things

This is part of the non-backwards compatible MIDI.translate guts rewrite discussed on the music21 list.

Coverage % is expected to drop because the amount of code has been reduced a lot.