### PR TITLE
Support RepeatBrackets for pianos

### DIFF
--- a/music21/musicxml/__init__.py
+++ b/music21/musicxml/__init__.py
@@ -12,10 +12,14 @@
 from __future__ import annotations
 
 __all__ = [
-    'archiveTools', 'lilypondTestSuite', 'm21ToXml',
+    'archiveTools',
+    'lilypondTestSuite',
+    'm21ToXml',
     'partStaffExporter',
-    'test_m21ToXml', 'test_xmlToM21',
-    'xmlObjects', 'xmlToM21',
+    'test_m21ToXml',
+    'test_xmlToM21',
+    'xmlObjects',
+    'xmlToM21',
 ]
 
 from music21.musicxml import archiveTools

--- a/music21/musicxml/testFiles.py
+++ b/music21/musicxml/testFiles.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import unittest
 
+from music21 import common
+
 _DOC_IGNORE_MODULE_OR_PACKAGE = True
 
 chantQuemQueritis = '''<?xml version="1.0" standalone="no"?>
@@ -16067,6 +16069,131 @@ tabTest = '''<?xml version="1.0" encoding="UTF-8" ?>
 '''
 
 
+pianoRepeatEndings = r'''
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <work>
+    <work-title>Piano-Repeat</work-title>
+    </work>
+  <part-list>
+    <score-part id="P1">
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1">
+      <barline location="left">
+        <bar-style>heavy-light</bar-style>
+        <repeat direction="forward"/>
+        </barline>
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <staff>2</staff>
+        </note>
+      </measure>
+    <measure number="2">
+      <barline location="left">
+        <ending number="1" type="start">1</ending>
+        </barline>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        <ending number="1" type="stop"/>
+        <repeat direction="backward"/>
+        </barline>
+      </measure>
+    <measure number="3">
+      <barline location="left">
+        <ending number="2" type="start">2</ending>
+        </barline>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>4</duration>
+        </backup>
+      <note>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+        <staff>2</staff>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        <ending number="2" type="discontinue"/>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>
+'''
+
+
+
 # ------------------------------------------------------------------------------
 # define all strings for access
 
@@ -16086,16 +16213,14 @@ tabTest = '''<?xml version="1.0" encoding="UTF-8" ?>
 ALL = [
     chantQuemQueritis, mozartTrioK581Excerpt, schumannOp48No1,
     binchoisMagnificat, edgefield82b, tabTest,
+    pianoRepeatEndings,
 ]
 
 
+@common.deprecated('v10', 'This has never been developed beyond one file')
 def get(contentRequest):
     '''
-    Get test material by type of content
-
-    >>> from music21.musicxml.testFiles import get
-
-    >>> a = get('lyrics')
+    Get test material by type of content -- Deprecated - to be removed in v10
     '''
     if contentRequest in ['lyrics']:
         return chantQuemQueritis

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -1679,7 +1679,7 @@ class Test(unittest.TestCase):
         self.assertTrue(s[layout.StaffGroup])
         sg = s[layout.StaffGroup].first()
 
-        for p_num in 0,1:
+        for p_num in (0, 1):
             p = s.parts[p_num]
             self.assertIn(p, sg)
             self.assertEqual(len(p[note.Note]), 3)
@@ -1715,6 +1715,7 @@ class Test(unittest.TestCase):
             p_expanded = repeat.Expander[stream.Part](p).process()
             p_notes2 = [n.name for n in p_expanded[note.Note]]
             self.assertEqual(p_notes2, ['G', 'A', 'G', 'B'])
+
 
 if __name__ == '__main__':
     import music21

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -8408,10 +8408,29 @@ class Test(unittest.TestCase):
     def testTemplateAll(self):
         b = corpus.parse('bwv66.6')
         bass = b.parts[3]
-        bassEmpty = bass.template(fillWithRests=False, removeClasses=True)
+        bassEmpty = bass.template(fillWithRests=False, removeAll=True)
         for x in bassEmpty:
             if isinstance(x, Measure):
                 self.assertEqual(len(x), 0)
+            else:
+                self.fail('remove all was supposed to remove all!')
+
+        bassEmpty2 = bass.template(fillWithRests=True,
+                                   removeAll=True,
+                                   exemptFromRemove={meter.TimeSignature})
+        foundTimeSignature = False
+        foundRest = False
+        for x in bassEmpty2.flatten(retainContainers=True):
+            self.assertIsInstance(x, (Measure, note.Rest, meter.TimeSignature))
+            if isinstance(x, meter.TimeSignature):
+                foundTimeSignature = True
+            elif isinstance(x, note.Rest):
+                foundRest = True
+
+        self.assertTrue(foundTimeSignature, 'No TimeSignature was found even though exempted')
+        self.assertTrue(foundRest, 'No Rest found even though fillWithRest=True')
+
+
 
     def testSetElements(self):
         s = Stream()


### PR DESCRIPTION
Longstanding bug discovered by @seffka and @OttavioCresos - thank you for the careful explanation and the amazing test file that made fixing this "almost" simple. 

Added to template() `exemptFromRemove` -- and removeAll (separate from removeClasses=True which will be removed in v10

Deprecate some unused test helpers.

Fixes #1812 