### PR TITLE
Support writing lyrics to midi

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1082,13 +1082,15 @@ class ConverterMidi(SubConverter):
               fp=None,
               subformats=(),
               *,
+              encoding: str = 'utf-8',
               addStartDelay: bool = False,
               **keywords):  # pragma: no cover
         from music21.midi import translate as midiTranslate
         if fp is None:
             fp = self.getTemporaryFile()
 
-        mf = midiTranslate.music21ObjectToMidiFile(obj, addStartDelay=addStartDelay)
+        mf = midiTranslate.music21ObjectToMidiFile(obj, addStartDelay=addStartDelay,
+                                                   encoding=encoding)
         mf.open(fp, 'wb')  # write binary
         mf.write()
         mf.close()

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1024,15 +1024,12 @@ class ConverterMidi(SubConverter):
     registerInputExtensions = ('mid', 'midi')
     registerOutputExtensions = ('mid',)
 
-    def __init__(self, **keywords):
-        super().__init__(**keywords)
-
     @property
     def encoding(self) -> str:
-        if "encoding" in self.keywords and self.keywords["encoding"]:
+        if 'encoding' in self.keywords and self.keywords['encoding']:
             # if the encoding is set to None or '', it will be ignored
-            return self.keywords["encoding"]
-        return "utf-8"
+            return self.keywords['encoding']
+        return 'utf-8'
 
     def parseData(self, strData, number=None, *, encoding: str = ''):
         '''
@@ -1078,7 +1075,7 @@ class ConverterMidi(SubConverter):
         '''
         from music21.midi import translate as midiTranslate
         keywords = {k: v for k, v in self.keywords.items()
-                    if k not in ('encoding',)} 
+                    if k not in ('encoding',)}
         midiTranslate.midiFilePathToStream(
             filePath,
             inputM21=self.stream,

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1024,9 +1024,15 @@ class ConverterMidi(SubConverter):
     registerInputExtensions = ('mid', 'midi')
     registerOutputExtensions = ('mid',)
 
-    def __init__(self, *, encoding='utf-8', **keywords):
-        self.encoding = encoding
+    def __init__(self, **keywords):
         super().__init__(**keywords)
+
+    @property
+    def encoding(self) -> str:
+        if "encoding" in self.keywords and self.keywords["encoding"]:
+            # if the encoding is set to None or '', it will be ignored
+            return self.keywords["encoding"]
+        return "utf-8"
 
     def parseData(self, strData, number=None, *, encoding: str = ''):
         '''
@@ -1043,10 +1049,12 @@ class ConverterMidi(SubConverter):
         (default "utf-8")
         '''
         from music21.midi import translate as midiTranslate
+        keywords = {k: v for k, v in self.keywords.items()
+                    if k not in ('encoding',)}
         self.stream = midiTranslate.midiStringToStream(
             strData,
             encoding=encoding or self.encoding,
-            **self.keywords
+            **keywords
         )
 
     def parseFile(self,
@@ -1069,6 +1077,8 @@ class ConverterMidi(SubConverter):
         (default "utf-8")
         '''
         from music21.midi import translate as midiTranslate
+        keywords = {k: v for k, v in self.keywords.items()
+                    if k not in ('encoding',)} 
         midiTranslate.midiFilePathToStream(
             filePath,
             inputM21=self.stream,
@@ -1082,15 +1092,15 @@ class ConverterMidi(SubConverter):
               fp=None,
               subformats=(),
               *,
-              encoding: str = 'utf-8',
               addStartDelay: bool = False,
+              encoding: str = '',
               **keywords):  # pragma: no cover
         from music21.midi import translate as midiTranslate
         if fp is None:
             fp = self.getTemporaryFile()
 
         mf = midiTranslate.music21ObjectToMidiFile(obj, addStartDelay=addStartDelay,
-                                                   encoding=encoding)
+                                                   encoding=encoding or self.encoding)
         mf.open(fp, 'wb')  # write binary
         mf.write()
         mf.close()

--- a/music21/midi/tests.py
+++ b/music21/midi/tests.py
@@ -630,7 +630,7 @@ class Test(unittest.TestCase):
         <music21.midi.DeltaTime (empty) track=1>,
         <music21.midi.MidiEvent PITCH_BEND, track=1, channel=1, parameter1=0, parameter2=64>,
         <music21.midi.DeltaTime (empty) track=1>,
-        <music21.midi.MidiEvent PROGRAM_CHANGE, track=1, channel=1, data=0>, 
+        <music21.midi.MidiEvent PROGRAM_CHANGE, track=1, channel=1, data=0>,
         <music21.midi.DeltaTime (empty) track=1>,
         <music21.midi.MidiEvent NOTE_ON, track=1, channel=1, pitch=62, velocity=90>]'''
 
@@ -1568,7 +1568,7 @@ class Test(unittest.TestCase):
                 self.assertEqual(n.lyric, l)
 
     def testMidiExportLyrics(self):
-        lyricEn = 'cat'# ascii characters should be supported by every encodings
+        lyricEn = 'cat'  # ascii characters should be supported by every encoding
         lyricZh = '明'
         lyricKo = '빛'
 
@@ -1604,6 +1604,7 @@ class Test(unittest.TestCase):
                 m = converter.parseData(b, fmt='midi', encoding=encoding)
                 for n in m.flatten().notes:
                     self.assertEqual(n.lyric, lyric)
+
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -515,12 +515,10 @@ def noteToMidiEvents(
     mt = None  # use a midi track set to None
     eventList: list[DeltaTime|MidiEvent] = []
 
-    if includeDeltaTime:
-        dt = DeltaTime(mt, channel=channel)
-        # add to track events
-        eventList.append(dt)
-
     if (inputM21.lyric is not None and inputM21.lyric != ''):
+        if includeDeltaTime:
+            dt = DeltaTime(mt, channel=channel)
+            eventList.append(dt)
         me = MidiEvent(track=mt)
         me.type = MetaEvents.LYRIC
         me.data = inputM21.lyric.encode(encoding, 'ignore')
@@ -744,11 +742,10 @@ def chordToMidiEvents(
     chordVolume = c.volume  # use if component volume are not defined
     hasComponentVolumes = c.hasComponentVolumes()
 
-    if includeDeltaTime:
-        dt = DeltaTime(track=mt)
-        eventList.append(dt)
-
     if (inputM21.lyric is not None and inputM21.lyric != ''):
+        if includeDeltaTime:
+            dt = DeltaTime(track=mt)
+            eventList.append(dt)
         me = MidiEvent(track=mt)
         me.type = MetaEvents.LYRIC
         me.data = inputM21.lyric.encode(encoding, 'ignore')
@@ -2572,7 +2569,8 @@ def packetStorageFromSubstreamList(
                 # maybe prepareStreamForMidi() wasn't run; create Conductor instance
                 instObj = Conductor()
 
-        trackPackets = streamToPackets(subs, trackId=trackId, addStartDelay=addStartDelay, encoding=encoding)
+        trackPackets = streamToPackets(subs, trackId=trackId, addStartDelay=addStartDelay,
+                                       encoding=encoding)
         # store packets in a dictionary; keys are trackIds
         packetStorage[trackId] = {
             'rawPackets': trackPackets,
@@ -2669,7 +2667,8 @@ def streamHierarchyToMidiTracks(
     for subs in substreamList:
         subs.stripTies(inPlace=True, matchByPitch=True)
 
-    packetStorage = packetStorageFromSubstreamList(substreamList, addStartDelay=addStartDelay, encoding=encoding)
+    packetStorage = packetStorageFromSubstreamList(substreamList, addStartDelay=addStartDelay,
+                                                   encoding=encoding)
     updatePacketStorageWithChannelInfo(packetStorage, channelByInstrument)
 
     initTrackIdToChannelMap = {}

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2616,7 +2616,7 @@ def streamHierarchyToMidiTracks(
     *,
     acceptableChannelList=None,
     addStartDelay=False,
-    encoding: str = 'utf-8',
+    encoding='utf-8',
 ):
     '''
     Given a Stream, Score, Part, etc., that may have substreams (i.e.,

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -294,8 +294,8 @@ def getEndEvents(
 def music21ObjectToMidiFile(
     music21Object: base.Music21Object,
     *,
-    encoding: str = 'utf-8',
     addStartDelay=False,
+    encoding: str = 'utf-8',
 ) -> MidiFile:
     '''
     Either calls streamToMidiFile on the music21Object or
@@ -466,9 +466,9 @@ def midiEventsToNote(
 def noteToMidiEvents(
     inputM21: note.Note|note.Unpitched,
     *,
-    encoding: str = 'utf-8',
     includeDeltaTime: bool = True,
     channel: int = 1,
+    encoding: str = 'utf-8',
 ) -> list[DeltaTime|MidiEvent]:
     # noinspection PyShadowingNames
     '''
@@ -697,9 +697,9 @@ def midiEventsToChord(
 def chordToMidiEvents(
     inputM21: chord.ChordBase,
     *,
-    encoding: str = 'utf-8',
     includeDeltaTime: bool = True,
     channel: int = 1,
+    encoding: str = 'utf-8',
 ) -> list[DeltaTime|MidiEvent]:
     # noinspection PyShadowingNames
     '''
@@ -1941,7 +1941,7 @@ def lyricTimingsFromEvents(
                 lyrics[time] = e.data.decode(encoding)
             except UnicodeDecodeError:
                 warnings.warn(
-                    f'Unable to decode lyrics from {e}',
+                    f'Unable to decode lyrics from {e} as {encoding}',
                     TranslateWarning)
     return lyrics
 
@@ -2480,8 +2480,8 @@ def channelInstrumentData(
 def packetStorageFromSubstreamList(
     substreamList: list[stream.Part],
     *,
-    encoding: str = 'utf-8',
     addStartDelay=False,
+    encoding: str = 'utf-8',
 ) -> dict[int, dict[str, t.Any]]:
     # noinspection PyShadowingNames
     r'''
@@ -2614,9 +2614,9 @@ def updatePacketStorageWithChannelInfo(
 def streamHierarchyToMidiTracks(
     inputM21,
     *,
-    encoding: str = 'utf-8',
     acceptableChannelList=None,
     addStartDelay=False,
+    encoding: str = 'utf-8',
 ):
     '''
     Given a Stream, Score, Part, etc., that may have substreams (i.e.,
@@ -2754,9 +2754,9 @@ def midiTracksToStreams(
 def streamToMidiFile(
     inputM21: stream.Stream,
     *,
-    encoding: str = 'utf-8',
     addStartDelay: bool = False,
     acceptableChannelList: list[int]|None = None,
+    encoding: str = 'utf-8',
 ) -> MidiFile:
     # noinspection PyShadowingNames
     '''


### PR DESCRIPTION
Midi files can contain lyrics. After this PR, the midi file exported from music21 will contain lyrics, which will show if you open it with musescore.

I've implemented reading lyrics from midi in #1769

Users can select the encoding which encoding to use when exporting by using `stream.write('midi', fp=filename, encoding=encoding)`. The default encoding is UTF-8.