### PR TITLE
Standardize "* New in vX:..."

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@
   by the agent or author).  Failure to do so may result in the user being banned from the project.
 - Agents must follow the [Code of Conduct](CODE_OF_CONDUCT.md). Agents that do not will be banned as well at their users.
   Not even the slightest bit of disrespect from an AI agent will be tolerated.
+- Mark changes in public interface with `* Changed in v[X]: One-line explanation.` Or new features with "New" instead of "Changed".
+- Changes to parsing formats (esp. musicxml) need to update the patch version of the version file.
+- Music21 uses even minor version numbers for alpha/beta and odd minor numbers for releases.
+- If the current version is MAJOR.0....  then mark `Changed in vMAJOR:` if it is `MAJOR.[even]` use the next odd number, like if it's 10.2 now use "Changed in 10.3".  If current version is odd that's likely a mistake or you caught it just before a new release. Use the following odd number instead.
 
 # Worktrees
 

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -50,7 +50,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '10.1.0'
+__version__ = '10.2.0b1'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -206,7 +206,7 @@ class ABCToken(prebase.ProtoM21Object, common.objects.EqualSlottedObjectMixin):
         >>> abcFormat.ABCToken.stripComment('b1 % a b-flat actually')
         'b1 '
 
-        * Changed in v6.2: made a staticmethod
+        * Changed in v6.2: made a staticmethod.
         '''
         if '%' in strSrc:
             return strSrc.split('%')[0]
@@ -1860,7 +1860,7 @@ class ABCHandler:
     define new phrases.  This is useful for parsing extra information from
     the Essen Folksong repertory
 
-    * New in v6.3: lineBreaksDefinePhrases -- does not yet do anything
+    * New in v6.3: lineBreaksDefinePhrases -- does not yet do anything.
     '''
     def __init__(self,
                  abcVersion: tuple[int, ...] = defaults.abcVersionDefault,
@@ -2041,7 +2041,7 @@ class ABCHandler:
         >>> ah.abcVersion
         (2, 3, 2)
 
-        Changed in v9: abcVersion defaults to (1, 3, 0) as documented.
+        * Changed in v9: abcVersion defaults to (1, 3, 0) as documented.
         '''
         verMats = reAbcVersion.search(inputSearch)
         if verMats:

--- a/music21/base.py
+++ b/music21/base.py
@@ -26,7 +26,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'10.1.0'
+'10.2.0b1'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":
@@ -1570,7 +1570,7 @@ class Music21Object(prebase.ProtoM21Object):
         and `priorityTargetOnly=True`.
 
         * Changed in v5.7: added followDerivation=False and made
-          everything but the class keyword only
+          everything but the class keyword only.
         * New in v6: added priorityTargetOnly -- see contextSites for description.
         * New in v7: added getElementMethod `all` and `ElementSearch` enum.
         * Changed in v8: class-based calls return properly typed items.  Putting
@@ -2288,7 +2288,7 @@ class Music21Object(prebase.ProtoM21Object):
         <music21.note.Note F#> <music21.stream.Part Soprano>
         <music21.bar.Barline type=final> <music21.stream.Part Soprano>
 
-        * Changed in v6: added activeSiteOnly -- see description in `.contextSites()`
+        * Changed in v6: added activeSiteOnly -- see description in `.contextSites()`.
         '''
         allSiteContexts = list(self.contextSites(
             returnSortTuples=True,
@@ -2375,7 +2375,7 @@ class Music21Object(prebase.ProtoM21Object):
         <music21.metadata.Metadata object at 0x11116d080>
         <music21.stream.Score bach/bwv66.6.mxl>
 
-        * Changed in v6: added activeSiteOnly -- see description in `.contextSites()`
+        * Changed in v6: added activeSiteOnly -- see description in `.contextSites()`.
         '''
         # allSiteContexts = list(self.contextSites(returnSortTuples=True))
         # maxRecurse = 20
@@ -3068,7 +3068,7 @@ class Music21Object(prebase.ProtoM21Object):
          <music21.stream.Part newPart>]
 
         * Changed in v5.7: `followDerivation` and
-          `includeNonStreamDerivations` are now keyword only
+          `includeNonStreamDerivations` are now keyword only.
         '''
         post = []
         focus = self
@@ -3212,7 +3212,7 @@ class Music21Object(prebase.ProtoM21Object):
         music21.duration.DurationException: cannot split a duration (0.5)
             at this quarterLength (7/10)
 
-        * Changed in v7: all but quarterLength are keyword only
+        * Changed in v7: all but quarterLength are keyword only.
         '''
         from music21 import chord
         from music21 import note
@@ -3764,8 +3764,7 @@ class Music21Object(prebase.ProtoM21Object):
         >>> math.isnan(isolatedNote.beat)
         True
 
-        * Changed in v6.3: returns `nan` if
-          there is no TimeSignature in sites.
+        * Changed in v6.3: returns `nan` if there is no TimeSignature in sites.
           Previously raised an exception.
         '''
         try:
@@ -3807,8 +3806,7 @@ class Music21Object(prebase.ProtoM21Object):
         >>> isolatedNote.beatStr
         'nan'
 
-        * Changed in v6.3: returns 'nan' if
-          there is no TimeSignature in sites.
+        * Changed in v6.3: returns 'nan' if there is no TimeSignature in sites.
           Previously raised an exception.
         '''
         try:

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -210,7 +210,7 @@ class ChordBase(note.NotRest):
 
         Also requires that notes be iterable.
 
-        Changed in v9: incorrect arguments raise TypeError
+        * Changed in v9: incorrect arguments raise TypeError.
         '''
         # quickDuration specifies whether the duration object for the chord
         # should be taken from the first note of the list.
@@ -565,7 +565,7 @@ class ChordBase(note.NotRest):
         >>> c.volume
         <music21.volume.Volume realized=0.76>
 
-        * New in v8: replaces setting .volume to a list
+        * New in v8: replaces setting .volume to a list.
         '''
         # if setting components, remove single velocity
         self._volume = None
@@ -2432,7 +2432,7 @@ class Chord(ChordBase):
         sets the value to be returned later, which might be useful for
         cases where the chords are poorly spelled, or there is an added note.
 
-        * Changed in v8: deal with chords without pitches
+        * Changed in v8: deal with chords without pitches.
         '''
         if not self.pitches:
             return -1
@@ -2975,7 +2975,7 @@ class Chord(ChordBase):
         >>> fr6c.isFrenchAugmentedSixth(permitAnyInversion=True)
         True
 
-        * Changed in v7: `permitAnyInversion` added
+        * Changed in v7: `permitAnyInversion` added.
 
         OMIT_FROM_DOCS
 
@@ -3020,7 +3020,7 @@ class Chord(ChordBase):
         >>> gr6c.isGermanAugmentedSixth(permitAnyInversion=True)
         True
 
-        * Changed in v7: `permitAnyInversion` added
+        * Changed in v7: `permitAnyInversion` added.
 
         OMIT_FROM_DOCS
 
@@ -3632,7 +3632,7 @@ class Chord(ChordBase):
         >>> ch3.isSwissAugmentedSixth(permitAnyInversion=True)
         True
 
-        * Changed in v7: `permitAnyInversion` added
+        * Changed in v7: `permitAnyInversion` added.
         '''
         return self._isAugmentedSixthHelper(
             (4, 27, -1),
@@ -3947,7 +3947,7 @@ class Chord(ChordBase):
         music21.chord.ChordException: no pitches in chord <music21.chord.Chord ...>
 
         * Changed in v5.2: `find` is a keyword-only parameter,
-          `newroot` finds `Pitch` in `Chord`
+          `newroot` finds `Pitch` in `Chord`.
         '''
         # None value for find indicates: return override if overridden, cache if cached
         # or find new value if neither is the case.
@@ -4878,7 +4878,7 @@ class Chord(ChordBase):
         >>> chord.Chord('C4 E-4 G4 A#4 D4').commonName
         'enharmonic equivalent to minor-ninth chord'
 
-        * Changed in v5.5: special cases for checking enharmonics in some cases
+        * Changed in v5.5: special cases for checking enharmonics in some cases.
         * Changed in v6.5: better handling of 0-, 1-, and 2-pitchClass and microtonal chords.
         * Changed in v7: Inversions of augmented sixth-chords are specified.
         * Changed in v7.3: Enharmonic equivalents to common seventh and ninth chords are specified.
@@ -5374,7 +5374,7 @@ class Chord(ChordBase):
         >>> c1
         <music21.chord.Chord D#4 C#4>
 
-        * New in v5.7
+        * New in v5.7.
         '''
         return tuple(self._notes)
 
@@ -5940,7 +5940,7 @@ class Chord(ChordBase):
         >>> chord.Chord('C4 E4 G4').scaleDegrees is None
         True
 
-        * Changed in v6.5: will return `None` if no context can be found:
+        * Changed in v6.5: will return `None` if no context can be found.
         '''
         from music21 import scale
         # roman numerals have this built in as the key attribute
@@ -5990,7 +5990,7 @@ class Chord(ChordBase):
         >>> c.seventh
         <music21.pitch.Pitch B#4>
 
-        * Changed in v6.5: return None on empty chords/errors
+        * Changed in v6.5: return `None` on empty chords/errors.
 
         OMIT_FROM_DOCS
 
@@ -6015,7 +6015,7 @@ class Chord(ChordBase):
         >>> cMaj1stInv.third.octave
         3
 
-        * Changed in v6.5: return `None` on empty chords/errors
+        * Changed in v6.5: return `None` on empty chords/errors.
 
         OMIT_FROM_DOCS
 

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -336,8 +336,7 @@ class PercussionClef(Clef):
     >>> pc.lowestLine == clef.TrebleClef().lowestLine
     True
 
-    * Changed in v7.3: setting `octaveChange` no longer affects
-      `lowestLine`
+    * Changed in v7.3: setting `octaveChange` no longer affects `lowestLine`.
     '''
     _DOC_ATTR: dict[str, str] = {}
 

--- a/music21/common/classTools.py
+++ b/music21/common/classTools.py
@@ -149,7 +149,7 @@ def isIterable(usrData: t.Any) -> t.TypeGuard[Iterable]:
     >>> common.isIterable(list)
     False
 
-    * Changed in v7.3: Classes (not instances) are not iterable
+    * Changed in v7.3: Classes (not instances) are not iterable.
     '''
     if isinstance(usrData, (str, bytes)):
         return False

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -292,7 +292,7 @@ def opFrac(num: OffsetQLIn) -> OffsetQL:
     0.0
 
     * Changed in v9.3: opFrac(None) should not be called.  If it is called,
-      it now returns 0.0
+      it now returns 0.0.
     '''
     # This is a performance critical operation, tuned to go as fast as possible.
     # hence redundancy -- first we check for type (no inheritance) and then we

--- a/music21/common/parallel.py
+++ b/music21/common/parallel.py
@@ -235,7 +235,7 @@ def safeToParallize() -> bool:
     Will return False if we are in a multiprocessing child process or if
     there is only one CPU or if pytest's x-dist worker flag is in the environment.
 
-    * New in v10
+    * New in v10.
     '''
     return (
         cpus() > 1

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -260,7 +260,7 @@ class SubConverter:
         >>> import os  #_DOCS_HIDE
         >>> os.remove(tf)  #_DOCS_HIDE
 
-        * Changed in v6: returns pathlib.Path
+        * Changed in v6: returns pathlib.Path.
         '''
         ext = self.getExtensionForSubformats(subformats)
         fp = environLocal.getTempFile(ext, returnPathlib=True)
@@ -888,7 +888,7 @@ class ConverterMusicXML(SubConverter):
         Writes `dataStr` which must be bytes to `fp`.
         Adds `.musicxml` suffix to `fp` if it does not already contain some suffix.
 
-        * Changed in v7: returns a pathlib.Path
+        * Changed in v7: returns a pathlib.Path.
 
         OMIT_FROM_DOCS
 

--- a/music21/corpus/__init__.py
+++ b/music21/corpus/__init__.py
@@ -364,7 +364,7 @@ def parse(
     >>> bachChorale.metadata.corpusFilePath
     'bach/bwv66.6.mxl'
 
-    Changed in v9: corpusFilePath is stored in metadata and now has a capital 'P'
+    * Changed in v9: corpusFilePath is stored in metadata and now has a capital 'P'.
     '''
     return manager.parse(
         workName=workName,

--- a/music21/corpus/corpora.py
+++ b/music21/corpus/corpora.py
@@ -172,7 +172,7 @@ class Corpus(prebase.ProtoM21Object):
         >>> coreCorpus.translateExtensions(('.mid', '.musicxml'))
         ('.mid', '.midi', '.xml', '.mxl', '.musicxml')
 
-        * Changed in v9: returns a tuple, not a list.  first element must be an Iterable of strings
+        * Changed in v9: returns a tuple, not a list. First element must be an Iterable of strings.
 
         TODO: unify with tools in common.formats
         '''

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -2460,7 +2460,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         '''
         Look to components and determine quarter length.
 
-        * Changed in v7: made private.  And faster
+        * Changed in v7: made private and faster.
         '''
         if self.linked is False:
             return

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -596,7 +596,7 @@ class Ornament(Expression):
         and a list of notes after the "main note".
 
         * New in v8: inPlace boolean; note that some ornaments
-          might not return a Note in the second position at all (such as trills)
+          might not return a Note in the second position at all (such as trills),
           so inPlace does nothing.
         * Changed in v9: Optional keySig can be passed in (useful in cases where there
           is no keySig in srcObj's context, or where a different keySig is desired).
@@ -1049,8 +1049,6 @@ class Mordent(GeneralMordent):
     <music21.interval.Interval M-2>
     >>> mNotFlatWithKeyFromContext.getSize(noteB3)
     <music21.interval.Interval M-2>
-
-
 
     * Changed in v7: Mordent sizes are GenericIntervals -- as was originally
       intended but programmed incorrectly.

--- a/music21/figuredBass/harmony.py
+++ b/music21/figuredBass/harmony.py
@@ -60,7 +60,7 @@ class FiguredBass(Harmony):
     >>> fb.pitches
     ()
 
-    * New in v9.3
+    * New in v9.3.
     '''
     def __init__(self,
                  figureString: str = '',

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -532,7 +532,7 @@ class Harmony(chord.Chord):
         >>> h.pitches
         (<music21.pitch.Pitch C3>, <music21.pitch.Pitch E3>, <music21.pitch.Pitch G-3>)
 
-        * Changed in v7: updatePitches is True by default
+        * Changed in v7: updatePitches is True by default.
         '''
         if not isinstance(degree, ChordStepModification):
             # TODO: possibly create ChordStepModification objects from other

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1036,7 +1036,7 @@ class ProtoSpine(prebase.ProtoM21Object):
     See :meth:`~music21.humdrum.spineParser.parseProtoSpinesAndEventCollections`
     for more details on how ProtoSpine objects are created.
 
-    * Changed in v10: ProtoSpines now iterate over their eventLists and are ProtoM21Objects
+    * Changed in v10: ProtoSpines now iterate over their eventLists and are ProtoM21Objects.
     '''
 
     def __init__(self, eventList: list[SpineEvent|None]|None = None) -> None:
@@ -2165,7 +2165,7 @@ class EventCollection(prebase.ProtoM21Object):
 
     In the future, EventCollection may enforce that all events have the same lineNumber
 
-    * New in v10: lineNumber
+    * New in v10: lineNumber.
     '''
     def __init__(self, maxSpines: int = 0, lineNumber: int = 0) -> None:
         self.events: common.defaultlist = common.defaultlist(lambda: None)
@@ -2495,10 +2495,10 @@ def hdStringToMeasure(
     kern uses an equals sign followed by processing instructions to
     create new measures.
 
-    Changed in v10: repeat dots are encoded as :class:`~music21.bar.Repeat`
-    objects instead of being stuffed into a non-existent ``Barline.repeatDots``
-    attribute.  ``:|:`` now produces an end-Repeat on the previous measure's
-    right barline AND a start-Repeat on the new measure's left barline.
+    * Changed in v10: repeat dots are encoded as :class:`~music21.bar.Repeat`
+        objects instead of being stuffed into a non-existent ``Barline.repeatDots``
+        attribute.  ``:|:`` now produces an end-Repeat on the previous measure's
+        right barline AND a start-Repeat on the new measure's left barline.
     '''
     if contents == '==|':
         environLocal.warn(

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -2425,7 +2425,7 @@ def fromString(instrumentString: str,
     (an honorary 'language' for these purposes).
 
     Alternatively, you can specify the language to search using the `language`
-    argument. (New in v7.3)
+    argument. (New in v7.3.)
 
     >>> t12 = instrument.fromString('Klarinette', language=instrument.SearchLanguage.GERMAN)
     >>> t12

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -893,7 +893,7 @@ class GenericInterval(IntervalBase):
     >>> threeOctaveThird.simpleNiceName
     'Third'
 
-    * Changed in v6: large intervals get abbreviations
+    * Changed in v6: large intervals get abbreviations.
     '''
     def __init__(self,
                  value: int|str = 'Unison',
@@ -1221,7 +1221,7 @@ class GenericInterval(IntervalBase):
         >>> interval.GenericInterval(44).niceName
         '44th'
 
-        * Changed in v6: large numbers get the 'th' or 'rd' etc. suffix
+        * Changed in v6: large numbers get the 'th' or 'rd' etc. suffix.
         '''
         return self._nameFromInt(self.undirected)
 
@@ -2168,7 +2168,7 @@ class DiatonicInterval(IntervalBase):
         <music21.pitch.Pitch F#5>
 
 
-        * Changed in v6: added inPlace
+        * Changed in v6: added inPlace.
         '''
         fullIntervalObject = Interval(diatonic=self, chromatic=self.getChromatic())
         return fullIntervalObject.transposePitch(p, inPlace=inPlace)
@@ -2505,7 +2505,7 @@ class ChromaticInterval(IntervalBase):
         >>> p.spellingIsInferred
         True
 
-        * Changed in v6: added inPlace
+        * Changed in v6: added inPlace.
         '''
         if p.octave is None:
             useImplicitOctave = True
@@ -3302,7 +3302,7 @@ class Interval(IntervalBase):
         >>> interval.Interval().intervalClass
         0
 
-        * Changed in v6.5: empty intervals return 0
+        * Changed in v6.5: empty intervals return 0.
         '''
         return self.chromatic.intervalClass
 
@@ -3393,8 +3393,7 @@ class Interval(IntervalBase):
         it is the same as `i.reverse().transposePitch(x)` and that format
         will be much faster when calling many times.
 
-        * Changed in v6: inPlace parameter added.  Reverse and maxAccidental
-          changed to keyword only.
+        * Changed in v6: inPlace parameter added. Reverse and maxAccidental changed to keyword only.
 
         OMIT_FROM_DOCS
 
@@ -3952,7 +3951,7 @@ def transposePitch(
     >>> C4
     <music21.pitch.Pitch G4>
 
-    * Changed in v6: added inPlace parameter
+    * Changed in v6: added inPlace parameter.
     '''
 
     # check if interval1 is a string,

--- a/music21/key.py
+++ b/music21/key.py
@@ -1140,7 +1140,7 @@ class Key(KeySignature, scale.DiatonicScale):
         searching, melodic minor scales cannot be used as abstracts
         for deriving by degree.
 
-        * New in v6: preserve mode in key.Key.deriveByDegree
+        * New in v6: preserve mode in key.Key.deriveByDegree.
         '''
         ret = super().deriveByDegree(degree, pitchRef)
         ret.mode = self.mode

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -1145,8 +1145,7 @@ class Metadata(base.Music21Object):
         (True, 'composer')
 
 
-        * New in v4: use a keyword argument to search
-          that field directly:
+        * New in v4: use a keyword argument to search that field directly:
 
         >>> md.search(composer='Joplin')
         (True, 'composer')
@@ -2497,7 +2496,7 @@ class RichMetadata(Metadata):
      'pitchHighest', 'pitchLowest', 'scoreQuarterLength', 'sourcePath', 'tempoFirst',
      'tempos', 'timeSignatureFirst', 'timeSignatures')
 
-    Changed in v10: renamed `quarterLength` to `scoreQuarterLength`.
+    * Changed in v10: renamed `quarterLength` to `scoreQuarterLength`.
        Because RichMetadata is a Music21Object, `quarterLength` is a property that must
        return the length of the RichMetadata object itself and should not have been
        ovewritten

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -1163,7 +1163,7 @@ class TimeSignature(TimeSignatureBase):
         >>> len(ts.beatSequence)
         6
 
-        * Changed in v7: favorCompound is keyword only
+        * Changed in v7: favorCompound is keyword only.
         '''
         # if a non-compound meter has been given, as in
         # not 3+1/4; just 5/4

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -1540,7 +1540,7 @@ class MeterSequence(MeterTerminal):
         >>> ms.isUniformPartition()
         False
 
-        * Changed in v7: depth is keyword only
+        * Changed in v7: depth is keyword only.
         '''
         n = []
         d = []

--- a/music21/midi/base.py
+++ b/music21/midi/base.py
@@ -106,7 +106,7 @@ def getNumber(midiBytes: bytes|int, length: int) -> tuple[int, bytes|int]:
     >>> midi.getNumber(516, 1)   # = 2*256 + 4
     (4, 512)
 
-    Changed in v10: remove Python 2 legacy string as input -- use bytes instead.
+    * Changed in v10: remove Python 2 legacy string as input -- use bytes instead.
     '''
     summation = 0
     if isinstance(midiBytes, bytes):
@@ -485,7 +485,7 @@ class MidiEvent(prebase.ProtoM21Object):
     >>> me2
     <music21.midi.MidiEvent SEQUENCE_TRACK_NAME, track=1, data=b'guitar'>
 
-    Changed in v9.7 - None is not a valid type anymore.  Use MetaEvents.UNKNOWN instead.
+    * Changed in v9.7: None is not a valid type anymore.  Use MetaEvents.UNKNOWN instead.
         Channel defaults to 1.
     '''
     # noinspection PyShadowingBuiltins
@@ -1291,7 +1291,7 @@ class DeltaTime(MidiEvent):
         >>> dt.readUntilLowByte(b'\x82hello')
         (360, b'ello')
 
-        Changed in v9: had an incompatible signature with MidiEvent
+        * Changed in v9: had an incompatible signature with MidiEvent.
         '''
         self.time, newBytes = getVariableLengthNumber(oldBytes)
         return self.time, newBytes
@@ -1359,7 +1359,7 @@ class MidiTrack(prebase.ProtoM21Object):
     >>> mt.length
     22
 
-    New in v9.7: len(mt) returns the same as mt.length, but more Pythonic.
+    * New in v9.7: len(mt) returns the same as mt.length, but more Pythonic.
 
     >>> len(mt)
     22
@@ -1399,7 +1399,7 @@ class MidiTrack(prebase.ProtoM21Object):
 
     def __len__(self) -> int:
         '''
-        New in v9.7
+        * New in v9.7.
         '''
         return len(self.data)
 

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -274,9 +274,8 @@ def getEndEvents(
     [<music21.midi.DeltaTime (empty) track=None>,
      <music21.midi.MidiEvent END_OF_TRACK, track=None, data=b''>]
 
-    Changed in v10 - getEndEvents does not take a channel
-
-    New in v10.2 - addEndDelay keyword
+    * Changed in v10: getEndEvents does not take a channel.
+    * New in v10.3: addEndDelay keyword.
 
     Note: the addEndDelay keyword and its threading through the MIDI export
     functions was AI-assisted (issue #1141).
@@ -313,7 +312,7 @@ def music21ObjectToMidiFile(
     not to change activeSites, etc.) and calls streamToMidiFile on
     that object.
 
-    New in v10.2 - addEndDelay keyword
+    * New in v10.3: addEndDelay keyword.
     '''
     if isinstance(music21Object, stream.Stream):
         if music21Object.atSoundingPitch is False:
@@ -346,9 +345,9 @@ def _constructOrUpdateNotRestSubclass(
     Construct (or edit the duration of) a NotRest subclass, usually
     a note.Note (or a chord.Chord if provided to `returnClass`).
 
-    * Changed in v8: no inputM21
+    * Changed in v8: no inputM21.
     * Changed in v10: Remove part about creating an Unpitched object -- that has been wrong
-      for some time (probably since PercussionChords were introduced)
+      for some time (probably since PercussionChords were introduced).
     '''
     if not issubclass(returnClass, note.NotRest):
         raise TypeError(f'Expected subclass of note.NotRest; got {returnClass}')
@@ -434,7 +433,7 @@ def midiEventsToNote(
         :class:`~music21.note.Unpitched` instance if the event is on Channel 10.
     * Changed in v8: `inputM21` is no longer supported.
         The only supported usage now is two tuples.
-    * Changed in v9.7: Expects a single TimedNoteEvent
+    * Changed in v9.7: Expects a single TimedNoteEvent.
     '''
     tOn, tOff, midiOnEvent = timedNoteEvent
 
@@ -516,7 +515,7 @@ def noteToMidiEvents(
      <music21.midi.MidiEvent NOTE_OFF, track=None, channel=9, pitch=61, velocity=0>]
 
     * Changed in v7: made keyword-only.
-    * Changed in v8: added support for :class:`~music21.note.Unpitched`
+    * Changed in v8: added support for :class:`~music21.note.Unpitched`.
     '''
     n = inputM21
 
@@ -647,7 +646,7 @@ def midiEventsToChord(
     * Changed in v7.3: Returns a :class:`~music21.percussion.PercussionChord` if
       any event is on channel 10.
     * Changed in v8: inputM21 is no longer supported.  Flat list format is removed.
-    * Changed in v9.7: expects a list of TimedNoteEvents
+    * Changed in v9.7: expects a list of TimedNoteEvents.
     '''
     # * Changed in v10: Fix long-standing bug where only the first on-time was being used
     #   not yet -- must fix quantization tests to do so...
@@ -738,7 +737,7 @@ def chordToMidiEvents(
      <music21.midi.MidiEvent NOTE_OFF, track=None, channel=1, pitch=83, velocity=0>]
 
     * Changed in v7: made keyword-only.
-    * Changed in v8: added support for :class:`~music21.percussion.PercussionChord`
+    * Changed in v8: added support for :class:`~music21.percussion.PercussionChord`.
     '''
     mt = None  # midi track
     eventList: list[DeltaTime|MidiEvent] = []
@@ -1814,7 +1813,7 @@ def packetsToMidiTrack(packets, trackId=1, channel=1, instrumentObj=None, *, add
 
     Use streamToPackets to convert the Stream to the packets
 
-    New in v10.2 - addEndDelay keyword
+    * New in v10.3: addEndDelay keyword.
     '''
     # TODO: for a given track id, need to find start/end channel
     mt = MidiTrack(trackId)
@@ -2680,7 +2679,7 @@ def streamHierarchyToMidiTracks(
 
     * Changed in v6: acceptableChannelList is keyword only.  addStartDelay is new.
     * Changed in v6.5: Track 0 (tempo/conductor track) always exported.
-    * New in v10.2: addEndDelay keyword.
+    * New in v10.3: addEndDelay keyword.
     '''
     # makes a deepcopy
     s = prepareStreamForMidi(inputM21)
@@ -2827,7 +2826,7 @@ def streamToMidiFile(
 
     Set `addEndDelay` to False to skip the trailing rest added by `getEndEvents`.
 
-    New in v10.2 - addEndDelay keyword
+    * New in v10.3: addEndDelay keyword.
     '''
     s = inputM21
     midiTracks = streamHierarchyToMidiTracks(s,

--- a/music21/note.py
+++ b/music21/note.py
@@ -203,7 +203,7 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
 
     Custom elision elements for composite components will be supported later.
 
-    * New in v6.7: composite components, elisionBefore
+    * New in v6.7: composite components, elisionBefore.
     * Changed in v8: lyric text can be an empty string, but not None.
     '''
     _styleClass = style.TextStylePlacement
@@ -722,7 +722,7 @@ class GeneralNote(base.Music21Object):
         'bon'
 
         * Changed in v6.7: added setting to a Lyric object.  Removed undocumented
-          setting to False instead of setting to None
+          setting to False instead of setting to None.
         '''
         if not self.lyrics:
             return None

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -1217,7 +1217,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         This is the argument that .name and .alter use to allow non-standard names
 
 
-        * Changed in v5: added allowNonStandardValue
+        * Changed in v5: added allowNonStandardValue.
         '''
         if isinstance(name, str):
             name = name.lower()  # sometimes args get capitalized
@@ -1338,7 +1338,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         Traceback (most recent call last):
         music21.pitch.AccidentalException: Cannot set attribute color independently of other parts.
 
-        * New in v5: needed because .name, .alter, and .modifier run .set()
+        * New in v5: needed because .name, .alter, and .modifier run .set().
         '''
         if attribute not in ('name', 'alter', 'modifier'):
             raise AccidentalException(
@@ -1396,7 +1396,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         >>> a.alter
         -1.0
 
-        * Changed in v5: changing the name here changes other values, conditionally
+        * Changed in v5: changing the name here changes other values, conditionally.
         '''
         return self._name
 
@@ -1430,7 +1430,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         >>> notSoFlat.name
         'flat'
 
-        * Changed in v5: changing the alter here changes other values, conditionally
+        * Changed in v5: changing the alter here changes other values, conditionally.
         '''
         return self._alter
 
@@ -1462,8 +1462,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
         >>> f.name
         'sharp'
 
-        * Changed in v5: changing the modifier here changes
-          other values, conditionally
+        * Changed in v5: changing the modifier here changes other values, conditionally.
         '''
         return self._modifier
 

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -116,7 +116,7 @@ class ProtoM21Object:
         {10.0} <music21.clef.GClef>
         {30.0} <music21.clef.FrenchViolinClef>
 
-        Changed in v2: returns a tuple, not a list.
+        * Changed in v2: returns a tuple, not a list.
         '''
         try:
             return self._classTupleCacheDict[self.__class__]

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -712,7 +712,7 @@ class Expander(t.Generic[StreamType]):
         {0.0} <music21.note.Note F>
         {3.0} <music21.bar.Barline type=final>
 
-    Changed in v9: Expander must be initialized with a Stream object.
+    * Changed in v9: Expander must be initialized with a Stream object.
 
     OMIT_FROM_DOCS
 

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -317,7 +317,7 @@ def _postFigureFromChordAndKey(chordObj: chord.Chord, keyObj: key.Key) -> str:
     Known bug: Fails on German Augmented 6th chords in root position.  Calls them
     half-diminished chords.
 
-    Changed in v10: made _postFigureFromChordAndKey private, keyObj is not optional.
+    * Changed in v10: made _postFigureFromChordAndKey private, keyObj is not optional.
     '''
     chordFigureTuples = figureTuples(chordObj, keyObj)
     bassFigureAlter = chordFigureTuples[0].alter
@@ -1909,10 +1909,8 @@ class RomanNumeral(harmony.Harmony):
     * Changed in v7: RomanNumeral.romanNumeral will always give a "b" for a flattened
       degree (i.e., '-II' becomes 'bII') as this is what people expect in looking at
       the figure.
-
     * Changed in v7.3: figures that are not normally used to indicate inversion
       such as V54 (a suspension) no longer give strange inversions.
-
     * Changed in v8: Figures are now validated as alphanumeric or containing one of
       the following symbols (after the example "V"):
 
@@ -2128,7 +2126,7 @@ class RomanNumeral(harmony.Harmony):
 
             Changing this value will not change existing pitches.
 
-            * Changed in v6.5: always returns a string, never None
+            * Changed in v6.5: always returns a string, never None.
             ''',
         'frontAlterationString': '''
             A string representing the chromatic alteration of a RomanNumeral, if any
@@ -2140,7 +2138,7 @@ class RomanNumeral(harmony.Harmony):
 
             Changing this value will not change existing pitches.
 
-            * Changed in v6.5: always returns a string, never None
+            * Changed in v6.5: always returns a string, never None.
             ''',
         'frontAlterationTransposeInterval': '''
             An optional :class:`~music21.interval.Interval` object
@@ -3070,7 +3068,7 @@ class RomanNumeral(harmony.Harmony):
         Note that this function is not called in parsing, but a private function having the
         guts of this function is called.
 
-        * Changed in v6.4: public function became hook to private function having the actual guts
+        * Changed in v6.5: public function became hook to private function having the actual guts.
         '''
         unused_workingFigure = self._adjustMinorVIandVIIByQuality('', useScale)
 
@@ -3101,7 +3099,7 @@ class RomanNumeral(harmony.Harmony):
         >>> ' '.join([p.name for p in rn.pitches])
         'G# B D G##'
 
-        * Changed in v6.4: Made private when `workingFigure`
+        * Changed in v6.5: Made private when `workingFigure`
           was added to the signature and returned.
         '''
         def sharpen(wFig: str) -> str:
@@ -3969,7 +3967,7 @@ RomanNumeral.figure.__doc__ = '''
 
     Changing this value will not change existing pitches.
 
-    * Changed in v6.5: empty RomanNumerals now have figure of '' not None
+    * Changed in v6.5: empty RomanNumerals now have figure of '' not None.
     '''
 
 

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -740,7 +740,7 @@ class AbstractDiatonicScale(AbstractScale):
         music21.scale.ScaleException: Cannot create a
             scale of the following mode: 'blues-like'
 
-        * Changed in v6: case-insensitive modes
+        * Changed in v6: case-insensitive modes.
         '''
         # reference: http://cnx.org/content/m11633/latest/
         # most diatonic scales will start with this collection

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -2707,7 +2707,7 @@ class IntervalNetwork:
         Traceback (most recent call last):
         ValueError: There must be at least one pitch given.
 
-        * Changed in v8: staticmethod.  Raise value error on empty
+        * Changed in v8: staticmethod.  Raise value error on empty.
         '''
         pitchList: list[pitch.Pitch]
         if not isinstance(pitchTarget, (list, tuple)):

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -469,7 +469,7 @@ class Sites(common.SlottedObjectMixin):
         * Changed in v3: changed dramatically from previously unused version
           `sortByCreationTime='reverse'` is removed, since the ordered dict takes
           care of it and was not working.
-        * Changed in v8: arguments are keyword only
+        * Changed in v8: arguments are keyword only.
         '''
         keyRepository = list(self.siteDict.keys())
         if sortByCreationTime is True:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -253,7 +253,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             def __init__(self, givenElements, craziness, **keywords):
                 ...
 
-    * New in v7: smart appending
+    * New in v7: smart appending.
     * New in v8: givenElementsBehavior keyword configures the smart appending.
     '''
     # this static attributes offer a performance boost over other
@@ -1446,7 +1446,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> s.hasElementOfClass('Measure')
         False
 
-        To be deprecated in v10 -- to be removed in v11, use:
+        To be deprecated in v11 -- to be removed in v12, use:
 
         >>> bool(s.getElementsByClass(meter.TimeSignature))
         True
@@ -1726,7 +1726,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         False
 
         * Changed in v5.3: firstMatchOnly removed -- impossible to have element
-          in stream twice.  recurse and shiftOffsets changed to keywordOnly arguments
+          in stream twice.  recurse and shiftOffsets changed to keywordOnly arguments.
         '''
         # experimental
         if not self._mutable:  # pragma: no cover
@@ -2105,10 +2105,10 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         music21.exceptions21.StreamException: Cannot set the offset for element
             <music21.note.Note D>, not in Stream <music21.stream.Stream Stream1>.
 
-        * Changed in v5.5: also sets .activeSite for the element
-        * Changed in v6.7: also runs coreElementsChanged()
+        * Changed in v5.5: also sets .activeSite for the element.
+        * Changed in v6.7: also runs coreElementsChanged().
         * Changed in v7: addElement is removed;
-          see :meth:`~music21.stream.core.StreamCoreMixin.coreSetElementOffset`
+          see :meth:`~music21.stream.core.StreamCoreMixin.coreSetElementOffset`.
         '''
         self.coreSetElementOffset(element,
                                   offset,
@@ -3010,7 +3010,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
           searches in derivation chain.
         * Changed in v5.3: `firstMatchOnly` removed -- impossible to have element
           in stream twice.  `recurse` and `shiftOffsets` changed to keywordOnly arguments
-        * Changed in v6: recurse works
+        * Changed in v6: recurse works.
         * Changed in v7: raises `StreamException` if replacement is already in the stream.
         '''
         def replaceDerived(startSite=self):
@@ -3431,7 +3431,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         in Jupyter notebook/JupyterLab/Google Colab.  The
         keyword `returnInNotebook` if True returns a plot no matter what.
 
-        Changed in v9: Changed default for return in notebook, and added
+        * Changed in v9: Changed default for return in notebook, and added
           `returnInNotebook` keyword based on changes to recent Jupyter and
           similar releases.
         '''
@@ -3570,7 +3570,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> s.recurse().notes[3].groups
         ['scaleNote']
 
-        * New in v6.7.1: recurse
+        * New in v6.7.1: recurse.
         '''
         sIterator = self.iter() if not recurse else self.recurse()
         if classFilter is not None:
@@ -4886,8 +4886,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         on bwv66.6)
 
         * Changed in v7: all arguments are keyword only.
-        * New in v9.9: added exemptFromRemove
-        * Note: in v10: removeClasses cannot be boolean -- use removeAll instead
+        * New in v9.9: added exemptFromRemove.
+        * Note: in v10: removeClasses cannot be boolean -- use removeAll instead.
         '''
         out = self.cloneEmpty(derivationMethod='template')
         if removeClasses is None:
@@ -5058,7 +5058,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         <music21.stream.Measure 3 offset=8.0> Tenor
         <music21.stream.Measure 3 offset=8.0> Bass
 
-        Changed in v9: classFilterList must be a list or tuple of strings or Music21Objects
+        * Changed in v9: classFilterList must be a list or tuple of strings or Music21Objects
 
         OMIT_FROM_DOCS
 
@@ -5460,9 +5460,9 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> sp.derivation.origin is p
         True
 
-        * Changed in v2.0.10: inPlace is False
-        * Changed in v5: returns None if inPlace=True
-        * Changed in v9: no transposition instead of exception if atSoundingPitch is 'unknown'
+        * Changed in v2.0.10: inPlace is False.
+        * Changed in v5: returns None if inPlace=True.
+        * Changed in v9: no transposition instead of exception if atSoundingPitch is 'unknown'.
         '''
         from music21 import spanner
 
@@ -5538,9 +5538,9 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> scWritten.recurse().notes[0].nameWithOctave
         'A4'
 
-        * Changed in v3: `inPlace` defaults to `False`
-        * Changed in v5 returns `None` if `inPlace=True`
-        * Changed in v9: no transposition instead of exception if atSoundingPitch is 'unknown'
+        * Changed in v3: `inPlace` defaults to `False`.
+        * Changed in v5 returns `None` if `inPlace=True`.
+        * Changed in v9: no transposition instead of exception if atSoundingPitch is 'unknown'.
         '''
         from music21 import spanner
 
@@ -6810,7 +6810,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         this returns a modified deep copy.
 
         * Changed in v6: does not return anything if inPlace is True.
-        * Changed in v7: default inPlace is False
+        * Changed in v7: default inPlace is False.
         * Changed in v8: altered unisons/octaves in Chords now supply clarifying naturals.
 
         All arguments are keyword only.
@@ -8003,7 +8003,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             requests them to be. The way to tell a modern IDE that a process may
             have consequences is to make it a `.method()` not a `.property`.
 
-        Changed in v.10 - Derivation method names changed to flatten and flatten_retain_containers
+        * Changed in v.10: Derivation method names changed to flatten and flatten_retain_containers
         '''
         # environLocal.printDebug(['flatten(): self', self,
         #  'self.activeSite', self.activeSite])
@@ -10353,13 +10353,10 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
          <music21.note.Note B->, <music21.note.Note A->]
 
         * Changed in v7:
-
-          * now finds notes in Voices without requiring `getOverlaps=True`
+          - now finds notes in Voices without requiring `getOverlaps=True`
             and iterates over Parts rather than flattening.
-
-          * If `noNone=False`, inserts `None`
+          - If `noNone=False`, inserts `None`
             when backing up to scan a subsequent voice or part.
-
         * Changed in v8: all parameters are keyword only.
 
 

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -707,7 +707,7 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         >>> {e.activeSite.id for e in sI_notes.matchingElements()}
         {'tn3/4'}
 
-        * New in v7: restoreActiveSites
+        * New in v7: restoreActiveSites.
         * Changed in v9.3: restoreActiveSites allows `None` which takes from the iterator's
           `restoreActiveSites` attribute.
         '''

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -403,9 +403,8 @@ def makeMeasures(
     >>> [allNotes[0].lyric, allNotes[1].lyric, allNotes[2].lyric]
     ['hi', None, None]
 
-    * Changed in v6: all but first attribute are keyword only
-
-    * Changed in v7: now safe to call `makeMeasures` directly on a score containing parts
+    * Changed in v6: all but first attribute are keyword only.
+    * Changed in v7: now safe to call `makeMeasures` directly on a score containing parts.
     '''
     from music21 import spanner
     from music21 import stream
@@ -830,11 +829,11 @@ def makeRests(
         {1.0 - 4.0} <music21.note.Rest dotted-half>
         {4.0 - 4.0} <music21.bar.Barline type=final>
 
-    * Changed in v6: all but first attribute are keyword only
+    * Changed in v6: all but first attribute are keyword only.
     * Changed in v7:
-      - `inPlace` defaults False
-      - Recurses into parts, measures, voices
-      - Gave priority to `timeRangeFromBarDuration` over `refStreamOrTimeRange`
+      - `inPlace` defaults False.
+      - Recurses into parts, measures, voices.
+      - Gave priority to `timeRangeFromBarDuration` over `refStreamOrTimeRange`.
     * Changed in v8: scores (or other streams having parts) edited `inPlace` return `None`.
     '''
     from music21 import stream
@@ -1085,9 +1084,9 @@ def makeTies(
     what to split.
 
     * Changed in v4: inPlace = False by default.
-    * Changed in v6: all but first attribute are keyword only
+    * Changed in v6: all but first attribute are keyword only.
     * New in v7: `classFilterList` acts as a filter on what elements will
-      be operated on (i.e. have durations split and/or ties made.)
+      be operated on (i.e. have durations split and/or ties made).
       The default `(note.GeneralNote,)` includes Notes, Chords, and Rests.
 
     Here will we split and make ties only on Notes, leaving the too-long
@@ -1391,7 +1390,7 @@ def makeTupletBrackets(s: StreamType, *, inPlace=False) -> StreamType|None:
 
     TODO: does not handle nested tuplets
 
-    * Changed in v1.8: `inPlace` is False by default
+    * Changed in v1.8: `inPlace` is False by default.
     * Changed in v7: Legacy behavior of taking in a list of durations removed.
     '''
     durationList: list[duration.Duration] = []

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -40,7 +40,7 @@ def listOfTreesByClass(
 ) -> list[trees.OffsetTree|timespanTree.TimespanTree]:
     # noinspection PyShadowingNames
     r'''
-    To be DEPRECATED in v8: this is no faster than calling streamToTimespanTree
+    To be DEPRECATED in v11: this is no faster than calling streamToTimespanTree
     multiple times with different classLists.
 
     Recurses through `inputStream`, and constructs TimespanTrees for each

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -731,7 +731,7 @@ class Verticality(prebase.ProtoM21Object):
          <...AllAttachArticulation>,
          <...OtherAllAttachArticulation>]
 
-        * New in v6.3: copyPitches option
+        * New in v6.3: copyPitches option.
 
         OMIT_FROM_DOCS
 

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -1755,7 +1755,7 @@ class Verticality(base.Music21Object):
         1.0
 
         * Changed in v8: renamed getVerticalityOffset to not conflict with
-            .offset property.  Made leftAlign keyword only
+            .offset property.  Made leftAlign keyword only.
         '''
         if not self.objects:
             return 0.0


### PR DESCRIPTION
From #1896 - there was no way for an AGENT or most humans to know how to specify these versions.  Make consistent and update AGENTS.md