### PR TITLE
Parse Noteflight .mxl files

### DIFF
--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -210,7 +210,10 @@ class ArchiveManager:
                 if 'META-INF' in subFp:
                     continue
                 # include .mxl to be kind to users who zipped up mislabeled files
-                if pathlib.Path(subFp).suffix not in ['.musicxml', '.xml', '.mxl']:
+                if pathlib.Path(subFp).suffix not in ['.musicxml',
+                                                      '.xml',
+                                                      '.mxl'] and subFp != '.xml':
+                    # Noteflight bug for untitled files puts filename as just '.xml'
                     continue
 
                 post = f.read(subFp)


### PR DESCRIPTION
Noteflight unsaved scores export mxl as "mxl.mxl" with the main score being just ".xml" inside rather than "file.xml" or something.

Patch converter to support this.

Fixes #1832