### PR TITLE
feat(midi): addEndDelay=False to skip trailing rest on export (AI)

### DIFF
--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -1089,6 +1089,7 @@ class ConverterMidi(SubConverter):
               subformats=(),
               *,
               addStartDelay: bool = False,
+              addEndDelay: bool = True,
               encoding: str = '',
               **keywords):  # pragma: no cover
         from music21.midi import translate as midiTranslate
@@ -1096,6 +1097,7 @@ class ConverterMidi(SubConverter):
             fp = self.getTemporaryFile()
 
         mf = midiTranslate.music21ObjectToMidiFile(obj, addStartDelay=addStartDelay,
+                                                   addEndDelay=addEndDelay,
                                                    encoding=encoding or self.encoding)
         mf.open(fp, 'wb')  # write binary
         mf.write()

--- a/music21/midi/tests.py
+++ b/music21/midi/tests.py
@@ -1608,6 +1608,27 @@ class Test(unittest.TestCase):
                 for n in m.flatten().notes:
                     self.assertEqual(n.lyric, lyric)
 
+    def testAddEndDelay(self):
+        from music21 import defaults
+        s = stream.Stream()
+        s.repeatAppend(note.Note('C4', quarterLength=1.0), 2)
+
+        # default keeps the trailing rest
+        mfDefault = streamToMidiFile(s)
+        endDtDefault = mfDefault.tracks[-1].events[-2]
+        self.assertEqual(endDtDefault.time, defaults.ticksAtStart)
+
+        # addEndDelay=False removes the trailing rest
+        mfNoDelay = streamToMidiFile(s, addEndDelay=False)
+        endDtNoDelay = mfNoDelay.tracks[-1].events[-2]
+        self.assertEqual(endDtNoDelay.time, 0)
+
+    def testGetEndEventsAddEndDelay(self):
+        from music21 import defaults
+        from music21.midi.translate import getEndEvents
+        self.assertEqual(getEndEvents()[0].time, defaults.ticksAtStart)
+        self.assertEqual(getEndEvents(addEndDelay=False)[0].time, 0)
+
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -258,6 +258,8 @@ def getStartEvents(
 
 def getEndEvents(
     midiTrack: MidiTrack|None = None,
+    *,
+    addEndDelay: bool = True,
 ) -> list[MidiEvent|DeltaTime]:
     '''
     Returns a list of midi.MidiEvent objects found at the end of a track.
@@ -266,12 +268,23 @@ def getEndEvents(
     [<music21.midi.DeltaTime t=10080, track=None>,
      <music21.midi.MidiEvent END_OF_TRACK, track=None, data=b''>]
 
+    Set `addEndDelay` to False to omit the trailing rest before END_OF_TRACK:
+
+    >>> midi.translate.getEndEvents(addEndDelay=False)
+    [<music21.midi.DeltaTime (empty) track=None>,
+     <music21.midi.MidiEvent END_OF_TRACK, track=None, data=b''>]
+
     Changed in v10 - getEndEvents does not take a channel
+
+    New in v10.2 - addEndDelay keyword
+
+    Note: the addEndDelay keyword and its threading through the MIDI export
+    functions was AI-assisted (issue #1141).
     '''
     events: list[MidiEvent|DeltaTime] = []
 
     dt = DeltaTime(track=midiTrack)
-    dt.time = defaults.ticksAtStart
+    dt.time = defaults.ticksAtStart if addEndDelay else 0
     events.append(dt)
 
     me = MidiEvent(
@@ -291,6 +304,7 @@ def music21ObjectToMidiFile(
     music21Object: base.Music21Object,
     *,
     addStartDelay=False,
+    addEndDelay=True,
     encoding: str = 'utf-8',
 ) -> MidiFile:
     '''
@@ -298,6 +312,8 @@ def music21ObjectToMidiFile(
     puts a copy of that object into a Stream (so as
     not to change activeSites, etc.) and calls streamToMidiFile on
     that object.
+
+    New in v10.2 - addEndDelay keyword
     '''
     if isinstance(music21Object, stream.Stream):
         if music21Object.atSoundingPitch is False:
@@ -305,12 +321,14 @@ def music21ObjectToMidiFile(
 
         return streamToMidiFile(t.cast(stream.Stream, music21Object),
                                 addStartDelay=addStartDelay,
+                                addEndDelay=addEndDelay,
                                 encoding=encoding)
     else:
         m21ObjectCopy = copy.deepcopy(music21Object)
         s: stream.Stream = stream.Stream()
         s.insert(0, m21ObjectCopy)
         return streamToMidiFile(s, addStartDelay=addStartDelay,
+                                addEndDelay=addEndDelay,
                                 encoding=encoding)
 
 
@@ -1783,7 +1801,7 @@ def packetsToDeltaSeparatedEvents(
     return events
 
 
-def packetsToMidiTrack(packets, trackId=1, channel=1, instrumentObj=None):
+def packetsToMidiTrack(packets, trackId=1, channel=1, instrumentObj=None, *, addEndDelay=True):
     '''
     Given packets already allocated with channel
     and/or instrument assignments, place these in a MidiTrack.
@@ -1795,6 +1813,8 @@ def packetsToMidiTrack(packets, trackId=1, channel=1, instrumentObj=None):
     will be assigned to
 
     Use streamToPackets to convert the Stream to the packets
+
+    New in v10.2 - addEndDelay keyword
     '''
     # TODO: for a given track id, need to find start/end channel
     mt = MidiTrack(trackId)
@@ -1808,7 +1828,7 @@ def packetsToMidiTrack(packets, trackId=1, channel=1, instrumentObj=None):
     mt.events += packetsToDeltaSeparatedEvents(trackPackets, mt)
 
     # must update all events with a ref to this MidiTrack
-    mt.events += getEndEvents(mt)
+    mt.events += getEndEvents(mt, addEndDelay=addEndDelay)
     mt.updateEvents()  # sets this track as .track for all events
     return mt
 
@@ -2633,6 +2653,7 @@ def streamHierarchyToMidiTracks(
     *,
     acceptableChannelList=None,
     addStartDelay=False,
+    addEndDelay=True,
     encoding='utf-8',
 ):
     '''
@@ -2659,6 +2680,7 @@ def streamHierarchyToMidiTracks(
 
     * Changed in v6: acceptableChannelList is keyword only.  addStartDelay is new.
     * Changed in v6.5: Track 0 (tempo/conductor track) always exported.
+    * New in v10.2: addEndDelay keyword.
     '''
     # makes a deepcopy
     s = prepareStreamForMidi(inputM21)
@@ -2714,7 +2736,8 @@ def streamHierarchyToMidiTracks(
         mt = packetsToMidiTrack(netPackets,
                                 trackId=trackId,
                                 channel=initChannel,
-                                instrumentObj=instrumentObj)
+                                instrumentObj=instrumentObj,
+                                addEndDelay=addEndDelay)
         midiTracks.append(mt)
 
     return midiTracks
@@ -2772,6 +2795,7 @@ def streamToMidiFile(
     inputM21: stream.Stream,
     *,
     addStartDelay: bool = False,
+    addEndDelay: bool = True,
     acceptableChannelList: list[int]|None = None,
     encoding: str = 'utf-8',
 ) -> MidiFile:
@@ -2800,10 +2824,15 @@ def streamToMidiFile(
     >>> #_DOCS_SHOW mf.close()
 
     See :func:`channelInstrumentData` for documentation on `acceptableChannelList`.
+
+    Set `addEndDelay` to False to skip the trailing rest added by `getEndEvents`.
+
+    New in v10.2 - addEndDelay keyword
     '''
     s = inputM21
     midiTracks = streamHierarchyToMidiTracks(s,
                                              addStartDelay=addStartDelay,
+                                             addEndDelay=addEndDelay,
                                              acceptableChannelList=acceptableChannelList,
                                              encoding=encoding,
                                              )


### PR DESCRIPTION
Adds an `addEndDelay` keyword (default True, preserving current behavior) threaded through the MIDI export functions so callers can skip the trailing rest produced by `getEndEvents()`, mirroring the existing `addStartDelay` keyword. When set to False the trailing `DeltaTime` before `END_OF_TRACK` is zero. Requested by @mscuthbert in #1141 ("Yes, very welcome feature"); this PR is entirely AI written, disclosed per CONTRIBUTING.md and CLAUDE.md.

Closes #1141