### PR TITLE
Braille translate smart quotes

### DIFF
--- a/music21/common/stringTools.py
+++ b/music21/common/stringTools.py
@@ -304,12 +304,27 @@ def stripAccents(inputString: str) -> str:
     >>> common.stripAccents(s)
     'tres vite'
 
-    Also handles the German Eszett
+    Also handles the German Eszett and smart quotes
 
     >>> common.stripAccents('Muß')
     'Muss'
+    >>> common.stripAccents('Süss, “êtré”')
+    'Suss, "etre"'
+
+    Note -- is is still possible to have non-Ascii characters after this,
+    like in this Japanese expression for music:
+
+    >>> common.stripAccents('音楽')
+    '音楽'
     '''
-    nfkd_form = unicodedata.normalize('NFKD', inputString).replace('ß', 'ss')
+    nfkd_form = (
+        unicodedata.normalize('NFKD', inputString)
+        .replace('ß', 'ss')
+        .replace('“', '"')
+        .replace('”', '"')
+        .replace('‘', "'")
+        .replace('’', "'")
+    )
     return ''.join([c for c in nfkd_form if not unicodedata.combining(c)])
 
 
@@ -324,7 +339,7 @@ def normalizeFilename(name: str) -> str:
     without any accented characters.
 
     >>> common.normalizeFilename('03-Niccolò all’lessandra.not really.xml')
-    '03-Niccolo_alllessandra_not_really.xml'
+    '03-Niccolo_all_lessandra_not_really.xml'
     '''
     extension = None
     lenName = len(name)

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -175,15 +175,16 @@ AmbitusShort = namedtuple('AmbitusShort',
 
 class Metadata(base.Music21Object):
     r'''
-    Metadata represent data for a work or fragment, including title, composer,
-    dates, and other relevant information.
+    Metadata objects contain information about a work, including title, composer,
+    dates, and other relevant information. Metadata objects can also cover a fragment
+    of a Score such as individual parts or a range of measures.
 
     Metadata is a :class:`~music21.base.Music21Object` subclass, meaning that it
     can be positioned on a Stream by offset and have a
     :class:`~music21.duration.Duration`.
 
-    In many cases, each Stream will have a single Metadata object at the zero
-    offset position.
+    In many cases, each Stream will have a single Metadata object at the zero-offset
+    position.
 
     To get a simple string, use attribute-style access by unique name.
     Some workIds from music21 v7 have been renamed (e.g. 'date' has been renamed


### PR DESCRIPTION
Translate smart quotes better in Braille.

Specify that not all characters will become ascii via stripAccents;