### PR TITLE
Remove Stream.flat - use .flatten() instead

### DIFF
--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -693,7 +693,7 @@ class StreamCore(Music21Object):
         '''
         sb = self.spannerBundle
         sIter: StreamIterator|RecursiveIterator
-        if recurse is True:
+        if recurse:
             sIter = self.recurse()  # type: ignore
         else:
             sIter = self.iter()  # type: ignore
@@ -708,16 +708,16 @@ class StreamCore(Music21Object):
                 if constrainingSpannerBundle is not None and sp not in constrainingSpannerBundle:
                     continue
                 if requireAllPresent:
-                    allFound = True
+                    allFound: bool = True
                     for spannedElement in sp.getSpannedElements():
                         if spannedElement not in sIter:
                             allFound = False
                             break
-                    if allFound is False:
+                    if not allFound:
                         continue
                 collectList.append(sp)
 
-        if insert is False:
+        if not insert:
             return collectList
 
         if collectList:  # do not run elementsChanged if nothing here.

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -79,9 +79,6 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
     * StreamIterator.streamLength -- length of elements.
 
     * StreamIterator.srcStreamElements -- srcStream._elements
-    * StreamIterator.cleanupOnStop -- should the StreamIterator delete the
-      reference to srcStream and srcStreamElements when stopping? default
-      False -- DEPRECATED: to be removed in v10.
     * StreamIterator.activeInformation -- a dict that contains information
       about where we are in the parse.  Especially useful for recursive
       streams:
@@ -114,6 +111,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
       - StreamIterator inherits from typing.Sequence, hence index
       was moved to elementIndex.
     * Changed in v9: cleanupOnStop is deprecated.  Was not working properly before: noone noticed.
+    * Changed in v10: remove cleanupOnStop.
 
     OMIT_FROM_DOCS
 
@@ -152,7 +150,6 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         self.sectionIndex: int = -1
         self.iterSection: t.Literal['_elements', '_endElements'] = '_elements'
 
-        self.cleanupOnStop: bool = False
         self.restoreActiveSites: bool = restoreActiveSites
 
         self.overrideDerivation: str|None = None
@@ -358,7 +355,6 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         >>> sI.srcStream is s
         True
 
-
         To request an element by id, put a '#' sign in front of the id,
         like in HTML DOM queries:
 
@@ -387,23 +383,6 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         <music21.clef.TrebleClef>
         >>> s.iter().notes[0]
         <music21.note.Note F#>
-
-        Demo of cleanupOnStop = True; the sI[0] call counts as another iteration, so
-        after it is called, there is nothing more to iterate over!  Note that cleanupOnStop
-        will be removed in music21 v10.
-
-        >>> sI.cleanupOnStop = True
-        >>> for n in sI:
-        ...    printer = (repr(n), repr(sI[0]))
-        ...    print(printer)
-        ('<music21.note.Note F#>', '<music21.note.Note F#>')
-        >>> sI.srcStream is s  # set to an empty stream
-        False
-        >>> for n in sI:
-        ...    printer = (repr(n), repr(sI[0]))
-        ...    print(printer)
-
-        (nothing is printed)
 
         * Changed in v8: for strings: prepend a '#' sign to get elements by id.
           The old behavior still works until v9.
@@ -652,23 +631,9 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
 
     def cleanup(self) -> None:
         '''
-        stop iteration; and cleanup if need be.
+        stop iteration; and cleanup if need be.  Can be subclassed. does nothing.
         '''
-        if self.cleanupOnStop:
-            self.reset()
-
-            # cleanupOnStop is rarely used, so we put in
-            # a dummy stream so that self.srcStream does not need
-            # to be typed as Stream|None
-
-            # eventually want this to work
-            # SrcStreamClass = t.cast(type[StreamType], self.srcStream.__class__)
-            SrcStreamClass = self.srcStream.__class__
-
-            del self.srcStream
-            del self.srcStreamElements
-            self.srcStream = SrcStreamClass()
-            self.srcStreamElements = ()
+        pass
 
     # ---------------------------------------------------------------
     # getting items

--- a/music21/stream/tests.py
+++ b/music21/stream/tests.py
@@ -28,6 +28,7 @@ from music21.stream.base import Part
 from music21.stream.base import Opus
 
 from music21 import bar
+from music21.base import Music21Object
 from music21 import beam
 from music21 import chord
 from music21 import clef
@@ -319,7 +320,7 @@ class Test(unittest.TestCase):
     def testIsFlat(self):
         a = Stream()
         for dummy in range(5):
-            a.insert(0, music21.Music21Object())
+            a.insert(0, Music21Object())
         self.assertTrue(a.isFlat)
         a[2] = note.Note('C#')
         self.assertTrue(a.isFlat)
@@ -328,7 +329,7 @@ class Test(unittest.TestCase):
 
     def testAppendFails(self):
         a = Stream()
-        others = [music21.Music21Object(), 'hello']
+        others = [Music21Object(), 'hello']
         with self.assertRaises(StreamException) as context:
             a.append(others)
         self.assertIn("'hello'", str(context.exception))
@@ -379,12 +380,31 @@ class Test(unittest.TestCase):
         sf1 = s1.flatten()
         sf1.id = 'flat s1'
 
-#        for site in n4.sites.get():
-#            print(site.id,)
-#            print(n4.sites.getOffsetBySite(site))
+        # for site in n4.sites.get():
+        #     print(site.id,)
+        #     print(n4.sites.getOffsetBySite(site))
 
         self.assertEqual(len(sf1), 4)
         assert sf1[1] is n2
+
+    def testFlattenDocTest(self):
+        '''
+        This test used to be in OMIT_FROM_DOCS in the flatten() doctest
+        '''
+        r = Stream()
+        for j in range(5):
+            q = Stream()
+            for i in range(5):
+                p = Stream()
+                p.repeatInsert(Music21Object(), [0, 1, 2, 3, 4])
+                q.insert(i * 10, p)
+            r.insert(j * 100, q)
+
+        self.assertEqual(len(r), 5)
+        self.assertEqual(len(r.flatten()), 125)
+
+        flattened = r.flatten()
+        self.assertAlmostEqual(flattened[124].offset, 444.0)
 
     def testActiveSiteCopiedStreams(self):
         srcStream = Stream()
@@ -395,12 +415,10 @@ class Test(unittest.TestCase):
         midStream = Stream()
         for x in range(2):
             srcNew = copy.deepcopy(srcStream)
-#             for n in srcNew:
-#                 offset = n.getOffsetBySite(srcStream)
+            # for n in srcNew:
+            #     offset = n.getOffsetBySite(srcStream)
 
             # gt = srcNew[0].getOffsetBySite(srcStream)
-
-            # for n in srcNew: pass
 
             srcNew.offset = x * 10
             midStream.insert(srcNew)
@@ -452,7 +470,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(srcStream.recurse()), 6)
         self.assertEqual(srcStream.flatten()[1].offset, 1.0)
 
-#        self.assertEqual(len(srcStream.getOverlaps()), 0)
+        # self.assertEqual(len(srcStream.getOverlaps()), 0)
 
         midStream = Stream()
         for x in range(4):
@@ -463,7 +481,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(midStream), 4)
         # environLocal.printDebug(['pre flat of mid stream'])
         self.assertEqual(len(midStream.flatten()), 24)
-#        self.assertEqual(len(midStream.getOverlaps()), 0)
+        # self.assertEqual(len(midStream.getOverlaps()), 0)
         mfs = midStream.flatten()
         self.assertEqual(mfs[7].getOffsetBySite(mfs), 11.0)
 
@@ -910,15 +928,15 @@ class Test(unittest.TestCase):
         Test basic Elements wrapping non music21 objects
         '''
         a = Stream()
-        a.insert(50, music21.Music21Object())
+        a.insert(50, Music21Object())
         self.assertEqual(len(a), 1)
 
         # there are two locations, default and the one just added
         self.assertEqual(len(a[0].sites), 2)
         # this works
-#        self.assertEqual(a[0].sites.getOffsetByIndex(-1), 50.0)
+        # self.assertEqual(a[0].sites.getOffsetByIndex(-1), 50.0)
 
-#        self.assertEqual(a[0].sites.getSiteByIndex(-1), a)
+        # self.assertEqual(a[0].sites.getSiteByIndex(-1), a)
         self.assertEqual(a[0].getOffsetBySite(a), 50.0)
         self.assertEqual(a[0].offset, 50.0)
 
@@ -6755,8 +6773,8 @@ class Test(unittest.TestCase):
         sSrc = corpus.parse('bach/bwv13.6.xml')
         sPart = sSrc.getElementById('Alto')
         ts = meter.TimeSignature('6/8')
-#         for n in sPart.flatten().notesAndRests:
-#             bs = n.beatStr
+        # for n in sPart.flatten().notesAndRests:
+        #     bs = n.beatStr
         # environLocal.printDebug(['calling makeMeasures'])
         sPartFlat = sPart.flatten()
         unused_notesAndRests = sPartFlat.notesAndRests


### PR DESCRIPTION
.flatten() has been around for 4+ years and .flat has been giving deprecation warnings for several years also.  Time to rip off the bandage and speedup IDEs and Debugging as we intended.