### PR TITLE
Add ChordSymbol.placement and MusicXML <harmony placement> round-trip

### DIFF
--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -198,6 +198,17 @@ class Harmony(chord.Chord):
 
     Accepts a keyword 'updatePitches'. By default, it
     is `True`, but can be set to `False` to initialize faster if pitches are not needed.
+
+    The `placement` attribute controls where the symbol appears relative to the staff,
+    matching the MusicXML `placement` attribute on `<harmony>`. Valid values are
+    ``'above'``, ``'below'``, or ``None`` (let the notation software decide):
+
+    >>> cs = harmony.ChordSymbol('G7')
+    >>> cs.placement is None
+    True
+    >>> cs.placement = 'below'
+    >>> cs.placement
+    'below'
     '''
     # sort harmony just before notes and chords and other default objects
     classSortOrder = base.Music21Object.classSortOrder - 1
@@ -224,6 +235,7 @@ class Harmony(chord.Chord):
         # a romanNumeral numeral object, musicxml stores this within a node
         # called <function> which might conflict with the Harmony
         self._roman = None
+        self.placement: str|None = None
         # specify an array of degree alteration objects
         self.chordStepModifications: list[ChordStepModification] = []
         self._degreesList: list[str] = []

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -6019,7 +6019,8 @@ class MeasureExporter(XMLExporterBase):
 
         self.setPrintObject(mxHarmony, cs)
         # TODO: attr: print-frame
-        # TODO: attrGroup: placement
+        if cs.placement is not None:
+            mxHarmony.set('placement', cs.placement)
 
         self.setPrintStyle(mxHarmony, cs)
 

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -278,6 +278,7 @@ class PartStaffExporterMixin:
         for group in deduplicatedGroups:
             prior_part_staff = None
             for part_staff in group:
+                assert isinstance(part_staff, stream.PartStaff)
                 for part_exporter in self.partExporterList:
                     if part_exporter.stream is not part_staff:
                         continue

--- a/music21/musicxml/test_m21ToXml.py
+++ b/music21/musicxml/test_m21ToXml.py
@@ -334,6 +334,18 @@ class Test(unittest.TestCase):
         self.assertEqual(explicitFm6.root(find=False), cs.root(find=False))
         self.assertEqual(explicitFm6.inversion(), cs.inversion())
 
+    def testExportChordSymbolPlacement(self):
+        cs = harmony.ChordSymbol('C')
+        cs.placement = 'below'
+        et = self.getET(cs)
+        harmonyEl = et.find('part/measure/harmony')
+        self.assertEqual(harmonyEl.get('placement'), 'below')
+
+        cs2 = harmony.ChordSymbol('G')
+        et2 = self.getET(cs2)
+        harmonyEl2 = et2.find('part/measure/harmony')
+        self.assertIsNone(harmonyEl2.get('placement'))
+
     def testExportNC(self):
         s = stream.Score()
         p = stream.Part()

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -1241,6 +1241,28 @@ class Test(unittest.TestCase):
                               offsets):
             self.assertEqual(ch.offset, offset)
 
+    def testChordSymbolPlacement(self):
+        from xml.etree.ElementTree import fromstring as EL
+        mp = MeasureParser()
+
+        h_below = EL('<harmony placement="below">'
+                     '<root><root-step>C</root-step></root>'
+                     '<kind>major</kind></harmony>')
+        cs = mp.xmlToChordSymbol(h_below)
+        self.assertEqual(cs.placement, 'below')
+
+        h_above = EL('<harmony placement="above">'
+                     '<root><root-step>G</root-step></root>'
+                     '<kind>major</kind></harmony>')
+        cs2 = mp.xmlToChordSymbol(h_above)
+        self.assertEqual(cs2.placement, 'above')
+
+        h_none = EL('<harmony>'
+                    '<root><root-step>F</root-step></root>'
+                    '<kind>major</kind></harmony>')
+        cs3 = mp.xmlToChordSymbol(h_none)
+        self.assertIsNone(cs3.placement)
+
     def testChordInversion(self):
         from xml.etree.ElementTree import fromstring as EL
         h = EL('''

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -5428,7 +5428,7 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
         self.setPrintObject(mxHarmony, cs)
 
         # TODO: attr: print-frame
-        # TODO: attrGroup: placement
+        self.setPlacement(mxHarmony, cs)
         # TODO: attr: use-symbols
         # TODO: attr: stack-degrees
         # TODO: attr: parentheses-degrees

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -2163,7 +2163,7 @@ class IntervalNetwork:
             fillMinMaxIfNone=False)  # avoid recursion by setting false
         # environLocal.printDebug(['realizeMinMax()', 'post', post, 'postNodeId', postNodeId])
 
-        postPairs = []
+        postPairs: list[tuple[pitch.Pitch, Terminus|int]] = []
         collect = False
         for i, nId in enumerate(postNodeId):
             p = post[i]
@@ -2180,7 +2180,7 @@ class IntervalNetwork:
                 postPairs.append((p, nId))
         # environLocal.printDebug(['realizeMinMax()', 'postPairs', postPairs])
 
-        prePairs = []
+        prePairs: list[tuple[pitch.Pitch, Terminus|int]] = []
         collect = False
         for i, nId in enumerate(preNodeId):
             p = pre[i]


### PR DESCRIPTION
## Summary

(AI-Assisted)

Fixes #1867.

- Adds `placement: str|None = None` to `Harmony` so chord symbols, Roman numerals etc. can carry a staff-placement hint (`'above'` or `'below'`).
- Exporter ([m21ToXml.py](music21/musicxml/m21ToXml.py)): writes `placement="above|below"` on the `<harmony>` element when set, replacing the `# TODO: attrGroup: placement` stub.
- Parser ([xmlToM21.py](music21/musicxml/xmlToM21.py)): calls the existing `setPlacement()` helper to read the attribute back into `cs.placement`, replacing the matching TODO stub.