### PR TITLE
sortTuple gets typing

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -50,7 +50,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '10.0.1b1'
+__version__ = '10.0.1b2'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -27,7 +27,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'10.0.1b1'
+'10.0.1b2'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/sorting.py
+++ b/music21/sorting.py
@@ -28,18 +28,26 @@ SortTuple(atEnd=0, offset=0.0, priority=inf, classSortOrder=0, isNotGrace=1, ins
 '''
 from __future__ import annotations
 
-from collections import namedtuple
 from math import inf as INFINITY
-from music21 import exceptions21
+import typing as t
 
+from music21.common.types import OffsetQL
+from music21 import exceptions21
 
 class SortingException(exceptions21.Music21Exception):
     pass
 
 
-class SortTuple(namedtuple('SortTuple', (
-    'atEnd', 'offset', 'priority', 'classSortOrder', 'isNotGrace', 'insertIndex'
-))):
+_SortTupleBase = t.NamedTuple('SortTuple', [   # type: ignore[name-match]
+    ('atEnd', int),
+    ('offset', OffsetQL),
+    ('priority', int),
+    ('classSortOrder', int),
+    ('isNotGrace', int),
+    ('insertIndex', int),
+])
+
+class SortTuple(_SortTupleBase):
     '''
     Derived class of namedTuple which allows for comparisons with pure ints/fractions.
 
@@ -255,9 +263,9 @@ class SortTuple(namedtuple('SortTuple', (
             raise SortingException('Cannot add attributes from a different class')
 
         outList = [min(getattr(self, attr), getattr(other, attr))
-                    if attr in ('atEnd', 'isNotGrace')
-                    else (getattr(self, attr) - getattr(other, attr))
-                    for attr in self._fields]  # _fields are the namedtuple attributes
+                   if attr in ('atEnd', 'isNotGrace')
+                   else (getattr(self, attr) - getattr(other, attr))
+                   for attr in self._fields]  # _fields are the namedtuple attributes
 
         return self.__class__(*outList)
 


### PR DESCRIPTION
cannot use the new class definition directly because of the magic not working with anything that includes self.__class__(*...) -- but we can subclass a typed base class.

```
a,b,c,d,e,f = ZeroSortTupleHigh
reveal_type((a, b, c, d, e, f))
tuple[builtins.int, builtins.float | fractions.Fraction, builtins.int, builtins.int, builtins.int, builtins.int]
```

```
reveal_type(ZeroSortTupleHigh)
tuple[builtins.int, builtins.float | fractions.Fraction, builtins.int, builtins.int, builtins.int, builtins.int,
           fallback=music21.sorting.SortTuple]
```

before:

```
reveal_type(ZeroSortTupleHigh)
tuple[Any, Any, Any, Any, Any, Any, fallback=music21.sorting.SortTuple]
```

update Version because removal of .flat invalidated caches