### PR TITLE
Stream.measures(): collect MetronomeMark by default

### DIFF
--- a/music21/midi/tests.py
+++ b/music21/midi/tests.py
@@ -1316,9 +1316,9 @@ class Test(unittest.TestCase):
         # part.show('midi')
 
         mf = streamToMidiFile(part)
-        match = [(0, 'KEY_SIGNATURE', None),  # Conductor track
+        match = [(0, 'SET_TEMPO', None),
+                 (0, 'KEY_SIGNATURE', None),  # Conductor track
                  (0, 'TIME_SIGNATURE', None),
-                 (0, 'SET_TEMPO', None),
                  (10080, 'END_OF_TRACK', None),
                  (0, 'SEQUENCE_TRACK_NAME', None),  # Music track
                  (0, 'PITCH_BEND', None),

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -13929,7 +13929,13 @@ class Score(Stream):
     # this is Score.measure
     def measure(self,
                 measureNumber,
-                collect=(clef.Clef, meter.TimeSignature, instrument.Instrument, key.KeySignature, tempo.MetronomeMark),
+                collect=(
+                    clef.Clef,
+                    meter.TimeSignature,
+                    instrument.Instrument,
+                    key.KeySignature,
+                    tempo.MetronomeMark
+                ),
                 gatherSpanners=GatherSpanners.ALL,
                 indicesNotNumbers=False):
         '''

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -4422,7 +4422,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         numberStart,
         numberEnd,
         *,
-        collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature'),
+        collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'MetronomeMark'),
         gatherSpanners=GatherSpanners.ALL,
         indicesNotNumbers=False
     ) -> Stream[Measure]:
@@ -4652,7 +4652,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
     def measure(self,
                 measureNumber,
                 *,
-                collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature'),
+                collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'MetronomeMark'),
                 indicesNotNumbers=False) -> Measure|None:
         '''
         Given a measure number, return a single
@@ -13881,7 +13881,7 @@ class Score(Stream):
     def measures(self,
                  numberStart,
                  numberEnd,
-                 collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature'),
+                 collect=('Clef', 'TimeSignature', 'Instrument', 'KeySignature', 'MetronomeMark'),
                  gatherSpanners=GatherSpanners.ALL,
                  indicesNotNumbers=False):
         # noinspection PyShadowingNames
@@ -13929,7 +13929,7 @@ class Score(Stream):
     # this is Score.measure
     def measure(self,
                 measureNumber,
-                collect=(clef.Clef, meter.TimeSignature, instrument.Instrument, key.KeySignature),
+                collect=(clef.Clef, meter.TimeSignature, instrument.Instrument, key.KeySignature, tempo.MetronomeMark),
                 gatherSpanners=GatherSpanners.ALL,
                 indicesNotNumbers=False):
         '''

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -13936,7 +13936,7 @@ class Score(Stream):
                     meter.TimeSignature,
                     instrument.Instrument,
                     key.KeySignature,
-                    tempo.MetronomeMark
+                    tempo.MetronomeMark,
                 ),
                 gatherSpanners=GatherSpanners.ALL,
                 indicesNotNumbers=False):

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -4509,6 +4509,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         ...     print(thing)
         P1: Soprano: Instrument 1
         <music21.clef.TrebleClef>
+        <music21.tempo.MetronomeMark Quarter=96 (playback only)>
         f# minor
         <music21.meter.TimeSignature 4/4>
         <music21.stream.Measure 7 offset=0.0>
@@ -4523,6 +4524,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         ...     print(thing)
         P1: Soprano: Instrument 1
         <music21.clef.TrebleClef>
+        <music21.tempo.MetronomeMark Quarter=96 (playback only)>
         D- major
         ...
 


### PR DESCRIPTION
Summary
Add 'MetronomeMark' to the default collect tuple in Stream.measures().

Motivation
When extracting a region of measures via measures(), the method collects context elements (Clef, TimeSignature, Instrument, KeySignature, etc.) from the surrounding stream so the excerpt is self-contained and playable. However, MetronomeMark was missing from the default collection list.

This means if a tempo indication (e.g. MetronomeMark(number=80)) appears before the extracted region but not inside it, the excerpt will have no tempo marking, causing playback to fall back to a default tempo (often 120 quarter notes per minute in music21's default, but missing the actual intended tempo). Adding 'MetronomeMark' ensures the most recent tempo marking is preserved in the extracted excerpt, matching the behavior of the other context elements already collected.