### PR TITLE
`music21.text.assembleLyrics`: support custom word separator

### DIFF
--- a/music21/search/lyrics.py
+++ b/music21/search/lyrics.py
@@ -744,7 +744,7 @@ class Test(unittest.TestCase):
         s = converter.parse(partXML, format='MusicXML')
         for lenWordSep in range(5):
             wordSep = ' ' * lenWordSep
-            ls = search.lyrics.LyricSearcher(s, wordSeparator = wordSep)
+            ls = search.lyrics.LyricSearcher(s, wordSeparator=wordSep)
             for pair in more_itertools.pairwise('长亭外古道边'):
                 keyword = pair[0] + wordSep + pair[1]
                 match = ls.search(keyword)

--- a/music21/text.py
+++ b/music21/text.py
@@ -152,7 +152,7 @@ def assembleAllLyrics(streamIn, maxLyrics=10, lyricSeparation='\n', *, wordSepar
     '''
     lyrics = ''
     for i in range(1, maxLyrics):
-        lyr = assembleLyrics(streamIn, i, wordSeparator)
+        lyr = assembleLyrics(streamIn, i, wordSeparator=wordSeparator)
         if lyr != '':
             if i > 1:
                 lyrics += lyricSeparation


### PR DESCRIPTION
This PR adds custom word separator support for `music21.text.assembleLyrics`.

Unlike European languages, in East Asian languages, words are not separated with space.

For example, This is a song's lyric extracted by music21:

`也 许 很 远 或 是 昨 天 在 这 里 或 在 对 岸 长 路 辗 转 离 合 悲 欢 人 聚 又 人 散 放 过 对 错 才 知 答 案 活 着 的 勇 敢 没 有 神 的 光 环 你 我 生 而 平 凡`

After this PR, I'll be able to extract the lyrics like this with `assembleLyrics(stream, wordSeparator='')`

`也许很远或是昨天在这里或在对岸长路辗转离合悲欢人聚又人散放过对错才知答案活着的勇敢没有神的光环你我生而平凡`

#1787 will be fixed.