### PR TITLE
MIDI/Instrument improvements + Misc

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.13"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ https://tinyurl.com/m21colab (runs music21 v7)
 And to install, see:
 https://www.music21.org/music21docs/usersGuide/usersGuide_01_installing.html
 
-`Music21` runs on Python 3.10+.  (Use version 4 on Python 2 or Py3.4, version 5
-on Py3.5, version 6 on Py3.6, version 7 on Py3.7, version 8 on Py3.8/Py3.9)
+`Music21` runs on Python 3.11+.  (Use music21 version 4 on Python 2 or Py3.4, v5
+on Py3.5, v6 on Py3.6, v7 on Py3.7, v8 on Py3.8/Py3.9, and v9 on Py3.10)
 
 Released under the BSD (3-clause) license. See LICENSE.
 Externally provided software (including the MIT-licensed Lilypond/MusicXML test Suite) and

--- a/documentation/source/installing/installLinux.rst
+++ b/documentation/source/installing/installLinux.rst
@@ -33,7 +33,7 @@ or terminal and enter the following command-line argument (where "$" is the prom
     
 it should display something like:
 
-    Python 3.10.7
+    Python 3.13.2
 
 if so, you're okay.  If not, upgrade your version of Python.  This is
 often a problem on some AWS configuations, Google Colab, etc.

--- a/documentation/source/installing/installMac.rst
+++ b/documentation/source/installing/installMac.rst
@@ -66,7 +66,7 @@ it should display in Terminal something like the following:
 .. image:: images/macScreenPythonVersion.*
     :width: 650
 
-If it says 3.8 or higher (or possibly a number like 3.10.7), you're okay.
+If it says 3.11 or higher (or possibly a number like 3.11.7), you're okay.
 If it says 2.7 or 3.4 or something,
 go to https://www.python.org/downloads/
 and download a newer version.  Multiple versions of Python can exist

--- a/documentation/source/installing/installWindows.rst
+++ b/documentation/source/installing/installWindows.rst
@@ -13,7 +13,7 @@ is written in and in which you will write your own programs that
 use `music21`.
 
 Windows users should download and install Python version
-3.10 or higher.
+3.11 or higher.
 
 To get Python for Windows, go to https://www.python.org/downloads/
 and click on the "Windows installer" link.  It is probably the
@@ -37,7 +37,7 @@ typing in "IDLE" or (on Windows Vista and newer) typing
 in "IDLE" in the Search Programs list.
 
 The first lines of text displayed will include a version number.
-Make sure it begins with 3.10 or higher.
+Make sure it begins with 3.11 or higher.
 
 If your version is too old, download a newer version as above.
 

--- a/music21/common/enums.py
+++ b/music21/common/enums.py
@@ -10,14 +10,12 @@
 # ------------------------------------------------------------------------------
 from __future__ import annotations
 
-from enum import Enum, EnumMeta, IntEnum
+from enum import Enum, EnumType, IntEnum
 import re
-
-# When Python 3.11 is minimum, import EnumType instead of EnumMeta
 
 # when Python 3.12 is minimum, will not need StrEnumMeta at all -- contains will work.
 
-class StrEnumMeta(EnumMeta):
+class StrEnumMeta(EnumType):
     def __contains__(cls, item):
         if isinstance(item, str):
             if item in cls.__members__.values():
@@ -30,9 +28,11 @@ class StrEnumMeta(EnumMeta):
             return False
 
 
-class ContainsMeta(EnumMeta):
+class ContainsMeta(EnumType):
     '''
     This is a backport of the Python 3.12 `EnumType` class's contains method.
+
+    This will be removed when Python 3.12 is the minimum version for music21.
     '''
     def __contains__(cls, item):
         try:

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -358,7 +358,7 @@ class PickleFilter:
         >>> pickFilter = converter.PickleFilter(fp)
         >>> #_DOCS_SHOW pickFilter.status()
         (PosixPath('/Users/Cuthbert/Desktop/musicFile.mxl'), True,
-              PosixPath('/tmp/music21/m21-7.0.0-py3.9-18b8c5a5f07826bd67ea0f20462f0b8d.p.gz'))
+              PosixPath('/tmp/music21/m21-10.0.0-py3.13-18b8c5a5f07826bd67ea0f20462f0b8d.p.gz'))
         '''
         fpScratch = environLocal.getRootTempDir()
         m21Format = common.findFormatFile(self.fp)

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -184,7 +184,7 @@ class Instrument(base.Music21Object):
         msg = []
         if self.partId is not None:
             msg.append(f'{self.partId}: ')
-        if self.partName is not None:
+        if self.partName is not None and self.partName != self.instrumentName:
             msg.append(f'{self.partName}: ')
         if self.instrumentName is not None:
             msg.append(self.instrumentName)
@@ -1867,7 +1867,7 @@ def deduplicate(s: stream.Stream, inPlace: bool = False) -> stream.Stream:
     [<music21.instrument.Flute 'Flute'>, <music21.instrument.Flute 'Flute'>]
     >>> s2 = instrument.deduplicate(s2, inPlace=True)
     >>> list(p1.getInstruments())
-    [<music21.instrument.Piccolo 'Piccolo: Piccolo'>]
+    [<music21.instrument.Piccolo 'Piccolo'>]
     >>> list(p2.getInstruments())
     [<music21.instrument.Flute 'Flute'>]
     '''

--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -1561,9 +1561,9 @@ def scoreDefFromElement(elem, slurBundle=None):
     >>> len(result)
     5
     >>> result['1']
-    {'instrument': <music21.instrument.Clarinet '1: Clarinet: Clarinet'>}
+    {'instrument': <music21.instrument.Clarinet '1: Clarinet'>}
     >>> result['3']
-    {'instrument': <music21.instrument.Violin '3: Violin: Violin'>}
+    {'instrument': <music21.instrument.Violin '3: Violin'>}
     >>> result['all-part objects']
     [<music21.meter.TimeSignature 3/4>]
     >>> result['whole-score objects']
@@ -1727,7 +1727,7 @@ def staffDefFromElement(elem, slurBundle=None):
     >>> len(result)
     1
     >>> result
-    {'instrument': <music21.instrument.Clarinet '1: Clarinet: Clarinet'>}
+    {'instrument': <music21.instrument.Clarinet '1: Clarinet'>}
     >>> result['instrument'].partId
     '1'
     >>> result['instrument'].partName
@@ -1747,7 +1747,7 @@ def staffDefFromElement(elem, slurBundle=None):
     >>> len(result)
     3
     >>> result['instrument']
-    <music21.instrument.Tuba '2: Tuba: Tuba'>
+    <music21.instrument.Tuba '2: Tuba'>
     >>> result['clef']
     <music21.clef.BassClef>
     >>> result['key']

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -1719,11 +1719,8 @@ class Metadata(base.Music21Object):
 
         >>> md.bestTitle = 'Bonaparte'
         Traceback (most recent call last):
-        AttributeError: ...'bestTitle'...
+        AttributeError: property 'bestTitle' of 'Metadata' object has no setter
         '''
-        # TODO: once Py3.11 is the minimum, change doctest output to:
-        #    AttributeError: property 'bestTitle' of 'Metadata' object has no setter
-
         searchId = (
             'title',
             'popularTitle',

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -1439,13 +1439,6 @@ class MeterSequence(MeterTerminal):
                 mtList += obj._getFlatList()
         return mtList
 
-    @property
-    def flat(self):
-        '''
-        deprecated.  Call .flatten() instead.  To be removed in v11.
-        '''
-        return self.flatten()
-
     def flatten(self) -> MeterSequence:
         '''
         Return a new MeterSequence composed of the flattened representation.

--- a/music21/midi/tests.py
+++ b/music21/midi/tests.py
@@ -29,7 +29,7 @@ from music21.midi.translate import (
     conductorStream,
     getMetaEvents,
     midiAsciiStringToBinaryString,
-    midiEventsToInstrument,
+    midiEventToInstrument,
     midiEventsToNote,
     midiFileToStream,
     noteToMidiEvents,
@@ -1391,12 +1391,12 @@ class Test(unittest.TestCase):
         '''
         event = MidiEvent()
         event.data = bytes('Piccolo\x00', 'utf-8')
-        i = midiEventsToInstrument(event)
+        i = midiEventToInstrument(event)
         self.assertIsInstance(i, instrument.Piccolo)
 
         # test that nothing was broken.
         event.data = bytes('Flute', 'utf-8')
-        i = midiEventsToInstrument(event)
+        i = midiEventToInstrument(event)
         self.assertIsInstance(i, instrument.Flute)
 
     def testLousyInstrumentData(self):
@@ -1406,7 +1406,7 @@ class Test(unittest.TestCase):
                 event = MidiEvent()
                 event.data = bytes(name, 'utf-8')
                 event.type = MetaEvents.INSTRUMENT_NAME
-                i = midiEventsToInstrument(event)
+                i = midiEventToInstrument(event)
                 self.assertIsNone(i.instrumentName)
 
         # lousy program change
@@ -1416,7 +1416,7 @@ class Test(unittest.TestCase):
         event.channel = 10
         event.type = ChannelVoiceMessages.PROGRAM_CHANGE
 
-        i = midiEventsToInstrument(event)
+        i = midiEventToInstrument(event)
         self.assertIsInstance(i, instrument.UnpitchedPercussion)
 
     def testConductorStream(self):

--- a/music21/musicxml/testFiles.py
+++ b/music21/musicxml/testFiles.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 import unittest
 
-from music21 import common
-
 _DOC_IGNORE_MODULE_OR_PACKAGE = True
 
 chantQuemQueritis = '''<?xml version="1.0" standalone="no"?>

--- a/music21/musicxml/testFiles.py
+++ b/music21/musicxml/testFiles.py
@@ -16217,15 +16217,6 @@ ALL = [
 ]
 
 
-@common.deprecated('v10', 'This has never been developed beyond one file')
-def get(contentRequest):
-    '''
-    Get test material by type of content -- Deprecated - to be removed in v10
-    '''
-    if contentRequest in ['lyrics']:
-        return chantQuemQueritis
-
-
 # ------------------------------------------------------------------------------
 class Test(unittest.TestCase):
 

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -220,6 +220,16 @@ class ProtoM21Object:
         The additional information is defined in the `_reprInternal` method,
         so objects inheriting from ProtoM21Object (such as Music21Object)
         should change `_reprInternal` and not `__repr__`.
+
+        Except for music21.base itself, any object in a file called base.py
+        has the base part removed.
+
+        >>> from music21.midi.base import MidiEvent
+        >>> me = MidiEvent()
+        >>> repr(me)
+        '<music21.midi.MidiEvent UNKNOWN, track=None>'
+        >>> me._reprInternal()
+        'UNKNOWN, track=None'
         '''
         reprHead = '<'
         if self.__module__ != '__main__':

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -115,12 +115,13 @@ figureShorthands = {
     'b7b53': 'ø7',
 }
 
-figureShorthandsMode: dict[str, dict] = {
-    'major': {
-    },
-    'minor': {
-    }
-}
+# not currently used
+# figureShorthandsMode: dict[str, dict] = {
+#     'major': {
+#     },
+#     'minor': {
+#     }
+# }
 
 
 # this is sort of a crock :-)  but it's very helpful.
@@ -324,7 +325,7 @@ def _postFigureFromChordAndKey(chordObj: chord.Chord, keyObj: key.Key) -> str:
     chordFigureTuples = figureTuples(chordObj, keyObj)
     bassFigureAlter = chordFigureTuples[0].alter
 
-    allFigureStringList = []
+    allFigureStringList: list[str] = []
 
     third = chordObj.third
     fifth = chordObj.fifth
@@ -375,12 +376,13 @@ def _postFigureFromChordAndKey(chordObj: chord.Chord, keyObj: key.Key) -> str:
                 allFigureStringList.append(figureString)
 
     allFigureString = ''.join(allFigureStringList)
-    key_mode = keyObj.mode
 
-    # first is not currently used.
-    if key_mode in figureShorthandsMode and allFigureString in figureShorthandsMode[key_mode]:
-        allFigureString = figureShorthandsMode[allFigureString]
-    elif allFigureString in figureShorthands:
+    # figureShorthandsMode is not currently used.
+    # key_mode = keyObj.mode
+    # if key_mode in figureShorthandsMode and allFigureString in figureShorthandsMode[key_mode]:
+    #     allFigureString = figureShorthandsMode[allFigureString]
+    # when uncommenting, the next if needs to become elif
+    if allFigureString in figureShorthands:
         allFigureString = figureShorthands[allFigureString]
 
     # simplify common omissions from 7th chords

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -273,7 +273,7 @@ def correctSuffixForChordQuality(chordObj, inversionString):
     return qualityName + inversionString
 
 
-def postFigureFromChordAndKey(chordObj, keyObj=None):
+def _postFigureFromChordAndKey(chordObj: chord.Chord, keyObj: key.Key) -> str:
     '''
     (Note: this will become a private function by v10.)
 
@@ -281,7 +281,7 @@ def postFigureFromChordAndKey(chordObj, keyObj=None):
 
     If keyObj is none, it uses the root as a major key:
 
-    >>> roman.postFigureFromChordAndKey(
+    >>> roman._postFigureFromChordAndKey(
     ...     chord.Chord(['F#2', 'D3', 'A-3', 'C#4']),
     ...     key.Key('C'),
     ...     )
@@ -289,19 +289,19 @@ def postFigureFromChordAndKey(chordObj, keyObj=None):
 
     The function substitutes shorthand (e.g., '6' not '63')
 
-    >>> roman.postFigureFromChordAndKey(
+    >>> roman._postFigureFromChordAndKey(
     ...     chord.Chord(['E3', 'C4', 'G4']),
     ...     key.Key('C'),
     ...     )
     '6'
 
-    >>> roman.postFigureFromChordAndKey(
+    >>> roman._postFigureFromChordAndKey(
     ...     chord.Chord(['E3', 'C4', 'G4', 'B-5']),
     ...     key.Key('F'),
     ...     )
     '65'
 
-    >>> roman.postFigureFromChordAndKey(
+    >>> roman._postFigureFromChordAndKey(
     ...     chord.Chord(['E3', 'C4', 'G4', 'B-5']),
     ...     key.Key('C'),
     ...     )
@@ -310,21 +310,17 @@ def postFigureFromChordAndKey(chordObj, keyObj=None):
     We reduce common omissions from seventh chords to be '7' instead
     of '75', '73', etc.
 
-    >>> roman.postFigureFromChordAndKey(
+    >>> roman._postFigureFromChordAndKey(
     ...     chord.Chord(['A3', 'E-4', 'G-4']),
     ...     key.Key('b-'),
     ...     )
     'o7'
 
-    OMIT_FROM_DOCS
-
-    Fails on German Augmented 6th chords in root position.  Calls them
+    Known bug: Fails on German Augmented 6th chords in root position.  Calls them
     half-diminished chords.
 
-    (This is in OMIT_FROM_etc.)
+    Changed in v10: made _postFigureFromChordAndKey private, keyObj is not optional.
     '''
-    if keyObj is None:
-        keyObj = key.Key(chordObj.root())
     chordFigureTuples = figureTuples(chordObj, keyObj)
     bassFigureAlter = chordFigureTuples[0].alter
 
@@ -398,8 +394,6 @@ def postFigureFromChordAndKey(chordObj, keyObj=None):
 
 def figureTuples(chordObject: chord.Chord, keyObject: key.Key) -> list[ChordFigureTuple]:
     '''
-    (This will become a private function in v10)
-
     Return a set of tuplets for each pitch showing the presence of a note, its
     interval above the bass its alteration (float) from a step in the given
     key, an `alterationString`, and the pitch object.
@@ -1185,7 +1179,7 @@ def romanNumeralFromChord(
         pass
     elif not isMajorThird:
         stepRoman = stepRoman.lower()
-    inversionString = postFigureFromChordAndKey(chordObj, alteredKeyObj)
+    inversionString = _postFigureFromChordAndKey(chordObj, alteredKeyObj)
 
     rnString = ft.prefix + stepRoman + inversionString
 
@@ -1383,14 +1377,7 @@ class Minor67Default(enum.Enum):
 
 # -----------------------------------------------------------------------------
 
-# Delete RomanException in v10
-class RomanException(exceptions21.Music21Exception):
-    '''
-    RomanException will be removed in v10.  Catch RomanNumeralException instead.
-    '''
-
-
-class RomanNumeralException(ValueError, RomanException):
+class RomanNumeralException(ValueError, exceptions21.Music21Exception):
     pass
 
 
@@ -4386,7 +4373,7 @@ class Test(unittest.TestCase):
     def testAugmentedOctave(self):
         c = chord.Chord(['C4', 'E5', 'G5', 'C#6'])
         k = key.Key('C')
-        f = postFigureFromChordAndKey(c, k)
+        f = _postFigureFromChordAndKey(c, k)
         self.assertEqual(f, '#853')
 
         rn = romanNumeralFromChord(c, k)

--- a/music21/tablature.py
+++ b/music21/tablature.py
@@ -261,13 +261,11 @@ class FirstFret:
         self.fretNum = fretNum
         self.location = location
 
-# class that combines a ChordSymbol and a FretBoard
-
 
 class ChordWithFretBoard(harmony.ChordSymbol, FretBoard):
     '''
     Music21Object subclass that combines a ChordSymbol with a FretBoard.
-    Tuning must be set!
+    Its tuning must be set.
 
     >>> fn4 = tablature.FretNote(string=4, fret=0)
     >>> fn3 = tablature.FretNote(string=3, fret=2, fingering=2)

--- a/music21/test/testRunner.py
+++ b/music21/test/testRunner.py
@@ -139,7 +139,7 @@ def fix312OrderedDict(textString, replacement='...') -> str:
     '''
     Function that fixes the OrderedDicts to work on Python 3.12 and above.
     (eventually when 3.12 is the norm, this should be replaced to neuter
-    the doctests for 3.10/3.11 instead.  Or just wait until 3.12 is the minimum version?)
+    the doctests for 3.11 instead.  Or just wait until 3.12 is the minimum version?)
 
     >>> fix312 = test.testRunner.fix312OrderedDict
     >>> fix312('OrderedDict([(0, 1), (1, 2), (2, 3)])')

--- a/music21/test/test_base.py
+++ b/music21/test/test_base.py
@@ -641,7 +641,7 @@ class Test(unittest.TestCase):
         storage = []
         for i in range(6):
             soundFile = Wave_read()
-            # el = music21.Music21Object()
+            # el = base.Music21Object()
             el = base.ElementWrapper(soundFile)
             storage.append(el)
             self.assertEqual(el.obj, soundFile)


### PR DESCRIPTION
Add MIDIEvent.isChannelEvent() to distinguish MIDIEvents where channels matter from ones which don't (since None is no longer an acceptable channel).  Update getChannels() to use it

Add midiEventToInstrument (singular event) and deprecate midiEventsToInstrument -- do it right or not at all.

Remove channel on midi.translate.getEndEvents

Use Python 3.11 error messages

Remove deprecated MeterSequence.flat -> for .flatten() Remove deprecated musicxml/testFiles.get(contentRequest) -- never used.

Add better docs to music21/prebase

make roman. _postFigureFromChordAndKey private as promised.  Leave figureTuples as public.

remove RomanException -- just use RomanNumeralException

clean up docs for v3.11