### PR TITLE
Two fixes in m21ToXML.py:parseFlatElements()

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -50,7 +50,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '9.7.1'
+__version__ = '9.7.2a4'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -27,7 +27,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'9.7.1'
+'9.7.2a4'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -38,6 +38,7 @@ from music21 import clef
 from music21 import chord
 from music21 import common
 from music21.common.enums import AppendSpanners
+from music21.common.numberTools import opFrac
 from music21 import defaults
 from music21 import duration
 from music21 import dynamics
@@ -3277,7 +3278,9 @@ class MeasureExporter(XMLExporterBase):
                         self.parseOneElement(obj, AppendSpanners.NORMAL)
 
             for n in notesForLater:
-                if n.isRest and n.style.hideObjectOnPrint and n.duration.type == 'inexpressible':
+                if (n.isRest
+                        and n.style.hideObjectOnPrint
+                        and n.duration.type in ('inexpressible', 'complex')):
                     # Prefer a gap in stream, to be filled with a <forward> tag by
                     # fill_gap_with_forward_tag() rather than raising exceptions
                     continue
@@ -3322,7 +3325,7 @@ class MeasureExporter(XMLExporterBase):
         else:
             # if necessary, jump to end of the measure.
             if self.offsetInMeasure < firstPassEndOffsetInMeasure:
-                self.moveForward(firstPassEndOffsetInMeasure)
+                self.moveForward(opFrac(firstPassEndOffsetInMeasure - self.offsetInMeasure))
 
         self.currentVoiceId = None
 


### PR DESCRIPTION
Two fixes in parseFlatElements: (1) prefer a gap to a complex duration hidden rest, not just for an inexpressible duration hidden rest. (2) jump to end of measure needs to pass the distance to end of measure, not the offset of end of measure.