### PR TITLE
Humdrum Typing and Improvements

### DIFF
--- a/documentation/source/usersGuide/usersGuide_44_advancedGraphing.ipynb
+++ b/documentation/source/usersGuide/usersGuide_44_advancedGraphing.ipynb
@@ -599,7 +599,7 @@
     "\n",
     "If you want to do the whole process without showing the figures in the meantime, then set `.doneAction = None` before calling run the first time.\n",
     "\n",
-    "..note:\n",
+    ".. note::\n",
     "\n",
     "    (Unfortunately, in the Jupyter notebook that I use to write\n",
     "    documentation, it'll generate the images still, but maybe it'll be fixed\n",

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1007,10 +1007,12 @@ class HumdrumSpine(prebase.ProtoM21Object):
     regardless of \*\*definition after spine path indicators have
     been simplified.
 
+    A subclass of HumdrumSpine should be defined for each \*\*type. Those
+    subclasses cannot redefine `__init__()`
+
     A HumdrumSpine is a collection of events arranged vertically that have a
     connection to each other.
     Each HumdrumSpine MUST have an id (numeric or string) attached to it.
-
 
     >>> SE = humdrum.spineParser.SpineEvent
     >>> spineEvents = [SE('**kern'), SE('c,4'), SE('d#8')]
@@ -1027,7 +1029,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
     >>> spine1.spineCollection = spineCollection1
 
     The spineType property searches the EventList or parentSpine to
-    figure out the spineType
+    figure out the spineType.
 
     >>> spine1.spineType
     'kern'
@@ -1049,6 +1051,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
     <music21.stream.Part ...>
     '''
 
+    @t.final
     def __init__(
         self,
         spineId: int = 0,
@@ -1076,10 +1079,10 @@ class HumdrumSpine(prebase.ProtoM21Object):
         self.insertionsDone: bool = False
 
         self.spineCollection: SpineCollection|None = None
-        self._spineType: str|None = None
+        self._spineType: str = ''
 
-        self.isFirstVoice: bool|None = None
-        self.iterIndex: int|None = None
+        self.isFirstVoice: bool = False
+        self.iterIndex: int = 0
 
     def _reprInternal(self) -> str:
         representation = ': ' + str(self.id)
@@ -1111,54 +1114,44 @@ class HumdrumSpine(prebase.ProtoM21Object):
         '''
         if self.iterIndex == len(self.eventList):
             raise StopIteration()
-        if t.TYPE_CHECKING:
-            assert self.iterIndex is not None
         thisEvent = self.eventList[self.iterIndex]
         self.iterIndex += 1
         return thisEvent
 
-    def _getLocalSpineType(self) -> str|None:
-        if self._spineType is not None:
+    def _getLocalSpineType(self) -> str:
+        if self._spineType:
             return self._spineType
-        else:
-            for thisEvent in self.eventList:
-                m1 = re.match(r'\*\*(.*)', thisEvent.contents)
-                if m1:
-                    self._spineType = m1.group(1)
-                    return self._spineType
-            return None
+        for thisEvent in self.eventList:
+            m1 = re.match(r'\*\*(.*)', thisEvent.contents)
+            if m1:
+                self._spineType = m1.group(1)
+                return self._spineType
+        return ''
 
-    def _getParentSpineType(self) -> str|None:
+    def _getParentSpineType(self) -> str:
         parentSpine = self.parentSpine
-        if parentSpine is not None:
-            psSpineType = parentSpine.spineType
-            if psSpineType is not None:
-                return psSpineType
-            return None
-        else:
-            return None
+        if parentSpine is None:
+            return ''
+        return parentSpine.spineType
 
     def _getSpineType(self) -> str:
         '''
         searches the current and parent spineType for a search
         '''
-        if self._spineType is not None:
+        if self._spineType:
             return self._spineType
-        else:
-            st = self._getLocalSpineType()
-            if st is not None:
-                self._spineType = st
-                return st
-            else:
-                st = self._getParentSpineType()
-                if st is not None:
-                    self._spineType = st
-                    return st
-                else:
-                    raise HumdrumException('Could not determine spineType '
-                                           + 'for spine with id ' + str(self.id))
+        st = self._getLocalSpineType()
+        if st:
+            self._spineType = st
+            return st
+        st = self._getParentSpineType()
+        if st:
+            self._spineType = st
+            return st
+        raise HumdrumException('Could not determine spineType '
+                               + 'for spine with id ' + str(self.id))
 
-    def _setSpineType(self, newSpineType: str|None = None) -> None:
+    def _setSpineType(self, newSpineType: str = '') -> None:
         self._spineType = newSpineType
 
     spineType = property(_getSpineType, _setSpineType)
@@ -1298,22 +1291,20 @@ class KernSpine(HumdrumSpine):
     r'''
     A KernSpine is a type of humdrum spine with the \*\*kern
     attribute set and thus events are processed as if they
-    are kern notes
-    '''
+    are kern notes.
 
-    def __init__(
-        self,
-        spineId: int = 0,
-        eventList: list[SpineEvent]|None = None,
-        streamClass: type[stream.Stream] = stream.Stream,
-    ) -> None:
-        super().__init__(spineId, eventList, streamClass)
-        self.lastContainer: stream.Measure|None = None
-        self.inTuplet: bool = False
-        self.lastNote: note.GeneralNote|None = None
-        self.currentBeamNumbers: int = 0
-        self.currentTupletDuration: OffsetQL = 0.0
-        self.desiredTupletDuration: OffsetQL = 0.0
+    Instances are not constructed directly; `reclassSpines` reassigns
+    `__class__` from `HumdrumSpine` to `KernSpine` once the spine's
+    exclusive interpretation is known.  All KernSpine-specific state
+    is initialized at the top of `parse()`.
+    '''
+    # Set in parse(); declared here so type-checkers see them.
+    lastContainer: stream.Measure|None
+    inTuplet: bool
+    lastNote: note.GeneralNote|None
+    currentBeamNumbers: int
+    currentTupletDuration: OffsetQL
+    desiredTupletDuration: OffsetQL
 
     def parse(self) -> None:
         if t.TYPE_CHECKING:
@@ -1689,8 +1680,6 @@ class SpineCollection(prebase.ProtoM21Object):
         self.newSpine.spineCollection = self
         self.spines.append(self.newSpine)
         self.nextFreeId += 1
-        # if this is a sub-spine (Voice) then does it need to close off measures, etc.
-        self.newSpine.isFirstVoice = False
         return self.newSpine
 
     def appendSpine(self, spine: HumdrumSpine) -> None:
@@ -1865,7 +1854,7 @@ class SpineCollection(prebase.ProtoM21Object):
             voiceNumber += 1
             voiceStr = 'voice' + str(voiceNumber)
             for insertEl in insertSpine.stream:
-                if insertSpine.isFirstVoice is False and isinstance(insertEl, stream.Measure):
+                if not insertSpine.isFirstVoice and isinstance(insertEl, stream.Measure):
                     pass  # only insert one measure object per spine
                 else:
                     insertEl.groups.append(voiceStr)

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -494,62 +494,51 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         # one of Events(horizontal slices)
         returnProtoSpines: list[ProtoSpine] = []
         returnEventCollections: list[EventCollection] = []
-        protoSpineEventList: list[SpineEvent|None] = []
 
         # noinspection PyShadowingNames
-        def doOneCell(i: int, j: int) -> None:
-            # get the currentEventCollection
+        def processEventForOneCell(i: int, j: int) -> SpineEvent|None:
+            '''
+            Process the (i, j) cell.  Mutates `returnEventCollections[i]`
+            and returns the SpineEvent to record in the protoSpine, or
+            None if there's no event at this cell.
+            '''
             thisEventCollection = returnEventCollections[i]
             currentLine = self.eventList[i]
 
-            # parse this cell
-            if isinstance(currentLine, SpineLine):
-                # not a global event
-                if len(currentLine.spineData) > j:
-                    # are there actually this many spines at this point?
-                    # thus, is there an event here? True
-                    thisEvent = SpineEvent(currentLine.spineData[j])
-                    thisEvent.position = i
-                    thisEvent.protoSpineId = j
-                    if thisEvent.contents in spinePathIndicators:
-                        thisEventCollection.spinePathData = True
-
-                    protoSpineEventList.append(thisEvent)
-                    thisEventCollection.addSpineEvent(j, thisEvent)
-                    if thisEvent.contents == '.' and i > 0:
-                        lastEvent = returnEventCollections[i - 1].events[j]
-                        if lastEvent is not None:
-                            occurringEvent = (
-                                returnEventCollections[i - 1].getSpineOccurring(j)
-                            )
-                            if occurringEvent is not None:
-                                thisEventCollection.addLastSpineEvent(j, occurringEvent)
-                else:  # no data here
-                    thisEvent = SpineEvent('')
-                    thisEvent.position = i
-                    thisEvent.protoSpineId = j
-                    thisEventCollection.addSpineEvent(j, thisEvent)
-
-                    protoSpineEventList.append(None)
-            else:  # Global event -- either GlobalCommentLine or GlobalReferenceLine
-                if j == 0:  # adds to all spines but just runs the first time.
-                    thisEventCollection.addGlobalEvent(self.eventList[i])
-                thisEvent = SpineEvent('')
+            if isinstance(currentLine, SpineLine) and len(currentLine.spineData) > j:
+                # actual event at this cell
+                thisEvent = SpineEvent(currentLine.spineData[j])
                 thisEvent.position = i
                 thisEvent.protoSpineId = j
+                if thisEvent.contents in spinePathIndicators:
+                    thisEventCollection.spinePathData = True
                 thisEventCollection.addSpineEvent(j, thisEvent)
-                protoSpineEventList.append(None)
+                if thisEvent.contents == '.' and i > 0:
+                    lastEvent = returnEventCollections[i - 1].events[j]
+                    if lastEvent is not None:
+                        occurringEvent = returnEventCollections[i - 1].getSpineOccurring(j)
+                        if occurringEvent is not None:
+                            thisEventCollection.addLastSpineEvent(j, occurringEvent)
+                return thisEvent
 
-        # end doOneCell
+            # placeholder cell: either a SpineLine with no data this far over,
+            # or a global (comment/reference) line. First check for Global Comment or Reference
+            if not isinstance(currentLine, SpineLine) and j == 0:
+                # not SpineLine = GlobalComment or GlobalReference.
+                # global events register once, against the first column
+                thisEventCollection.addGlobalEvent(currentLine)
+            placeholder = SpineEvent('')
+            placeholder.position = i
+            placeholder.protoSpineId = j
+            thisEventCollection.addSpineEvent(j, placeholder)
+            return None
+
         for j in range(self.maxSpines):
-            protoSpineEventList = []
-
+            protoSpineEventList: list[SpineEvent|None] = []
             for i in range(self.fileLength):
                 if j == 0:
                     returnEventCollections.append(EventCollection(self.maxSpines))
-
-                doOneCell(i, j)
-
+                protoSpineEventList.append(processEventForOneCell(i, j))
             returnProtoSpines.append(ProtoSpine(protoSpineEventList))
 
         self.protoSpines = returnProtoSpines

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -46,7 +46,12 @@ SpineParsing consists of several steps.
     removed from HumdrumLine and all subclasses. `isinstance(...)` is a bit slower than
     checking these, but adds correct typing.  Nothing is stored with weakrefs.  `.iterIndex`
     and hand roled iterator/generators are gone now (could've gone when Python 2.4 became
-    the minimum version).
+    the minimum version).  `HumdrumDataCollection.parsePositionInStream` is gone (was
+    duplicating `numLines`); `HumdrumDataCollection.fileLength` is now the read-only
+    property `numLines` (= `len(self.dataStream)`); `HumdrumLine.position` and
+    `SpineEvent.position` were both renamed to `lineNumber` and now hold the 1-based
+    source line number (was eventList index for SpineEvent),
+    advancing on blank lines too.
 '''
 from __future__ import annotations
 
@@ -145,8 +150,6 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         # attributes
         self.eventList: list[HumdrumLine] = []
         self.maxSpines: int = 0
-        self.parsePositionInStream: int = 0
-        self.fileLength: int = 0
         self.protoSpines: list[ProtoSpine] = []
         self.eventCollections: list[EventCollection] = []
         self.spineCollection: SpineCollection|None = None
@@ -158,6 +161,13 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         # Defaults to a Score; parseOpusDataCollections will replace it with
         # an Opus if the input turns out to be a multipart file.
         self.stream: stream.Score|stream.Opus = stream.Score()
+
+    @property
+    def numLines(self) -> int:
+        '''
+        The number of lines in `self.dataStream`, including blank lines.
+        '''
+        return len(self.dataStream)
 
     def parse(self) -> stream.Score|stream.Opus:
         '''
@@ -189,12 +199,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         self.maxSpines = 0
 
         # parse global comments and figure out the maximum number of spines we will have
-        self.parsePositionInStream = 0
-        self.parseEventListFromDataStream(dataStream)  # sets self.eventList and fileLength
-        try:
-            assert self.parsePositionInStream == self.fileLength
-        except AssertionError:  # pragma: no cover
-            raise HumdrumException('getEventListFromDataStream failed: did not parse entire file')
+        self.parseEventListFromDataStream(dataStream)  # sets self.eventList
         self.parseProtoSpinesAndEventCollections()
         self.spineCollection = self.createHumdrumSpines()
         self.spineCollection.createMusic21Streams()
@@ -361,9 +366,6 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         largest number of spine events found on any line
         in the file.
 
-        It sets `self.fileLength` to the number of lines (excluding
-        totally blank lines) in the file.
-
         The difference between the dataStream and `self.eventList`
         are the following:
 
@@ -388,11 +390,14 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         ...     print(e)
         <music21.humdrum.spineParser.GlobalReferenceLine COM: 'Beethoven, Ludwig van'>
         <music21.humdrum.spineParser.GlobalCommentLine 'Not really a piece by Beethoven'>
-        <music21.humdrum.spineParser.SpineLine line 2 (2 spines)>
         <music21.humdrum.spineParser.SpineLine line 3 (2 spines)>
         <music21.humdrum.spineParser.SpineLine line 4 (2 spines)>
+        <music21.humdrum.spineParser.SpineLine line 5 (2 spines)>
         >>> print(eList[0].value)
         Beethoven, Ludwig van
+
+        Print line number 4 (which is eList[3] in zero indexed)
+
         >>> print(eList[3].spineData)
         ['C4', 'pp']
         '''
@@ -401,23 +406,22 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
             if dataStream is None:
                 raise HumdrumException('Need a list of lines (dataStream) to parse!')
 
-        self.parsePositionInStream = 0
         self.eventList = []
+        lineNumber = 0  # 1-based file line number; advances on blanks too
 
         for line in dataStream:
+            lineNumber += 1
             line = line.rstrip()
             if line == '':
                 continue  # technically forbidden by Humdrum but the source of so many errors!
-            elif re.match(r'!!!', line):
-                self.eventList.append(GlobalReferenceLine(self.parsePositionInStream, line))
+            if re.match(r'!!!', line):
+                self.eventList.append(GlobalReferenceLine(lineNumber, line))
             elif re.match(r'!!', line):  # find global comments at the top of the line
-                self.eventList.append(GlobalCommentLine(self.parsePositionInStream, line))
+                self.eventList.append(GlobalCommentLine(lineNumber, line))
             else:
-                thisLine = SpineLine(self.parsePositionInStream, line)
+                thisLine = SpineLine(lineNumber, line)
                 self.maxSpines = max(self.maxSpines, thisLine.numSpines)
                 self.eventList.append(thisLine)
-            self.parsePositionInStream += 1
-        self.fileLength = self.parsePositionInStream
         return self.eventList
 
     def parseProtoSpinesAndEventCollections(
@@ -460,7 +464,6 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         ...                'D8\t.\n')
         >>> hdc = humdrum.spineParser.HumdrumDataCollection(eventString)
         >>> hdc.maxSpines = 2
-        >>> hdc.fileLength = 5
         >>> protoSpines, eventCollections = hdc.parseProtoSpinesAndEventCollections()
         >>> protoSpines is hdc.protoSpines
         True
@@ -471,21 +474,29 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
         >>> for thisSlice in eventCollections:
         ...    print(thisSlice)
-        <music21.humdrum.spineParser.EventCollection object at 0x...>
-        <music21.humdrum.spineParser.EventCollection object at 0x...>
-        <music21.humdrum.spineParser.EventCollection object at 0x...>
-        <music21.humdrum.spineParser.EventCollection object at 0x...>
-        <music21.humdrum.spineParser.EventCollection object at 0x...>
+        <music21.humdrum.spineParser.EventCollection 2 events, 2 spines>
+        <music21.humdrum.spineParser.EventCollection 2 events, 2 spines>
+        <music21.humdrum.spineParser.EventCollection 2 events, 2 spines>
+        <music21.humdrum.spineParser.EventCollection 2 events, 2 spines>
+        <music21.humdrum.spineParser.EventCollection 2 events, 2 spines>
 
         >>> for thisSlice in protoSpines:
         ...    print(thisSlice)
-        <music21.humdrum.spineParser.ProtoSpine object at 0x...>
-        <music21.humdrum.spineParser.ProtoSpine object at 0x...>
+        <music21.humdrum.spineParser.ProtoSpine 5 events>
+        <music21.humdrum.spineParser.ProtoSpine 5 events>
 
         But looking at the individual slices is revealing:
 
         >>> eventCollections[4].getAllOccurring()
         [<music21.humdrum.spineParser.SpineEvent D8>, <music21.humdrum.spineParser.SpineEvent pp>]
+
+        >>> for protoEvent in protoSpines[0]:
+        ...    print(repr(protoEvent))
+        None
+        None
+        <music21.humdrum.spineParser.SpineEvent **kern>
+        <music21.humdrum.spineParser.SpineEvent C4>
+        <music21.humdrum.spineParser.SpineEvent D8>
         '''
         if not self.eventList:
             self.parseEventListFromDataStream()
@@ -507,8 +518,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
             if isinstance(currentLine, SpineLine) and len(currentLine.spineData) > j:
                 # actual event at this cell
-                thisEvent = SpineEvent(currentLine.spineData[j])
-                thisEvent.position = i
+                thisEvent = SpineEvent(currentLine.spineData[j], currentLine.lineNumber)
                 thisEvent.protoSpineId = j
                 if thisEvent.contents in spinePathIndicators:
                     thisEventCollection.spinePathData = True
@@ -527,15 +537,15 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                 # not SpineLine = GlobalComment or GlobalReference.
                 # global events register once, against the first column
                 thisEventCollection.addGlobalEvent(currentLine)
-            placeholder = SpineEvent('')
-            placeholder.position = i
+            placeholder = SpineEvent('', currentLine.lineNumber)
             placeholder.protoSpineId = j
             thisEventCollection.addSpineEvent(j, placeholder)
             return None
 
+        numEvents = len(self.eventList)
         for j in range(self.maxSpines):
             protoSpineEventList: list[SpineEvent|None] = []
-            for i in range(self.fileLength):
+            for i in range(numEvents):
                 if j == 0:
                     returnEventCollections.append(EventCollection(self.maxSpines))
                 protoSpineEventList.append(processEventForOneCell(i, j))
@@ -583,7 +593,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         spineCollection = SpineCollection()
 
         # go through the event collections line by line
-        for i in range(self.fileLength):
+        for i in range(len(eventCollections)):
             thisEventCollection = eventCollections[i]
             for j in range(maxSpines):
                 thisEvent = protoSpines[j].eventList[i]
@@ -842,7 +852,7 @@ class HumdrumLine(prebase.ProtoM21Object):
     See the documentation for the specific classes mentioned above
     for more details.
     '''
-    position: int = 0
+    lineNumber: int = 0
     contents: str = ''
     numSpines: int = 0
 
@@ -853,22 +863,21 @@ class SpineLine(HumdrumLine):
     contains one or more spine elements (separated by tabs)
     and not Global elements.
 
-    Takes in a position (line number in file, excluding blank lines)
-    and a string of contents.
+    Takes in a 1-based line number in the file and a string of contents.
 
     >>> hsl = humdrum.spineParser.SpineLine(
-    ...         position=7, contents='C4\t!local comment\t*M[4/4]\t.\n')
+    ...         lineNumber=7, contents='C4\t!local comment\t*M[4/4]\t.\n')
     >>> hsl
     <music21.humdrum.spineParser.SpineLine line 7 (4 spines)>
-    >>> hsl.position
+    >>> hsl.lineNumber
     7
     >>> hsl.numSpines
     4
     >>> hsl.spineData
     ['C4', '!local comment', '*M[4/4]', '.']
     '''
-    def __init__(self, position: int = 0, contents: str = '') -> None:
-        self.position = position
+    def __init__(self, lineNumber: int = 0, contents: str = '') -> None:
+        self.lineNumber = lineNumber
         contents = contents.rstrip()
         returnList = re.split('\t+', contents)
         self.numSpines = len(returnList)
@@ -876,7 +885,7 @@ class SpineLine(HumdrumLine):
         self.spineData: list[str] = returnList
 
     def _reprInternal(self) -> str:
-        return f'line {self.position} ({self.numSpines} spines)'
+        return f'line {self.lineNumber} ({self.numSpines} spines)'
 
 
 class GlobalReferenceLine(HumdrumLine):
@@ -896,20 +905,20 @@ class GlobalReferenceLine(HumdrumLine):
 
     The GlobalReferenceLine object takes two inputs::
 
-        position   line number in the humdrum file
-        contents   string of contents
+        lineNumber   1-based line number in the humdrum file
+        contents     string of contents
 
     And stores them as three attributes::
 
-        position: as above
-        code:     non-whitespace code (usually three letters)
-        value:    its value
+        lineNumber: as above
+        code:       non-whitespace code (usually three letters)
+        value:      its value
 
     >>> gr = humdrum.spineParser.GlobalReferenceLine(
-    ...        position=20, contents='!!!COM: Stravinsky, Igor Fyodorovich\n')
+    ...        lineNumber=20, contents='!!!COM: Stravinsky, Igor Fyodorovich\n')
     >>> gr
     <music21.humdrum.spineParser.GlobalReferenceLine COM: 'Stravinsky, Igor Fyodorovich'>
-    >>> gr.position
+    >>> gr.lineNumber
     20
     >>> gr.code
     'COM'
@@ -921,8 +930,8 @@ class GlobalReferenceLine(HumdrumLine):
         and propagate language/isPrimary so that GlobalReference.updateMetadata
         can attach `metadata.Text(value, language=...)` instead of bare strings.
     '''
-    def __init__(self, position: int = 0, contents: str = '!!! NUL: None') -> None:
-        self.position = position
+    def __init__(self, lineNumber: int = 0, contents: str = '!!! NUL: None') -> None:
+        self.lineNumber = lineNumber
         noExclaim = re.sub(r'^!!!+', '', contents)
         try:
             (code, value) = noExclaim.split(':', 1)
@@ -949,19 +958,19 @@ class GlobalCommentLine(HumdrumLine):
 
     The GlobalComment object takes two inputs and stores them as attributes::
 
-        position (line number in the humdrum file)
-        contents (string of contents)
-        value    (contents minus !!)
+        lineNumber (1-based line number in the humdrum file)
+        contents   (string of contents)
+        value      (contents minus !!)
 
-    The constructor can be passed (position, contents)
-    if contents begins with bangs, they are removed along with up to one space directly afterwards
+    The constructor can be passed (lineNumber, contents); if contents begins with
+    bangs, they are removed along with up to one space directly afterwards.
 
 
     >>> com1 = humdrum.spineParser.GlobalCommentLine(
-    ...          position=4, contents='!! this comment is global')
+    ...          lineNumber=4, contents='!! this comment is global')
     >>> com1
     <music21.humdrum.spineParser.GlobalCommentLine 'this comment is global'>
-    >>> com1.position
+    >>> com1.lineNumber
     4
     >>> com1.contents
     '!! this comment is global'
@@ -970,8 +979,8 @@ class GlobalCommentLine(HumdrumLine):
     '''
     value: str = ''
 
-    def __init__(self, position: int = 0, contents: str = '') -> None:
-        self.position = position
+    def __init__(self, lineNumber: int = 0, contents: str = '') -> None:
+        self.lineNumber = lineNumber
         value = re.sub(r'^!!+\s?', '', contents)
         self.contents = contents
         self.value = value
@@ -991,12 +1000,20 @@ class ProtoSpine(prebase.ProtoM21Object):
 
     See :meth:`~music21.humdrum.spineParser.parseProtoSpinesAndEventCollections`
     for more details on how ProtoSpine objects are created.
+
+    * Changed in v10: ProtoSpines now iterate over their eventLists and are ProtoM21Objects
     '''
 
     def __init__(self, eventList: list[SpineEvent|None]|None = None) -> None:
         if eventList is None:
             eventList = []
         self.eventList: list[SpineEvent|None] = eventList
+
+    def __iter__(self) -> t.Iterator[SpineEvent|None]:
+        return iter(self.eventList)
+
+    def _reprInternal(self) -> str:
+        return f'{len(self.eventList)} events'
 
 
 # HUMDRUM SPINES #
@@ -1050,7 +1067,6 @@ class HumdrumSpine(prebase.ProtoM21Object):
     >>> spine2.stream
     <music21.stream.Part ...>
     '''
-
     @t.final
     def __init__(
         self,
@@ -1267,7 +1283,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
                 thisObject = base.ElementWrapper(event)
 
             if thisObject is not None:
-                humdrumPositions[thisObject] = event.position
+                humdrumPositions[thisObject] = event.lineNumber
                 self.stream.coreAppend(thisObject)
         self.stream.coreElementsChanged()
 
@@ -1330,14 +1346,17 @@ class KernSpine(HumdrumSpine):
                     thisObject = self.processNoteEvent(eventC)
 
                 if thisObject is not None:
-                    humdrumPositions[thisObject] = event.position
-                    thisObject.priority = event.position
+                    humdrumPositions[thisObject] = event.lineNumber
+                    # priority is doing double duty: real Stream sort priority
+                    # (used by insertGlobalEvents) AND a proxy for humdrum line
+                    # number (used by attachNonKernEvents to align spines).
+                    thisObject.priority = event.lineNumber
                     self.stream.coreAppend(thisObject)
             except Exception as e:  # pylint: disable=broad-exception-caught  # pragma: no cover
                 import traceback
                 environLocal.warn(
                     f'Error in parsing event ({event.contents!r}) '
-                    f'at position {event.position!r} '
+                    f'at line {event.lineNumber} '
                     f'for spine {event.spineId}: {e}'
                 )
                 tb = traceback.format_exc()
@@ -1470,7 +1489,7 @@ class DynamSpine(HumdrumSpine):
                 thisObject = dynamics.Dynamic(eventC)
 
             if thisObject is not None:
-                humdrumPositions[thisObject] = event.position
+                humdrumPositions[thisObject] = event.lineNumber
                 if thisContainer is None:
                     self.stream.coreAppend(thisObject)
                 else:
@@ -1528,8 +1547,8 @@ class HarmSpine(HumdrumSpine):
                 )
 
             if thisObject is not None:
-                humdrumPositions[thisObject] = event.position
-                thisObject.priority = event.position
+                humdrumPositions[thisObject] = event.lineNumber
+                thisObject.priority = event.lineNumber
                 self.stream.coreAppend(thisObject)
         self.stream.coreElementsChanged()
 
@@ -1547,11 +1566,11 @@ class SpineEvent(prebase.ProtoM21Object):
     at this moment in the humdrum file.  Happens if no ProtoSpine exists
     at this point in the file in this tab position.
 
-    Should be initialized with its contents and position in file.
+    Should be initialized with its contents and 1-based source line number.
 
     These attributes are optional but likely to be very helpful::
 
-        position -- event position in the file
+        lineNumber -- 1-based source line number in the humdrum file
         protoSpineId -- ProtoSpine id (0 to N)
         spineId -- id of HumdrumSpine actually attached to (after SpinePaths are parsed)
 
@@ -1559,7 +1578,7 @@ class SpineEvent(prebase.ProtoM21Object):
     if it's kern -- useful to have in all spine types.
 
     >>> se1 = humdrum.spineParser.SpineEvent('EEE-8')
-    >>> se1.position = 40
+    >>> se1.lineNumber = 40
     >>> se1.contents
     'EEE-8'
     >>> se1
@@ -1568,9 +1587,9 @@ class SpineEvent(prebase.ProtoM21Object):
     >>> n
     <music21.note.Note E->
     '''
-    def __init__(self, contents: str = '', position: int = 0) -> None:
+    def __init__(self, contents: str = '', lineNumber: int = 0) -> None:
         self.contents: str = contents
-        self.position: int = position
+        self.lineNumber: int = lineNumber
         self.protoSpineId: int = 0
         self.spineId: int|None = None
 
@@ -1709,7 +1728,7 @@ class SpineCollection(prebase.ProtoM21Object):
             self.parseMusic21()
             self.performInsertions()
             self.moveObjectsToMeasures()
-            self.moveDynamicsAndLyricsToStreams()
+            self.attachNonKernEvents()
             self.makeVoices()
             self.assignIds()
         '''
@@ -1717,7 +1736,7 @@ class SpineCollection(prebase.ProtoM21Object):
         self.parseMusic21()
         self.performInsertions()
         self.moveObjectsToMeasures()
-        self.moveDynamicsAndLyricsToStreams()
+        self.attachNonKernEvents()
         self.makeVoices()
         self.assignIds()
 
@@ -1898,7 +1917,7 @@ class SpineCollection(prebase.ProtoM21Object):
 
                 thisSpine.measuresMoved = True
 
-    def moveDynamicsAndLyricsToStreams(self) -> None:
+    def attachNonKernEvents(self) -> None:
         '''
         move :samp:`**dynam` and :samp:`**lyrics/**text` information to the appropriate staff.
 
@@ -1931,11 +1950,10 @@ class SpineCollection(prebase.ProtoM21Object):
                     stavesAppliedTo = [int(x) for x in staffInfoStr.split('/')]
                     break
             if thisSpine.spineType == 'dynam':
-                for dynamic in thisSpine.stream.flatten():
-                    if isinstance(dynamic, dynamics.Dynamic):
-                        dynamicPos = self.humdrumPositions.get(dynamic)
-                        if dynamicPos is not None:
-                            prioritiesToSearch[dynamicPos] = dynamic
+                for dynamic in thisSpine.stream[dynamics.Dynamic]:
+                    dynamicPos = self.humdrumPositions.get(dynamic)
+                    if dynamicPos is not None:
+                        prioritiesToSearch[dynamicPos] = dynamic
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]
                     for el in applyStream.recurse():
@@ -1950,11 +1968,10 @@ class SpineCollection(prebase.ProtoM21Object):
                             # el.activeSite.insert(el.offset,
                             #    copy.deepcopy(prioritiesToSearch[el.priority]))
             elif thisSpine.spineType == 'harm':
-                for harm in thisSpine.stream.flatten():
-                    if isinstance(harm, roman.RomanNumeral):
-                        harmPos = self.humdrumPositions.get(harm)
-                        if harmPos is not None:
-                            prioritiesToSearch[harmPos] = harm
+                for harm in thisSpine.stream[roman.RomanNumeral]:
+                    harmPos = self.humdrumPositions.get(harm)
+                    if harmPos is not None:
+                        prioritiesToSearch[harmPos] = harm
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]
                     for el in applyStream.recurse():
@@ -1969,17 +1986,22 @@ class SpineCollection(prebase.ProtoM21Object):
                             # el.activeSite.insert(el.offset,
                             #    copy.deepcopy(prioritiesToSearch[el.priority]))
             elif thisSpine.spineType in ('lyrics', 'text'):
-                for text in thisSpine.stream.recurse():
-                    if isinstance(text, base.ElementWrapper):
-                        textPos = self.humdrumPositions.get(text)
-                        if textPos is not None:
-                            prioritiesToSearch[textPos] = text.obj
+                for wrapper in thisSpine.stream[base.ElementWrapper]:
+                    wrapperPos = self.humdrumPositions.get(wrapper)
+                    if wrapperPos is not None:
+                        prioritiesToSearch[wrapperPos] = wrapper.obj
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]
-                    for el in applyStream.recurse():
+                    matched = 0
+                    for el in applyStream.recurse().getElementsByClass(note.GeneralNote):
                         if el.priority in prioritiesToSearch:
                             wrappedEvent = prioritiesToSearch[el.priority]
                             el.lyric = wrappedEvent.contents  # type: ignore[attr-defined]
+                            matched += 1
+                    if not matched and prioritiesToSearch:
+                        environLocal.warn(
+                            f'No notes/rests on staff {applyStaff} matched any '
+                            f'lyric/text events from spine {thisSpine.id}.')
 
     def makeVoices(self) -> None:
         '''
@@ -2045,7 +2067,7 @@ class SpineCollection(prebase.ProtoM21Object):
     # TODO: append global comments and have a way of recalling them
 
 
-class EventCollection:
+class EventCollection(prebase.ProtoM21Object):
     '''
     An EventCollection is a time slice of all events that have
     an onset of a certain time.  If an event does not occur at
@@ -2063,7 +2085,6 @@ class EventCollection:
 
     and ec2 is:
          D4     .
-
 
     >>> SE = humdrum.spineParser.SpineEvent
     >>> eventList1 = [SE('C4'),SE('pp')]
@@ -2085,6 +2106,9 @@ class EventCollection:
         self.maxSpines: int = maxSpines
         self.spinePathData: bool = False
         # true if the line contains data about changing spinePaths
+
+    def _reprInternal(self) -> str:
+        return f'{len(self.events)} events, {self.maxSpines} spines'
 
     def addSpineEvent(self, spineNum: int, spineEvent: SpineEvent) -> None:
         self.events[spineNum] = spineEvent
@@ -2122,12 +2146,10 @@ def hdStringToNote(contents: str) -> note.GeneralNote:
     matching the current SpineEvent.
     Does not check to see that it is sane or part of a :samp:`**kern` spine, etc.
 
-
     New rhythmic extensions formerly defined in
     `wiki.humdrum.org/index.php/Rational_rhythms`
     and now at https://extras.humdrum.org/man/rscale/
     are fully implemented:
-
 
     >>> n = humdrum.spineParser.hdStringToNote('CC3%2')
     >>> n.duration.quarterLength
@@ -2311,7 +2333,6 @@ def hdStringToNote(contents: str) -> note.GeneralNote:
         elif '\\' in contents:
             thisObject.stemDirection = 'down'
 
-
     # 3.2.7 Duration +
     # 3.2.8 N-Tuplets
 
@@ -2398,7 +2419,6 @@ def hdStringToNote(contents: str) -> note.GeneralNote:
 
     return thisObject
 
-
 def hdStringToMeasure(
     contents: str,
     previousMeasure: stream.Measure|None = None,
@@ -2473,7 +2493,6 @@ def hdStringToMeasure(
         m.leftBarline = makeBar('start') if startRepeat else rightBar
 
     return m
-
 
 def kernTandemToObject(tandem: str) -> base.Music21Object|None:
     '''
@@ -2972,7 +2991,7 @@ class Test(unittest.TestCase):
     def x_testMoveDynamics(self):
         hf1 = HumdrumDataCollection(testFiles.fakeTest)
         hf1.parse()
-        # hf1.spineCollection.moveDynamicsAndLyricsToStreams()
+        # hf1.spineCollection.attachNonKernEvents()
         unused_s = hf1.stream
         # unused_s.show('text')
 
@@ -2980,7 +2999,7 @@ class Test(unittest.TestCase):
         from music21 import text
         hf1 = HumdrumDataCollection(testFiles.fakeTest)
         hf1.parse()
-        # hf1.spineCollection.moveDynamicsAndLyricsToStreams()
+        # hf1.spineCollection.attachNonKernEvents()
         s = hf1.stream
         lyrics = text.assembleLyrics(s)
         # noinspection SpellCheckingInspection

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -44,7 +44,7 @@ SpineParsing consists of several steps.
 
 Changed in v10: flag attributes `isSpineLine, isComment, isGlobal, isReference` have been
     removed from HumdrumLine and all subclasses. `isinstance(...)` is a bit slower than
-    checking these, but adds correct typing.
+    checking these, but adds correct typing.  Nothing is stored with weakrefs.
 '''
 from __future__ import annotations
 
@@ -53,6 +53,7 @@ import math
 import re
 import typing as t
 import unittest
+import weakref
 
 from music21.common.types import OffsetQL
 
@@ -184,7 +185,6 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         self.maxSpines = 0
 
         # parse global comments and figure out the maximum number of spines we will have
-
         self.parsePositionInStream = 0
         self.parseEventListFromDataStream(dataStream)  # sets self.eventList and fileLength
         try:
@@ -1266,6 +1266,9 @@ class HumdrumSpine(prebase.ProtoM21Object):
         as ElementWrappers.  Should be overridden in
         specific Spine subclasses.
         '''
+        if t.TYPE_CHECKING:
+            assert self.spineCollection is not None
+        humdrumPositions = self.spineCollection.humdrumPositions
         lastContainer = hdStringToMeasure('=0')
 
         for event in self.eventList:
@@ -1283,11 +1286,10 @@ class HumdrumSpine(prebase.ProtoM21Object):
             elif eventC.startswith('!'):
                 thisObject = SpineComment(eventC)
             else:
-                wrapper = base.ElementWrapper(event)
-                wrapper.humdrumPosition = event.position
-                thisObject = wrapper
+                thisObject = base.ElementWrapper(event)
 
             if thisObject is not None:
+                humdrumPositions[thisObject] = event.position
                 self.stream.coreAppend(thisObject)
         self.stream.coreElementsChanged()
 
@@ -1314,6 +1316,9 @@ class KernSpine(HumdrumSpine):
         self.desiredTupletDuration: OffsetQL = 0.0
 
     def parse(self) -> None:
+        if t.TYPE_CHECKING:
+            assert self.spineCollection is not None
+        humdrumPositions = self.spineCollection.humdrumPositions
         self.lastContainer = hdStringToMeasure('=0')
         self.inTuplet = False
         self.lastNote = None
@@ -1346,7 +1351,7 @@ class KernSpine(HumdrumSpine):
                     thisObject = self.processNoteEvent(eventC)
 
                 if thisObject is not None:
-                    thisObject.humdrumPosition = event.position  # type: ignore[attr-defined]
+                    humdrumPositions[thisObject] = event.position
                     thisObject.priority = event.position
                     self.stream.coreAppend(thisObject)
             except Exception as e:  # pylint: disable=broad-exception-caught  # pragma: no cover
@@ -1455,6 +1460,9 @@ class DynamSpine(HumdrumSpine):
     are dynamics.
     '''
     def parse(self) -> None:
+        if t.TYPE_CHECKING:
+            assert self.spineCollection is not None
+        humdrumPositions = self.spineCollection.humdrumPositions
         thisContainer: stream.Measure|None = None
         for event in self.eventList:
             eventC = str(event.contents)  # is str already; just so Eclipse gives the right tools
@@ -1483,8 +1491,7 @@ class DynamSpine(HumdrumSpine):
                 thisObject = dynamics.Dynamic(eventC)
 
             if thisObject is not None:
-                # pylint: disable=attribute-defined-outside-init
-                thisObject.humdrumPosition = event.position  # type: ignore[attr-defined]
+                humdrumPositions[thisObject] = event.position
                 if thisContainer is None:
                     self.stream.coreAppend(thisObject)
                 else:
@@ -1505,6 +1512,9 @@ class HarmSpine(HumdrumSpine):
     RomanText and the MuseScore roman numeral notations.
     '''
     def parse(self) -> None:
+        if t.TYPE_CHECKING:
+            assert self.spineCollection is not None
+        humdrumPositions = self.spineCollection.humdrumPositions
         lastContainer = hdStringToMeasure('=0')
         currentKey = key.Key('C')
         for event in self.eventList:
@@ -1539,8 +1549,7 @@ class HarmSpine(HumdrumSpine):
                 )
 
             if thisObject is not None:
-                # pylint: disable=attribute-defined-outside-init
-                thisObject.humdrumPosition = event.position  # type: ignore[attr-defined]
+                humdrumPositions[thisObject] = event.position
                 thisObject.priority = event.position
                 self.stream.coreAppend(thisObject)
         self.stream.coreElementsChanged()
@@ -1624,13 +1633,16 @@ class SpineCollection(prebase.ProtoM21Object):
     When you iterate over a SpineCollection, it goes from right to
     left, since that's the order that humdrum expects.
     '''
-
     def __init__(self) -> None:
         self.spines: list[HumdrumSpine] = []
         self.nextFreeId: int = 0
         self.spineReclassDone: bool = False
         self.iterIndex: int = 0
         self.newSpine: HumdrumSpine|None = None
+        # Maps each parsed Music21Object to its humdrum file line position.
+        self.humdrumPositions: weakref.WeakKeyDictionary[base.Music21Object, int] = (
+            weakref.WeakKeyDictionary()
+        )
 
     def __iter__(self) -> SpineCollection:
         '''
@@ -1658,7 +1670,6 @@ class SpineCollection(prebase.ProtoM21Object):
         by passing in a different streamClass.
 
         Automatically sets the id of the Spine.
-
 
         >>> hsc = humdrum.spineParser.SpineCollection()
         >>> newSpine = hsc.addSpine()
@@ -1702,8 +1713,7 @@ class SpineCollection(prebase.ProtoM21Object):
 
     def removeSpineById(self, spineId: int) -> None:
         '''
-        deletes a spine from the SpineCollection (after inserting, integrating, etc.)
-
+        Deletes a spine from the SpineCollection (after inserting, integrating, etc.)
 
         >>> hsc = humdrum.spineParser.SpineCollection()
         >>> newSpine = hsc.addSpine()
@@ -1749,8 +1759,8 @@ class SpineCollection(prebase.ProtoM21Object):
 
     def assignIds(self) -> None:
         '''
-        assign an ID based on the instrument or just a string of a number if none
-
+        Assign an ID based on the instrument, or just a string of a number
+        if there is no instrument.
 
         >>> hsc = humdrum.spineParser.SpineCollection()
         >>> newSpineDefault = hsc.addSpine()
@@ -1797,8 +1807,8 @@ class SpineCollection(prebase.ProtoM21Object):
 
     def performInsertions(self) -> None:
         '''
-        take a parsed spineCollection as music21 objects and take
-        sub-spines and put them in their proper location
+        Take a parsed spineCollection as Music21Objects and take
+        sub-spines and put them in their proper location.
         '''
         for thisSpine in self.spines:
             # removeSpines = []
@@ -1811,10 +1821,9 @@ class SpineCollection(prebase.ProtoM21Object):
             newStream = thisSpine.stream.__class__()
             insertPoints = sorted(thisSpine.childSpineInsertPoints)
             lastHumdrumPosition = -1
-            # use _elements for being faster.
-            for el in thisSpine.stream._elements:
-                try:
-                    humdrumPosition = el.humdrumPosition  # type: ignore[attr-defined]
+            for el in thisSpine.stream:
+                humdrumPosition = self.humdrumPositions.get(el)
+                if humdrumPosition is not None:
                     for i in insertPoints:
                         if lastHumdrumPosition > i or humdrumPosition < i:
                             continue
@@ -1822,9 +1831,7 @@ class SpineCollection(prebase.ProtoM21Object):
                         self.performSpineInsertion(thisSpine, newStream, i)
                         insertPoints.remove(i)
                     lastHumdrumPosition = humdrumPosition
-                    del el.humdrumPosition  # type: ignore[attr-defined]
-                except AttributeError:  # no el.humdrumPosition
-                    pass
+                    del self.humdrumPositions[el]
                 newStream.coreAppend(el)
                 # newStream.append(el)
             newStream.coreElementsChanged()
@@ -1857,7 +1864,7 @@ class SpineCollection(prebase.ProtoM21Object):
             # removeSpines.append(insertSpine.id)
             voiceNumber += 1
             voiceStr = 'voice' + str(voiceNumber)
-            for insertEl in insertSpine.stream._elements:
+            for insertEl in insertSpine.stream:
                 if insertSpine.isFirstVoice is False and isinstance(insertEl, stream.Measure):
                     pass  # only insert one measure object per spine
                 else:
@@ -1868,7 +1875,7 @@ class SpineCollection(prebase.ProtoM21Object):
 
     def reclassSpines(self) -> None:
         r'''
-        changes the classes of HumdrumSpines to more specific types
+        Changes the classes of HumdrumSpines to more specific types
         (KernSpine, DynamicSpine)
         according to their spineType (e.g., \*\*kern, \*\*dynam)
         '''
@@ -1885,8 +1892,8 @@ class SpineCollection(prebase.ProtoM21Object):
         self,
     ) -> dict[int, tuple[OffsetQL, list[base.Music21Object]]]:
         '''
-        iterates through the spines by location
-        and records the offset and priority for each
+        Iterates through the spines by location
+        and records the offset and priority for each element in the spines.
 
         Returns a dictionary where each index is humdrumPosition and the value is a
         two-element tuple where the first element is the music21 offset and the
@@ -1895,17 +1902,14 @@ class SpineCollection(prebase.ProtoM21Object):
         positionDict: dict[int, tuple[OffsetQL, list[base.Music21Object]]] = {}
         for thisSpine in self.spines:
             if thisSpine.parentSpine is None:
-                sf = thisSpine.stream.flatten()
-                for el in sf:
-                    if hasattr(el, 'humdrumPosition'):
-                        if el.humdrumPosition not in positionDict:
-                            elementList = [el]
-                            valueTuple = (el.offset, elementList)
-                            positionDict[el.humdrumPosition] = valueTuple
-                        else:
-                            elementList = positionDict[el.humdrumPosition][1]
-                            elementList.append(el)
-        # print(positionDict)
+                for el in thisSpine.stream.flatten():
+                    pos = self.humdrumPositions.get(el)
+                    if pos is None:
+                        continue
+                    if pos not in positionDict:
+                        positionDict[pos] = (el.offset, [el])
+                    else:
+                        positionDict[pos][1].append(el)
         return positionDict
 
     def moveObjectsToMeasures(self) -> None:
@@ -1965,8 +1969,9 @@ class SpineCollection(prebase.ProtoM21Object):
             if thisSpine.spineType == 'dynam':
                 for dynamic in thisSpine.stream.flatten():
                     if isinstance(dynamic, dynamics.Dynamic):
-                        dynamicPos = dynamic.humdrumPosition  # type: ignore[attr-defined]
-                        prioritiesToSearch[dynamicPos] = dynamic
+                        dynamicPos = self.humdrumPositions.get(dynamic)
+                        if dynamicPos is not None:
+                            prioritiesToSearch[dynamicPos] = dynamic
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]
                     for el in applyStream.recurse():
@@ -1983,8 +1988,9 @@ class SpineCollection(prebase.ProtoM21Object):
             elif thisSpine.spineType == 'harm':
                 for harm in thisSpine.stream.flatten():
                     if isinstance(harm, roman.RomanNumeral):
-                        harmPos = harm.humdrumPosition  # type: ignore[attr-defined]
-                        prioritiesToSearch[harmPos] = harm
+                        harmPos = self.humdrumPositions.get(harm)
+                        if harmPos is not None:
+                            prioritiesToSearch[harmPos] = harm
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]
                     for el in applyStream.recurse():
@@ -2001,8 +2007,9 @@ class SpineCollection(prebase.ProtoM21Object):
             elif thisSpine.spineType in ('lyrics', 'text'):
                 for text in thisSpine.stream.recurse():
                     if isinstance(text, base.ElementWrapper):
-                        textPos = text.humdrumPosition  # type: ignore[attr-defined]
-                        prioritiesToSearch[textPos] = text.obj
+                        textPos = self.humdrumPositions.get(text)
+                        if textPos is not None:
+                            prioritiesToSearch[textPos] = text.obj
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]
                     for el in applyStream.recurse():
@@ -2643,8 +2650,6 @@ def kernTandemToObject(tandem: str) -> base.Music21Object|None:
 
 
 class MiscTandem(base.Music21Object):
-    humdrumPosition: int = 0
-
     def __init__(self, tandem: str = '', **keywords) -> None:
         super().__init__(**keywords)
         self.tandem: str = tandem
@@ -2664,8 +2669,6 @@ class SpineComment(base.Music21Object):
     >>> sc.comment
     'this is a spine comment'
     '''
-    humdrumPosition: int = 0
-
     def __init__(self, comment: str = '', **keywords) -> None:
         super().__init__(**keywords)
         commentPart = re.sub(r'^!+\s?', '', comment)

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -718,8 +718,10 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         uses `self.spineCollection.getOffsetsAndPrioritiesByLineNumber()`
         '''
         spineCollection = self.spineCollection
-        if t.TYPE_CHECKING:
-            assert spineCollection is not None
+        if spineCollection is None:
+            raise HumdrumException(
+                'cannot insert global events: no spineCollection. '
+                'Call parse() (or createHumdrumSpines() and parseMusic21()) first.')
         lineNumberDict = spineCollection.getOffsetsAndPrioritiesByLineNumber()
         eventList = self.eventList
         maxEventList = len(eventList)
@@ -1073,7 +1075,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
     A spine knows the SpineCollection it belongs to:
 
     >>> spineCollection1 = humdrum.spineParser.SpineCollection()
-    >>> spine1.spineCollection = spineCollection1
+    >>> spine1.parentSpineCollection = spineCollection1
 
     The spineType property searches the EventList or parentSpine to
     figure out the spineType.
@@ -1103,6 +1105,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
         spineId: int = 0,
         eventList: list[SpineEvent]|None = None,
         streamClass: type[stream.Stream] = stream.Stream,
+        parentSpineCollection: SpineCollection|None = None,
     ) -> None:
         self.id: int = spineId
         if eventList is None:
@@ -1124,7 +1127,11 @@ class HumdrumSpine(prebase.ProtoM21Object):
         self.measuresMoved: bool = False
         self.insertionsDone: bool = False
 
-        self.spineCollection: SpineCollection|None = None
+        if parentSpineCollection is None:
+            # Mostly for unit tests / direct construction.  Real spines come
+            # from SpineCollection.addSpine() which always passes the parent.
+            parentSpineCollection = SpineCollection()
+        self.parentSpineCollection: SpineCollection = parentSpineCollection
         self._spineType: str = ''
 
         self.isFirstVoice: bool = False
@@ -1290,9 +1297,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
         as ElementWrappers.  Should be overridden in
         specific Spine subclasses.
         '''
-        if t.TYPE_CHECKING:
-            assert self.spineCollection is not None
-        humdrumLineNumbers = self.spineCollection.humdrumLineNumbers
+        humdrumLineNumbers = self.parentSpineCollection.humdrumLineNumbers
         lastContainer = hdStringToMeasure('=0')
 
         for event in self.eventList:
@@ -1341,9 +1346,7 @@ class KernSpine(HumdrumSpine):
     desiredTupletQL: OffsetQL
 
     def parse(self) -> None:
-        if t.TYPE_CHECKING:
-            assert self.spineCollection is not None
-        humdrumLineNumbers = self.spineCollection.humdrumLineNumbers
+        humdrumLineNumbers = self.parentSpineCollection.humdrumLineNumbers
         self.lastContainer = hdStringToMeasure('=0')
         self.inTuplet = False
         self.lastNote = None
@@ -1488,9 +1491,7 @@ class DynamSpine(HumdrumSpine):
     are dynamics.
     '''
     def parse(self) -> None:
-        if t.TYPE_CHECKING:
-            assert self.spineCollection is not None
-        humdrumLineNumbers = self.spineCollection.humdrumLineNumbers
+        humdrumLineNumbers = self.parentSpineCollection.humdrumLineNumbers
         thisContainer: stream.Measure|None = None
         for event in self.eventList:
             eventC = event.contents
@@ -1540,9 +1541,7 @@ class HarmSpine(HumdrumSpine):
     RomanText and the MuseScore roman numeral notations.
     '''
     def parse(self) -> None:
-        if t.TYPE_CHECKING:
-            assert self.spineCollection is not None
-        humdrumLineNumbers = self.spineCollection.humdrumLineNumbers
+        humdrumLineNumbers = self.parentSpineCollection.humdrumLineNumbers
         lastContainer = hdStringToMeasure('=0')
         currentKey = key.Key('C')
         for event in self.eventList:
@@ -1700,8 +1699,11 @@ class SpineCollection(prebase.ProtoM21Object):
         >>> newSpine2.stream
         <music21.stream.Stream ...>
         '''
-        self.newSpine = HumdrumSpine(self.nextFreeId, streamClass=streamClass)
-        self.newSpine.spineCollection = self
+        self.newSpine = HumdrumSpine(
+            self.nextFreeId,
+            streamClass=streamClass,
+            parentSpineCollection=self
+        )
         self.spines.append(self.newSpine)
         self.nextFreeId += 1
         return self.newSpine

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -95,21 +95,20 @@ class HumdrumException(exceptions21.Music21Exception):
 
 class HumdrumDataCollection(prebase.ProtoM21Object):
     r'''
+    .. note:: Most users should not need to be here.  Just run `converter.parse('file.krn')`
+        and it will give you a stream.Score instead.
+        Intermediate users who want to get into the guts of Humdrum are still
+        probably better off running humdrum.parseFile("filename")
+        which returns a humdrum.SpineCollection directly.
+
     A HumdrumDataCollection takes in a mandatory list where each element
     is a line of humdrum data.  Together this list represents a collection
     of spines.  Essentially it's the contents of a humdrum file.
-
 
     Usually you will probably want to use HumdrumFile which can read
     in a file directly.  This class exists in case you have your Humdrum
     data in another format (database, from the web, etc.) and already
     have it as a string.
-
-
-    You are probably better off running humdrum.parseFile("filename")
-    which returns a humdrum.SpineCollection directly, or even better,
-    converter.parse('file.krn') which will just give you a stream.Score
-    instead.
 
     LIMITATIONS:
     (1) Spines cannot change definition (\*\*exclusive interpretations) mid-spine.
@@ -126,7 +125,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
         The Aarden/Miller Palestrina dataset uses `\*-` followed by `\*\*kern`
         at the changes of sections thus some parsing of multiple exclusive
-        interpretations in a protospine may be necessary.
+        interpretations in a protospine may be necessary.  But none change definition.
 
     (2) Split spines are assumed to be voices in a single spine staff.
     '''

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -42,7 +42,7 @@ SpineParsing consists of several steps.
 * Stream elements are moved into their measures within a Stream.
 * Measures are searched for elements with voice groups and Voice objects are created.
 
-Changed in v10: flag attributes `isSpineLine, isComment, isGlobal, isReference` have been
+* Changed in v10: flag attributes `isSpineLine, isComment, isGlobal, isReference` have been
     removed from HumdrumLine and all subclasses. `isinstance(...)` is a bit slower than
     checking these, but adds correct typing.  Nothing is stored with weakrefs.  `.iterIndex`
     and hand roled iterator/generators are gone now (could've gone when Python 2.4 became
@@ -57,6 +57,7 @@ import typing as t
 import unittest
 import weakref
 
+from music21.common.numberTools import opFrac
 from music21.common.types import OffsetQL
 
 from music21 import articulations
@@ -80,6 +81,7 @@ from music21 import prebase
 from music21 import stream
 from music21 import tempo
 from music21 import tie
+from music21.duration import GraceDuration
 
 from music21.humdrum import testFiles
 from music21.humdrum import harmparser
@@ -448,9 +450,8 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         Calls :meth:`~music21.humdrum.spineParser.parseEventListFromDataStream`
         if it hasn't already been called.
 
-        returns a tuple of protoSpines and eventCollections in addition to
+        Returns a tuple of protoSpines and eventCollections in addition to
         setting it in the calling object.
-
 
         >>> eventString = ('!!!COM: Beethoven, Ludwig van\n' +
         ...                '!! Not really a piece by Beethoven\n' +
@@ -466,7 +467,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         >>> eventCollections is hdc.eventCollections
         True
 
-        Looking at individual slices is unlikely to tell you much.
+        Looking at individual slices is unlikely to tell you much:
 
         >>> for thisSlice in eventCollections:
         ...    print(thisSlice)
@@ -1292,14 +1293,17 @@ class KernSpine(HumdrumSpine):
     `__class__` from `HumdrumSpine` to `KernSpine` once the spine's
     exclusive interpretation is known.  All KernSpine-specific state
     is initialized at the top of `parse()`.
+
+    * Changed in v10: `currentTupletDuration` / `desiredTupletDuration`
+        renamed to `currentTupletQL` / `desiredTupletQL`.
     '''
     # Set in parse(); declared here so type-checkers see them.
     lastContainer: stream.Measure|None
     inTuplet: bool
     lastNote: note.GeneralNote|None
     currentBeamNumbers: int
-    currentTupletDuration: OffsetQL
-    desiredTupletDuration: OffsetQL
+    currentTupletQL: OffsetQL
+    desiredTupletQL: OffsetQL
 
     def parse(self) -> None:
         if t.TYPE_CHECKING:
@@ -1309,8 +1313,8 @@ class KernSpine(HumdrumSpine):
         self.inTuplet = False
         self.lastNote = None
         self.currentBeamNumbers = 0
-        self.currentTupletDuration = 0.0
-        self.desiredTupletDuration = 0.0
+        self.currentTupletQL = 0.0
+        self.desiredTupletQL = 0.0
 
         for event in self.eventList:
             # event is a SpineEvent object
@@ -1417,26 +1421,26 @@ class KernSpine(HumdrumSpine):
 
         if not self.inTuplet and nTuplets:
             self.inTuplet = True
-            self.desiredTupletDuration = nTuplets[0].totalTupletLength()
-            self.currentTupletDuration = nDur.quarterLength
+            self.desiredTupletQL = nTuplets[0].totalTupletLength()
+            self.currentTupletQL = nDur.quarterLength
             n.duration.tuplets[0].type = 'start'
         elif self.inTuplet and not nTuplets:
             self.inTuplet = False
-            self.desiredTupletDuration = 0.0
-            self.currentTupletDuration = 0.0
+            self.desiredTupletQL = 0.0
+            self.currentTupletQL = 0.0
             if self.lastNote is not None:
                 self.lastNote.duration.tuplets[0].type = 'stop'
         elif self.inTuplet:
-            self.currentTupletDuration += nDur.quarterLength
-            if (self.currentTupletDuration == self.desiredTupletDuration
-                # check for things like 6 6 3 6 6;
-                # redundant with previous, but written out for clarity
-                    or (self.currentTupletDuration / self.desiredTupletDuration) == int(
-                        self.currentTupletDuration / self.desiredTupletDuration)):
+            self.currentTupletQL = opFrac(self.currentTupletQL + nDur.quarterLength)
+            # Stop on the first integer multiple of desiredTupletQL --
+            # handles both exact fits and overshoots like trying to get 3 1/6ths to
+            # add to 0.5, but getting instead 1/6+1/6+1/3+1/6+1/6 = 2*0.5.
+            if (self.currentTupletQL >= self.desiredTupletQL
+                    and self.currentTupletQL % self.desiredTupletQL == 0):
                 nTuplets[0].type = 'stop'
                 self.inTuplet = False
-                self.currentTupletDuration = 0.0
-                self.desiredTupletDuration = 0.0
+                self.currentTupletQL = 0.0
+                self.desiredTupletQL = 0.0
 
 
 class DynamSpine(HumdrumSpine):
@@ -1451,7 +1455,7 @@ class DynamSpine(HumdrumSpine):
         humdrumPositions = self.spineCollection.humdrumPositions
         thisContainer: stream.Measure|None = None
         for event in self.eventList:
-            eventC = str(event.contents)  # is str already; just so Eclipse gives the right tools
+            eventC = event.contents
             thisObject: base.Music21Object|None = None
             if eventC == '.':
                 pass
@@ -1564,7 +1568,6 @@ class SpineEvent(prebase.ProtoM21Object):
 
     The `toNote()` method converts the contents into a music21 note as
     if it's kern -- useful to have in all spine types.
-
 
     >>> se1 = humdrum.spineParser.SpineEvent('EEE-8')
     >>> se1.position = 40
@@ -2157,7 +2160,6 @@ def hdStringToNote(contents: str) -> note.GeneralNote:
     >>> n.duration.fullName
     'Imperfect Maxima'
 
-
     Note that the following example is interpreted as one note in the time of a
     double-dotted quarter not a double-dotted quarter-note triplet.
 
@@ -2384,8 +2386,10 @@ def hdStringToNote(contents: str) -> note.GeneralNote:
         thisObject.duration.type = 'eighth'
     elif 'Q' in contents:
         thisObject = thisObject.getGrace()
-        thisObject.duration.slash = False  # type: ignore[attr-defined]
-        thisObject.duration.type = 'eighth'
+        dur = thisObject.duration
+        assert isinstance(dur, GraceDuration)
+        dur.slash = False
+        dur.type = 'eighth'
     elif 'P' in contents:
         thisObject = thisObject.getGrace(appoggiatura=True)
     elif 'p' in contents:
@@ -2414,89 +2418,72 @@ def hdStringToMeasure(
     kern uses an equals sign followed by processing instructions to
     create new measures.
 
-    N.B. -- much of the code for describing how repeat
-    signs are encoded is among the oldest code for music21
-    and was not updated when musicxml parsing was added.
-    It does not yet use the bar.RepeatMark() class
-    or any other post 2009 additions.
+    Changed in v10: repeat dots are encoded as :class:`~music21.bar.Repeat`
+    objects instead of being stuffed into a non-existent ``Barline.repeatDots``
+    attribute.  ``:|:`` now produces an end-Repeat on the previous measure's
+    right barline AND a start-Repeat on the new measure's left barline.
     '''
-    # TODO(msc): fix!!!
+    if contents == '==|':
+        environLocal.warn(
+            '"Double bar visually rendered as a single bar" is not supported '
+            'in music21; storing as a double bar.')
 
-    m1 = stream.Measure()
-    rematchMN = re.search(r'(\d+)([a-z]?)', contents)
+    m = stream.Measure()
+    match_measure_number = re.search(r'(\d+)([a-z]?)', contents)
+    if match_measure_number:
+        m.number = int(match_measure_number.group(1))
+        if match_measure_number.group(2):
+            m.numberSuffix = match_measure_number.group(2)
 
-    if rematchMN:
-        m1.number = int(rematchMN.group(1))
-        if rematchMN.group(2):
-            m1.numberSuffix = rematchMN.group(2)
-
-    barline = bar.Barline()
-
+    # Bar type from the bar character(s).
+    barType = ''
     if '-' in contents:
-        barline.type = 'none'
+        barType = 'none'
     elif "'" in contents:
-        barline.type = 'short'
+        barType = 'short'
     elif '`' in contents:
-        barline.type = 'tick'
-    elif '||' in contents:
-        barline.type = 'double'
-        if contents.count(':') > 1:
-            barline.repeatDots = 'both'  # type: ignore[attr-defined]
-        elif ':|' in contents:
-            barline.repeatDots = 'left'  # type: ignore[attr-defined]
-        elif '|:' in contents:
-            barline.repeatDots = 'right'  # type: ignore[attr-defined]
+        barType = 'tick'
+    elif '||' in contents or '==' in contents:
+        barType = 'double'
     elif '!!' in contents:
-        barline.type = 'heavy-heavy'
-        if contents.count(':') > 1:
-            barline.repeatDots = 'both'  # type: ignore[attr-defined]
-        elif ':!' in contents:
-            barline.repeatDots = 'left'  # type: ignore[attr-defined]
-        elif '!:' in contents:
-            barline.repeatDots = 'right'  # type: ignore[attr-defined]
+        barType = 'heavy-heavy'
     elif '|!' in contents:
-        barline.type = 'final'
-        if contents.count(':') > 1:
-            barline.repeatDots = 'both'  # type: ignore[attr-defined]
-        elif ':|' in contents:
-            barline.repeatDots = 'left'  # type: ignore[attr-defined]
-        elif '!:' in contents:
-            barline.repeatDots = 'right'  # type: ignore[attr-defined]
+        barType = 'final'
     elif '!|' in contents:
-        barline.type = 'heavy-light'
-        if contents.count(':') > 1:
-            barline.repeatDots = 'both'  # type: ignore[attr-defined]
-        elif ':!' in contents:
-            barline.repeatDots = 'left'  # type: ignore[attr-defined]
-        elif '|:' in contents:
-            barline.repeatDots = 'right'  # type: ignore[attr-defined]
+        barType = 'heavy-light'
     elif '|' in contents:
-        barline.type = 'regular'
-        if contents.count(':') > 1:
-            barline.repeatDots = 'both'  # type: ignore[attr-defined]
-        elif ':|' in contents:
-            barline.repeatDots = 'left'  # type: ignore[attr-defined]
-        elif '|:' in contents:
-            barline.repeatDots = 'right'  # type: ignore[attr-defined]
-    elif '==' in contents:
-        barline.type = 'double'
-        if contents.count(':') > 1:
-            barline.repeatDots = 'both'  # type: ignore[attr-defined]
-            # cannot specify single repeat dots without styles
-        if contents == '==|':
-            raise HumdrumException(
-                'Cannot import a double bar visually rendered as a single bar -- '
-                + 'not sure exactly what that would mean anyhow.')
+        barType = 'regular'
 
+    # Repeat dots:
+    #   ':' before a bar character → end-repeat (dots on the left of the bar)
+    #   ':' after a bar character  → start-repeat (dots on the right of the bar)
+    #   two or more ':' anywhere   → both
+    bothRepeats = contents.count(':') > 1
+    endRepeat = bothRepeats or bool(re.search(r':[|!=]', contents))
+    startRepeat = bothRepeats or bool(re.search(r'[|!=]:', contents))
+
+    def makeBar(direction: str|None) -> bar.Barline:
+        if direction is not None:
+            b: bar.Barline = bar.Repeat(direction=direction)
+        else:
+            b = bar.Barline()
+        if barType:
+            b.type = barType
+        return b
+
+    rightBar = makeBar('end' if endRepeat else None)
     if ';' in contents:
-        barline.pause = expressions.Fermata()
+        rightBar.pause = expressions.Fermata()
 
     if previousMeasure is not None:
-        previousMeasure.rightBarline = barline
+        previousMeasure.rightBarline = rightBar
+        if startRepeat:
+            m.leftBarline = makeBar('start')
     else:
-        m1.leftBarline = barline
+        # No previous measure to attach to: put whatever we have on m's left.
+        m.leftBarline = makeBar('start') if startRepeat else rightBar
 
-    return m1
+    return m
 
 
 def kernTandemToObject(tandem: str) -> base.Music21Object|None:
@@ -2504,7 +2491,6 @@ def kernTandemToObject(tandem: str) -> base.Music21Object|None:
     Kern uses symbols such as :samp:`*M5/4` and :samp:`*clefG2`, etc., to control processing
 
     This method converts them to music21 objects.
-
 
     >>> m = humdrum.spineParser.kernTandemToObject('*M3/1')
     >>> m
@@ -2634,7 +2620,6 @@ class SpineComment(base.Music21Object):
     '''
     A Music21Object that represents a comment in a single spine.
 
-
     >>> sc = humdrum.spineParser.SpineComment('! this is a spine comment')
     >>> sc
     <music21.humdrum.spineParser.SpineComment 'this is a spine comment'>
@@ -2684,7 +2669,7 @@ class GlobalReference(base.Music21Object):
     >>> sc.value
     'this is a global reference'
 
-    Alternate form
+    Alternate form:
 
     >>> sc = humdrum.spineParser.GlobalReference('REF', 'this is a global reference')
     >>> sc
@@ -2919,10 +2904,14 @@ class Test(unittest.TestCase):
         m1 = hdStringToMeasure('=29a;:|:', m0)
         self.assertEqual(m1.number, 29)
         self.assertEqual(m1.numberSuffix, 'a')
+        # ':|:' produces an end-Repeat on m0's right and a start-Repeat on m1's left.
+        self.assertIsInstance(m0.rightBarline, bar.Repeat)
+        self.assertEqual(m0.rightBarline.direction, 'end')
         self.assertEqual(m0.rightBarline.type, 'regular')
-        self.assertEqual(m0.rightBarline.repeatDots, 'both')
-        self.assertIsNotNone(m0.rightBarline.pause)
         self.assertIsInstance(m0.rightBarline.pause, expressions.Fermata)
+        self.assertIsInstance(m1.leftBarline, bar.Repeat)
+        self.assertEqual(m1.leftBarline.direction, 'start')
+        self.assertEqual(m1.leftBarline.type, 'regular')
 
     def testMeterBreve(self):
         m = kernTandemToObject('*M3/1')
@@ -3227,5 +3216,4 @@ class TestExternal(unittest.TestCase):
 
 if __name__ == '__main__':
     import music21
-    music21.mainTest(Test)  # , runTest='testSplitSpines2') #, TestExternal)
-
+    music21.mainTest(Test)

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -51,7 +51,9 @@ SpineParsing consists of several steps.
     property `numLines` (= `len(self.dataStream)`); `HumdrumLine.position` and
     `SpineEvent.position` were both renamed to `lineNumber` and now hold the 1-based
     source line number (was eventList index for SpineEvent),
-    advancing on blank lines too.
+    advancing on blank lines too.  Blank lines now produce `BlankLine` HumdrumLine
+    entries rather than being skipped, so `eventList[lineNumber - 1]` always
+    resolves to the line at that source position.
 '''
 from __future__ import annotations
 
@@ -282,37 +284,37 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         if dataStream is None:  # pragma: no cover
             raise TypeError('dataStream cannot be None')
 
-        startPositions = []
-        endPositions = []
+        startIndices = []
+        endIndices = []
         for i, line in enumerate(dataStream):
             line = line.rstrip()
             if re.search(r'^(\*-\t)*\*-$', line):
-                endPositions.append(i)
+                endIndices.append(i)
             elif re.search(r'^(\*\*\w+\t)*\*\*\w+$', line):
-                startPositions.append(i)
-        if len(startPositions) < 2:
+                startIndices.append(i)
+        if len(startIndices) < 2:
             return (False, None)
-        if endPositions[-1] > startPositions[-1]:
+        if endIndices[-1] > startIndices[-1]:
             # properly formed .krn with *- at end
             pass
         else:
             # improperly formed .krn without *- at end
-            endPositions.append(len(dataStream))
+            endIndices.append(len(dataStream))
 
         dataCollections = []
-        for i in range(len(endPositions)):
+        for i in range(len(endIndices)):
             if i == 0:
-                endPos = endPositions[i]
+                endPos = endIndices[i]
                 dataCollections.append(dataStream[:endPos + 1])
-            elif i == len(endPositions) - 1:
+            elif i == len(endIndices) - 1:
                 # ignore endPosition and grab to end of file
-                startPos = endPositions[i - 1] + 1
-                dataCollections.append(dataStream[startPos:])
+                startIndex = endIndices[i - 1] + 1
+                dataCollections.append(dataStream[startIndex:])
             else:
-                # ignore startPositions, grab comments etc. between scores
-                startPos = endPositions[i - 1] + 1
-                endPos = endPositions[i] + 1
-                dataCollections.append(dataStream[startPos:endPos])
+                # ignore startIndices, grab comments etc. between scores
+                startIndex = endIndices[i - 1] + 1
+                endIndex = endIndices[i] + 1
+                dataCollections.append(dataStream[startIndex:endIndex])
 
         if len(dataCollections) > 1:
             return (True, dataCollections)
@@ -413,8 +415,10 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
             lineNumber += 1
             line = line.rstrip()
             if line == '':
-                continue  # technically forbidden by Humdrum but the source of so many errors!
-            if re.match(r'!!!', line):
+                # Humdrum forbids blanks, but they appear in real files; keep
+                # eventList aligned with the source so eventList[n-1] is line n.
+                self.eventList.append(BlankLine(lineNumber))
+            elif re.match(r'!!!', line):
                 self.eventList.append(GlobalReferenceLine(lineNumber, line))
             elif re.match(r'!!', line):  # find global comments at the top of the line
                 self.eventList.append(GlobalCommentLine(lineNumber, line))
@@ -439,14 +443,13 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         of ProtoSpines, that is a vertical slice of everything that
         happens in a column, regardless of spine-path indicators.
 
-        EventCollection objects store global events at the position.
-        ProtoSpines do not.
+        EventCollection objects store global events. ProtoSpines do not.
 
         So `self.eventCollections` and `self.protoSpines` can each be
         thought of as a two-dimensional sheet of cells, but where
-        the first index of the former is the vertical position in
+        the first index of the former is the vertical index in
         the dataStream and the first index of the latter is the
-        horizontal position in the dataStream.  The contents of
+        horizontal index in the dataStream.  The contents of
         each cell is a SpineEvent object or None (if there's no
         data at that point).  Even '.' (continuation events) get
         translated into SpineEvent objects.
@@ -532,9 +535,9 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                 return thisEvent
 
             # placeholder cell: either a SpineLine with no data this far over,
-            # or a global (comment/reference) line. First check for Global Comment or Reference
+            # or a global line (GlobalComment, GlobalReference, or BlankLine).
             if not isinstance(currentLine, SpineLine) and j == 0:
-                # not SpineLine = GlobalComment or GlobalReference.
+                # not SpineLine = GlobalComment, GlobalReference, or BlankLine.
                 # global events register once, against the first column
                 thisEventCollection.addGlobalEvent(currentLine)
             placeholder = SpineEvent('', currentLine.lineNumber)
@@ -623,6 +626,9 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
             # *x     *x     C#4
 
             newSpineList = common.defaultlist(lambda: None)
+
+            # These are either False OR the spine being merged/exchanged.
+            # TODO: separate the two concepts.
             mergerActive = False
             exchangeActive = False
             for j in range(maxSpines):
@@ -635,7 +641,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                 elif thisEvent is None:
                     continue
                 elif thisEvent.contents == '*-':  # terminate spine
-                    currentSpine.endingPosition = i
+                    currentSpine.endingPoint = i
                 elif thisEvent.contents == '*^':  # split spine assume they are voices
                     newSpine1 = spineCollection.addSpine(streamClass=stream.Voice)
                     newSpine1.insertPoint = i + 1
@@ -644,7 +650,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                     newSpine2 = spineCollection.addSpine(streamClass=stream.Voice)
                     newSpine2.insertPoint = i + 1
                     newSpine2.parentSpine = currentSpine
-                    currentSpine.endingPosition = i  # will be overridden if merged
+                    currentSpine.endingPoint = i  # will be overridden if merged
                     currentSpine.childSpines.append(newSpine1)
                     currentSpine.childSpines.append(newSpine2)
 
@@ -661,11 +667,11 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                             mergerActive = currentSpine.parentSpine
                         else:
                             mergerActive = True
-                        currentSpine.endingPosition = i
+                        currentSpine.endingPoint = i
                     else:
                         # if second merger code is not found then
                         # a one-to-one spine 'merge' occurs
-                        currentSpine.endingPosition = i
+                        currentSpine.endingPoint = i
                         # merge back to parent if possible:
                         if currentSpine.parentSpine is not None:
                             newSpineList.append(currentSpine.parentSpine)
@@ -709,12 +715,12 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
         Run after `self.spineCollection.createMusic21Streams()`.
         Is run automatically by `self.parse()`.
-        uses `self.spineCollection.getOffsetsAndPrioritiesByPosition()`
+        uses `self.spineCollection.getOffsetsAndPrioritiesByLineNumber()`
         '''
         spineCollection = self.spineCollection
         if t.TYPE_CHECKING:
             assert spineCollection is not None
-        positionDict = spineCollection.getOffsetsAndPrioritiesByPosition()
+        lineNumberDict = spineCollection.getOffsetsAndPrioritiesByLineNumber()
         eventList = self.eventList
         maxEventList = len(eventList)
         numberOfGlobalEventsInARow = 0
@@ -727,10 +733,10 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                 insertOffset: OffsetQL|None = None
                 insertPriority = 0
                 for j in range(i + 1, maxEventList):
-                    if j in positionDict:
-                        insertOffset = positionDict[j][0]
+                    if j in lineNumberDict:
+                        insertOffset = lineNumberDict[j][0]
                         # hopefully not more than 20 events in a row!
-                        insertPriority = (positionDict[j][1][0].priority
+                        insertPriority = (lineNumberDict[j][1][0].priority
                                           - 40
                                           + numberOfGlobalEventsInARow)
                         break
@@ -989,6 +995,30 @@ class GlobalCommentLine(HumdrumLine):
         return repr(self.value)
 
 
+class BlankLine(HumdrumLine):
+    '''
+    A blank line in a humdrum source.  Humdrum forbids blank lines, but
+    they appear in the wild.  Storing them as BlankLine objects keeps
+    `eventList` aligned with the source: `eventList[lineNumber - 1]` is
+    always the HumdrumLine at that 1-based source line.
+
+    Treated as a global event by `parseProtoSpinesAndEventCollections`
+    (no SpineEvent is created at this line for any spine).
+
+    >>> b = humdrum.spineParser.BlankLine(lineNumber=12)
+    >>> b
+    <music21.humdrum.spineParser.BlankLine line 12>
+    >>> b.lineNumber
+    12
+    '''
+    def __init__(self, lineNumber: int = 0) -> None:
+        self.lineNumber = lineNumber
+        self.contents = ''
+
+    def _reprInternal(self) -> str:
+        return f'line {self.lineNumber}'
+
+
 class ProtoSpine(prebase.ProtoM21Object):
     '''
     A ProtoSpine is a collection of events arranged vertically.
@@ -1036,7 +1066,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
     >>> spine1Id = 5
     >>> spine1 = humdrum.spineParser.HumdrumSpine(spine1Id, spineEvents)
     >>> spine1.insertPoint = 5
-    >>> spine1.endingPosition = 6
+    >>> spine1.endingPoint = 6
     >>> spine1.parentSpine = 3  # spine 3 is the previous spine leading to this one
     >>> spine1.childSpines = [7, 8]  # the spine ends by being split into spines 7 and 8
 
@@ -1083,7 +1113,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
         self.eventList: list[SpineEvent] = eventList
         self.stream: stream.Stream = streamClass()
         self.insertPoint: int = 0
-        self.endingPosition: int = 0
+        self.endingPoint: int = 0
         self.parentSpine: HumdrumSpine|None = None
         self.newSpine: HumdrumSpine|None = None
         self.isLastSpine: bool = False
@@ -1262,7 +1292,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
         '''
         if t.TYPE_CHECKING:
             assert self.spineCollection is not None
-        humdrumPositions = self.spineCollection.humdrumPositions
+        humdrumLineNumbers = self.spineCollection.humdrumLineNumbers
         lastContainer = hdStringToMeasure('=0')
 
         for event in self.eventList:
@@ -1283,7 +1313,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
                 thisObject = base.ElementWrapper(event)
 
             if thisObject is not None:
-                humdrumPositions[thisObject] = event.lineNumber
+                humdrumLineNumbers[thisObject] = event.lineNumber
                 self.stream.coreAppend(thisObject)
         self.stream.coreElementsChanged()
 
@@ -1313,7 +1343,7 @@ class KernSpine(HumdrumSpine):
     def parse(self) -> None:
         if t.TYPE_CHECKING:
             assert self.spineCollection is not None
-        humdrumPositions = self.spineCollection.humdrumPositions
+        humdrumLineNumbers = self.spineCollection.humdrumLineNumbers
         self.lastContainer = hdStringToMeasure('=0')
         self.inTuplet = False
         self.lastNote = None
@@ -1346,7 +1376,7 @@ class KernSpine(HumdrumSpine):
                     thisObject = self.processNoteEvent(eventC)
 
                 if thisObject is not None:
-                    humdrumPositions[thisObject] = event.lineNumber
+                    humdrumLineNumbers[thisObject] = event.lineNumber
                     # priority is doing double duty: real Stream sort priority
                     # (used by insertGlobalEvents) AND a proxy for humdrum line
                     # number (used by attachNonKernEvents to align spines).
@@ -1460,7 +1490,7 @@ class DynamSpine(HumdrumSpine):
     def parse(self) -> None:
         if t.TYPE_CHECKING:
             assert self.spineCollection is not None
-        humdrumPositions = self.spineCollection.humdrumPositions
+        humdrumLineNumbers = self.spineCollection.humdrumLineNumbers
         thisContainer: stream.Measure|None = None
         for event in self.eventList:
             eventC = event.contents
@@ -1489,7 +1519,7 @@ class DynamSpine(HumdrumSpine):
                 thisObject = dynamics.Dynamic(eventC)
 
             if thisObject is not None:
-                humdrumPositions[thisObject] = event.lineNumber
+                humdrumLineNumbers[thisObject] = event.lineNumber
                 if thisContainer is None:
                     self.stream.coreAppend(thisObject)
                 else:
@@ -1512,7 +1542,7 @@ class HarmSpine(HumdrumSpine):
     def parse(self) -> None:
         if t.TYPE_CHECKING:
             assert self.spineCollection is not None
-        humdrumPositions = self.spineCollection.humdrumPositions
+        humdrumLineNumbers = self.spineCollection.humdrumLineNumbers
         lastContainer = hdStringToMeasure('=0')
         currentKey = key.Key('C')
         for event in self.eventList:
@@ -1547,7 +1577,7 @@ class HarmSpine(HumdrumSpine):
                 )
 
             if thisObject is not None:
-                humdrumPositions[thisObject] = event.lineNumber
+                humdrumLineNumbers[thisObject] = event.lineNumber
                 thisObject.priority = event.lineNumber
                 self.stream.coreAppend(thisObject)
         self.stream.coreElementsChanged()
@@ -1636,7 +1666,7 @@ class SpineCollection(prebase.ProtoM21Object):
         self.spineReclassDone: bool = False
         self.newSpine: HumdrumSpine|None = None
         # Maps each parsed Music21Object to its humdrum file line position.
-        self.humdrumPositions: weakref.WeakKeyDictionary[base.Music21Object, int] = (
+        self.humdrumLineNumbers: weakref.WeakKeyDictionary[base.Music21Object, int] = (
             weakref.WeakKeyDictionary()
         )
 
@@ -1803,18 +1833,18 @@ class SpineCollection(prebase.ProtoM21Object):
             # only spines with children spines and parent spines continue
             newStream = thisSpine.stream.__class__()
             insertPoints = sorted(thisSpine.childSpineInsertPoints)
-            lastHumdrumPosition = -1
+            lastLineNumber = -1
             for el in thisSpine.stream:
-                humdrumPosition = self.humdrumPositions.get(el)
-                if humdrumPosition is not None:
+                lineNumber = self.humdrumLineNumbers.get(el)
+                if lineNumber is not None:
                     for i in insertPoints:
-                        if lastHumdrumPosition > i or humdrumPosition < i:
+                        if lastLineNumber > i or lineNumber < i:
                             continue
                         # insert a sub-spine into this Stream at the current location
                         self.performSpineInsertion(thisSpine, newStream, i)
                         insertPoints.remove(i)
-                    lastHumdrumPosition = humdrumPosition
-                    del self.humdrumPositions[el]
+                    lastLineNumber = lineNumber
+                    del self.humdrumLineNumbers[el]
                 newStream.coreAppend(el)
                 # newStream.append(el)
             newStream.coreElementsChanged()
@@ -1871,29 +1901,28 @@ class SpineCollection(prebase.ProtoM21Object):
                 thisSpine.__class__ = HarmSpine
         self.spineReclassDone = True
 
-    def getOffsetsAndPrioritiesByPosition(
+    def getOffsetsAndPrioritiesByLineNumber(
         self,
     ) -> dict[int, tuple[OffsetQL, list[base.Music21Object]]]:
         '''
         Iterates through the spines by location
         and records the offset and priority for each element in the spines.
 
-        Returns a dictionary where each index is humdrumPosition and the value is a
-        two-element tuple where the first element is the music21 offset and the
-        second element is a list of Music21Objects at that position
+        Returns a dictionary keyed by humdrum line number whose values are
+        two-element tuples: (music21 offset, list of Music21Objects at that line).
         '''
-        positionDict: dict[int, tuple[OffsetQL, list[base.Music21Object]]] = {}
+        lineNumberDict: dict[int, tuple[OffsetQL, list[base.Music21Object]]] = {}
         for thisSpine in self.spines:
             if thisSpine.parentSpine is None:
                 for el in thisSpine.stream.flatten():
-                    pos = self.humdrumPositions.get(el)
+                    pos = self.humdrumLineNumbers.get(el)
                     if pos is None:
                         continue
-                    if pos not in positionDict:
-                        positionDict[pos] = (el.offset, [el])
+                    if pos not in lineNumberDict:
+                        lineNumberDict[pos] = (el.offset, [el])
                     else:
-                        positionDict[pos][1].append(el)
-        return positionDict
+                        lineNumberDict[pos][1].append(el)
+        return lineNumberDict
 
     def moveObjectsToMeasures(self) -> None:
         '''
@@ -1951,7 +1980,7 @@ class SpineCollection(prebase.ProtoM21Object):
                     break
             if thisSpine.spineType == 'dynam':
                 for dynamic in thisSpine.stream[dynamics.Dynamic]:
-                    dynamicPos = self.humdrumPositions.get(dynamic)
+                    dynamicPos = self.humdrumLineNumbers.get(dynamic)
                     if dynamicPos is not None:
                         prioritiesToSearch[dynamicPos] = dynamic
                 for applyStaff in stavesAppliedTo:
@@ -1969,7 +1998,7 @@ class SpineCollection(prebase.ProtoM21Object):
                             #    copy.deepcopy(prioritiesToSearch[el.priority]))
             elif thisSpine.spineType == 'harm':
                 for harm in thisSpine.stream[roman.RomanNumeral]:
-                    harmPos = self.humdrumPositions.get(harm)
+                    harmPos = self.humdrumLineNumbers.get(harm)
                     if harmPos is not None:
                         prioritiesToSearch[harmPos] = harm
                 for applyStaff in stavesAppliedTo:
@@ -1987,7 +2016,7 @@ class SpineCollection(prebase.ProtoM21Object):
                             #    copy.deepcopy(prioritiesToSearch[el.priority]))
             elif thisSpine.spineType in ('lyrics', 'text'):
                 for wrapper in thisSpine.stream[base.ElementWrapper]:
-                    wrapperPos = self.humdrumPositions.get(wrapper)
+                    wrapperPos = self.humdrumLineNumbers.get(wrapper)
                     if wrapperPos is not None:
                         prioritiesToSearch[wrapperPos] = wrapper.obj
                 for applyStaff in stavesAppliedTo:

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -4,7 +4,7 @@
 #
 # Authors:      Michael Scott Asato Cuthbert
 #
-# Copyright:    Copyright © 2009-2012, 2020 Michael Scott Asato Cuthbert
+# Copyright:    Copyright © 2009-2026 Michael Scott Asato Cuthbert
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
@@ -34,13 +34,17 @@ SpineParsing consists of several steps.
 * All reclassed HumdrumSpines are filled with music21 objects in their .stream property.
     Measures are put into the spine but are empty containers.  The resulting
     HumdrumSpine.stream objects
-    look like Stream.semiFlat versions in many ways.
+    look like `Stream.flatten(retainContainers=True)` versions in many ways.
 * For HumdrumSpines with parent spines their .stream contents are then
     inserted into their parent spines with
     voice tagged as a music21 Group property.
 * Lyrics and Dynamics are placed into their corresponding HumdrumSpine.stream objects
 * Stream elements are moved into their measures within a Stream
 * Measures are searched for elements with voice groups and Voice objects are created
+
+Changed in v10: flag attributes `isSpineLine, isComment, isGlobal, isReference` have been
+    removed from HumdrumLine and all subclasses. `isinstance(...)` is a bit slower than
+    checking these, but adds correct typing.
 '''
 from __future__ import annotations
 
@@ -49,6 +53,8 @@ import math
 import re
 import typing as t
 import unittest
+
+from music21.common.types import OffsetQL
 
 from music21 import articulations
 from music21 import bar
@@ -130,54 +136,51 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
     (2) Split spines are assumed to be voices in a single spine staff.
     '''
 
-    def __init__(self, dataStream=None):
+    def __init__(self, dataStream: str|list[str]) -> None:
         # attributes
-        self.eventList = None
-        self.maxSpines = None
-        self.parsePositionInStream = None
-        self.fileLength = None
-        self.protoSpines = None
-        self.eventCollections = None
-        self.spineCollection = None
+        self.eventList: list[HumdrumLine] = []
+        self.maxSpines: int = 0
+        self.parsePositionInStream: int = 0
+        self.fileLength: int = 0
+        self.protoSpines: list[ProtoSpine] = []
+        self.eventCollections: list[EventCollection] = []
+        self.spineCollection: SpineCollection|None = None
 
-        if dataStream is not None and not dataStream:
-            raise HumdrumException('dataStream is not optional, specify some lines: \n'
-                                   + 'dataStream was: ' + repr(dataStream))
-        if dataStream is None:
-            dataStream = []
-        elif isinstance(dataStream, str):
+        if isinstance(dataStream, str):
             dataStream = dataStream.splitlines()
 
-        self.dataStream = dataStream
-        self.stream = None
+        self.dataStream: list[str] = dataStream
+        # Defaults to a Score; parseOpusDataCollections will replace it with
+        # an Opus if the input turns out to be a multipart file.
+        self.stream: stream.Score|stream.Opus = stream.Score()
 
-    def parse(self):
+    def parse(self) -> stream.Score|stream.Opus:
         '''
-        Parse a list (dataStream) of lines into a HumdrumSpineCollection
-        (which contains HumdrumSpines)
-        and set it in self.spineCollection
+        Parse `self.dataStream` into music21 objects, returning the resulting
+        :class:`~music21.stream.Score` (or :class:`~music21.stream.Opus`
+        for multipart files like the Palestrina dataset).
 
-
-        if dataStream is None, look for it in self.dataStream.  If that's None too,
-        return an exception.
-
+        The parsed stream is also stored on `self.stream`.
         '''
-        dataStream = self.dataStream
-        if dataStream is None:
+        if not self.dataStream:
             raise HumdrumException('Need a list of lines (dataStream) to parse!')
 
-        hasOpus, dataCollections = self.determineIfDataStreamIsOpus(dataStream)
-        if hasOpus is True:  # True for the Palestrina data collection, maybe others
+        hasOpus, dataCollections = self.determineIfDataStreamIsOpus(self.dataStream)
+        if hasOpus and dataCollections is not None:
+            # True for the Palestrina data collection, maybe others
             return self.parseOpusDataCollections(dataCollections)
         else:
-            return self.parseNonOpus(dataStream)
+            return self.parseNonOpus(self.dataStream)
 
-    def parseNonOpus(self, dataStream):
+    def parseNonOpus(self, dataStream: list[str]) -> stream.Score:
         '''
         The main parse function for non-opus data collections.
-        '''
-        self.stream = stream.Score()
 
+        Populates `self.stream` (a :class:`~music21.stream.Score`) and returns it.
+        '''
+        # Reset to a fresh Score in case parse() is called more than once.
+        score = stream.Score()
+        self.stream = score
         self.maxSpines = 0
 
         # parse global comments and figure out the maximum number of spines we will have
@@ -196,19 +199,23 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
             thisSpine.stream.id = 'spine_' + str(thisSpine.id)
         for thisSpine in self.spineCollection:
             if thisSpine.parentSpine is None and thisSpine.spineType == 'kern':
-                self.stream.insert(thisSpine.stream)
+                score.insert(thisSpine.stream)
 
         self.parseMetadata()
+        return score
 
     # noinspection SpellCheckingInspection
-    def determineIfDataStreamIsOpus(self, dataStream=None):
+    def determineIfDataStreamIsOpus(
+        self,
+        dataStream: list[str]|None = None,
+    ) -> tuple[bool, list[list[str]]|None]:
         # noinspection PyShadowingNames
         r'''
         Some Humdrum files contain multiple pieces in one file
         which are better represented as :class:`~music21.stream.Opus`
         file containing multiple scores.
 
-        This method examines that dataStream (or self.dataStream) and
+        This method examines that dataStream (or `self.dataStream`) and
         if it only has a single piece then it returns (False, None).
 
         If it has multiple pieces, it returns True and a list of dataStreams.
@@ -303,11 +310,11 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                 + 'possibly multiple **tags without closing information. Or a *tandem tag '
                 + 'accidentally encoded as a **spine tag.')
 
-    def parseOpusDataCollections(self, dataCollections):
+    def parseOpusDataCollections(self, dataCollections: list[list[str]]) -> stream.Opus:
         # noinspection PyShadowingNames
         '''
         Take a dataCollection from `determineIfDataStreamIsOpus`
-        and set self.stream to be an Opus instead.
+        and set `self.stream` to be an Opus instead.
 
         >>> mps = humdrum.testFiles.multipartSanctus
         >>> hdc = humdrum.spineParser.HumdrumDataCollection(mps)
@@ -325,8 +332,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         opus = stream.Opus()
         for i, dc in enumerate(dataCollections):
             hdc = HumdrumDataCollection(dc)
-            hdc.parse()
-            sc = hdc.stream
+            sc = hdc.parse()
             sc.id = 'section_' + str(i + 1)
             sc.metadata.number = i + 1
             opus.append(sc)
@@ -338,17 +344,20 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         self.stream = opus
         return opus
 
-    def parseEventListFromDataStream(self, dataStream=None):
+    def parseEventListFromDataStream(
+        self,
+        dataStream: list[str]|None = None,
+    ) -> list[HumdrumLine]:
         r'''
-        Sets self.eventList from a dataStream (that is, a
-        list of lines).  It sets self.maxSpines to the
+        Sets `self.eventList` from a dataStream (that is, a
+        list of lines).  It sets `self.maxSpines` to the
         largest number of spine events found on any line
         in the file.
 
-        It sets self.fileLength to the number of lines (excluding
+        It sets `self.fileLength` to the number of lines (excluding
         totally blank lines) in the file.
 
-        The difference between the dataStream and self.eventList
+        The difference between the dataStream and `self.eventList`
         are the following:
 
             * Blank lines are skipped.
@@ -356,8 +365,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
             * !! lines become :class:`~music21.humdrum.spineParser.GlobalCommentLine` objects
             * all other lines become :class:`~music21.humdrum.spineParser.SpineLine` objects
 
-        Returns eventList in addition to setting it as self.eventList.
-
+        Returns eventList in addition to setting it as `self.eventList`.
 
         >>> eventString = ('!!! COM: Beethoven, Ludwig van\n' +
         ...                '!! Not really a piece by Beethoven\n' +
@@ -371,11 +379,11 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         True
         >>> for e in eList:
         ...     print(e)
-        <music21.humdrum.spineParser.GlobalReferenceLine object at 0x...>
-        <music21.humdrum.spineParser.GlobalCommentLine object at 0x...>
-        <music21.humdrum.spineParser.SpineLine object at 0x...>
-        <music21.humdrum.spineParser.SpineLine object at 0x...>
-        <music21.humdrum.spineParser.SpineLine object at 0x...>
+        <music21.humdrum.spineParser.GlobalReferenceLine COM: 'Beethoven, Ludwig van'>
+        <music21.humdrum.spineParser.GlobalCommentLine 'Not really a piece by Beethoven'>
+        <music21.humdrum.spineParser.SpineLine line 2 (2 spines)>
+        <music21.humdrum.spineParser.SpineLine line 3 (2 spines)>
+        <music21.humdrum.spineParser.SpineLine line 4 (2 spines)>
         >>> print(eList[0].value)
         Beethoven, Ludwig van
         >>> print(eList[3].spineData)
@@ -405,23 +413,25 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         self.fileLength = self.parsePositionInStream
         return self.eventList
 
-    def parseProtoSpinesAndEventCollections(self):
+    def parseProtoSpinesAndEventCollections(
+        self,
+    ) -> tuple[list[ProtoSpine], list[EventCollection]]:
         r'''
         Run after
         :meth:`~music21.humdrum.spineParser.HumdrumDataCollection.parseEventListFromDataStream()`
-        to take self.eventList and slice it horizontally
-        to get self.eventCollections, which is a list of
+        to take `self.eventList` and slice it horizontally
+        to get `self.eventCollections`, which is a list of
         EventCollection objects, or things that happen simultaneously.
 
-        And, more importantly, this method slices self.eventList
-        vertically to get self.protoSpines which is a list
+        And, more importantly, this method slices `self.eventList`
+        vertically to get `self.protoSpines` which is a list
         of ProtoSpines, that is a vertical slice of everything that
         happens in a column, regardless of spine-path indicators.
 
         EventCollection objects store global events at the position.
         ProtoSpines do not.
 
-        So self.eventCollections and self.protoSpines can each be
+        So `self.eventCollections` and `self.protoSpines` can each be
         thought of as a two-dimensional sheet of cells, but where
         the first index of the former is the vertical position in
         the dataStream and the first index of the latter is the
@@ -476,22 +486,23 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
         # we make two lists: one of ProtoSpines (vertical slices) and
         # one of Events(horizontal slices)
-        returnProtoSpines = []
-        returnEventCollections = []
-        protoSpineEventList = []
+        returnProtoSpines: list[ProtoSpine] = []
+        returnEventCollections: list[EventCollection] = []
+        protoSpineEventList: list[SpineEvent|None] = []
 
         # noinspection PyShadowingNames
-        def doOneCell(i, j):
+        def doOneCell(i: int, j: int) -> None:
             # get the currentEventCollection
             thisEventCollection = returnEventCollections[i]
+            currentLine = self.eventList[i]
 
             # parse this cell
-            if self.eventList[i].isSpineLine is True:
+            if isinstance(currentLine, SpineLine):
                 # not a global event
-                if len(self.eventList[i].spineData) > j:
+                if len(currentLine.spineData) > j:
                     # are there actually this many spines at this point?
                     # thus, is there an event here? True
-                    thisEvent = SpineEvent(self.eventList[i].spineData[j])
+                    thisEvent = SpineEvent(currentLine.spineData[j])
                     thisEvent.position = i
                     thisEvent.protoSpineId = j
                     if thisEvent.contents in spinePathIndicators:
@@ -502,12 +513,13 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                     if thisEvent.contents == '.' and i > 0:
                         lastEvent = returnEventCollections[i - 1].events[j]
                         if lastEvent is not None:
-                            thisEventCollection.addLastSpineEvent(
-                                j,
+                            occurringEvent = (
                                 returnEventCollections[i - 1].getSpineOccurring(j)
                             )
+                            if occurringEvent is not None:
+                                thisEventCollection.addLastSpineEvent(j, occurringEvent)
                 else:  # no data here
-                    thisEvent = SpineEvent(None)
+                    thisEvent = SpineEvent('')
                     thisEvent.position = i
                     thisEvent.protoSpineId = j
                     thisEventCollection.addSpineEvent(j, thisEvent)
@@ -516,7 +528,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
             else:  # Global event -- either GlobalCommentLine or GlobalReferenceLine
                 if j == 0:  # adds to all spines but just runs the first time.
                     thisEventCollection.addGlobalEvent(self.eventList[i])
-                thisEvent = SpineEvent(None)
+                thisEvent = SpineEvent('')
                 thisEvent.position = i
                 thisEvent.protoSpineId = j
                 thisEventCollection.addSpineEvent(j, thisEvent)
@@ -539,7 +551,11 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
         return (returnProtoSpines, returnEventCollections)
 
-    def createHumdrumSpines(self, protoSpines=None, eventCollections=None):
+    def createHumdrumSpines(
+        self,
+        protoSpines: list[ProtoSpine]|None = None,
+        eventCollections: list[EventCollection]|None = None,
+    ) -> SpineCollection:
         '''
         Takes the data from the object's protoSpines and eventCollections
         and returns a :class:`~music21.humdrum.spineParser.SpineCollection`
@@ -593,7 +609,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                 thisEvent.protoSpineId = currentSpine.id
 
             # check for spinePathData
-            if thisEventCollection.spinePathData is False:
+            if not thisEventCollection.spinePathData:
                 continue
 
             # note that nothing else can happen in an eventCollection
@@ -681,26 +697,28 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
         return spineCollection
 
-    def insertGlobalEvents(self):
+    def insertGlobalEvents(self) -> None:
         '''
         Insert the Global Events (GlobalReferenceLines and GlobalCommentLines) into an appropriate
         place in the outer Stream.
 
-        Run after self.spineCollection.createMusic21Streams().
-        Is run automatically by self.parse().
-        uses self.spineCollection.getOffsetsAndPrioritiesByPosition()
+        Run after `self.spineCollection.createMusic21Streams()`.
+        Is run automatically by `self.parse()`.
+        uses `self.spineCollection.getOffsetsAndPrioritiesByPosition()`
         '''
+        if t.TYPE_CHECKING:
+            assert self.spineCollection is not None
         positionDict = self.spineCollection.getOffsetsAndPrioritiesByPosition()
         eventList = self.eventList
         maxEventList = len(eventList)
         numberOfGlobalEventsInARow = 0
-        insertList = []
-        appendList = []
+        insertList: list[tuple[OffsetQL, GlobalReference|GlobalComment]] = []
+        appendList: list[GlobalReference|GlobalComment] = []
 
         for i, event in enumerate(eventList):
-            if event.isSpineLine is False:
+            if isinstance(event, (GlobalReferenceLine, GlobalCommentLine)):
                 numberOfGlobalEventsInARow += 1
-                insertOffset = None
+                insertOffset: OffsetQL|None = None
                 insertPriority = 0
                 for j in range(i + 1, maxEventList):
                     if j in positionDict:
@@ -710,7 +728,8 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                                           - 40
                                           + numberOfGlobalEventsInARow)
                         break
-                if event.isReference is True:
+                el: GlobalReference|GlobalComment
+                if isinstance(event, GlobalReferenceLine):
                     # TODO: Fix GlobalReference -- ???
                     el = GlobalReference(event.code, event.value)
                 else:
@@ -763,7 +782,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
     #         self._storedStream = masterStream
     #         return masterStream
 
-    def parseMetadata(self, s=None):
+    def parseMetadata(self, s: stream.Stream|None = None) -> None:
         '''
         Create a metadata object for the file.
         '''
@@ -771,7 +790,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
             s = self.stream
         md = metadata.Metadata()
         s.metadata = md
-        grToRemove = []
+        grToRemove: list[GlobalReference] = []
 
         for gr in s[GlobalReference]:
             gr.updateMetadata(md)
@@ -787,32 +806,32 @@ class HumdrumFile(HumdrumDataCollection):
     as a mandatory argument a filename to be opened and read.
     '''
 
-    def __init__(self, filename: str|pathlib.Path|None = None):
-        super().__init__()
-        self.filename = filename
+    def __init__(self, filename: str|pathlib.Path) -> None:
+        super().__init__([])
+        self.filename: str|pathlib.Path = filename
 
-    def parseFilename(self, filename: str|pathlib.Path|None = None):
+    def parseFilename(self, filename: str|pathlib.Path|None = None) -> None:
         if filename is None:
             filename = self.filename
-        if filename is None:
-            raise HumdrumException('Cannot parse humdrum file without a filename!')
 
         with open(filename, encoding='latin-1') as humFH:
-            self.eventList = self.parseFileHandle(humFH)
+            self.parseFileHandle(humFH)
         # might raise IOError
 
-    def parseFileHandle(self, fileHandle):
+    def parseFileHandle(self, fileHandle: t.Iterable[str]) -> stream.Score|stream.Opus:
         '''
-        takes a fileHandle and returns a HumdrumCollection by calling parse()
+        Read all lines from `fileHandle` into ``self.dataStream``, then call
+        :meth:`parse` and return its result (a :class:`~music21.stream.Score`
+        or :class:`~music21.stream.Opus`).
         '''
-        spineDataCollection = []
+        spineDataCollection: list[str] = []
         for line in fileHandle:
             spineDataCollection.append(line)
         self.dataStream = spineDataCollection
         return self.parse()
 
 
-class HumdrumLine:
+class HumdrumLine(prebase.ProtoM21Object):
     '''
     HumdrumLine is a dummy class for subclassing
     :class:`~music21.humdrum.spineParser.SpineLine`,
@@ -826,10 +845,9 @@ class HumdrumLine:
     See the documentation for the specific classes mentioned above
     for more details.
     '''
-    isReference = False
-    isGlobal = False
-    isComment = False
-    position = 0
+    position: int = 0
+    contents: str = ''
+    numSpines: int = 0
 
 
 class SpineLine(HumdrumLine):
@@ -841,9 +859,10 @@ class SpineLine(HumdrumLine):
     Takes in a position (line number in file, excluding blank lines)
     and a string of contents.
 
-
     >>> hsl = humdrum.spineParser.SpineLine(
-    ...         position = 7, contents='C4\t!local comment\t*M[4/4]\t.\n')
+    ...         position=7, contents='C4\t!local comment\t*M[4/4]\t.\n')
+    >>> hsl
+    <music21.humdrum.spineParser.SpineLine line 7 (4 spines)>
     >>> hsl.position
     7
     >>> hsl.numSpines
@@ -851,18 +870,16 @@ class SpineLine(HumdrumLine):
     >>> hsl.spineData
     ['C4', '!local comment', '*M[4/4]', '.']
     '''
-    position = 0
-    contents = ''
-    isSpineLine = True
-    numSpines = 0
-
-    def __init__(self, position: int = 0, contents: str = ''):
+    def __init__(self, position: int = 0, contents: str = '') -> None:
         self.position = position
         contents = contents.rstrip()
         returnList = re.split('\t+', contents)
         self.numSpines = len(returnList)
         self.contents = contents
-        self.spineData = returnList
+        self.spineData: list[str] = returnList
+
+    def _reprInternal(self) -> str:
+        return f'line {self.position} ({self.numSpines} spines)'
 
 
 class GlobalReferenceLine(HumdrumLine):
@@ -891,9 +908,10 @@ class GlobalReferenceLine(HumdrumLine):
         code:     non-whitespace code (usually three letters)
         value:    its value
 
-
     >>> gr = humdrum.spineParser.GlobalReferenceLine(
-    ...        position = 20, contents = '!!!COM: Stravinsky, Igor Fyodorovich\n')
+    ...        position=20, contents='!!!COM: Stravinsky, Igor Fyodorovich\n')
+    >>> gr
+    <music21.humdrum.spineParser.GlobalReferenceLine COM: 'Stravinsky, Igor Fyodorovich'>
     >>> gr.position
     20
     >>> gr.code
@@ -903,15 +921,7 @@ class GlobalReferenceLine(HumdrumLine):
 
     TODO: add parsing of three-digit Kern comment codes into fuller metadata
     '''
-    position = 0
-    contents = ''
-    isGlobal = True
-    isReference = True
-    isComment = True
-    isSpineLine = False
-    numSpines = 0
-
-    def __init__(self, position: int = 0, contents: str = '!!! NUL: None'):
+    def __init__(self, position: int = 0, contents: str = '!!! NUL: None') -> None:
         self.position = position
         noExclaim = re.sub(r'^!!!+', '', contents)
         try:
@@ -925,8 +935,11 @@ class GlobalReferenceLine(HumdrumLine):
                                    f'this is probably a problem! {contents} ')
 
         self.contents = contents
-        self.code = code
-        self.value = value
+        self.code: str = code
+        self.value: str = value
+
+    def _reprInternal(self) -> str:
+        return f'{self.code}: {self.value!r}'
 
 
 class GlobalCommentLine(HumdrumLine):
@@ -945,7 +958,9 @@ class GlobalCommentLine(HumdrumLine):
 
 
     >>> com1 = humdrum.spineParser.GlobalCommentLine(
-    ...          position = 4, contents='!! this comment is global')
+    ...          position=4, contents='!! this comment is global')
+    >>> com1
+    <music21.humdrum.spineParser.GlobalCommentLine 'this comment is global'>
     >>> com1.position
     4
     >>> com1.contents
@@ -953,20 +968,16 @@ class GlobalCommentLine(HumdrumLine):
     >>> com1.value
     'this comment is global'
     '''
-    position = 0
-    contents = ''
-    value = ''
-    isGlobal = True
-    isReference = False
-    isComment = True
-    isSpineLine = False
-    numSpines = 0
+    value: str = ''
 
-    def __init__(self, position: int = 0, contents: str = ''):
+    def __init__(self, position: int = 0, contents: str = '') -> None:
         self.position = position
         value = re.sub(r'^!!+\s?', '', contents)
         self.contents = contents
         self.value = value
+
+    def _reprInternal(self) -> str:
+        return repr(self.value)
 
 
 class ProtoSpine(prebase.ProtoM21Object):
@@ -982,10 +993,10 @@ class ProtoSpine(prebase.ProtoM21Object):
     for more details on how ProtoSpine objects are created.
     '''
 
-    def __init__(self, eventList=None):
+    def __init__(self, eventList: list[SpineEvent|None]|None = None) -> None:
         if eventList is None:
             eventList = []
-        self.eventList = eventList
+        self.eventList: list[SpineEvent|None] = eventList
 
 
 # HUMDRUM SPINES #
@@ -1010,8 +1021,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
     >>> spine1.parentSpine = 3  # spine 3 is the previous spine leading to this one
     >>> spine1.childSpines = [7, 8]  # the spine ends by being split into spines 7 and 8
 
-    we keep weak references to the spineCollection so that we
-    don't have circular references
+    A spine knows the SpineCollection it belongs to:
 
     >>> spineCollection1 = humdrum.spineParser.SpineCollection()
     >>> spine1.spineCollection = spineCollection1
@@ -1039,34 +1049,39 @@ class HumdrumSpine(prebase.ProtoM21Object):
     <music21.stream.Part ...>
     '''
 
-    def __init__(self, spineId: int = 0, eventList=None, streamClass=stream.Stream):
+    def __init__(
+        self,
+        spineId: int = 0,
+        eventList: list[SpineEvent]|None = None,
+        streamClass: type[stream.Stream] = stream.Stream,
+    ) -> None:
         self.id: int = spineId
         if eventList is None:
             eventList = []
         for event in eventList:
             event.spineId = spineId
 
-        self.eventList = eventList
-        self.stream = streamClass()
-        self.insertPoint = 0
-        self.endingPosition = 0
-        self.parentSpine = None
-        self.newSpine = None
-        self.isLastSpine = False
+        self.eventList: list[SpineEvent] = eventList
+        self.stream: stream.Stream = streamClass()
+        self.insertPoint: int = 0
+        self.endingPosition: int = 0
+        self.parentSpine: HumdrumSpine|None = None
+        self.newSpine: HumdrumSpine|None = None
+        self.isLastSpine: bool = False
         self.childSpines: list[HumdrumSpine] = []
         self.childSpineInsertPoints: dict[int, tuple[HumdrumSpine, ...]] = {}
 
-        self.parsed = False
-        self.measuresMoved = False
-        self.insertionsDone = False
+        self.parsed: bool = False
+        self.measuresMoved: bool = False
+        self.insertionsDone: bool = False
 
-        self._spineCollection = None
-        self._spineType = None
+        self.spineCollection: SpineCollection|None = None
+        self._spineType: str|None = None
 
         self.isFirstVoice: bool|None = None
-        self.iterIndex = None
+        self.iterIndex: int|None = None
 
-    def _reprInternal(self):
+    def _reprInternal(self) -> str:
         representation = ': ' + str(self.id)
         if self.parentSpine:
             representation += ' [child of: ' + str(self.parentSpine.id) + ']'
@@ -1077,38 +1092,32 @@ class HumdrumSpine(prebase.ProtoM21Object):
             representation += ' ]'
         return representation
 
-    def append(self, event):
+    def append(self, event: SpineEvent) -> None:
         '''
         add an item to this Spine
         '''
         self.eventList.append(event)
 
-    def __iter__(self):
+    def __iter__(self) -> HumdrumSpine:
         '''
         Resets the counter to 0 so that iteration is correct
         '''
         self.iterIndex = 0
         return self
 
-    def __next__(self):
+    def __next__(self) -> SpineEvent:
         '''
         Returns the current event and increments the iteration index.
         '''
         if self.iterIndex == len(self.eventList):
             raise StopIteration()
+        if t.TYPE_CHECKING:
+            assert self.iterIndex is not None
         thisEvent = self.eventList[self.iterIndex]
         self.iterIndex += 1
         return thisEvent
 
-    def _getSpineCollection(self):
-        return common.unwrapWeakref(self._spineCollection)
-
-    def _setSpineCollection(self, sc=None):
-        self._spineCollection = common.wrapWeakref(sc)
-
-    spineCollection = property(_getSpineCollection, _setSpineCollection)
-
-    def _getLocalSpineType(self):
+    def _getLocalSpineType(self) -> str|None:
         if self._spineType is not None:
             return self._spineType
         else:
@@ -1119,7 +1128,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
                     return self._spineType
             return None
 
-    def _getParentSpineType(self):
+    def _getParentSpineType(self) -> str|None:
         parentSpine = self.parentSpine
         if parentSpine is not None:
             psSpineType = parentSpine.spineType
@@ -1129,7 +1138,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
         else:
             return None
 
-    def _getSpineType(self):
+    def _getSpineType(self) -> str:
         '''
         searches the current and parent spineType for a search
         '''
@@ -1149,12 +1158,12 @@ class HumdrumSpine(prebase.ProtoM21Object):
                     raise HumdrumException('Could not determine spineType '
                                            + 'for spine with id ' + str(self.id))
 
-    def _setSpineType(self, newSpineType=None):
+    def _setSpineType(self, newSpineType: str|None = None) -> None:
         self._spineType = newSpineType
 
     spineType = property(_getSpineType, _setSpineType)
 
-    def moveElementsIntoMeasures(self, streamIn):
+    def moveElementsIntoMeasures(self, streamIn: stream.Stream) -> stream.Stream:
         # noinspection PyShadowingNames
         '''
         Takes a parsed stream and moves the elements inside the
@@ -1202,10 +1211,10 @@ class HumdrumSpine(prebase.ProtoM21Object):
         currentMeasure = stream.Measure()
         currentMeasure.number = 0
         currentMeasureNumber = 0
-        currentMeasureOffset = 0
+        currentMeasureOffset: OffsetQL = 0.0
         hasMeasureOne = False
         for el in streamIn:
-            if isinstance(el, stream.Stream):
+            if isinstance(el, stream.Measure):
                 if currentMeasureNumber != 0 or currentMeasure:
                     currentMeasure.coreElementsChanged()
                     # streamOut.append(currentMeasure)
@@ -1251,7 +1260,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
 
         return streamOut
 
-    def parse(self):
+    def parse(self) -> None:
         '''
         Dummy method that pushes all these objects to HumdrumSpine.stream
         as ElementWrappers.  Should be overridden in
@@ -1261,7 +1270,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
 
         for event in self.eventList:
             eventC = str(event.contents)
-            thisObject = None
+            thisObject: base.Music21Object|None = None
             if eventC == '.':
                 pass
             elif eventC.startswith('*'):
@@ -1274,8 +1283,9 @@ class HumdrumSpine(prebase.ProtoM21Object):
             elif eventC.startswith('!'):
                 thisObject = SpineComment(eventC)
             else:
-                thisObject = base.ElementWrapper(event)
-                thisObject.humdrumPosition = event.position
+                wrapper = base.ElementWrapper(event)
+                wrapper.humdrumPosition = event.position
+                thisObject = wrapper
 
             if thisObject is not None:
                 self.stream.coreAppend(thisObject)
@@ -1289,16 +1299,21 @@ class KernSpine(HumdrumSpine):
     are kern notes
     '''
 
-    def __init__(self, spineId: int = 0, eventList=None, streamClass=stream.Stream):
+    def __init__(
+        self,
+        spineId: int = 0,
+        eventList: list[SpineEvent]|None = None,
+        streamClass: type[stream.Stream] = stream.Stream,
+    ) -> None:
         super().__init__(spineId, eventList, streamClass)
-        self.lastContainer = None
-        self.inTuplet = None
-        self.lastNote = None
-        self.currentBeamNumbers = 0
-        self.currentTupletDuration = 0.0
-        self.desiredTupletDuration = 0.0
+        self.lastContainer: stream.Measure|None = None
+        self.inTuplet: bool = False
+        self.lastNote: note.GeneralNote|None = None
+        self.currentBeamNumbers: int = 0
+        self.currentTupletDuration: OffsetQL = 0.0
+        self.desiredTupletDuration: OffsetQL = 0.0
 
-    def parse(self):
+    def parse(self) -> None:
         self.lastContainer = hdStringToMeasure('=0')
         self.inTuplet = False
         self.lastNote = None
@@ -1310,7 +1325,7 @@ class KernSpine(HumdrumSpine):
             # event is a SpineEvent object
             try:
                 eventC = event.contents
-                thisObject = None
+                thisObject: base.Music21Object|None = None
                 if eventC == '.':
                     pass
                 elif eventC.startswith('*'):
@@ -1322,16 +1337,16 @@ class KernSpine(HumdrumSpine):
                     self.lastContainer = hdStringToMeasure(eventC, self.lastContainer)
                     thisObject = self.lastContainer
                 elif eventC.startswith('!'):
-                    thisObject = SpineComment(eventC)
-                    if thisObject.comment == '':
-                        thisObject = None
+                    spineCommentObj = SpineComment(eventC)
+                    if spineCommentObj.comment != '':
+                        thisObject = spineCommentObj
                 elif ' ' in eventC:
                     thisObject = self.processChordEvent(eventC)
                 else:  # Note or Rest
                     thisObject = self.processNoteEvent(eventC)
 
                 if thisObject is not None:
-                    thisObject.humdrumPosition = event.position
+                    thisObject.humdrumPosition = event.position  # type: ignore[attr-defined]
                     thisObject.priority = event.position
                     self.stream.coreAppend(thisObject)
             except Exception as e:  # pylint: disable=broad-exception-caught  # pragma: no cover
@@ -1348,7 +1363,7 @@ class KernSpine(HumdrumSpine):
         self.stream.coreElementsChanged()
         # still to be done later. Move things before first measure to first measure!
 
-    def processNoteEvent(self, eventC):
+    def processNoteEvent(self, eventC: str) -> note.GeneralNote:
         '''
         similar to hdStringToNote, this method processes a string representing a single
         note, but stores information about current beam and tuplet state.
@@ -1361,7 +1376,7 @@ class KernSpine(HumdrumSpine):
         self.lastNote = eventNote
         return eventNote
 
-    def processChordEvent(self, eventC):
+    def processChordEvent(self, eventC: str) -> chord.Chord:
         '''
         Process a single chord event
 
@@ -1369,10 +1384,11 @@ class KernSpine(HumdrumSpine):
         '''
         # multipleNotes
         notesToProcess = eventC.split()
-        chordNotes = []
+        chordNotes: list[note.Note] = []
         for noteToProcess in notesToProcess:
             thisNote = hdStringToNote(noteToProcess)
-            chordNotes.append(thisNote)
+            if isinstance(thisNote, note.Note):
+                chordNotes.append(thisNote)
         eventChord = chord.Chord(chordNotes, beams=chordNotes[-1].beams)
         eventChord.duration = chordNotes[0].duration
 
@@ -1382,7 +1398,7 @@ class KernSpine(HumdrumSpine):
 
         return eventChord
 
-    def setBeamsForNote(self, n):
+    def setBeamsForNote(self, n: note.GeneralNote) -> None:
         '''
         sets the beams for a Note (or Chord) given self.currentBeamNumbers
         and updates self.currentBeamNumbers based on stop beams.
@@ -1403,22 +1419,23 @@ class KernSpine(HumdrumSpine):
                     if thisBeam.type != 'stop':
                         self.currentBeamNumbers += 1
 
-    def setTupletTypeForNote(self, n):
+    def setTupletTypeForNote(self, n: note.GeneralNote) -> None:
         # nested tuplets not supported by humdrum.
         nDur = n.duration
         nTuplets = n.duration.tuplets
 
-        if self.inTuplet is False and nTuplets:
+        if not self.inTuplet and nTuplets:
             self.inTuplet = True
             self.desiredTupletDuration = nTuplets[0].totalTupletLength()
             self.currentTupletDuration = nDur.quarterLength
             n.duration.tuplets[0].type = 'start'
-        elif self.inTuplet is True and not nTuplets:
+        elif self.inTuplet and not nTuplets:
             self.inTuplet = False
             self.desiredTupletDuration = 0.0
             self.currentTupletDuration = 0.0
-            self.lastNote.duration.tuplets[0].type = 'stop'
-        elif self.inTuplet is True:
+            if self.lastNote is not None:
+                self.lastNote.duration.tuplets[0].type = 'stop'
+        elif self.inTuplet:
             self.currentTupletDuration += nDur.quarterLength
             if (self.currentTupletDuration == self.desiredTupletDuration
                 # check for things like 6 6 3 6 6;
@@ -1437,11 +1454,11 @@ class DynamSpine(HumdrumSpine):
     attribute set and thus events are processed as if they
     are dynamics.
     '''
-    def parse(self):
-        thisContainer = None
+    def parse(self) -> None:
+        thisContainer: stream.Measure|None = None
         for event in self.eventList:
             eventC = str(event.contents)  # is str already; just so Eclipse gives the right tools
-            thisObject = None
+            thisObject: base.Music21Object|None = None
             if eventC == '.':
                 pass
             elif eventC.startswith('*'):
@@ -1454,9 +1471,9 @@ class DynamSpine(HumdrumSpine):
                     self.stream.coreAppend(thisContainer)
                 thisContainer = hdStringToMeasure(eventC)
             elif eventC.startswith('!'):
-                thisObject = SpineComment(eventC)
-                if thisObject.comment == '':
-                    thisObject = None
+                spineCommentObj = SpineComment(eventC)
+                if spineCommentObj.comment != '':
+                    thisObject = spineCommentObj
 
             elif eventC.startswith('<'):
                 thisObject = dynamics.Diminuendo()
@@ -1466,7 +1483,8 @@ class DynamSpine(HumdrumSpine):
                 thisObject = dynamics.Dynamic(eventC)
 
             if thisObject is not None:
-                thisObject.humdrumPosition = event.position  # pylint: disable=attribute-defined-outside-init
+                # pylint: disable=attribute-defined-outside-init
+                thisObject.humdrumPosition = event.position  # type: ignore[attr-defined]
                 if thisContainer is None:
                     self.stream.coreAppend(thisObject)
                 else:
@@ -1486,12 +1504,12 @@ class HarmSpine(HumdrumSpine):
     for python and extending the syntax based on other projects like the
     RomanText and the MuseScore roman numeral notations.
     '''
-    def parse(self):
+    def parse(self) -> None:
         lastContainer = hdStringToMeasure('=0')
         currentKey = key.Key('C')
         for event in self.eventList:
             eventC = event.contents
-            thisObject = None
+            thisObject: base.Music21Object|None = None
             if eventC == '.':
                 pass
             elif eventC.startswith('*'):
@@ -1522,7 +1540,7 @@ class HarmSpine(HumdrumSpine):
 
             if thisObject is not None:
                 # pylint: disable=attribute-defined-outside-init
-                thisObject.humdrumPosition = event.position
+                thisObject.humdrumPosition = event.position  # type: ignore[attr-defined]
                 thisObject.priority = event.position
                 self.stream.coreAppend(thisObject)
         self.stream.coreElementsChanged()
@@ -1563,19 +1581,19 @@ class SpineEvent(prebase.ProtoM21Object):
     >>> n
     <music21.note.Note E->
     '''
-    def __init__(self, contents: str = '', position: int = 0):
+    def __init__(self, contents: str = '', position: int = 0) -> None:
         self.contents: str = contents
         self.position: int = position
         self.protoSpineId: int = 0
         self.spineId: int|None = None
 
-    def _reprInternal(self):
+    def _reprInternal(self) -> str:
         return self.contents
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.contents
 
-    def toNote(self, convertString=None):
+    def toNote(self, convertString: str|None = None) -> note.GeneralNote:
         r'''
         parse the object as a \*\*kern note and return a
         :class:`~music21.note.Note` object (or Rest, or Chord)
@@ -1607,21 +1625,21 @@ class SpineCollection(prebase.ProtoM21Object):
     left, since that's the order that humdrum expects.
     '''
 
-    def __init__(self):
-        self.spines = []
-        self.nextFreeId = 0
-        self.spineReclassDone = False
-        self.iterIndex = None
-        self.newSpine = None
+    def __init__(self) -> None:
+        self.spines: list[HumdrumSpine] = []
+        self.nextFreeId: int = 0
+        self.spineReclassDone: bool = False
+        self.iterIndex: int = 0
+        self.newSpine: HumdrumSpine|None = None
 
-    def __iter__(self):
+    def __iter__(self) -> SpineCollection:
         '''
         Resets the counter to len(self.spines) so that iteration is correct
         '''
         self.iterIndex = len(self.spines) - 1
         return self
 
-    def __next__(self):
+    def __next__(self) -> HumdrumSpine:
         '''
         Returns the current spine and decrements the iteration index.
         '''
@@ -1631,7 +1649,7 @@ class SpineCollection(prebase.ProtoM21Object):
         self.iterIndex -= 1
         return thisSpine
 
-    def addSpine(self, streamClass: type[stream.Stream] = stream.Part):
+    def addSpine(self, streamClass: type[stream.Stream] = stream.Part) -> HumdrumSpine:
         '''
         creates a new spine in the collection and returns it.
 
@@ -1664,14 +1682,14 @@ class SpineCollection(prebase.ProtoM21Object):
         self.newSpine.isFirstVoice = False
         return self.newSpine
 
-    def appendSpine(self, spine):
+    def appendSpine(self, spine: HumdrumSpine) -> None:
         '''
         appendSpine(spine) -- appends an already existing HumdrumSpine
         to the SpineCollection.  Returns void
         '''
         self.spines.append(spine)
 
-    def getSpineById(self, spineId):
+    def getSpineById(self, spineId: int) -> HumdrumSpine:
         '''
         returns the HumdrumSpine with the given id.
 
@@ -1682,7 +1700,7 @@ class SpineCollection(prebase.ProtoM21Object):
                 return thisSpine
         raise HumdrumException('Could not find a Spine with that ID')
 
-    def removeSpineById(self, spineId):
+    def removeSpineById(self, spineId: int) -> None:
         '''
         deletes a spine from the SpineCollection (after inserting, integrating, etc.)
 
@@ -1709,7 +1727,7 @@ class SpineCollection(prebase.ProtoM21Object):
                 return None
         raise HumdrumException(f'Could not find a Spine with that ID {id}')
 
-    def createMusic21Streams(self):
+    def createMusic21Streams(self) -> None:
         '''
         Create Music21 Stream objects from spineCollections by running:
 
@@ -1729,7 +1747,7 @@ class SpineCollection(prebase.ProtoM21Object):
         self.makeVoices()
         self.assignIds()
 
-    def assignIds(self):
+    def assignIds(self) -> None:
         '''
         assign an ID based on the instrument or just a string of a number if none
 
@@ -1752,8 +1770,8 @@ class SpineCollection(prebase.ProtoM21Object):
         Oboe-2
         Trumpet
         '''
-        usedIds = {None: 0}
-        firstStreamForEachInstrument = {}
+        usedIds: dict[str|None, int] = {None: 0}
+        firstStreamForEachInstrument: dict[str|None, stream.Stream] = {}
         for thisSpine in self.spines:
             spineStream = thisSpine.stream
             instrumentsStream = spineStream.getElementsByClass(instrument.Instrument)
@@ -1765,18 +1783,19 @@ class SpineCollection(prebase.ProtoM21Object):
             if spineInstrument not in usedIds:
                 firstStreamForEachInstrument[spineInstrument] = spineStream
                 usedIds[spineInstrument] = 1
-                spineStream.id = spineInstrument
+                if spineInstrument is not None:
+                    spineStream.id = spineInstrument
             elif spineInstrument is None:
                 usedIds[None] += 1
                 spineStream.id = str(usedIds[None])
             else:
                 if usedIds[spineInstrument] == 1:
                     myFirstStream = firstStreamForEachInstrument[spineInstrument]
-                    myFirstStream.id = myFirstStream.id + '-1'
+                    myFirstStream.id = str(myFirstStream.id) + '-1'
                 usedIds[spineInstrument] += 1
                 spineStream.id = spineInstrument + '-' + str(usedIds[spineInstrument])
 
-    def performInsertions(self):
+    def performInsertions(self) -> None:
         '''
         take a parsed spineCollection as music21 objects and take
         sub-spines and put them in their proper location
@@ -1795,7 +1814,7 @@ class SpineCollection(prebase.ProtoM21Object):
             # use _elements for being faster.
             for el in thisSpine.stream._elements:
                 try:
-                    humdrumPosition = el.humdrumPosition
+                    humdrumPosition = el.humdrumPosition  # type: ignore[attr-defined]
                     for i in insertPoints:
                         if lastHumdrumPosition > i or humdrumPosition < i:
                             continue
@@ -1803,7 +1822,7 @@ class SpineCollection(prebase.ProtoM21Object):
                         self.performSpineInsertion(thisSpine, newStream, i)
                         insertPoints.remove(i)
                     lastHumdrumPosition = humdrumPosition
-                    del el.humdrumPosition
+                    del el.humdrumPosition  # type: ignore[attr-defined]
                 except AttributeError:  # no el.humdrumPosition
                     pass
                 newStream.coreAppend(el)
@@ -1820,7 +1839,12 @@ class SpineCollection(prebase.ProtoM21Object):
             #    # needed for some tests
             #    self.removeSpineById(removeMe)
 
-    def performSpineInsertion(self, thisSpine, newStream, insertionPoint):
+    def performSpineInsertion(
+        self,
+        thisSpine: HumdrumSpine,
+        newStream: stream.Stream,
+        insertionPoint: int,
+    ) -> None:
         '''
         Insert all the spines into newStream that should be
         inserted into thisSpine at insertionPoint.
@@ -1842,7 +1866,7 @@ class SpineCollection(prebase.ProtoM21Object):
                     newStream.coreInsert(startPoint + insertEl.offset, insertEl)
         newStream.coreElementsChanged()  # call between coreInsert and coreAppend
 
-    def reclassSpines(self):
+    def reclassSpines(self) -> None:
         r'''
         changes the classes of HumdrumSpines to more specific types
         (KernSpine, DynamicSpine)
@@ -1857,7 +1881,9 @@ class SpineCollection(prebase.ProtoM21Object):
                 thisSpine.__class__ = HarmSpine
         self.spineReclassDone = True
 
-    def getOffsetsAndPrioritiesByPosition(self):
+    def getOffsetsAndPrioritiesByPosition(
+        self,
+    ) -> dict[int, tuple[OffsetQL, list[base.Music21Object]]]:
         '''
         iterates through the spines by location
         and records the offset and priority for each
@@ -1866,7 +1892,7 @@ class SpineCollection(prebase.ProtoM21Object):
         two-element tuple where the first element is the music21 offset and the
         second element is a list of Music21Objects at that position
         '''
-        positionDict = {}
+        positionDict: dict[int, tuple[OffsetQL, list[base.Music21Object]]] = {}
         for thisSpine in self.spines:
             if thisSpine.parentSpine is None:
                 sf = thisSpine.stream.flatten()
@@ -1882,7 +1908,7 @@ class SpineCollection(prebase.ProtoM21Object):
         # print(positionDict)
         return positionDict
 
-    def moveObjectsToMeasures(self):
+    def moveObjectsToMeasures(self) -> None:
         '''
         run moveElementsIntoMeasures for each HumdrumSpine
         that is not a sub-spine.
@@ -1904,13 +1930,13 @@ class SpineCollection(prebase.ProtoM21Object):
 
                 thisSpine.measuresMoved = True
 
-    def moveDynamicsAndLyricsToStreams(self):
+    def moveDynamicsAndLyricsToStreams(self) -> None:
         '''
         move :samp:`**dynam` and :samp:`**lyrics/**text` information to the appropriate staff.
 
         Assumes that :samp:`*staff` is consistent through the spine.
         '''
-        kernStreams = {}
+        kernStreams: dict[int, stream.Stream] = {}
         for thisSpine in self.spines:
             if thisSpine.parentSpine is not None:
                 continue
@@ -1929,17 +1955,18 @@ class SpineCollection(prebase.ProtoM21Object):
             if thisSpine.spineType == 'kern':
                 continue
 
-            stavesAppliedTo = []
-            prioritiesToSearch = {}
+            stavesAppliedTo: list[int] = []
+            prioritiesToSearch: dict[int, base.Music21Object] = {}
             for tandem in thisSpine.stream[MiscTandem]:
                 if tandem.tandem.startswith('*staff'):
-                    staffInfo = tandem.tandem[6:]  # could be multiple staves
-                    stavesAppliedTo = [int(x) for x in staffInfo.split('/')]
+                    staffInfoStr = tandem.tandem[6:]  # could be multiple staves
+                    stavesAppliedTo = [int(x) for x in staffInfoStr.split('/')]
                     break
             if thisSpine.spineType == 'dynam':
                 for dynamic in thisSpine.stream.flatten():
                     if isinstance(dynamic, dynamics.Dynamic):
-                        prioritiesToSearch[dynamic.humdrumPosition] = dynamic
+                        dynamicPos = dynamic.humdrumPosition  # type: ignore[attr-defined]
+                        prioritiesToSearch[dynamicPos] = dynamic
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]
                     for el in applyStream.recurse():
@@ -1956,7 +1983,8 @@ class SpineCollection(prebase.ProtoM21Object):
             elif thisSpine.spineType == 'harm':
                 for harm in thisSpine.stream.flatten():
                     if isinstance(harm, roman.RomanNumeral):
-                        prioritiesToSearch[harm.humdrumPosition] = harm
+                        harmPos = harm.humdrumPosition  # type: ignore[attr-defined]
+                        prioritiesToSearch[harmPos] = harm
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]
                     for el in applyStream.recurse():
@@ -1972,14 +2000,15 @@ class SpineCollection(prebase.ProtoM21Object):
                             #    copy.deepcopy(prioritiesToSearch[el.priority]))
             elif thisSpine.spineType in ('lyrics', 'text'):
                 for text in thisSpine.stream.recurse():
-                    if 'ElementWrapper' in text.classes:
-                        prioritiesToSearch[text.humdrumPosition] = text.obj
+                    if isinstance(text, base.ElementWrapper):
+                        textPos = text.humdrumPosition  # type: ignore[attr-defined]
+                        prioritiesToSearch[textPos] = text.obj
                 for applyStaff in stavesAppliedTo:
                     applyStream = kernStreams[applyStaff]
                     for el in applyStream.recurse():
                         if el.priority in prioritiesToSearch:
-                            lyric = prioritiesToSearch[el.priority].contents
-                            el.lyric = lyric
+                            wrappedEvent = prioritiesToSearch[el.priority]
+                            el.lyric = wrappedEvent.contents  # type: ignore[attr-defined]
 
     def makeVoices(self) -> None:
         '''
@@ -2034,7 +2063,7 @@ class SpineCollection(prebase.ProtoM21Object):
                 el.coreElementsChanged()
                 # print(el.number, 'has voices at', lowestVoiceOffset)
 
-    def parseMusic21(self):
+    def parseMusic21(self) -> None:
         '''
         runs spine.parse() for each Spine.
         thus populating the spine.stream for each Spine
@@ -2079,28 +2108,28 @@ class EventCollection:
     [<music21.humdrum.spineParser.SpineEvent D4>, <music21.humdrum.spineParser.SpineEvent pp>]
     '''
 
-    def __init__(self, maxSpines=0):
-        self.events = common.defaultlist(lambda: None)
-        self.lastEvents = common.defaultlist(lambda: None)
-        self.maxSpines = maxSpines
-        self.spinePathData = False
+    def __init__(self, maxSpines: int = 0) -> None:
+        self.events: common.defaultlist = common.defaultlist(lambda: None)
+        self.lastEvents: common.defaultlist = common.defaultlist(lambda: None)
+        self.maxSpines: int = maxSpines
+        self.spinePathData: bool = False
         # true if the line contains data about changing spinePaths
 
-    def addSpineEvent(self, spineNum, spineEvent):
+    def addSpineEvent(self, spineNum: int, spineEvent: SpineEvent) -> None:
         self.events[spineNum] = spineEvent
 
-    def addLastSpineEvent(self, spineNum, spineEvent):
+    def addLastSpineEvent(self, spineNum: int, spineEvent: SpineEvent) -> None:
         # should only add if current 'event' is '.' or a comment
         self.lastEvents[spineNum] = spineEvent
 
-    def addGlobalEvent(self, globalEvent):
+    def addGlobalEvent(self, globalEvent: HumdrumLine) -> None:
         for i in range(self.maxSpines):
             self.events[i] = globalEvent
 
-    def getSpineEvent(self, spineNum):
+    def getSpineEvent(self, spineNum: int) -> SpineEvent|None:
         return self.events[spineNum]
 
-    def getSpineOccurring(self, spineNum):
+    def getSpineOccurring(self, spineNum: int) -> SpineEvent|None:
         # returns the lastEvent if set (
         # should only happen if currentEvent is '.')
         # or the current event
@@ -2109,14 +2138,14 @@ class EventCollection:
         else:
             return self.events[spineNum]
 
-    def getAllOccurring(self):
-        retEvents = []
+    def getAllOccurring(self) -> list[SpineEvent|None]:
+        retEvents: list[SpineEvent|None] = []
         for i in range(self.maxSpines):
             retEvents.append(self.getSpineOccurring(i))
         return retEvents
 
 
-def hdStringToNote(contents):
+def hdStringToNote(contents: str) -> note.GeneralNote:
     '''
     returns a :class:`~music21.note.Note` (or Rest or Unpitched, etc.)
     matching the current SpineEvent.
@@ -2202,10 +2231,9 @@ def hdStringToNote(contents):
     # 3.2.1 Pitches and 3.3 Rests
 
     matchedNote = re.search('([a-gA-G]+)', contents)
-    thisObject = None
-
     # Detect rests first, because rests can contain manual positioning information,
     # which is also detected by the `matchedNote` variable above.
+    thisObject: note.GeneralNote
     if 'r' in contents:
         thisObject = note.Rest()
 
@@ -2216,8 +2244,9 @@ def hdStringToNote(contents):
             octave = 3 + len(kernNoteName)
         else:  # below middle C
             octave = 4 - len(kernNoteName)
-        thisObject = note.Note(octave=octave)
-        thisObject.step = step
+        builtNote = note.Note(octave=octave)
+        builtNote.step = step  # type: ignore[assignment]
+        thisObject = builtNote
 
     else:
         raise HumdrumException(f'Could not parse {contents} for note information')
@@ -2225,12 +2254,13 @@ def hdStringToNote(contents):
     matchedSharp = re.search(r'(#+)', contents)
     matchedFlat = re.search(r'(-+)', contents)
 
-    if matchedSharp:
-        thisObject.pitch.accidental = matchedSharp.group(0)
-    elif matchedFlat:
-        thisObject.pitch.accidental = matchedFlat.group(0)
-    elif 'n' in contents:
-        thisObject.pitch.accidental = 'n'
+    if isinstance(thisObject, note.Note):
+        if matchedSharp:
+            thisObject.pitch.accidental = matchedSharp.group(0)
+        elif matchedFlat:
+            thisObject.pitch.accidental = matchedFlat.group(0)
+        elif 'n' in contents:
+            thisObject.pitch.accidental = 'n'
 
     # 3.2.2 -- Slurs, Ties, Phrases
     # TODO: add music21 phrase information
@@ -2305,10 +2335,11 @@ def hdStringToNote(contents):
         thisObject.articulations.append(articulations.DownBow())
 
     # 3.2.6 Stem Directions
-    if '/' in contents:
-        thisObject.stemDirection = 'up'
-    elif '\\' in contents:
-        thisObject.stemDirection = 'down'
+    if isinstance(thisObject, note.NotRest):
+        if '/' in contents:
+            thisObject.stemDirection = 'up'
+        elif '\\' in contents:
+            thisObject.stemDirection = 'down'
 
 
     # 3.2.7 Duration +
@@ -2359,12 +2390,12 @@ def hdStringToNote(contents):
             # humdrum tuplets that breaks normal usage.  TODO: Refactor adding a Flavor = 'JRP'
             # code that uses this other method.
             JRP = flavors['JRP']
-            if JRP is False and '.' in contents:
+            if not JRP and '.' in contents:
                 newTup.durationNormal = duration.durationTupleFromTypeDots(
                     newTup.durationNormal.type, contents.count('.'))
 
             thisObject.duration.appendTuplet(newTup)
-            if JRP is True and '.' in contents:
+            if JRP and '.' in contents:
                 thisObject.duration.dots = contents.count('.')
             # call Duration.TupletFixer after to correct this.
 
@@ -2374,7 +2405,7 @@ def hdStringToNote(contents):
         thisObject.duration.type = 'eighth'
     elif 'Q' in contents:
         thisObject = thisObject.getGrace()
-        thisObject.duration.slash = False
+        thisObject.duration.slash = False  # type: ignore[attr-defined]
         thisObject.duration.type = 'eighth'
     elif 'P' in contents:
         thisObject = thisObject.getGrace(appoggiatura=True)
@@ -2383,19 +2414,23 @@ def hdStringToNote(contents):
 
     # 3.2.10 Beaming
     # TODO: Support really complex beams
-    for i in range(contents.count('L')):
-        thisObject.beams.append('start')
-    for i in range(contents.count('J')):
-        thisObject.beams.append('stop')
-    for i in range(contents.count('k')):
-        thisObject.beams.append('partial', 'right')
-    for i in range(contents.count('K')):
-        thisObject.beams.append('partial', 'right')
+    if isinstance(thisObject, note.NotRest):
+        for i in range(contents.count('L')):
+            thisObject.beams.append('start')
+        for i in range(contents.count('J')):
+            thisObject.beams.append('stop')
+        for i in range(contents.count('k')):
+            thisObject.beams.append('partial', 'right')
+        for i in range(contents.count('K')):
+            thisObject.beams.append('partial', 'right')
 
     return thisObject
 
 
-def hdStringToMeasure(contents, previousMeasure=None):
+def hdStringToMeasure(
+    contents: str,
+    previousMeasure: stream.Measure|None = None,
+) -> stream.Measure:
     '''
     kern uses an equals sign followed by processing instructions to
     create new measures.
@@ -2427,47 +2462,47 @@ def hdStringToMeasure(contents, previousMeasure=None):
     elif '||' in contents:
         barline.type = 'double'
         if contents.count(':') > 1:
-            barline.repeatDots = 'both'
+            barline.repeatDots = 'both'  # type: ignore[attr-defined]
         elif ':|' in contents:
-            barline.repeatDots = 'left'
+            barline.repeatDots = 'left'  # type: ignore[attr-defined]
         elif '|:' in contents:
-            barline.repeatDots = 'right'
+            barline.repeatDots = 'right'  # type: ignore[attr-defined]
     elif '!!' in contents:
         barline.type = 'heavy-heavy'
         if contents.count(':') > 1:
-            barline.repeatDots = 'both'
+            barline.repeatDots = 'both'  # type: ignore[attr-defined]
         elif ':!' in contents:
-            barline.repeatDots = 'left'
+            barline.repeatDots = 'left'  # type: ignore[attr-defined]
         elif '!:' in contents:
-            barline.repeatDots = 'right'
+            barline.repeatDots = 'right'  # type: ignore[attr-defined]
     elif '|!' in contents:
         barline.type = 'final'
         if contents.count(':') > 1:
-            barline.repeatDots = 'both'
+            barline.repeatDots = 'both'  # type: ignore[attr-defined]
         elif ':|' in contents:
-            barline.repeatDots = 'left'
+            barline.repeatDots = 'left'  # type: ignore[attr-defined]
         elif '!:' in contents:
-            barline.repeatDots = 'right'
+            barline.repeatDots = 'right'  # type: ignore[attr-defined]
     elif '!|' in contents:
         barline.type = 'heavy-light'
         if contents.count(':') > 1:
-            barline.repeatDots = 'both'
+            barline.repeatDots = 'both'  # type: ignore[attr-defined]
         elif ':!' in contents:
-            barline.repeatDots = 'left'
+            barline.repeatDots = 'left'  # type: ignore[attr-defined]
         elif '|:' in contents:
-            barline.repeatDots = 'right'
+            barline.repeatDots = 'right'  # type: ignore[attr-defined]
     elif '|' in contents:
         barline.type = 'regular'
         if contents.count(':') > 1:
-            barline.repeatDots = 'both'
+            barline.repeatDots = 'both'  # type: ignore[attr-defined]
         elif ':|' in contents:
-            barline.repeatDots = 'left'
+            barline.repeatDots = 'left'  # type: ignore[attr-defined]
         elif '|:' in contents:
-            barline.repeatDots = 'right'
+            barline.repeatDots = 'right'  # type: ignore[attr-defined]
     elif '==' in contents:
         barline.type = 'double'
         if contents.count(':') > 1:
-            barline.repeatDots = 'both'
+            barline.repeatDots = 'both'  # type: ignore[attr-defined]
             # cannot specify single repeat dots without styles
         if contents == '==|':
             raise HumdrumException(
@@ -2485,7 +2520,7 @@ def hdStringToMeasure(contents, previousMeasure=None):
     return m1
 
 
-def kernTandemToObject(tandem):
+def kernTandemToObject(tandem: str) -> base.Music21Object|None:
     '''
     Kern uses symbols such as :samp:`*M5/4` and :samp:`*clefG2`, etc., to control processing
 
@@ -2530,35 +2565,33 @@ def kernTandemToObject(tandem):
             except clef.ClefException:
                 raise HumdrumException(f'Unknown clef type {tandem} found')
     elif tandem.startswith('*MM'):
-        metronomeMark = tandem[3:]
+        metronomeMarkText = tandem[3:]
         try:
-            metronomeMark = float(metronomeMark)
-            MM = tempo.MetronomeMark(number=metronomeMark)
+            metronomeMarkNumber = float(metronomeMarkText)
+            MM = tempo.MetronomeMark(number=metronomeMarkNumber)
             return MM
         except ValueError:
-            # assuming that metronomeMark here is text now
-            metronomeMark = re.sub(r'^\[', '', metronomeMark)
-            metronomeMark = re.sub(r']\s*$', '', metronomeMark)
-            MS = tempo.MetronomeMark(text=metronomeMark)
+            # assuming that metronomeMarkText is text now
+            metronomeMarkText = re.sub(r'^\[', '', metronomeMarkText)
+            metronomeMarkText = re.sub(r']\s*$', '', metronomeMarkText)
+            MS = tempo.MetronomeMark(text=metronomeMarkText)
             return MS
     elif tandem.startswith('*M'):
         meterType = tandem[2:]
         tsTemp = re.match(r'(\d+)/(\d+)', meterType)
         if tsTemp:
             numerator = int(tsTemp.group(1))
-            denominator = tsTemp.group(2)
-            if denominator not in ('0', '00', '000'):
+            denominatorStr = tsTemp.group(2)
+            if denominatorStr not in ('0', '00', '000'):
                 return meter.TimeSignature(meterType)
             else:
-                if denominator == '0':
+                denominator = 1
+                if denominatorStr == '0':
                     numerator *= 2
-                    denominator = 1
-                elif denominator == '00':
+                elif denominatorStr == '00':
                     numerator *= 4
-                    denominator = 1
-                elif denominator == '000':
+                elif denominatorStr == '000':
                     numerator *= 8
-                    denominator = 1
                 return meter.TimeSignature(f'{numerator}/{denominator}')
         else:
             raise HumdrumException(f'Incorrect meter: {tandem} found')
@@ -2610,11 +2643,13 @@ def kernTandemToObject(tandem):
 
 
 class MiscTandem(base.Music21Object):
-    def __init__(self, tandem='', **keywords):
-        super().__init__(**keywords)
-        self.tandem = tandem
+    humdrumPosition: int = 0
 
-    def _reprInternal(self):
+    def __init__(self, tandem: str = '', **keywords) -> None:
+        super().__init__(**keywords)
+        self.tandem: str = tandem
+
+    def _reprInternal(self) -> str:
         return f'{self.tandem}'
 
 
@@ -2629,12 +2664,14 @@ class SpineComment(base.Music21Object):
     >>> sc.comment
     'this is a spine comment'
     '''
-    def __init__(self, comment='', **keywords):
+    humdrumPosition: int = 0
+
+    def __init__(self, comment: str = '', **keywords) -> None:
         super().__init__(**keywords)
         commentPart = re.sub(r'^!+\s?', '', comment)
-        self.comment = commentPart
+        self.comment: str = commentPart
 
-    def _reprInternal(self):
+    def _reprInternal(self) -> str:
         return repr(self.comment)
 
 
@@ -2648,13 +2685,13 @@ class GlobalComment(base.Music21Object):
     >>> sc.comment
     'this is a global comment'
     '''
-    def __init__(self, comment='', **keywords):
+    def __init__(self, comment: str = '', **keywords) -> None:
         super().__init__(**keywords)
         commentPart = re.sub(r'^!!+\s?', '', comment)
         commentPart = commentPart.strip()
-        self.comment = commentPart
+        self.comment: str = commentPart
 
-    def _reprInternal(self):
+    def _reprInternal(self) -> str:
         return repr(self.comment)
 
 
@@ -2700,24 +2737,29 @@ class GlobalReference(base.Music21Object):
     >>> sc.isPrimary
     False
     '''
-    def __init__(self, codeOrAll='', valueOrNone=None, **keywords):
+    def __init__(
+        self,
+        codeOrAll: str = '',
+        valueOrNone: str|None = None,
+        **keywords,
+    ) -> None:
         super().__init__(**keywords)
         codeOrAll = re.sub(r'^!!!+', '', codeOrAll)
         codeOrAll = codeOrAll.strip()
         if valueOrNone is None and ':' in codeOrAll:
             valueOrNone = re.sub(r'^.*?:', '', codeOrAll)
             codeOrAll = re.sub(r':.*$', '', codeOrAll)
-        self.code = codeOrAll
-        self.value = valueOrNone
-        self.language = None  # does it have a language code?
-        self.isPrimary = False  # is this language marked as primary?
+        self.code: str = codeOrAll
+        self.value: str|None = valueOrNone
+        self.language: str|None = None  # does it have a language code?
+        self.isPrimary: bool = False  # is this language marked as primary?
         if '@@' in self.code:
             self.isPrimary = True
             self.code = self.code.replace('@@', '@')
         if '@' in self.code:
             self.code, self.language = self.code.split('@')
 
-    humdrumKeyToUniqueName: dict = {
+    humdrumKeyToUniqueName: dict[str, str] = {
         # dict value is music21's unique name or '' (if there is no supported equivalent)
         # Authorship information:
         'COM': 'composer',              # composer's name
@@ -2827,7 +2869,7 @@ class GlobalReference(base.Music21Object):
         'RWB': ''  # a warning about the representation
     }
 
-    def updateMetadata(self, md: metadata.Metadata):
+    def updateMetadata(self, md: metadata.Metadata) -> None:
         '''
         update a metadata object according to information in this GlobalReference
 
@@ -2846,12 +2888,12 @@ class GlobalReference(base.Music21Object):
             # it's a free-form key
             md.addCustom(c, v)
 
-    def _reprInternal(self):
+    def _reprInternal(self) -> str:
         return f'{self.code} {self.value!r}'
 
 
 class Test(unittest.TestCase):
-    def testCopyAndDeepcopy(self):
+    def testCopyAndDeepcopy(self) -> None:
         from music21.test.commonTest import testCopyAll
         testCopyAll(self, globals())
 

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -38,13 +38,15 @@ SpineParsing consists of several steps.
 * For HumdrumSpines with parent spines their .stream contents are then
     inserted into their parent spines with
     voice tagged as a music21 Group property.
-* Lyrics and Dynamics are placed into their corresponding HumdrumSpine.stream objects
-* Stream elements are moved into their measures within a Stream
-* Measures are searched for elements with voice groups and Voice objects are created
+* Lyrics and Dynamics are placed into their corresponding HumdrumSpine.stream objects.
+* Stream elements are moved into their measures within a Stream.
+* Measures are searched for elements with voice groups and Voice objects are created.
 
 Changed in v10: flag attributes `isSpineLine, isComment, isGlobal, isReference` have been
     removed from HumdrumLine and all subclasses. `isinstance(...)` is a bit slower than
-    checking these, but adds correct typing.  Nothing is stored with weakrefs.
+    checking these, but adds correct typing.  Nothing is stored with weakrefs.  `.iterIndex`
+    and hand roled iterator/generators are gone now (could've gone when Python 2.4 became
+    the minimum version).
 '''
 from __future__ import annotations
 
@@ -122,13 +124,13 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
         So if you start off with \*\*kern, the rest of the spine needs to be
         \*\*kern (actually, the first exclusive interpretation for a spine is
-        used throughout)
+        used throughout).
 
         Note that, even though changing exclusive interpretations mid-spine
         seems to be legal by the humdrum definition, it looks like none of the
         conventional humdrum parsing tools allow for changing
         definitions mid-spine, so I don't think this limitation is a problem.
-        (Craig Stuart Sapp confirmed this to me)
+        (Craig Stuart Sapp confirmed this to me.)
 
         The Aarden/Miller Palestrina dataset uses `\*-` followed by `\*\*kern`
         at the changes of sections thus some parsing of multiple exclusive
@@ -269,6 +271,9 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         '''
         if dataStream is None:
             dataStream = self.dataStream
+
+        if dataStream is None:  # pragma: no cover
+            raise TypeError('dataStream cannot be None')
 
         startPositions = []
         endPositions = []
@@ -706,9 +711,10 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         Is run automatically by `self.parse()`.
         uses `self.spineCollection.getOffsetsAndPrioritiesByPosition()`
         '''
+        spineCollection = self.spineCollection
         if t.TYPE_CHECKING:
-            assert self.spineCollection is not None
-        positionDict = self.spineCollection.getOffsetsAndPrioritiesByPosition()
+            assert spineCollection is not None
+        positionDict = spineCollection.getOffsetsAndPrioritiesByPosition()
         eventList = self.eventList
         maxEventList = len(eventList)
         numberOfGlobalEventsInARow = 0
@@ -730,7 +736,8 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                         break
                 el: GlobalReference|GlobalComment
                 if isinstance(event, GlobalReferenceLine):
-                    # TODO: Fix GlobalReference -- ???
+                    # TODO: Fix GlobalReference (added in 2012; as of 2016 not sure what to fix)
+                    #    might add language?
                     el = GlobalReference(event.code, event.value)
                 else:
                     el = GlobalComment(event.value)
@@ -886,7 +893,7 @@ class GlobalReferenceLine(HumdrumLine):
     # noinspection SpellCheckingInspection
     r'''
     A GlobalReferenceLine is a type of HumdrumLine that contains
-    information about the humdrum document.
+    information/metadata about the humdrum document.
 
     In humdrum it is represented by three exclamation points
     followed by non-whitespace followed by a colon.  Examples::
@@ -920,6 +927,9 @@ class GlobalReferenceLine(HumdrumLine):
     'Stravinsky, Igor Fyodorovich'
 
     TODO: add parsing of three-digit Kern comment codes into fuller metadata
+    TODO: parse `@`/`@@` language tags here (e.g. `!!!OPT@@RUS:`, `!!!OPT@FRE:`)
+        and propagate language/isPrimary so that GlobalReference.updateMetadata
+        can attach `metadata.Text(value, language=...)` instead of bare strings.
     '''
     def __init__(self, position: int = 0, contents: str = '!!! NUL: None') -> None:
         self.position = position
@@ -1082,7 +1092,6 @@ class HumdrumSpine(prebase.ProtoM21Object):
         self._spineType: str = ''
 
         self.isFirstVoice: bool = False
-        self.iterIndex: int = 0
 
     def _reprInternal(self) -> str:
         representation = ': ' + str(self.id)
@@ -1101,22 +1110,8 @@ class HumdrumSpine(prebase.ProtoM21Object):
         '''
         self.eventList.append(event)
 
-    def __iter__(self) -> HumdrumSpine:
-        '''
-        Resets the counter to 0 so that iteration is correct
-        '''
-        self.iterIndex = 0
-        return self
-
-    def __next__(self) -> SpineEvent:
-        '''
-        Returns the current event and increments the iteration index.
-        '''
-        if self.iterIndex == len(self.eventList):
-            raise StopIteration()
-        thisEvent = self.eventList[self.iterIndex]
-        self.iterIndex += 1
-        return thisEvent
+    def __iter__(self) -> t.Iterator[SpineEvent]:
+        return iter(self.eventList)
 
     def _getLocalSpineType(self) -> str:
         if self._spineType:
@@ -1628,29 +1623,17 @@ class SpineCollection(prebase.ProtoM21Object):
         self.spines: list[HumdrumSpine] = []
         self.nextFreeId: int = 0
         self.spineReclassDone: bool = False
-        self.iterIndex: int = 0
         self.newSpine: HumdrumSpine|None = None
         # Maps each parsed Music21Object to its humdrum file line position.
         self.humdrumPositions: weakref.WeakKeyDictionary[base.Music21Object, int] = (
             weakref.WeakKeyDictionary()
         )
 
-    def __iter__(self) -> SpineCollection:
+    def __iter__(self) -> t.Iterator[HumdrumSpine]:
         '''
-        Resets the counter to len(self.spines) so that iteration is correct
+        Iterates spines right-to-left, the order humdrum expects.
         '''
-        self.iterIndex = len(self.spines) - 1
-        return self
-
-    def __next__(self) -> HumdrumSpine:
-        '''
-        Returns the current spine and decrements the iteration index.
-        '''
-        if self.iterIndex < 0:
-            raise StopIteration()
-        thisSpine = self.spines[self.iterIndex]
-        self.iterIndex -= 1
-        return thisSpine
+        return reversed(self.spines)
 
     def addSpine(self, streamClass: type[stream.Stream] = stream.Part) -> HumdrumSpine:
         '''

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -67,9 +67,9 @@ def makeBeams(
     If `inPlace` is True, this is done in-place; if `inPlace` is False,
     this returns a modified deep copy.
 
-    .. note: Before Version 1.6, `inPlace` default was `True`; now `False`
-             like most `inPlace` options in music21.  Also, in 1.8, no tuplets are made
-             automatically.  Use makeTupletBrackets()
+    .. note:: Before Version 1.6, `inPlace` default was `True`; now `False`
+        like most `inPlace` options in music21.  Also, in 1.8, no tuplets are made
+        automatically.  Use makeTupletBrackets()
 
     See :meth:`~music21.meter.TimeSignature.getBeams` for the algorithm used.
 


### PR DESCRIPTION
Wanting to solve #62 (and #1882) means understanding how Humdrum Spine Parsing works, a topic that I last looked at around 2010.  So before changing the code to something new, need to get it back up to date.  AI-assisted PR to clean up the code:

1. Type annotations throughout.
  2. Removed legacy patterns — like weakrefs for spineCollection and manual `__iter__/__next__/iterIndex`,  is True/is False checks, _elements private access, `class.__class__` swaps without running `__init__`.                                                             
  3. Stop using "position" -- a meaningless term.  Use lineNumber (yes, it's 1-based sadly, but that's how it goes). fileLength replaced by numLines property.                     
  4. **Real bar.Repeat** objects instead of poking a non-existent Barline.repeatDots.
  5. WeakKeyDictionary humdrumLineNumbers maps M21Objects to their line numbers rather than adding and removing attributes.           
  6. Renamed moveDynamicsAndLyricsToStreams → attachNonKernEvents and consolidated a lot of branches (that routine already did much more than just Dynamics and Lyrics). 
  7. Tuplet sums use opFrac; redundant integer-ratio fallback removed.
  8. Removed flag attributes isSpineLine, isComment, isGlobal, isReference from HumdrumLine and subclasses; use isinstance() instead and get type narrowing.
  9. Add _reprInternal to most classes (and make remaining also be ProtoM21Objects)
  10. Blank lines (technically illegal in Humdrum, but seen often in practice) are stored so that line numbers between files and eventLists remain constant (-1)