### PR TITLE
start v10 (beta1)

### DIFF
--- a/.github/workflows/maincheck.yml
+++ b/.github/workflows/maincheck.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.10", "3.11", "3.12", "3.13"]  # "3.10" must be in quotes to not have it eval to 3.1
+                python-version: [3.11, 3.12, 3.13]
         steps:
         - uses: actions/setup-python@v4
           with:
@@ -40,7 +40,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: '3.11'
+                  python-version: '3.13'
                   cache: 'pip'
             - name: Install dependencies
               run: |
@@ -63,7 +63,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: '3.11'
+                  python-version: '3.13'
                   cache: 'pip'
             - name: Install dependencies
               run: |
@@ -83,7 +83,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                  python-version: '3.11'
+                  python-version: '3.13'
                   cache: 'pip'
             - name: Install dependencies
               run: |

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -50,7 +50,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '9.9.0'
+__version__ = '10.0.1b1'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -27,7 +27,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'9.9.0'
+'10.0.1b1'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":


### PR DESCRIPTION
We don't use "alpha" because we try to make it so that the latest HEAD/main/master is always a usable version of m21 which alpha does not imply.

Removes 3.10 as a required test -- will add 3.14 before release assuming Github Actions makes it available.