### PR TITLE
Fix RST Problems

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -103,7 +103,8 @@ language = 'en'
 exclude_patterns = []
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-# default_role = None
+# 'literal' makes single backticks render as inline code, like Markdown.
+default_role = 'literal'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -19,7 +19,6 @@ can change functionality until 2.1, 3.1, etc. is released.  This is against the 
 but I don't want to have lots of 2.0.0-alpha2, etc., I'd rather call it 2.0.2, and tell users
 to wait for 2.1.  Even numbered first decimal releases (e.g. 5.4) are also beta.
 
-
 Q: Why is this here and not in music21/__init__.py?
 
 A: Keeping the information here makes it available to package managers and others who
@@ -32,9 +31,7 @@ of Music21 makes installation cleaner, and also helps other software - like
 package managers in various Linux distributions - work with Music21 without
 complaint.
 
-
 Thanks to Andrew Hankinson for suggesting this way of dealing with versions to begin with.
-
 
 Changing Versions
 ==================

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -601,7 +601,6 @@ class ABCMetadata(ABCToken):
         Return a music21 :class:`~music21.key.KeySignature` or :class:`~music21.key.Key`
         object for this metadata tag.
 
-
         >>> am = abcFormat.ABCMetadata('K:G')
         >>> am.preParse()
         >>> ks = am.getKeySignatureObject()
@@ -771,7 +770,6 @@ class ABCMetadata(ABCToken):
         >>> am.getDefaultQuarterLength()
         0.5
 
-
         If taking from meter, find the "fraction" and if < 0.75 use sixteenth notes.
         If >= 0.75 use eighth notes.
 
@@ -785,12 +783,10 @@ class ABCMetadata(ABCToken):
         >>> am.getDefaultQuarterLength()
         0.5
 
-
         >>> am = abcFormat.ABCMetadata('M:6/8')
         >>> am.preParse()
         >>> am.getDefaultQuarterLength()
         0.5
-
 
         Meter is only used for default length if there is no L:
 
@@ -1059,7 +1055,6 @@ class ABCTuplet(ABCToken):
         >>> at.updateRatio()
         >>> at.numberNotesActual, at.numberNotesNormal
         (2, 3)
-
 
         Some other types:
 
@@ -1476,7 +1471,6 @@ class ABCNote(ABCToken):
 
         >>> an.getPitchName('{c}')
         ('C5', None)
-
 
         Given an active KeySignature object, the pitch name might
         change:
@@ -2764,7 +2758,6 @@ class ABCHandler:
 
         Used in polyphonic metadata merge
 
-
         >>> abcStr = 'M:6/8\\nL:1/8\\nK:G\\n'
         >>> ah1 = abcFormat.ABCHandler()
         >>> junk = ah1.process(abcStr)
@@ -2798,13 +2791,11 @@ class ABCHandler:
         Return True if this token structure defines more than 1 reference number,
         usually implying multiple pieces encoded in one file.
 
-
         >>> abcStr = 'X:5\\nM:6/8\\nL:1/8\\nK:G\\nB3 A3 | G6 | B3 A3 | G6 ||'
         >>> ah = abcFormat.ABCHandler()
         >>> junk = ah.process(abcStr)
         >>> ah.definesReferenceNumbers()  # only one returns False
         False
-
 
         >>> abcStr = 'X:5\\nM:6/8\\nL:1/8\\nK:G\\nB3 A3 | G6 | B3 A3 | G6 ||\\n'
         >>> abcStr += 'X:6\\nM:6/8\\nL:1/8\\nK:G\\nB3 A3 | G6 | B3 A3 | G6 ||'
@@ -2939,7 +2930,6 @@ class ABCHandler:
         '''
         If tokens are processed, get the first
         reference number defined.
-
 
         >>> abcStr = 'X:5\\nM:6/8\\nL:1/8\\nK:G\\nB3 A3 | G6 | B3 A3 | G6 ||'
         >>> ah = abcFormat.ABCHandler()
@@ -3487,7 +3477,6 @@ class ABCFile(prebase.ProtoM21Object):
         Traceback (most recent call last):
         music21.abcFormat.ABCFileException: cannot find requested
             reference number in source file: 99
-
 
         If the same number is defined twice in one file (should not be) only
         the first data is returned.

--- a/music21/alpha/analysis/aligner.py
+++ b/music21/alpha/analysis/aligner.py
@@ -200,7 +200,6 @@ class StreamAligner:
         >>> target0 = converter.parse('tinyNotation: C4 D C E')
         >>> source0 = converter.parse('tinyNotation: C4 D C')
 
-
         >>> sa0 = alpha.analysis.aligner.StreamAligner(target0, source0)
         >>> sa0.setupDistanceMatrix()
         >>> sa0.distanceMatrix.size
@@ -423,7 +422,6 @@ class StreamAligner:
                [4, 2, 0, 2],
                [6, 4, 2, 0],
                [8, 6, 4, 2]])
-
 
         >>> sa.getOpFromLocation(4, 3)
         <ChangeOps.Insertion: 0>

--- a/music21/alpha/analysis/fixer.py
+++ b/music21/alpha/analysis/fixer.py
@@ -100,7 +100,6 @@ class EnharmonicFixer(OMRMidiFixer):
     >>> omrStream1[1]
     <music21.note.Note A#>
 
-
     TEST 2, no changes in OMR stream
 
     >>> omrStream2 = stream.Stream()
@@ -126,7 +125,6 @@ class EnharmonicFixer(OMRMidiFixer):
     >>> omrStream1[1]
     <music21.note.Note A#>
 
-
     TEST 3 (case 1)
 
     >>> midiNote3 = note.Note('A4')
@@ -141,7 +139,6 @@ class EnharmonicFixer(OMRMidiFixer):
     >>> fixer3 = alpha.analysis.fixer.EnharmonicFixer(changes3, None, None)
     >>> fixer3.fix()
     >>> omrNote3.pitch.accidental
-
 
     TEST 4 (case 2-1) e.g MIDI = g#, ground truth = a-, OMR = an
 
@@ -159,7 +156,6 @@ class EnharmonicFixer(OMRMidiFixer):
     >>> omrNote4.pitch.accidental
     <music21.pitch.Accidental flat>
 
-
     TEST 5 (case 2-2) e.g midi = g-, gt = f#, omr = fn
 
     >>> midiNote5 = note.Note('G-4')
@@ -175,7 +171,6 @@ class EnharmonicFixer(OMRMidiFixer):
     >>> fixer5.fix()
     >>> omrNote5.pitch.accidental
     <music21.pitch.Accidental sharp>
-
 
     TEST 6.1 (case 3) e.g. midi = g#, gt = g#, omr = gn or omr = g-
 
@@ -200,7 +195,6 @@ class EnharmonicFixer(OMRMidiFixer):
     <music21.pitch.Accidental sharp>
     >>> omrNote6_2.pitch.accidental
     <music21.pitch.Accidental sharp>
-
 
     TEST 7 (case 4-1, 4-2) notes are on different step, off by an interval of 2:
     * 4-1: e.g. midi = g#, gt = a-, omr = a#

--- a/music21/analysis/discrete.py
+++ b/music21/analysis/discrete.py
@@ -698,7 +698,6 @@ class KeyWeightKeyAnalysis(DiscreteAnalysis):
         Note that all alternative solutions are returned as Key objects and stored
         on a list found at Key.alternateInterpretations.
 
-
         >>> s = corpus.parse('bach/bwv66.6')
         >>> p = analysis.discrete.KrumhanslSchmuckler()
         >>> p.getSolution(s)  # this seems correct
@@ -1331,7 +1330,6 @@ def analyzeStream(
     <music21.key.Key of f# minor>
     >>> analysis.discrete.analyzeStream(s, 'span')
     <music21.interval.Interval m21>
-
 
     Note that the same results can be obtained by calling "analyze" directly on the stream object:
     >>> s.analyze('key')

--- a/music21/analysis/patel.py
+++ b/music21/analysis/patel.py
@@ -17,11 +17,9 @@ def nPVI(streamForAnalysis):
     Algorithm to give the normalized pairwise variability index
     (Low, Grabe, & Nolan, 2000) of the rhythm of a stream.
 
-
     Used by Aniruddh D. Patel to argue for national differences between musical
     themes.  First encountered it in a presentation by Patel, Chew, Francois,
     and Child at MIT.
-
 
     n.b. -- takes the distance between each element, including clefs, keys, etc.
     use .notesAndRests etc. to filter out elements that are not useful (though this will skip

--- a/music21/analysis/pitchAnalysis.py
+++ b/music21/analysis/pitchAnalysis.py
@@ -31,7 +31,6 @@ def pitchAttributeCount(s, pitchAttr='name'):
      9: 17
     11: 14
 
-
     List in most common order:
 
     >>> nameCount = analysis.pitchAnalysis.pitchAttributeCount(bach, 'name')
@@ -40,7 +39,6 @@ def pitchAttributeCount(s, pitchAttr='name'):
      D: 26
      A: 17
     F#: 15
-
 
     >>> nameOctaveCount = analysis.pitchAnalysis.pitchAttributeCount(bach, 'nameWithOctave')
     >>> for n in sorted(nameOctaveCount):

--- a/music21/analysis/windowed.py
+++ b/music21/analysis/windowed.py
@@ -127,7 +127,6 @@ class WindowedAnalysis:
         minus the window size plus one. If we have 20 1/4 windows, then the results lists
         will be of length 20 for window size 1, 19 for window size 2, 18 for window size 3, etc.
 
-
         >>> s = corpus.parse('bach/bwv66.6')
         >>> p = analysis.discrete.Ambitus()
         >>> wa = analysis.windowed.WindowedAnalysis(s.flatten(), p)
@@ -258,7 +257,6 @@ class WindowedAnalysis:
         If `minWindow` or `maxWindow` is None, the largest window size available will be set.
 
         If `includeTotalWindow` is True, the largest window size will always be added.
-
 
         >>> s = corpus.parse('bach/bwv324')
         >>> ksAnalyzer = analysis.discrete.KrumhanslSchmuckler()

--- a/music21/audioSearch/__init__.py
+++ b/music21/audioSearch/__init__.py
@@ -189,7 +189,6 @@ def prepareThresholds(useScale=None):
     scale + octave repetition.  If useScale is a ChromaticScale, `prepareThresholds`
     will return a 12-element list.  If it's a diatonic scale, it'll have 7 elements.
 
-
     >>> pitchThresholds, pitches = audioSearch.prepareThresholds(scale.MajorScale('A3'))
     >>> for i in range(len(pitchThresholds)):
     ...    print(f'{pitches[i]} < {pitchThresholds[i]:.2f} < {pitches[i + 1]}')
@@ -573,7 +572,6 @@ def smoothFrequencies(
     >>> audioSearch.smoothFrequencies(inputPitches, smoothLevels=28)[:5]
     [432, 432, 432, 432, 432]
 
-
     If inPlace is True then the list is modified in place and nothing is returned:
 
     >>> audioSearch.smoothFrequencies(inputPitches, inPlace=True)
@@ -836,7 +834,6 @@ def notesAndDurationsToStream(
     a metadata object and a single :class:`~music21.stream.Part` object, which in turn
     contains the notes, etc.  Does not run :meth:`~music21.stream.base.Stream.makeNotation`
     on the Score.
-
 
     >>> durationList = [20, 19, 10, 30, 6, 21]
     >>> n = note.Note

--- a/music21/audioSearch/scoreFollower.py
+++ b/music21/audioSearch/scoreFollower.py
@@ -222,7 +222,6 @@ class ScoreFollower:
         >>> ScF.silencePeriodCounter
         1
 
-
         >>> ScF = scoreFollower.ScoreFollower(scoreStream=scNotes)
         >>> notesList = []
         >>> notesList.append(note.Rest())

--- a/music21/base.py
+++ b/music21/base.py
@@ -218,7 +218,6 @@ class Groups(list):  # no need to inherit from slotted object
 
     NOTE: In the future, spaces will not be allowed in group names.
 
-
     >>> g = Groups()
     >>> g.append('hello')
     >>> g[0]
@@ -1242,7 +1241,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> set(d.getSpannerSites(['Slur', 'Diminuendo'])) == {dim, slur1}
         True
 
-
         Example: see which pairs of notes are in the same slur.
 
         >>> e = note.Note('E4')
@@ -1558,7 +1556,6 @@ class Music21Object(prebase.ProtoM21Object):
 
         >>> n2.getOffsetBySite(n2.getContextByClass(stream.Measure))
         2.0
-
 
         Raises `ValueError` if `getElementMethod` is not a value in `ElementSearch`.
 
@@ -2047,7 +2044,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> print(c.next('Note', activeSiteOnly=True))
         None
 
-
         *  Removed in v3: priorityTarget cannot be set, in order
            to use `.sites.yieldSites()`
         *  Changed in v5.5: all arguments are keyword only.
@@ -2189,7 +2185,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> s.append(meter.TimeSignature('3/4'))
         >>> n = note.Note('D')
         >>> s.append(n)
-
 
         >>> for ts in n.getAllContextsByClass(meter.TimeSignature):
         ...     print(ts, ts.offset)
@@ -2725,7 +2720,6 @@ class Music21Object(prebase.ProtoM21Object):
         SortTuple(atEnd=1, offset=0.0, priority=0, classSortOrder=-5,
                     isNotGrace=1, insertIndex=...)
 
-
         Normally if there's a site specified and the element is not in the site,
         the offset of None will be used, but if raiseExceptionOnMiss is set to True
         then a SitesException will be raised:
@@ -3029,7 +3023,6 @@ class Music21Object(prebase.ProtoM21Object):
          <music21.stream.Part Soprano>,
          <music21.stream.Score bach/bwv66.6.mxl>]
 
-
         Note that derived objects also can follow the container hierarchy:
 
         >>> import copy
@@ -3053,7 +3046,6 @@ class Music21Object(prebase.ProtoM21Object):
          <music21.stream.Measure 1 offset=1.0>,
          <music21.stream.Part Soprano>,
          <music21.stream.Score bach/bwv66.6.mxl>]
-
 
         The method follows activeSites, so set the activeSite as necessary.
 
@@ -3154,7 +3146,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> st.spannerList
         [<music21.expressions.TrillExtension <music21.note.Note C#><music21.note.Note C#>>]
 
-
         Make sure that ties and accidentals remain as they should be:
 
         >>> d = note.Note('D#4')
@@ -3183,7 +3174,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> h[2].pitch.accidental.displayStatus, i[2].pitch.accidental.displayStatus
         (None, False)
 
-
         If quarterLength == self.quarterLength then the second element will be None.
 
         >>> n = note.Note()
@@ -3201,7 +3191,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> firstPart, secondPart = n.splitAtQuarterLength(0.5, retainOrigin=False)
         >>> firstPart is n
         False
-
 
         If quarterLength > self.quarterLength then a DurationException will be raised:
 
@@ -3481,7 +3470,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> g.tie is None
         True
 
-
         It should work for complex notes with tuplets.
 
         (this duration occurs in Modena A, Le greygnour bien, from the ars subtilior, c. 1380;
@@ -3519,7 +3507,6 @@ class Music21Object(prebase.ProtoM21Object):
         ('eighth', 0, (<music21.duration.Tuplet 3/2/eighth>,))
         >>> (last.duration.type, last.duration.dots, last.duration.tuplets)
         ('64th', 0, (<music21.duration.Tuplet 3/2/64th>,))
-
 
         TODO: unite this and other functions into a "split" function -- document obscure uses.
 
@@ -3569,7 +3556,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> m2.number = 11
         >>> n2.measureNumber
         11
-
 
         The most recent measure added to is used unless activeSite is a measure:
 
@@ -3698,7 +3684,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> [n.beat for n in m.notes]
         [1.0, 1.5, 2.0, 2.5, 3.0, 3.5]
 
-
         Fractions are returned for positions that cannot be represented perfectly using floats:
 
         >>> m.timeSignature = meter.TimeSignature('6/8')
@@ -3710,7 +3695,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> s.repeatAppend(note.Note(), 8)
         >>> [n.beat for n in s.notes]
         [1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 2.0]
-
 
         Notes inside flat streams can still find the original beat placement from outer
         streams:
@@ -3729,7 +3713,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> p.append([m1, m2])
         >>> [n.beat for n in p.flatten().notes]
         [1.0, 1.5, 2.0, 2.5, 1.0, 1.5, 2.0, 2.5]
-
 
         Fractions print out as improper fraction strings
 
@@ -3780,7 +3763,6 @@ class Music21Object(prebase.ProtoM21Object):
         this object as found in the most recently positioned
         Measure. Beat values count from 1 and contain a
         fractional designation to show progress through the beat.
-
 
         >>> n = note.Note(type='eighth')
         >>> m = stream.Measure()
@@ -3882,7 +3864,6 @@ class Music21Object(prebase.ProtoM21Object):
         of this object does not match a defined accent weight, a
         minimum accent weight will be returned.
 
-
         >>> n = note.Note(type='eighth')
         >>> m = stream.Measure()
         >>> m.timeSignature = meter.TimeSignature('3/4')
@@ -3902,7 +3883,6 @@ class Music21Object(prebase.ProtoM21Object):
         >>> [n.beatStrength for n in m.notes]
         [1.0, 0.25, 0.25, 0.5, 0.25, 0.25]
 
-
         Importantly, the actual numbers here have no particular meaning.  You cannot
         "add" two beatStrengths of 0.25 and say that they have the same beat strength
         as one note of 0.5.  Only the ordinal relations really matter.  Even taking
@@ -3921,14 +3901,12 @@ class Music21Object(prebase.ProtoM21Object):
         >>> [n.beatStrength for n in s.notes]
         [1.0, 0.25, 0.5, 0.25, 1.0, 0.25, 0.5, 0.25, 1.0, 0.25, 0.5, 0.25]
 
-
         Changing the meter changes the output, of course, as can be seen from the
         fourth quarter note onward:
 
         >>> s.insert(4.0, meter.TimeSignature('3/4'))
         >>> [n.beatStrength for n in s.notes]
         [1.0, 0.25, 0.5, 0.25, 1.0, 0.5, 0.5, 1.0, 0.5, 0.5, 1.0, 0.5]
-
 
         The method returns correct numbers for the prevailing time signature
         even if no measures have been made:

--- a/music21/beam.py
+++ b/music21/beam.py
@@ -461,7 +461,6 @@ class Beams(prebase.ProtoM21Object, EqualSlottedObjectMixin):
         >>> beams.beamsList
         [<music21.beam.Beam 1/start>, <music21.beam.Beam 2/partial/right>]
 
-
         A beam object can also be specified:
 
         >>> beams = beam.Beams()

--- a/music21/braille/basic.py
+++ b/music21/braille/basic.py
@@ -117,7 +117,6 @@ def chordToBraille(music21Chord, descending=True, showOctave=True):
     Takes in a :class:`~music21.chord.Chord` and returns its representation
     as a braille string in UTF-8 unicode.
 
-
     In braille, only one pitch of a chord is brailled, with the rest represented
     as numeric intervals from that one pitch. If descending is True, the highest
     (sounding) pitch is brailled, and intervals are labeled in descending order;
@@ -125,7 +124,6 @@ def chordToBraille(music21Chord, descending=True, showOctave=True):
     intervals are labeled in ascending order. Convention dictates that chords
     found in the treble clef are brailled descending, and those found in the bass
     clef are brailled ascending.
-
 
     If showOctave is True, the octave of the brailled pitch is shown. Other
     octave marks are shown in context relative to the brailled pitch.
@@ -375,10 +373,8 @@ def dynamicToBraille(music21Dynamic, precedeByWordSign=True):
     :attr:`~music21.dynamics.Dynamic.value` as a braille string in
     UTF-8 unicode.
 
-
     If precedeByWordSign is True, the value is preceded by a word
     sign (⠜).
-
 
     >>> from music21.braille.basic import dynamicToBraille
     >>> print(dynamicToBraille(dynamics.Dynamic('f')))
@@ -627,15 +623,12 @@ def noteToBraille(
     Given a :class:`~music21.note.Note`, returns the appropriate braille
     characters as a string in UTF-8 unicode.
 
-
     The format for note display in braille is the accidental (if necessary)
     + octave (if necessary) + pitch name with length.
-
 
     If the note has an :class:`~music21.pitch.Accidental`, the accidental is always
     displayed unless its :attr:`~music21.pitch.Accidental.displayStatus` is set to
     False. The octave of the note is only displayed if showOctave is set to True.
-
 
     >>> from music21.braille.basic import noteToBraille
     >>> C4 = note.Note('C4')
@@ -657,7 +650,6 @@ def noteToBraille(
     >>> print(noteToBraille(A2))
     ⠘⠎⠄
 
-
     >>> B = note.Note('B4')
     >>> f = expressions.Fermata()
     >>> B.expressions.append(f)
@@ -677,7 +669,6 @@ def noteToBraille(
     Octave 4 ⠐
     B quarter ⠺
     Note-fermata: Shape square: ⠰⠣⠇
-
 
     >>> C4 = note.Note('C4')
     >>> print(noteToBraille(C4))
@@ -912,7 +903,6 @@ def restToBraille(music21Rest):
     '''
     Given a :class:`~music21.note.Rest`, returns the appropriate braille
     characters as a string in UTF-8 unicode.
-
 
     Currently, only supports single rests with or without dots.
     Complex rests are not supported.
@@ -1156,10 +1146,8 @@ def showOctaveWithNote(previousNote, currentNote):
     1) If a braille measure goes to a new line, the first note in the measure carries an
        octave designation regardless of what the previous note was.
 
-
     2) If a braille measure contains a new key or time signature, the first note carries
        an octave designation regardless of what the previous note was.
-
 
     3) If a new key or time signature occurs in the middle of a measure, or if a double bar
        line is encountered, both of which would necessitate a music hyphen, the next note after
@@ -1370,7 +1358,6 @@ def transcribeNoteFingering(sampleNoteFingering='1', upperFirstInFingering=True)
     ⠂⠄
     >>> print(transcribeNoteFingering('4,x', upperFirstInFingering=False))
     ⠠⠂
-
 
     A change of fingering and a choice of fingering combined (thanks to Bo-cheng Jhan
     for the patch):

--- a/music21/braille/examples.py
+++ b/music21/braille/examples.py
@@ -9,7 +9,6 @@
 '''
 The melody to the "Happy Birthday" song, in G major and 3/4 time.
 
-
 >>> from music21.braille import examples
 >>> hb = examples.happyBirthday()
 >>> #_DOCS_SHOW hb.show('braille')
@@ -17,10 +16,8 @@ The melody to the "Happy Birthday" song, in G major and 3/4 time.
 ⠼⠁⠀⠐⠑⠄⠵⠫⠱⠀⠳⠟⠀⠑⠄⠵⠫⠱⠀⠪⠗⠀⠑⠄⠵⠨⠱⠺⠀⠓⠄⠷⠻⠫
 ⠀⠀⠨⠙⠄⠽⠺⠳⠀⠪⠗⠣⠅
 
-
 A piano reduction of Giuseppi Verdi's famous aria from the opera
 Rigoletto, "La Donna É Mobile," in Bb major and 3/8 time.
-
 
 >>> verdi = corpus.parse('verdi/laDonnaEMobile')
 >>> #_DOCS_SHOW verdi.show('braille')
@@ -60,9 +57,7 @@ Rigoletto, "La Donna É Mobile," in Bb major and 3/8 time.
 ⠉⠙⠀⠨⠜⠄⠜⠋⠋⠰⠃⠨⠦⠨⠮⠄⠗⠿⠄⠏⠵⠄⠝⠀⠐⠾⠘⠆⠍⠜⠋⠋⠋⠨⠚⠼⠴⠭⠣⠅
 ⠀⠀⠀⠸⠜⠄⠄⠄⠧⠸⠛⠬⠒⠣⠜⠸⠫⠄⠬⠴⠀⠀⠀⠀⠸⠾⠬⠍⠘⠚⠬⠔⠭⠣⠅⠀⠀⠀⠀⠀
 
-
 The exposition to movement 1 of Mozart's K545.
-
 
 >>> #_DOCS_SHOW mozart = converter.parse('mozart_k545_exposition.xml')
 >>> #_DOCS_SHOW mozart.show('braille')
@@ -79,9 +74,6 @@ The exposition to movement 1 of Mozart's K545.
 ⠀⠀⠀⠸⠜⠸⠻⠄⠓⠪⠄⠩⠛⠀⠀⠀⠀⠀⠀⠀⠀⠀
 ⠁⠁⠀⠨⠜⠐⠚⠨⠓⠋⠙⠑⠓⠋⠙⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠨⠱⠳⠼⠴⠐⠳⠧⠣⠅
 ⠀⠀⠀⠸⠜⠘⠷⠚⠑⠓⠘⠷⠸⠙⠋⠓⠘⠷⠚⠑⠓⠘⠷⠸⠙⠋⠓⠀⠘⠳⠸⠳⠘⠳⠧⠣⠅⠀
-
-
-
 
 >>> print(braille.translate.objectToBraille(verdi.measures(1, 3), debug=True))
 ---begin grand segment---

--- a/music21/braille/lookup.py
+++ b/music21/braille/lookup.py
@@ -12,7 +12,6 @@
 This file contains some basic lookups for symbols (used where there is not much more
 logical code to deduce).
 
-
 Music21 standards generally follow Mary Turner De Garmo,
 Introduction to Braille Music Transcription (2005) (called "degarmo" or "IBMT2005" below).
 

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -322,7 +322,6 @@ class BrailleSegment(text.BrailleText):
         >>> brailleSeg.showFirstMeasureNumber
         True
 
-
         Possible showHand values are None, 'right', 'left':
 
         >>> brailleSeg.showHand is None
@@ -682,7 +681,6 @@ class BrailleSegment(text.BrailleText):
         >>> bs1.suppressOctaveMarks = True
         >>> bs1.showLeadingOctaveFromNoteGrouping(beg2)
         False
-
 
         We also show octaves if for some reason two noteGroups in the same measure have
         different BrailleElementGroupings keyed to consecutive ordinals.  The code simulates
@@ -1503,7 +1501,6 @@ def findSegments(music21Part,
     ===
     ---end segment---
 
-
     Second segment
 
     >>> print(str(allSegments[1]))
@@ -1616,7 +1613,6 @@ def prepareSlurredNotes(music21Part,
     slur covers up to four notes. A short slur symbol should follow each
     note except the last.
 
-
     >>> import copy
     >>> from music21.braille import segment
     >>> short = converter.parse('tinynotation: 3/4 c4 d e')
@@ -1638,13 +1634,11 @@ def prepareSlurredNotes(music21Part,
     >>> shortA.recurse().notes[1].shortSlur
     True
 
-
     In a long phrase, a slur covers more than four notes. There are two
     options for slurring long phrases. The first is by using the bracket
     slur. By default, slurLongPhraseWithBrackets is True. The opening
     bracket sign is put before the first note, and the closing bracket
     sign is put before the last note.
-
 
     >>> long = converter.parse('tinynotation: 3/4 c8 d e f g a')
     >>> s2 = spanner.Slur(long[note.Note].first(), long[note.Note].last())
@@ -1668,7 +1662,6 @@ def prepareSlurredNotes(music21Part,
     >>> longA[note.Note].last().endLongBracketSlur
     True
 
-
     The other way is by using the double slur, setting `slurLongPhraseWithBrackets`
     to False. The opening sign of the double slur is put after the first note
     (i.e. before the second note) and the closing sign is put before the last
@@ -1677,7 +1670,6 @@ def prepareSlurredNotes(music21Part,
     If a value is not supplied for `showLongSlursAndTiesTogether`, it will take the
     value set for `slurLongPhraseWithBrackets`, which defaults True.
 
-
     >>> longB = copy.deepcopy(long)
     >>> segment.prepareSlurredNotes(longB, slurLongPhraseWithBrackets=False)
     >>> longB.recurse().notes[1].beginLongDoubleSlur
@@ -1685,17 +1677,14 @@ def prepareSlurredNotes(music21Part,
     >>> longB.recurse().notes[-2].endLongDoubleSlur
     True
 
-
     In the event that slurs and ties are shown together in print, the slur is
     redundant. Examples are shown for slurring a short phrase; the process is
     identical for slurring a long phrase.
-
 
     Below, a tie has been added between the first two notes of the short phrase
     defined above. If showShortSlursAndTiesTogether is set to its default value of
     False, then the slur on either side of the phrase is reduced by the amount that
     ties are present, as shown below.
-
 
     >>> short.recurse().notes[0].tie = tie.Tie('start')
     >>> shortB = copy.deepcopy(short)
@@ -1707,7 +1696,6 @@ def prepareSlurredNotes(music21Part,
     <music21.tie.Tie start>
     >>> shortB.recurse().notes[1].shortSlur
     True
-
 
     If showShortSlursAndTiesTogether is set to True, then the slurs and ties are
     shown together (i.e. the note has both a shortSlur and a tie).
@@ -2029,7 +2017,6 @@ def extractBrailleElements(
     {2.0} <music21.spanner.Slur <music21.note.Note C><music21.note.Note D>>
     {2.0} <music21.bar.Barline type=final>
 
-
     Spanners are dealt with in :func:`~music21.braille.segment.prepareSlurredNotes`,
     so they are not returned by this function, as seen below.
 
@@ -2213,7 +2200,6 @@ def setAffinityCode(music21Object: base.Music21Object):
     A BrailleSegmentException is raised if an affinity code cannot be assigned to
     the object.
 
-
     As seen in the following example, the affinity code of a :class:`~music21.note.Note`
     and a :class:`~music21.clef.TrebleClef` are the same, because they should be grouped
     together. However, the classSortOrder indicates that the TrebleClef should come first
@@ -2307,7 +2293,6 @@ def splitNoteGrouping(noteGrouping, beatDivisionOffset=0):
     >>> right
     <music21.braille.segment.BrailleElementGrouping
         [<music21.note.Rest quarter>, <music21.note.Note E>]>
-
 
     Now split one beat division earlier than it should be.  For 2/2 that means
     one half of a beat, or one quarter note earlier:

--- a/music21/braille/translate.py
+++ b/music21/braille/translate.py
@@ -15,16 +15,13 @@ available from the Library of Congress
 `here <https://www.loc.gov/nls/services-and-resources/music-service-and-materials/>`_,
 and will henceforth be referred to as BMTM.
 
-
 The most important function, and the only one that is needed to translate music
 into braille, is :func:`~music21.braille.translate.objectToBraille`. This function,
 as well as the others, accepts keyword arguments that serve to modify the output.
 If no keyword arguments are needed, then using the function is equivalent to
 calling :meth:`~music21.base.Music21Object.show` on the music.
 
-
 Keywords:
-
 
 * **inPlace** (False): If False, then :meth:`~music21.stream.base.Stream.makeNotation` is called
   on all :class:`~music21.stream.Measure`, :class:`~music21.stream.Part`, and
@@ -36,7 +33,6 @@ Keywords:
   to be organized into measures for transcription to work.
 * **debug** (False): If True, a braille-english representation of the music is returned. Useful
   for knowing how the music was interpreted by the braille transcriber.
-
 
 The rest of the keywords are segment keywords. A segment is "a group of measures occupying
 more than one braille line." Music is divided into segments to "present the music to
@@ -130,26 +126,20 @@ def objectToBraille(music21Obj: base.Music21Object,
     >>> samplePart = converter.parse('tinynotation: 3/4 C4 D16 E F G# r4 e2.')
     >>> #_DOCS_SHOW samplePart.show()
 
-
         .. image:: images/objectToBraille.*
             :width: 700
-
 
     >>> print(translate.objectToBraille(samplePart))
     ⠀⠀⠀⠀⠀⠀⠀⠼⠉⠲⠀⠀⠀⠀⠀⠀⠀
     ⠼⠁⠀⠸⠹⠵⠋⠛⠩⠓⠧⠀⠐⠏⠄⠣⠅
 
-
     For normal users, you'll just call this, which starts a text editor:
-
 
     >>> #_DOCS_SHOW samplePart.show('braille')
     ⠀⠀⠀⠀⠀⠀⠀⠼⠉⠲⠀⠀⠀⠀⠀⠀⠀
     ⠼⠁⠀⠸⠹⠵⠋⠛⠩⠓⠧⠀⠐⠏⠄⠣⠅
 
-
     Other examples:
-
 
     >>> sampleNote = note.Note('C3')
     >>> print(translate.objectToBraille(sampleNote))

--- a/music21/capella/fromCapellaXML.py
+++ b/music21/capella/fromCapellaXML.py
@@ -429,7 +429,6 @@ class CapellaImporter:
         is returned if the <chord> has one <head> element, a `Chord` is
         returned if there are multiple <head> elements.
 
-
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> chordElement = ci.domElementFromText(
         ...     '<chord><duration base="1/1"/><heads><head pitch="G4"/></heads></chord>')
@@ -573,7 +572,6 @@ class CapellaImporter:
 
         if begin == 'true' then Tie.type = start
 
-
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> tieEl = ci.domElementFromText('<tie begin="true"/>')
         >>> ci.tieFromTie(tieEl)
@@ -614,7 +612,6 @@ class CapellaImporter:
     def lyricListFromLyric(self, lyricElement):
         '''
         returns a list of :class:`~music21.note.Lyric` objects from a <lyric> tag
-
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> lyricEl = ci.domElementFromText(
@@ -779,7 +776,6 @@ class CapellaImporter:
         >>> d2.tuplets
         (<music21.duration.Tuplet 3/2>,)
 
-
         Does not handle noDuration='true', display, churchStyle on rest durations
         '''
         dur = duration.Duration()
@@ -807,7 +803,6 @@ class CapellaImporter:
     def tupletFromTuplet(self, tupletElement):
         '''
         Returns a :class:`~music21.duration.Tuplet` object from a <tuplet> tag.
-
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> tupletTag = ci.domElementFromText('<tuplet count="3"/>')
@@ -850,7 +845,6 @@ class CapellaImporter:
 
         Returns a LIST of :class:`~music21.bar.Barline` or :class:`~music21.bar.Repeat` objects
         because the `repEndBegin` type requires two `bar.Repeat` objects to encode in `music21`.
-
 
         >>> ci = capella.fromCapellaXML.CapellaImporter()
         >>> barlineTag = ci.domElementFromText('<barline type="end"/>')

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -70,7 +70,6 @@ class ChordBase(note.NotRest):
     >>> cb.notes
     (<music21.note.Note C>, <music21.note.Note E>, <music21.note.Note G>)
 
-
     **Equality**
 
     Equality on ChordBase is strange, but necessary to help Chord and PercussionChord
@@ -326,7 +325,6 @@ class ChordBase(note.NotRest):
         >>> c.remove(pitch.Pitch('F#5'))
         Traceback (most recent call last):
         ValueError: Chord.remove(x), x not in chord
-
 
         The Note also does not need to be the exact note of the
         chord, just matches on equality
@@ -608,7 +606,6 @@ class Chord(ChordBase):
     >>> myChord
     <music21.chord.Chord A4 C#5 E5>
 
-
     Or you can combine already created Notes or Pitches:
 
     >>> cNote = note.Note('C')
@@ -650,7 +647,6 @@ class Chord(ChordBase):
     12, then a MIDI number.  To create chords below MIDI 12, create a Pitch object with that
     MIDI number instead and then pass that to the Chord creator).
 
-
     Duration or quarterLength also works:
 
     >>> d = duration.Duration(2.0)
@@ -667,7 +663,6 @@ class Chord(ChordBase):
     'half'
     >>> myChord.duration.dots
     3
-
 
     OMIT_FROM_DOCS
 
@@ -1341,7 +1336,6 @@ class Chord(ChordBase):
         >>> strange_chord.bass()
         <music21.pitch.Pitch G--4>
 
-
         By default, if nothing has been overridden, this method uses a
         quick algorithm to find the bass among the
         chord's pitches, if no bass has been previously specified. If this is
@@ -1665,7 +1659,6 @@ class Chord(ChordBase):
         >>> cChord = chord.Chord(['C', 'E', 'G', 'B'])
         >>> cChord.containsSeventh()
         True
-
 
         Empty chord returns False
 
@@ -2916,7 +2909,6 @@ class Chord(ChordBase):
         each third and fifth above the root.
         Chord MAY BE SPELLED INCORRECTLY. Otherwise returns False.
 
-
         >>> c = chord.Chord('C D# G- A')
         >>> c.isFalseDiminishedSeventh()
         True
@@ -2998,7 +2990,6 @@ class Chord(ChordBase):
         Returns True if the chord is a German augmented sixth chord
         (flat 6th scale degree in bass, tonic, flat third scale degree, and raised 4th).
 
-
         >>> gr6a = chord.Chord(['A-3', 'C4', 'E-4', 'F#4'])
         >>> gr6a.isGermanAugmentedSixth()
         True
@@ -3050,7 +3041,6 @@ class Chord(ChordBase):
         fifth, and seventh above the root.
         Chord must be spelled correctly. Otherwise returns false.
 
-
         >>> c1 = chord.Chord(['C4', 'E-4', 'G-4', 'B-4'])
         >>> c1.isHalfDiminishedSeventh()
         True
@@ -3075,7 +3065,6 @@ class Chord(ChordBase):
         '''
         Returns True if the chord is an incomplete Major triad, or, essentially,
         a dyad of root and major third
-
 
         >>> c1 = chord.Chord(['C4', 'E3'])
         >>> c1.isMajorTriad()
@@ -3358,7 +3347,6 @@ class Chord(ChordBase):
         >>> chord.Chord(['A#', 'D', 'F']).forteClassTn == '3-11B'
         True
 
-
         OMIT_FROM_DOCS
 
         Strange chords like [C,E###,G---] used to return True.  E### = G
@@ -3369,7 +3357,6 @@ class Chord(ChordBase):
         False
         >>> chord.Chord(['C', 'E', 'G', 'E###', 'G---']).isMajorTriad()
         False
-
 
         >>> chord.Chord().isMajorTriad()
         False
@@ -3889,7 +3876,6 @@ class Chord(ChordBase):
         >>> cSus4.root() is cSus4.pitches[0]
         True
 
-
         You might also want to supply an "implied root." For instance, some people
         call a diminished seventh chord (generally viio7)
         a dominant chord with an omitted root (Vo9) -- here we will specify the root
@@ -3938,7 +3924,6 @@ class Chord(ChordBase):
         There is no need to set find=False in this case, however, the
         algorithm will skip the slow part of finding the root if it
         has been specified (or already found and no pitches have changed).
-
 
         A chord with no pitches has no root and raises a ChordException.
 
@@ -4145,7 +4130,6 @@ class Chord(ChordBase):
         8
         >>> print(aChord.semitonesFromChordStep(2))
         None
-
 
         Test whether this strange chord gets the B# as 0 semitones:
 
@@ -4809,7 +4793,6 @@ class Chord(ChordBase):
         >>> c4b.commonName
         'German augmented sixth chord in root position'
 
-
         Dyads are called by actual name:
 
         >>> dyad1 = chord.Chord('C E')
@@ -4831,15 +4814,12 @@ class Chord(ChordBase):
         >>> dyad1.commonName
         'Major Third with octave doublings'
 
-
         If there are multiple enharmonics present just the simple
         number of semitones is returned.
 
         >>> dyad1 = chord.Chord('C4 E5 F-5 B#7')
         >>> dyad1.commonName
         '4 semitones'
-
-
 
         Special handling of one- and two-pitchClass chords:
 
@@ -5625,7 +5605,6 @@ class Chord(ChordBase):
         >>> c4.pitchedCommonName
         'enharmonic equivalent to major triad above D'
 
-
         A single pitch just returns that pitch name:
 
         >>> chord.Chord(['D3']).pitchedCommonName
@@ -5638,7 +5617,6 @@ class Chord(ChordBase):
         >>> chord.Chord('D3 D4 D5').pitchedCommonName
         'multiple octaves above D'
 
-
         Two different pitches give interval names:
 
         >>> chord.Chord('F3 C4').pitchedCommonName
@@ -5650,7 +5628,6 @@ class Chord(ChordBase):
         'Major Thirteenth above Eb'
         >>> chord.Chord('E-3 C5 C6').pitchedCommonName
         'Major Sixth with octave doublings above Eb'
-
 
         These one-pitch-class and two-pitch-class chords with multiple enharmonics are unusual:
 
@@ -5717,7 +5694,6 @@ class Chord(ChordBase):
 
         >>> c.root()
         <music21.pitch.Pitch A4>
-
 
         Note here that the list will be converted to a tuple:
 

--- a/music21/clef.py
+++ b/music21/clef.py
@@ -742,7 +742,6 @@ def clefFromString(clefString, octaveShift=0) -> Clef:
 
     Does not refer to a violin/guitar string.
 
-
     >>> tc = clef.clefFromString('G2')
     >>> tc
     <music21.clef.TrebleClef>
@@ -758,7 +757,6 @@ def clefFromString(clefString, octaveShift=0) -> Clef:
     'D'
     >>> nonStandard2.line
     4
-
 
     >>> tc8vb = clef.clefFromString('G2', -1)
     >>> tc8vb
@@ -790,7 +788,6 @@ def clefFromString(clefString, octaveShift=0) -> Clef:
     Traceback (most recent call last):
     music21.clef.ClefException: line number (second character) must be 1-5;
                 do not use this function for clefs on special staves such as 'F6'
-
 
     Can find any clef in the module
 
@@ -939,7 +936,6 @@ def bestClef(streamObj: stream.Stream,
 
     >>> clef.bestClef(c, recurse=True)
     <music21.clef.TrebleClef>
-
 
     Notes around middle C can get Treble8vb if the setting is allowed:
 

--- a/music21/common/classTools.py
+++ b/music21/common/classTools.py
@@ -50,7 +50,6 @@ def isNum(usrData: t.Any) -> t.TypeGuard[t.Union[float, int, Fraction]]:
     Differs from `isinstance(usrData, Rational)` primarily in that this function
     does not return True for `True, False`. See below for other differences.
 
-
     >>> common.isNum(3.0)
     True
     >>> common.isNum(3)

--- a/music21/common/decorators.py
+++ b/music21/common/decorators.py
@@ -87,7 +87,6 @@ def deprecated(method, startDate=None, removeDate=None, message=None):
     >>> hi('myke')
     myke
 
-
     Now a new function demonstrating the argument form.
 
     >>> @common.deprecated('February 1972', 'September 2099', 'You should be okay.')

--- a/music21/common/formats.py
+++ b/music21/common/formats.py
@@ -96,7 +96,6 @@ def findFormat(fmt):
 
     DEPRECATED May 2014 -- moving to converter
 
-
     All but the first element of the tuple are deprecated for use, since
     the extension can vary by subConverter (e.g., lily.png)
 
@@ -127,15 +126,12 @@ def findFormat(fmt):
     >>> common.findFormat('capx')
     ('capella', '.capx')
 
-
     Works the same whether you have a leading dot or not:
-
 
     >>> common.findFormat('md')
     ('musedata', '.md')
     >>> common.findFormat('.md')
     ('musedata', '.md')
-
 
     If you give something we can't deal with, returns a Tuple of None, None:
 
@@ -238,7 +234,6 @@ def findFormatFile(fp):
 
     DEPRECATED May 2014 -- moving to converter
 
-
     >>> common.findFormatFile('test.xml')
     'musicxml'
     >>> common.findFormatFile('long/file/path/test-2009.03.02.xml')
@@ -301,7 +296,6 @@ def findFormatExtURL(url):
     This may scrub arguments in a URL, or simply look at the last characters.
 
     DEPRECATED May 2014 -- moving to converter
-
 
     >>> urlA = 'http://somesite.com/?l=cc/schubert/piano/d0576&file=d0576-06.krn&f=xml'
     >>> urlB = 'http://somesite.com/cgi-bin/ksdata?l=cc/schubert/d0576&file=d0576-06.krn&f=kern'

--- a/music21/common/misc.py
+++ b/music21/common/misc.py
@@ -110,7 +110,6 @@ def getMissingImportStr(modNameList):
     Given a list of missing module names, returns a nicely-formatted message to the user
     that gives instructions on how to expand music21 with optional packages.
 
-
     >>> print(common.getMissingImportStr(['matplotlib']))
     Certain music21 functions might need the optional package matplotlib;
     if you run into errors, install it by following the instructions at

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -165,17 +165,17 @@ def _preFracLimitDenominator(n: int, d: int) -> tuple[int, int]:
 
     Timing differences are huge!
 
-    t is timeit.timeit
+    t is timeit.timeit::
 
-    t('Fraction(*common.numberTools._preFracLimitDenominator(*x.as_integer_ratio()))',
-       setup='x = 1000001/3000001; from music21 import common;from fractions import Fraction',
-       number=100000)
-    1.0814228057861328
+        t('Fraction(*common.numberTools._preFracLimitDenominator(*x.as_integer_ratio()))',
+           setup='x = 1000001/3000001; from music21 import common; from fractions import Fraction',
+           number=100000)
+        1.0814228057861328
 
-    t('Fraction(x).limit_denominator(65535)',
-       setup='x = 1000001/3000001; from fractions import Fraction',
-       number=100000)
-    7.941488981246948
+        t('Fraction(x).limit_denominator(65535)',
+           setup='x = 1000001/3000001; from fractions import Fraction',
+           number=100000)
+        7.941488981246948
 
     Nothing changed in 2023, in fact, it's faster now with the cache, and even
     without the cache, it's still 4x faster.

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -116,7 +116,6 @@ def numToIntOrFloat(value: OffsetQLIn) -> int|float:
     Traceback (most recent call last):
     ValueError: could not convert string to float: 'one'
 
-
     Fractions also become ints or floats
 
     >>> from fractions import Fraction
@@ -707,7 +706,6 @@ def unitNormalizeProportion(values: Sequence[int|float]) -> list[float]:
     >>> common.unitNormalizeProportion([1.0, 1, 1.0])
     [0.3333333..., 0.333333..., 0.333333...]
 
-
     On 32-bit computers this number may be inexact even for small floats.
     On 64-bit it works fine.  This is the 32-bit output for this result.
 
@@ -862,7 +860,6 @@ def contiguousList(inputListOrTuple) -> bool:
 
     requires the list to be sorted first
 
-
     >>> l = [3, 4, 5, 6]
     >>> common.contiguousList(l)
     True
@@ -940,7 +937,6 @@ def fromRoman(num: str, *, strictModern=False) -> int:
 
     https://code.activestate.com/recipes/81611-roman-numerals/
 
-
     >>> common.fromRoman('ii')
     2
     >>> common.fromRoman('vii')
@@ -953,7 +949,6 @@ def fromRoman(num: str, *, strictModern=False) -> int:
     >>> common.fromRoman('MCDLXXXIX')
     1489
 
-
     Some people consider this an error, but you see it in medieval and ancient roman documents:
 
     >>> common.fromRoman('ic')
@@ -964,7 +959,6 @@ def fromRoman(num: str, *, strictModern=False) -> int:
     >>> common.fromRoman('ic', strictModern=True)
     Traceback (most recent call last):
     ValueError: input contains an invalid subtraction element (modern interpretation): ic
-
 
     But things like this are never seen, and thus cause an error:
 

--- a/music21/configure.py
+++ b/music21/configure.py
@@ -1074,7 +1074,7 @@ class SelectFilePath(SelectFromList):
         comparisonFunction = function (lambda function on path returning True/False)
         path0 = os-specific string
         post = list of matching results to fill
-        glob = string to glob for (default **/*, but **/*.exe on Windows and * on Mac).
+        glob = string to glob for (default ``**/*``, but ``**/*.exe`` on Windows and ``*`` on Mac).
         '''
         path0_as_path = pathlib.Path(path0)
         for path1 in path0_as_path.glob(glob):

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -1103,7 +1103,6 @@ class Converter:
         >>> c.formatFromHeader(b'binary-data')
         (None, b'binary-data')
 
-
         New formats can register new headers, like this old Amiga format:
 
         >>> class ConverterSonix(converter.subConverters.SubConverter):
@@ -1329,7 +1328,6 @@ def parse(value: bundles.MetadataEntry|bytes|str|pathlib.Path|list|tuple,
     URL:
 
     >>> #_DOCS_SHOW s = converter.parse('https://midirepository.org/file220/file.mid')
-
 
     Data is preceded by an identifier such as "tinynotation:"
 

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -62,7 +62,6 @@ class SubConverter:
         stringEncoding = string (default 'utf-8'). If codecWrite is True, this specifies what
             encoding to use
 
-
     '''
     readBinary: bool = False
     canBePickled: bool = True
@@ -743,7 +742,6 @@ class ConverterNoteworthy(SubConverter):
     Gets data with the file format .nwctxt
 
     Users should not need this routine.  The basic format is converter.parse('file.nwctxt')
-
 
     >>> nwcTranslatePath = common.getSourceFilePath() / 'noteworthy' #_DOCS_HIDE
     >>> paertPath = nwcTranslatePath / 'Part_OWeisheit.nwctxt' #_DOCS_HIDE

--- a/music21/corpus/chorales.py
+++ b/music21/corpus/chorales.py
@@ -1196,7 +1196,6 @@ class Iterator:
         >>> riemenschneider371.metadata.title
         'Christ lag in Todesbanden'
 
-
         >>> BCI.numberingSystem = 'title'
         >>> BCI._returnChorale()
         Traceback (most recent call last):

--- a/music21/corpus/corpora.py
+++ b/music21/corpus/corpora.py
@@ -164,7 +164,6 @@ class Corpus(prebase.ProtoM21Object):
         >>> coreCorpus.translateExtensions(('xml',))
         ('.xml', '.mxl', '.musicxml')
 
-
         # With multiple extensions:
 
         >>> coreCorpus.translateExtensions(('.mid', '.musicxml'), expandExtensions=False)

--- a/music21/corpus/manager.py
+++ b/music21/corpus/manager.py
@@ -59,7 +59,6 @@ def fromName(name):
     >>> corpus.manager.fromName(None)
     <music21.corpus.corpora.LocalCorpus: 'local'>
 
-
     Note that this corpus probably does not exist on disk, but it's ready to have
     paths added to it and to be stored on disk.
 
@@ -274,7 +273,6 @@ def search(
     >>> #_DOCS_SHOW corpus.search(sourcePath='bach', numberOfParts=4)
     >>> corpus.search(sourcePath='bach', numberOfParts=4, corpusNames=('core',))  #_DOCS_HIDE
     <music21.metadata.bundles.MetadataBundle {368 entries}>
-
 
     This function is implemented in `corpus.manager` as a method there but also directly
     available in the corpus module for ease of use.

--- a/music21/derivation.py
+++ b/music21/derivation.py
@@ -89,7 +89,6 @@ class Derivation(SlottedObjectMixin):
     >>> sNew.derivation.method
     '__deepcopy__'
 
-
     >>> s1 = stream.Stream()
     >>> s1.id = 'DerivedStream'
     >>> d1 = derivation.Derivation(s1)

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -411,7 +411,6 @@ def quarterLengthToTuplet(
     Note that 4:3 tuplets won't be found, but will be found as dotted notes
     by dottedMatch.
 
-
     >>> duration.quarterLengthToTuplet(0.33333333)
     [<music21.duration.Tuplet 3/2/eighth>, <music21.duration.Tuplet 3/1/quarter>]
 
@@ -419,7 +418,6 @@ def quarterLengthToTuplet(
     [<music21.duration.Tuplet 5/4/16th>,
      <music21.duration.Tuplet 5/2/eighth>,
      <music21.duration.Tuplet 5/1/quarter>]
-
 
     By specifying only 1 `maxToReturn`, a single-length list containing the
     Tuplet with the smallest type will be returned.
@@ -522,7 +520,6 @@ def quarterConversion(qLen: OffsetQLIn) -> QuarterLengthConversion:
     >>> tup.durationActual
     DurationTuple(type='quarter', dots=0, quarterLength=1.0)
 
-
     A triplet eighth note, where 3 eights are in the place of 2.
     Or, an eighth that is 1/3 of a quarter
     Or, an eighth that is 2/3 of eighth
@@ -542,14 +539,12 @@ def quarterConversion(qLen: OffsetQLIn) -> QuarterLengthConversion:
     QuarterLengthConversion(components=(DurationTuple(type='16th', dots=0, quarterLength=0.25),),
         tuplet=<music21.duration.Tuplet 3/2/16th>)
 
-
     A sixteenth that is 1/5 of a quarter
     Or, a sixteenth that is 4/5ths of a 16th
 
     >>> duration.quarterConversion(1/5)
     QuarterLengthConversion(components=(DurationTuple(type='16th', dots=0, quarterLength=0.25),),
         tuplet=<music21.duration.Tuplet 5/4/16th>)
-
 
     A 16th that is  1/7th of a quarter
     Or, a 16th that is 4/7 of a 16th
@@ -574,7 +569,6 @@ def quarterConversion(qLen: OffsetQLIn) -> QuarterLengthConversion:
                                         DurationTuple(type='eighth', dots=0, quarterLength=0.5)),
                             tuplet=None)
 
-
     Since tuplets apply to the entire Duration (since v2), expect some odder tuplets for unusual
     values that should probably be split generally:
 
@@ -588,7 +582,6 @@ def quarterConversion(qLen: OffsetQLIn) -> QuarterLengthConversion:
     >>> duration.quarterConversion(1/3).tuplet is duration.quarterConversion(1/3).tuplet
     True
 
-
     This is a very close approximation:
 
     >>> duration.quarterConversion(0.18333333333333)
@@ -598,7 +591,6 @@ def quarterConversion(qLen: OffsetQLIn) -> QuarterLengthConversion:
     >>> duration.quarterConversion(0.0)
     QuarterLengthConversion(components=(DurationTuple(type='zero', dots=0, quarterLength=0.0),),
         tuplet=None)
-
 
     >>> duration.quarterConversion(99.0)
     QuarterLengthConversion(components=(DurationTuple(type='inexpressible',
@@ -955,7 +947,6 @@ class Tuplet(prebase.ProtoM21Object):
     DurationTuple(type='eighth', dots=0, quarterLength=0.5)
     >>> myTup
     <music21.duration.Tuplet 5/4/eighth>
-
 
     In this case, the tupletMultiplier is a float because it can be expressed
     as a binary number:
@@ -1927,7 +1918,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         (DurationTuple(type='half', dots=0, quarterLength=2.0),
          DurationTuple(type='32nd', dots=0, quarterLength=0.125))
 
-
         By default, when augmenting or diminishing, we will delete any
         unusual components or tuplets:
 
@@ -2033,7 +2023,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
         Note that for 0 and the last value, the object is returned.
 
-
         >>> components = []
         >>> components.append(duration.Duration('quarter'))
         >>> components.append(duration.Duration('quarter'))
@@ -2049,7 +2038,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         1
         >>> a.componentIndexAtQtrPosition(2.5)
         2
-
 
         this is odd behavior:
 
@@ -2361,7 +2349,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         (DurationTuple(type='quarter', dots=0, quarterLength=1.0),
          DurationTuple(type='16th', dots=0, quarterLength=0.25))
 
-
         Generally, just look at `.components`
 
         >>> d = duration.Duration(1.25)
@@ -2492,7 +2479,6 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> d = duration.Duration(1/3)
         >>> d.components
         (DurationTuple(type='eighth', dots=0, quarterLength=0.5),)
-
 
         With a complex duration it becomes clearer why multiple components are needed.
         Here is a duration that cannot be expressed as a single note.
@@ -3391,7 +3377,6 @@ class TupletFixer:
         >>> [n.duration.tuplets[0].type for n in tg0]
         ['start', 'stop']
 
-
         More complex example, from a piece by Josquin:
 
         >>> humdrumExcerpt = '**kern *M3/1 3.c 6d 3e 3f 3d 3%2g 3e 3f#'
@@ -3440,7 +3425,6 @@ class TupletFixer:
          <music21.duration.Tuplet 3/2/half>, <music21.duration.Tuplet 3/2/half>]
         >>> [n.duration.tuplets[0].type for n in tupletGroups[1]]
         ['start', None, None, None, 'stop']
-
 
         Fix the last broken tuplet group.
 

--- a/music21/dynamics.py
+++ b/music21/dynamics.py
@@ -56,7 +56,6 @@ def dynamicStrFromDecimal(n):
     with 0 being the softest (0.01 = 'ppp') and 1 being the loudest (0.9+ = 'fff')
     0 returns "n" (niente), while ppp and fff are the loudest dynamics used.
 
-
     >>> dynamics.dynamicStrFromDecimal(0.25)
     'pp'
     >>> dynamics.dynamicStrFromDecimal(1)
@@ -162,7 +161,6 @@ class Dynamic(base.Music21Object):
     0.87
 
     Dynamics can be placed anywhere in a stream.
-
 
     >>> s = stream.Stream()
     >>> s.insert(0, note.Note('E-4', type='half'))

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -100,7 +100,6 @@ class LocalCorpusSettings(list):
                         name='theWholeEnchilada',
                         cacheFilePath='/home/enchilada.json')
 
-
     >>> list(lcs)
     ['/tmp', '/home']
     >>> lcs.name

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -272,7 +272,6 @@ class RehearsalMark(Expression):
         >>> expressions.RehearsalMark('Z').nextContent()
         'AA'
 
-
         With rehearsal mark 'I' default is to consider it
         as a roman numeral:
 
@@ -312,7 +311,6 @@ class RehearsalMark(Expression):
         >>> rm = expressions.RehearsalMark('C')
         >>> rm.nextMark()
         <music21.expressions.RehearsalMark 'D'>
-
 
         >>> rm = expressions.RehearsalMark('IV', numbering='roman')
         >>> nm = rm.nextMark()
@@ -796,7 +794,6 @@ class GeneralMordent(Ornament):
         If no key signature is found, a key signature with no sharps and no flats
         will be used.
 
-
         A mordent on a G in a key with no sharps or flats (ornamental pitch will be F).
 
         >>> noSharpsOrFlats = key.KeySignature(sharps=0)
@@ -1000,7 +997,6 @@ class Mordent(GeneralMordent):
 
         A musical ornament consisting of the alternation of the written note
         with the note immediately below it.
-
 
     A mordent has the size of a second, of some form, depending on the note
     that will have the mordent, the current key signature in that note's context, as
@@ -1648,7 +1644,6 @@ class Trill(Ornament):
           <music21.note.Note D#>,
           <music21.note.Note C>,
           <music21.note.Note D#>], None, [])
-
 
         To avoid this case, create a :class:`~music21.expressions.HalfStepTrill` or
         :class:`~music21.expressions.WholeStepTrill`.
@@ -2485,7 +2480,6 @@ class GeneralAppoggiatura(Ornament):
         >>> a1.realize(n1)
         ([<music21.note.Note D>], <music21.note.Note C>, [])
 
-
         >>> n2 = note.Note('C4')
         >>> n2.quarterLength = 1
         >>> a2 = expressions.HalfStepInvertedAppoggiatura()
@@ -2656,7 +2650,6 @@ class Tremolo(Ornament):
         {0.625} <music21.note.Note C>
         {0.75} <music21.note.Note C>
         {0.875} <music21.note.Note C>
-
 
         >>> trem.numberOfMarks = 1
         >>> y = stream.makeNotation.realizeOrnaments(s)

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -718,7 +718,6 @@ class DataSet:
 
     Comprises multiple DataInstance objects, a FeatureSet, and an OutputFormat.
 
-
     >>> ds = features.DataSet(classLabel='Composer')
     >>> f = [features.jSymbolic.PitchClassDistributionFeature,
     ...      features.jSymbolic.ChangesOfMeterFeature,
@@ -735,7 +734,6 @@ class DataSet:
     0.0288..., 0.0, 0, 4, 4, 'Bach']
 
     >>> ds = ds.getString()
-
 
     By default, all exceptions are caught and printed if debug mode is on.
 
@@ -784,7 +782,6 @@ class DataSet:
         '''
         Return a list of all attribute labels. Optionally add a class
         label field and/or an id field.
-
 
         >>> f = [features.jSymbolic.PitchClassDistributionFeature,
         ...      features.jSymbolic.ChangesOfMeterFeature]
@@ -1156,7 +1153,6 @@ def extractorsById(idOrList, library=('jSymbolic', 'native')):
     >>> [x.id for x in features.extractorsById(['p19', 'p20'])]
     ['P19', 'P20']
 
-
     Normalizes case:
 
     >>> [x.id for x in features.extractorsById(['r31', 'r32', 'r33', 'r34', 'r35', 'p1', 'p2'])]
@@ -1242,7 +1238,6 @@ def getIndex(featureString, extractorType=None):
 
     optionally include the extractorType ('jsymbolic' or 'native') if known
     and searching will be made more efficient
-
 
     >>> features.getIndex('Range')
     (61, 'jsymbolic')

--- a/music21/features/jSymbolic.py
+++ b/music21/features/jSymbolic.py
@@ -1884,7 +1884,6 @@ class StrengthRatioOfTwoStrongestRhythmicPulsesFeature(
     The frequency of the higher (in terms of frequency) of the two beat bins
     corresponding to the peaks with the highest frequency divided by the frequency of the lower.
 
-
     >>> sch = corpus.parse('schoenberg/opus19', 2)
     >>> for p in sch.parts:
     ...     p.insert(0, tempo.MetronomeMark('Langsam', 70))
@@ -2102,7 +2101,6 @@ class BeatHistogramFeature(featuresModule.FeatureExtractor):
 
     A feature extractor that finds a feature array with entries corresponding to the frequency
     values of each of the bins of the beat histogram (except the first 40 empty ones).
-
 
     '''
     id = 'R14'
@@ -2911,7 +2909,6 @@ class VariationOfDynamicsFeature(featuresModule.FeatureExtractor):
 
     Standard deviation of loudness levels of all notes.
 
-
     TODO: implement
 
     '''
@@ -2954,7 +2951,6 @@ class AverageNoteToNoteDynamicsChangeFeature(featuresModule.FeatureExtractor):
 
     Average change of loudness from one note to the next note in the
     same channel (in MIDI velocity units).
-
 
     TODO: implement
 
@@ -3070,7 +3066,6 @@ class VariabilityOfNumberOfIndependentVoicesFeature(
     Standard deviation of number of different channels in which notes have sounded simultaneously.
     Rests are not included in this calculation.
 
-
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.jSymbolic.VariabilityOfNumberOfIndependentVoicesFeature(s)
     >>> f = fe.extract()
@@ -3110,8 +3105,6 @@ class VoiceEqualityNumberOfNotesFeature(featuresModule.FeatureExtractor):
     '''
     Not implemented
 
-
-
     TODO: implement
 
     Standard deviation of the total number of Note Ons in each channel
@@ -3133,8 +3126,6 @@ class VoiceEqualityNoteDurationFeature(featuresModule.FeatureExtractor):
     '''
     Not implemented
 
-
-
     TODO: implement
 
     '''
@@ -3154,8 +3145,6 @@ class VoiceEqualityDynamicsFeature(featuresModule.FeatureExtractor):
     '''
     Not implemented
 
-
-
     TODO: implement
 
     '''
@@ -3174,8 +3163,6 @@ class VoiceEqualityDynamicsFeature(featuresModule.FeatureExtractor):
 class VoiceEqualityMelodicLeapsFeature(featuresModule.FeatureExtractor):
     '''
     Not implemented
-
-
 
     TODO: implement
 
@@ -3277,8 +3264,6 @@ class RangeOfHighestLineFeature(featuresModule.FeatureExtractor):
 class RelativeNoteDensityOfHighestLineFeature(featuresModule.FeatureExtractor):
     '''
     Not implemented
-
-
 
     TODO: implement
 
@@ -3510,8 +3495,6 @@ class NotePrevalenceOfUnpitchedInstrumentsFeature(
     '''
     Not implemented
 
-
-
     TODO: implement
 
     '''
@@ -3626,7 +3609,6 @@ class VariabilityOfNotePrevalenceOfUnpitchedInstrumentsFeature(
     Map instrument that is used to play at least one note. It should be noted that only
     instruments 35 to 81 are included here, as they are the ones that are included in the
     official standard.
-
 
     TODO: implement
 

--- a/music21/features/native.py
+++ b/music21/features/native.py
@@ -81,7 +81,6 @@ class QualityFeature(featuresModule.FeatureExtractor):
     >>> f2.vector
     [1]
 
-
     OMIT_FROM_DOCS
 
     # for monophonic melodies
@@ -653,7 +652,6 @@ class TriadSimultaneityPrevalence(featuresModule.FeatureExtractor):
     '''
     Gives the proportion of all simultaneities which form triads (major,
     minor, diminished, or augmented)
-
 
     >>> s = corpus.parse('bwv66.6')
     >>> fe = features.native.TriadSimultaneityPrevalence(s)

--- a/music21/features/outputFormats.py
+++ b/music21/features/outputFormats.py
@@ -140,7 +140,6 @@ class OutputCSV(OutputFormat):
         '''
         Get the header as a list of lines.
 
-
         >>> f = [features.jSymbolic.ChangesOfMeterFeature]
         >>> ds = features.DataSet(classLabel='Composer')
         >>> ds.addFeatureExtractors(f)
@@ -176,7 +175,6 @@ class OutputARFF(OutputFormat):
     See
     https://web.archive.org/web/20160212022757/http://weka.wikispaces.com/ARFF+%28stable+version%29
     for more details
-
 
     >>> oa = features.outputFormats.OutputARFF()
     >>> oa.ext

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -34,7 +34,6 @@ def getVoiceLeadingMoments(music21Stream):
     .. image:: images/figuredBass/corelli_grave.*
             :width: 700
 
-
     >>> from music21.figuredBass import checker
     >>> score = corpus.parse('bwv66.6') #_DOCS_HIDE
     >>> vlMoments = checker.getVoiceLeadingMoments(score)
@@ -80,7 +79,6 @@ def extractHarmonies(music21Stream):
 
     .. image:: images/figuredBass/corelli_grave.*
             :width: 700
-
 
     >>> from music21.figuredBass import checker
     >>> allHarmonies = checker.extractHarmonies(score)
@@ -209,7 +207,6 @@ def checkSinglePossibilities(music21Stream, functionToApply, color='#FF0000', de
     notes in the :class:`~music21.stream.Score` which comprise rule violations as determined by
     functionToApply.
 
-
     .. note:: Colored notes are NOT supported in Finale.
 
     >>> music21Stream = corpus.parse('corelli/opus3no1/1grave').measures(1, 6)
@@ -217,7 +214,6 @@ def checkSinglePossibilities(music21Stream, functionToApply, color='#FF0000', de
 
     .. image:: images/figuredBass/corelli_grave2.*
             :width: 700
-
 
     >>> from music21.figuredBass import checker
     >>> functionToApply = checker.voiceCrossing
@@ -229,7 +225,6 @@ def checkSinglePossibilities(music21Stream, functionToApply, color='#FF0000', de
 
     Voice Crossing is present in the fifth measure between the first and second voices,
     and the notes in question are highlighted in the music21Stream.
-
 
     >>> #_DOCS_SHOW music21Stream.show()
 
@@ -273,7 +268,6 @@ def checkConsecutivePossibilities(music21Stream, functionToApply, color='#FF0000
     Changes the color of notes in the :class:`~music21.stream.Score` which comprise rule violations
     as determined by functionToApply.
 
-
     .. note:: Colored notes are NOT supported in Finale.
 
     >>> music21Stream = corpus.parse('theoryExercises/checker_demo.xml')
@@ -281,7 +275,6 @@ def checkConsecutivePossibilities(music21Stream, functionToApply, color='#FF0000
 
     .. image:: images/figuredBass/checker_demo.*
             :width: 700
-
 
     >>> from music21.figuredBass import checker
     >>> functionToApply = checker.parallelOctaves
@@ -295,7 +288,6 @@ def checkConsecutivePossibilities(music21Stream, functionToApply, color='#FF0000
     Parallel octaves can be found in the first measure, between the first two measures,
     and between the third and the fourth measure. The notes in question are highlighted
     in the music21Stream, as shown below.
-
 
     >>> #_DOCS_SHOW music21Stream.show()
 
@@ -399,7 +391,6 @@ def parallelFifths(possibA, possibB):
     Returns a list of (partNumberA, partNumberB) pairs, each representing
     two voices which form parallel fifths.
 
-
     If pitchA1 and pitchA2 in possibA are separated by
     a simple interval of a perfect fifth, and they move
     to a pitchB1 and pitchB2 in possibB also separated
@@ -414,27 +405,22 @@ def parallelFifths(possibA, possibB):
     >>> A4 = pitch.Pitch('A4')
     >>> B4 = pitch.Pitch('B4')
 
-
     Here, the bass moves from C3 to D3 and the tenor moves
     from G3 to A3. The interval between C3 and G3, as well
     as between D3 and A3, is a perfect fifth. These two
     parts, and therefore the two possibilities, have
     parallel fifths.
 
-
     >>> possibA1 = (B4, G3, C3)
     >>> possibB1 = (A4, A3, D3)
     >>> checker.parallelFifths(possibA1, possibB1)
     [(2, 3)]
-
-
 
     Now, the tenor moves instead to F3. The interval between
     D3 and F3 is a minor third. The bass and tenor parts
     don't form parallel fifths. The soprano part forms parallel
     fifths with neither the bass nor tenor parts. The
     two possibilities, therefore, have no parallel fifths.
-
 
     >>> F3 = pitch.Pitch('F3')
     >>> possibA2 = (B4, G3, C3)
@@ -477,7 +463,6 @@ def hiddenFifth(possibA, possibB):
     a hidden fifth between shared outer parts of possibA and possibB. The
     outer parts here are the first and last elements of each possibility.
 
-
     If sopranoPitchA and bassPitchA in possibA move to a sopranoPitchB
     and bassPitchB in possibB in similar motion, and the simple interval
     between sopranoPitchB and bassPitchB is that of a perfect fifth,
@@ -491,22 +476,18 @@ def hiddenFifth(possibA, possibB):
     >>> E5 = pitch.Pitch('E5')
     >>> A5 = pitch.Pitch('A5')
 
-
     Here, the bass part moves up from C3 to D3 and the soprano part moves
     up from E5 to A5. The simple interval between D3 and A5 is a perfect
     fifth. Therefore, there is a hidden fifth between the two possibilities.
-
 
     >>> possibA1 = (E5, E3, C3)
     >>> possibB1 = (A5, F3, D3)
     >>> checker.hiddenFifth(possibA1, possibB1)
     [(1, 3)]
 
-
     Here, the soprano and bass parts also move in similar motion, but the
     simple interval between D3 and Ab5 is a diminished fifth. Consequently,
     there is no hidden fifth.
-
 
     >>> Ab5 = pitch.Pitch('A-5')
     >>> possibA2 = (E5, E3, C3)
@@ -514,11 +495,9 @@ def hiddenFifth(possibA, possibB):
     >>> checker.hiddenFifth(possibA2, possibB2)
     []
 
-
     Now, we have the soprano and bass parts again moving to A5 and D3, whose
     simple interval is a perfect fifth. However, the bass moves up while the
     soprano moves down. Therefore, there is no hidden fifth.
-
 
     >>> E6 = pitch.Pitch('E6')
     >>> possibA3 = (E6, E3, C3)
@@ -557,7 +536,6 @@ def parallelOctaves(possibA, possibB):
     Returns a list of (partNumberA, partNumberB) pairs, each representing
     two voices which form parallel octaves.
 
-
     If pitchA1 and pitchA2 in possibA are separated by
     a simple interval of a perfect octave, and they move
     to a pitchB1 and pitchB2 in possibB also separated
@@ -572,18 +550,15 @@ def parallelOctaves(possibA, possibB):
     >>> C4 = pitch.Pitch('C4')
     >>> D4 = pitch.Pitch('D4')
 
-
     Here, the soprano moves from C4 to D4 and the bass moves
     from C3 to D3. The interval between C3 and C4, as well as
     between D3 and D4, is a parallel octave. The two parts,
     and therefore the two possibilities, have parallel octaves.
 
-
     >>> possibA1 = (C4, G3, C3)
     >>> possibB1 = (D4, A3, D3)
     >>> checker.parallelOctaves(possibA1, possibB1)
     [(1, 3)]
-
 
     Now, the soprano moves down to B3. The interval between
     D3 and B3 is a major sixth. The soprano and bass parts
@@ -592,7 +567,6 @@ def parallelOctaves(possibA, possibB):
     so the two possibilities do not have parallel octaves.
     (Notice, however, the parallel fifth between the bass
     and tenor!)
-
 
     >>> B3 = pitch.Pitch('B3')
     >>> possibA2 = (C4, G3, C3)
@@ -635,7 +609,6 @@ def hiddenOctave(possibA, possibB):
     a hidden octave between shared outer parts of possibA and possibB. The
     outer parts here are the first and last elements of each possibility.
 
-
     If sopranoPitchA and bassPitchA in possibA move to a sopranoPitchB
     and bassPitchB in possibB in similar motion, and the simple interval
     between sopranoPitchB and bassPitchB is that of a perfect octave,
@@ -649,22 +622,18 @@ def hiddenOctave(possibA, possibB):
     >>> A5 = pitch.Pitch('A5')
     >>> D6 = pitch.Pitch('D6')
 
-
     Here, the bass part moves up from C3 to D3 and the soprano part moves
     up from A5 to D6. The simple interval between D3 and D6 is a perfect
     octave. Therefore, there is a hidden octave between the two possibilities.
-
 
     >>> possibA1 = (A5, E3, C3)
     >>> possibB1 = (D6, F3, D3)  # Perfect octave between soprano and bass.
     >>> checker.hiddenOctave(possibA1, possibB1)
     [(1, 3)]
 
-
     Here, the bass part moves up from C3 to D3 but the soprano part moves
     down from A6 to D6. There is no hidden octave since the parts move in
     contrary motion.
-
 
     >>> A6 = pitch.Pitch('A6')
     >>> possibA2 = (A6, E3, C3)

--- a/music21/figuredBass/examples.py
+++ b/music21/figuredBass/examples.py
@@ -45,7 +45,6 @@ def exampleA():
     The soprano part is limited to stepwise motion, and the alto and tenor parts are
     limited to motions within a perfect octave.
 
-
     >>> from music21.figuredBass import rules
     >>> fbRules = rules.Rules()
     >>> fbRules.partMovementLimits = [(1, 2), (2, 12), (3, 12)]
@@ -57,10 +56,8 @@ def exampleA():
     .. image:: images/figuredBass/fbExamples_sol1A.*
             :width: 700
 
-
     Now, the restriction on upper parts being within a perfect octave of each other is
     removed, and fbLine is realized again.
-
 
     >>> fbRules.upperPartsMaxSemitoneSeparation = None
     >>> fbRealization2 = fbLine.realize(fbRules)
@@ -155,7 +152,6 @@ def exampleB():
 
     First, fbLine is realized with the default rules set.
 
-
     >>> fbRealization1 = fbLine.realize()
     >>> fbRealization1.getNumSolutions()
     422
@@ -164,10 +160,8 @@ def exampleB():
     .. image:: images/figuredBass/fbExamples_sol1B.*
         :width: 700
 
-
     Now, a Rules object is created, and the restriction that the chords
     need to be complete is lifted. fbLine is realized once again.
-
 
     >>> from music21.figuredBass import rules
     >>> fbRules = rules.Rules()
@@ -208,7 +202,6 @@ def exampleC():
 
     .. image:: images/figuredBass/fbExamples_sol1C.*
         :width: 700
-
 
     Now, parallel fifths are allowed in realizations. The image below
     shows one of them. There is a parallel fifth between the bass and
@@ -264,7 +257,6 @@ def viio65ResolutionExample():
     :attr:`~music21.figuredBass.rules.Rules.doubledRootInDim7`.
     However, when resolving a diminished 6,5, the third is found in the bass and the
     proper resolution is determined in context, regardless of user preference.
-
 
     The following shows both cases involving a diminished 6,5. The resolution of the
     first diminished chord has a doubled D, while that of the second has a doubled F#.
@@ -329,7 +321,6 @@ def italianA6ResolutionExample():
     chord could map internally to two different resolutions.
     Every other special resolution in fbRealizer
     consists of a 1:1 mapping of special chords to resolutions.
-
 
     Here, the It+6 chord is resolving to the dominant, minor tonic,
     and major tonic, respectively. In the

--- a/music21/figuredBass/notation.py
+++ b/music21/figuredBass/notation.py
@@ -267,7 +267,6 @@ class Notation(prebase.ProtoM21Object):
         >>> notation2.origModStrings
         ('-', '-')
 
-
         An example of a seventh chord with extender:
 
         >>> notation3 = n.Notation('7_')
@@ -420,7 +419,6 @@ class Notation(prebase.ProtoM21Object):
         '''
         Turns the numbers and Modifier objects into Figure objects, each corresponding
         to a number with its Modifier.
-
 
         >>> from music21.figuredBass import notation as n
         >>> notation2 = n.Notation('-6,-')  #__init__ method calls _getFigures()
@@ -583,7 +581,6 @@ class Modifier(prebase.ProtoM21Object):
     :attr:`~music21.figuredBass.notation.Notation.notationColumn`)
     to an :class:`~music21.pitch.Accidental`. A ModifierException
     is raised if the modifierString is not valid.
-
 
     Accepted inputs are those accepted by Accidental, as well as the following:
 

--- a/music21/figuredBass/possibility.py
+++ b/music21/figuredBass/possibility.py
@@ -14,10 +14,8 @@ the ordering of a possibility does matter. The assumption throughout fbRealizer
 is that a possibility is always in order from the highest part to the lowest part, and
 the last element of each possibility is the bass.
 
-
 .. note:: fbRealizer supports voice crossing, so the order of pitches from lowest
     to highest may not correspond to the ordering of parts.
-
 
 Here, a possibility is created. G5 is in the highest part, and C4 is the bass. The highest
 part contains the highest Pitch, and the lowest part contains the lowest Pitch. No voice
@@ -29,38 +27,29 @@ crossing is present.
 >>> C4 = pitch.Pitch('C4')
 >>> p1 = (G5, C5, E4, C4)
 
-
 Here, another possibility is created with the same pitches, but this time,
 with voice crossing present.
 C5 is in the highest part, but the highest Pitch G5 is in the second highest part.
 
-
 >>> p2 = (C5, G5, E4, C4)
-
 
 The methods in this module are applied to possibilities, and fall into three main categories:
 
-
 1) Single Possibility Methods. These methods are applied in finding correct possibilities in
 :meth:`~music21.figuredBass.segment.Segment.allCorrectSinglePossibilities`.
-
 
 2) Consecutive Possibility Methods. These methods are applied to (possibA, possibB) pairs
 in :meth:`~music21.figuredBass.segment.Segment.allCorrectConsecutivePossibilities`,
 possibA being any correct possibility in segmentA and possibB being any correct possibility
 in segmentB.
 
-
 3) Special Resolution Methods. These methods are applied in
 :meth:`~music21.figuredBass.segment.Segment.allCorrectConsecutivePossibilities`
 as applicable if the pitch names of a Segment correctly spell out an augmented sixth, dominant
 seventh, or diminished seventh chord. They are located in :mod:`~music21.figuredBass.resolution`.
 
-
 The application of these methods is controlled by corresponding instance variables in a
 :class:`~music21.figuredBass.rules.Rules` object provided to a Segment.
-
-
 
 .. note:: The number of parts and maxPitch are universal for a
     :class:`~music21.figuredBass.realizer.FiguredBassLine`.
@@ -118,7 +107,6 @@ def isIncomplete(possibA, pitchNamesToContain):
     For a Segment, pitchNamesToContain is
     :attr:`~music21.figuredBass.segment.Segment.pitchNamesInChord`.
 
-
     If possibA contains excessive pitch names, a PossibilityException is
     raised, although this is not a concern with the current implementation
     of fbRealizer.
@@ -175,9 +163,7 @@ def upperPartsWithinLimit(possibA, maxSemitoneSeparation=12):
     >>> possibility.upperPartsWithinLimit(possibA1)
     True
 
-
     Here, C5 and E3 are separated by almost two octaves.
-
 
     >>> possibA2 = (C5, G4, E3, C3)
     >>> possibility.upperPartsWithinLimit(possibA2)
@@ -209,11 +195,9 @@ def pitchesWithinLimit(possibA, maxPitch=DEFAULT_MAX_PITCH):
     comparison methods, which are based on pitch space values
     (see :class:`~music21.pitch.Pitch`).
 
-
     Used in :class:`~music21.figuredBass.segment.Segment` to filter
     resolutions of special Segments which can have pitches exceeding
     the universal maxPitch of a :class:`~music21.figuredBass.realizer.FiguredBassLine`.
-
 
     >>> from music21.figuredBass import possibility
     >>> from music21.figuredBass import resolution
@@ -287,13 +271,11 @@ def parallelFifths(possibA, possibB):
     Returns True if there are parallel fifths between any
     two shared parts of possibA and possibB.
 
-
     If pitchA1 and pitchA2 in possibA are separated by
     a simple interval of a perfect fifth, and they move
     to a pitchB1 and pitchB2 in possibB also separated
     by the simple interval of a perfect fifth, then this
     constitutes parallel fifths between these two parts.
-
 
     If the method returns False, then no two shared parts
     have parallel fifths. The method returns True as soon
@@ -307,27 +289,22 @@ def parallelFifths(possibA, possibB):
     >>> A4 = pitch.Pitch('A4')
     >>> B4 = pitch.Pitch('B4')
 
-
     Here, the bass moves from C3 to D3 and the tenor moves
     from G3 to A3. The interval between C3 and G3, as well
     as between D3 and A3, is a perfect fifth. These two
     parts, and therefore the two possibilities, have
     parallel fifths.
 
-
     >>> possibA1 = (B4, G3, C3)
     >>> possibB1 = (A4, A3, D3)
     >>> possibility.parallelFifths(possibA1, possibB1)
     True
-
-
 
     Now, the tenor moves instead to F3. The interval between
     D3 and F3 is a minor third. The bass and tenor parts
     don't form parallel fifths. The soprano part forms parallel
     fifths with neither the bass nor tenor parts. The
     two possibilities, therefore, have no parallel fifths.
-
 
     >>> F3 = pitch.Pitch('F3')
     >>> possibA2 = (B4, G3, C3)
@@ -367,13 +344,11 @@ def parallelOctaves(possibA, possibB):
     Returns True if there are parallel octaves between any
     two shared parts of possibA and possibB.
 
-
     If pitchA1 and pitchA2 in possibA are separated by
     a simple interval of a perfect octave, and they move
     to a pitchB1 and pitchB2 in possibB also separated
     by the simple interval of a perfect octave, then this
     constitutes parallel octaves between these two parts.
-
 
     If the method returns False, then no two shared parts
     have parallel octaves. The method returns True as soon
@@ -387,18 +362,15 @@ def parallelOctaves(possibA, possibB):
     >>> C4 = pitch.Pitch('C4')
     >>> D4 = pitch.Pitch('D4')
 
-
     Here, the soprano moves from C4 to D4 and the bass moves
     from C3 to D3. The interval between C3 and C4, as well as
     between D3 and D4, is a parallel octave. The two parts,
     and therefore the two possibilities, have parallel octaves.
 
-
     >>> possibA1 = (C4, G3, C3)
     >>> possibB1 = (D4, A3, D3)
     >>> possibility.parallelOctaves(possibA1, possibB1)
     True
-
 
     Now, the soprano moves down to B3. The interval between
     D3 and B3 is a major sixth. The soprano and bass parts
@@ -407,7 +379,6 @@ def parallelOctaves(possibA, possibB):
     so the two possibilities do not have parallel octaves.
     (Notice, however, the parallel fifth between the bass
     and tenor!)
-
 
     >>> B3 = pitch.Pitch('B3')
     >>> possibA2 = (C4, G3, C3)
@@ -448,7 +419,6 @@ def hiddenFifth(possibA, possibB):
     of possibA and possibB. The outer parts here are the first and last
     elements of each possibility.
 
-
     If sopranoPitchA and bassPitchA in possibA move to a sopranoPitchB
     and bassPitchB in possibB in similar motion, and the simple interval
     between sopranoPitchB and bassPitchB is that of a perfect fifth,
@@ -462,22 +432,18 @@ def hiddenFifth(possibA, possibB):
     >>> E5 = pitch.Pitch('E5')
     >>> A5 = pitch.Pitch('A5')
 
-
     Here, the bass part moves up from C3 to D3 and the soprano part moves
     up from E5 to A5. The simple interval between D3 and A5 is a perfect
     fifth. Therefore, there is a hidden fifth between the two possibilities.
-
 
     >>> possibA1 = (E5, E3, C3)
     >>> possibB1 = (A5, F3, D3)
     >>> possibility.hiddenFifth(possibA1, possibB1)
     True
 
-
     Here, the soprano and bass parts also move in similar motion, but the
     simple interval between D3 and Ab5 is a diminished fifth. Consequently,
     there is no hidden fifth.
-
 
     >>> Ab5 = pitch.Pitch('A-5')
     >>> possibA2 = (E5, E3, C3)
@@ -485,11 +451,9 @@ def hiddenFifth(possibA, possibB):
     >>> possibility.hiddenFifth(possibA2, possibB2)
     False
 
-
     Now, we have the soprano and bass parts again moving to A5 and D3, whose
     simple interval is a perfect fifth. However, the bass moves up while the
     soprano moves down. Therefore, there is no hidden fifth.
-
 
     >>> E6 = pitch.Pitch('E6')
     >>> possibA3 = (E6, E3, C3)
@@ -522,7 +486,6 @@ def hiddenOctave(possibA, possibB):
     of possibA and possibB. The outer parts here are the first and last
     elements of each possibility.
 
-
     If sopranoPitchA and bassPitchA in possibA move to a sopranoPitchB
     and bassPitchB in possibB in similar motion, and the simple interval
     between sopranoPitchB and bassPitchB is that of a perfect octave,
@@ -536,22 +499,18 @@ def hiddenOctave(possibA, possibB):
     >>> A5 = pitch.Pitch('A5')
     >>> D6 = pitch.Pitch('D6')
 
-
     Here, the bass part moves up from C3 to D3 and the soprano part moves
     up from A5 to D6. The simple interval between D3 and D6 is a perfect
     octave. Therefore, there is a hidden octave between the two possibilities.
-
 
     >>> possibA1 = (A5, E3, C3)
     >>> possibB1 = (D6, F3, D3)  # Perfect octave between soprano and bass.
     >>> possibility.hiddenOctave(possibA1, possibB1)
     True
 
-
     Here, the bass part moves up from C3 to D3 but the soprano part moves
     down from A6 to D6. There is no hidden octave since the parts move in
     contrary motion.
-
 
     >>> A6 = pitch.Pitch('A6')
     >>> possibA2 = (A6, E3, C3)
@@ -583,21 +542,16 @@ def voiceOverlap(possibA, possibB):
     Returns True if there is voice overlap between any two shared parts
     of possibA and possibB.
 
-
     Voice overlap can occur in two ways:
-
 
     1) If a pitch in a lower part in possibB is higher than a pitch in
     a higher part in possibA. This case is demonstrated below.
 
-
     2) If a pitch in a higher part in possibB is lower than a pitch in
     a lower part in possibA.
 
-
         .. image:: images/figuredBass/fbPossib_voiceOverlap.*
             :width: 75
-
 
     In the above example, possibA has G4 in the bass and B4 in the soprano.
     If the bass moves up to C5 in possibB, that would constitute voice overlap
@@ -611,12 +565,10 @@ def voiceOverlap(possibA, possibB):
     >>> G4 = pitch.Pitch('G4')
     >>> C5 = pitch.Pitch('C5')
 
-
     Here, case #2 is demonstrated. There is overlap between the soprano and
     alto parts, because F4 in the soprano in possibB1 is lower than the G4
     in the alto in possibA1. Note that neither possibility has to have voice
     crossing for voice overlap to occur, as shown.
-
 
     >>> possibA1 = (C5, G4, E4, C4)
     >>> possibB1 = (F4, F4, D4, D4)
@@ -627,11 +579,9 @@ def voiceOverlap(possibA, possibB):
     >>> possibility.voiceCrossing(possibB1)
     False
 
-
     Here is the same example as above, except the soprano of the second
     possibility is now B4, which does not overlap the G4 of the first.
     Now, there is no voice overlap.
-
 
     >>> B4 = pitch.Pitch('B4')
     >>> possibA2 = (C5, G4, E4, C4)
@@ -795,19 +745,16 @@ def couldBeItalianA6Resolution(possibA, possibB, threePartChordInfo=None, restri
     >>> possibility.couldBeItalianA6Resolution(possibA1, possibB3)
     True
 
-
     A PossibilityException is raised if possibA is not an Italian A6 chord, but this only
     applies if `threePartChordInfo=None`, because otherwise the chord information is
     coming from :class:`~music21.figuredBass.segment.Segment` and the fact that possibA is
     an It+6 chord is assumed.
-
 
     >>> possibA2 = (Gs4, E4, D4, Bb2)
     >>> possibB2 = (A4, E4, Cs4, A2)
     >>> possibility.couldBeItalianA6Resolution(possibA2, possibB2)
     Traceback (most recent call last):
     music21.figuredBass.possibility.PossibilityException: possibA does not spell out an It+6 chord.
-
 
     The method is called `couldBeItalianA6Resolution` as opposed
     to `isItalianA6Resolution` because it is designed to work in
@@ -816,7 +763,6 @@ def couldBeItalianA6Resolution(possibA, possibB, threePartChordInfo=None, restri
     a Segment. Consider the following examples with possibA1 above as the
     augmented sixth chord to resolve.
 
-
     >>> possibA1 = (Gs4, D4, D4, Bb2)
     >>> possibB4 = (A4, D4, D4, A2)  # No 3rd
     >>> possibB5 = (A4, Cs4, Cs4, A2)  # No 5th
@@ -824,7 +770,6 @@ def couldBeItalianA6Resolution(possibA, possibB, threePartChordInfo=None, restri
     True
     >>> possibility.couldBeItalianA6Resolution(possibA1, possibB5)  # parallel octaves
     True
-
 
     >>> possibA3 = (Gs4, Gs4, D4, Bb2)
     >>> possibB6 = (A4, A4, Cs4, A2)

--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -27,11 +27,9 @@ from start to finish. See :class:`~music21.figuredBass.realizer.FiguredBassLine`
     .. image:: images/figuredBass/fbRealizer_intro.*
         :width: 500
 
-
 The same can be accomplished by taking the notes and notations
 from a :class:`~music21.stream.Stream`.
 See :meth:`~music21.figuredBass.realizer.figuredBassFromStream` for more details.
-
 
 >>> s = converter.parse('tinynotation: C4 D4_4,3 C2', makeNotation=False)
 >>> fbLine = realizer.figuredBassFromStream(s)
@@ -197,7 +195,6 @@ class FiguredBassLine:
     :attr:`~music21.note.GeneralNote.quarterLength` or duration of a realization above a bassNote
     is identical to that of the bassNote.
 
-
     `inKey` defaults to C major.
 
     `inTime` defaults to 4/4.
@@ -240,7 +237,6 @@ class FiguredBassLine:
         '''
         Use this method to add (bassNote, notationString) pairs to the bass line. Elements
         are realized in the order they are added.
-
 
         >>> from music21.figuredBass import realizer
         >>> fbLine = realizer.FiguredBassLine(key.Key('B'), meter.TimeSignature('3/4'))
@@ -289,7 +285,6 @@ class FiguredBassLine:
 
         .. image:: images/figuredBass/fbRealizer_bassLine.*
             :width: 200
-
 
         >>> sBach = corpus.parse('bach/bwv307')
         >>> sBach.parts.last().measure(0).show('text')
@@ -548,7 +543,6 @@ class Realization:
     :meth:`~music21.figuredBass.realizer.FiguredBassLine.realize`. Allows for the
     generation of realizations as a :class:`~music21.stream.Score`.
 
-
     * See the :mod:`~music21.figuredBass.examples` module for examples on the generation
       of realizations.
     * A possibility progression is a valid progression through a string of
@@ -628,7 +622,6 @@ class Realization:
         '''
         Compiles each unique possibility progression, adding
         it to a master list. Returns the master list.
-
 
         .. warning:: This method is unoptimized, and may take a prohibitive amount
             of time for a Realization which has more than 200,000 solutions.
@@ -756,7 +749,6 @@ class Realization:
         '''
         Generates all unique realizations as a :class:`~music21.stream.Score`.
 
-
         .. warning:: This method is unoptimized, and may take a prohibitive amount
             of time for a Realization which has more than 100 solutions.
         '''
@@ -787,7 +779,6 @@ class Realization:
     def generateRandomRealizations(self, amountToGenerate=20):
         '''
         Generates *amountToGenerate* unique realizations as a :class:`~music21.stream.Score`.
-
 
         .. warning:: This method is unoptimized, and may take a prohibitive amount
             of time if amountToGenerate is more than 100.

--- a/music21/figuredBass/realizerScale.py
+++ b/music21/figuredBass/realizerScale.py
@@ -34,7 +34,6 @@ class FiguredBassScale:
     Acts as a wrapper for :class:`~music21.scale.Scale`. Used to represent the
     concept of a figured bass scale, with a scale value and mode.
 
-
     Accepted scale types: major, minor, dorian, phrygian, and hypophrygian.
     A FiguredBassScaleException is raised if an invalid scale type is provided.
 

--- a/music21/figuredBass/resolution.py
+++ b/music21/figuredBass/resolution.py
@@ -77,7 +77,6 @@ def augmentedSixthToDominant(
         .. image:: images/figuredBass/fbResolution_a6toV.*
             :width: 700
 
-
     Above: French, German, and Swiss resolutions, respectively.
     '''
     if augSixthChordInfo is None:
@@ -131,7 +130,6 @@ def augmentedSixthToMajorTonic(
     Resolves French (augSixthType = 1), German (augSixthType = 2), and Swiss (augSixthType = 3)
     augmented sixth chords to the major tonic 6,4.
 
-
     Proper Italian augmented sixth resolutions not supported within this method.
 
     >>> from music21.figuredBass import resolution
@@ -160,7 +158,6 @@ def augmentedSixthToMajorTonic(
 
         .. image:: images/figuredBass/fbResolution_a6toI.*
             :width: 700
-
 
     Above: French, German, and Swiss resolutions, respectively.
     '''
@@ -246,7 +243,6 @@ def augmentedSixthToMinorTonic(
         .. image:: images/figuredBass/fbResolution_a6toIm.*
             :width: 700
 
-
     Above: French, German, and Swiss resolutions, respectively.
     '''
     if augSixthChordInfo is None:
@@ -296,7 +292,6 @@ def dominantSeventhToMajorTonic(domPossib, resolveV43toI6=False, domChordInfo=No
     '''
     Resolves a dominant seventh chord in root position or any of its
     inversions to the major tonic, in root position or first inversion.
-
 
     The second inversion (4,3) dominant seventh chord can resolve to
     the tonic in either inversion. This is controlled by
@@ -371,7 +366,6 @@ def dominantSeventhToMinorTonic(domPossib, resolveV43toi6=False, domChordInfo=No
     Resolves a dominant seventh chord in root position or any of its
     inversions to the minor tonic, in root position or first inversion,
     accordingly.
-
 
     The second inversion (4,3) dominant seventh chord can resolve to
     the tonic in either inversion. This is controlled by
@@ -587,7 +581,6 @@ def diminishedSeventhToMajorTonic(dimPossib, doubledRoot=False, dimChordInfo=Non
     Resolves a fully diminished seventh chord to the major tonic,
     in root position or either inversion.
 
-
     The resolution of the diminished seventh chord can have a
     doubled third (standard resolution) or a doubled root
     (alternate resolution), because the third of the diminished
@@ -632,7 +625,6 @@ def diminishedSeventhToMinorTonic(dimPossib, doubledRoot=False, dimChordInfo=Non
     '''
     Resolves a fully diminished seventh chord to the minor tonic,
     in root position or either inversion.
-
 
     The resolution of the diminished seventh chord can have a
     doubled third (standard resolution) or a doubled root

--- a/music21/figuredBass/rules.py
+++ b/music21/figuredBass/rules.py
@@ -104,16 +104,13 @@ class Rules(prebase.ProtoM21Object):
     and controls the application of methods designed to filter out undesired possibilities in
     a single Segment or undesired progressions between two consecutive Segments.
 
-
     The rules are categorized in an identical manner to methods
     in :mod:`~music21.figuredBass.possibility`:
-
 
     1) Single Possibility Rules. These rules apply to any possibility within a
     single Segment (possibA), and
     are applied in finding correct possibilities for a Segment
     in :meth:`~music21.figuredBass.segment.Segment.allCorrectSinglePossibilities`.
-
 
     2) Consecutive Possibility Rules. These rules apply between any correct
     single possibility in segmentA
@@ -123,13 +120,11 @@ class Rules(prebase.ProtoM21Object):
     two Segments
     in :meth:`~music21.figuredBass.segment.Segment.allCorrectConsecutivePossibilities`.
 
-
     3) Special Resolution Rules. These rules apply to Segments
     whose :attr:`~music21.figuredBass.segment.Segment.segmentChord` is an
     augmented sixth, dominant seventh, or diminished seventh chord, and are
     applied as necessary in
     :meth:`~music21.figuredBass.segment.Segment.allCorrectConsecutivePossibilities`.
-
 
     >>> from music21.figuredBass import rules
     >>> fbRules = rules.Rules()

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -91,7 +91,6 @@ class Segment:
         if fbRules is None, a rules.Rules() instance is created.  Each Segment gets
         its own deepcopy of the one given.
 
-
         Here, a Segment is created using the default values: a FiguredBassScale in C,
         a bassNote of C3, an empty notationString, and a default
         Rules object.
@@ -302,9 +301,7 @@ class Segment:
 
         Items are added within this method in the following form:
 
-
         (willRunOnlyIfTrue, methodToRun, optionalArgs)
-
 
         These items are compiled internally
         when :meth:`~music21.figuredBass.segment.Segment.allCorrectConsecutivePossibilities`
@@ -552,7 +549,6 @@ class Segment:
         is resolved
         as an ordinary Segment.
 
-
         >>> from music21.figuredBass import segment
         >>> segmentA = segment.Segment(bassNote=note.Note('A-2'), notationString='#6,b5,3')
         >>> segmentA.pitchNamesInChord  # spell out a Gr+6 chord
@@ -638,13 +634,11 @@ class Segment:
         >>> allPossib.__class__
         <... 'itertools.product'>
 
-
         The number of naive possibilities is always the length of
         :attr:`~music21.figuredBass.segment.Segment.allPitchesAboveBass`
         raised to the (:attr:`~music21.figuredBass.segment.Segment.numParts` - 1)
         power. The power is 1 less than the number of parts because
         the bass pitch is constant.
-
 
         >>> allPossibList = list(allPossib)
         >>> len(segmentA.allPitchesAboveBass)
@@ -673,16 +667,13 @@ class Segment:
         a Segment, all possibilities which pass all filters in
         :meth:`~music21.figuredBass.segment.Segment.singlePossibilityRules`.
 
-
         >>> from music21.figuredBass import segment
         >>> segmentA = segment.Segment()
         >>> allPossib = segmentA.allSinglePossibilities()
         >>> allCorrectPossib = segmentA.allCorrectSinglePossibilities()
 
-
         Most of the 729 naive possibilities were filtered out using the default rules set,
         leaving only 21.
-
 
         >>> allPossibList = list(allPossib)
         >>> len(allPossibList)
@@ -798,7 +789,6 @@ class Segment:
         '''
         An ordinary segment is defined as a segment which needs no special resolution, where the
         segment does not spell out a special chord, for example, a dominant seventh.
-
 
         Finds iterators through all possibA and possibB by calling
         :meth:`~music21.figuredBass.segment.Segment.allCorrectSinglePossibilities`

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -163,7 +163,6 @@ class StreamFreezer(StreamFreezeThawBase):
     {6.0} <music21.note.Note F#>
     {7.0} <music21.note.Note G>
 
-
     >>> c = corpus.parse('luca/gloria')
     >>> sf = freezeThaw.StreamFreezer(c)
     >>> data = sf.writeStr(fmt='pickle')
@@ -492,7 +491,6 @@ class StreamFreezer(StreamFreezeThawBase):
 
         if hierarchyObject is None, uses self.stream.
 
-
         >>> sc = stream.Score()
         >>> p1 = stream.Part()
         >>> p2 = stream.Part()
@@ -799,7 +797,6 @@ class StreamThawer(StreamFreezeThawBase):
         _storedElementOffsetTuples
         and restore it to the ._elements and ._endElements lists
         in the proper locations:
-
 
         >>> s = stream.Measure()
         >>> s._elements, s._endElements

--- a/music21/graph/__init__.py
+++ b/music21/graph/__init__.py
@@ -119,7 +119,6 @@ def plotStream(
     * :class:`~music21.graph.plot.WindowedAmbitus`
     * :class:`~music21.graph.plot.Dolan`
 
-
     >>> s = corpus.parse('bach/bwv324.xml') #_DOCS_HIDE
     >>> thePlot = s.plot('histogram', 'pitch', doneAction=None) #_DOCS_HIDE
     >>> #_DOCS_SHOW s = corpus.parse('bach/bwv57.8')
@@ -127,7 +126,6 @@ def plotStream(
 
     .. image:: images/HistogramPitchSpace.*
         :width: 600
-
 
     >>> s = corpus.parse('bach/bwv324.xml') #_DOCS_HIDE
     >>> thePlot = s.plot('pianoroll', doneAction=None) #_DOCS_HIDE

--- a/music21/graph/axis.py
+++ b/music21/graph/axis.py
@@ -493,7 +493,6 @@ class PitchClassAxis(PitchAxis):
         9 A
         11 B
 
-
         >>> s = corpus.parse('bach/bwv281.xml')
         >>> plotS = graph.plot.PlotStream(s)
         >>> ax = graph.axis.PitchClassAxis(plotS)
@@ -567,7 +566,6 @@ class PitchClassAxis(PitchAxis):
         9 A
         10 B♭
         11 B
-
 
         OMIT_FROM_DOCS
 
@@ -857,7 +855,6 @@ class OffsetAxis(PositionAxis):
         >>> ax.ticks()
         [(0.0, '0'), (9.0, '3'), (21.0, '6'), (29.0, '8')]
 
-
         We can also plot on a part:
 
         >>> soprano = bach.parts.first()
@@ -874,7 +871,6 @@ class OffsetAxis(PositionAxis):
         >>> ax.ticks()
         [(0.0, '0'), (29.0, '8')]
 
-
         Only show ticks between minValue and maxValue (in offsets):
 
         >>> ax.minMaxMeasureOnly = False
@@ -882,7 +878,6 @@ class OffsetAxis(PositionAxis):
         >>> ax.maxValue = 12
         >>> ax.ticks()
         [(9.0, '3')]
-
 
         Double bars and other heavy bars always show up.
         (Let's get a new axis object to see.)

--- a/music21/graph/findPlot.py
+++ b/music21/graph/findPlot.py
@@ -110,7 +110,6 @@ def getAxisQuantities(synonyms=False, axesToCheck=None):
     ['count', 'quantity', 'frequency', 'counting',
      'offset', 'measure', 'offsets', 'measures', 'time']
 
-
     '''
     if axesToCheck is None:
         axesToCheck = getAxisClasses()
@@ -217,7 +216,6 @@ def axisMatchesValue(axisClass: type[axis.Axis]|axis.Axis,
     >>> graph.findPlot.axisMatchesValue(ax, 'offset')
     False
 
-
     Works on an instantiated object as well:
 
     >>> ax = graph.axis.CountingAxis()
@@ -246,9 +244,7 @@ def getPlotsToMake(graphFormat: str|None = None,
     or a list of tuples where the first element of each tuple is the plot class
     and the second is a dict of {'x': axisXClass, 'y': axisYClass} etc.
 
-
     Default is pianoroll
-
 
     >>> graph.findPlot.getPlotsToMake()
     [<class 'music21.graph.plot.HorizontalBarPitchSpaceOffset'>]
@@ -289,7 +285,6 @@ def getPlotsToMake(graphFormat: str|None = None,
     [(<class 'music21.graph.plot.Scatter'>,
       OrderedDict([('x', <class 'music21.graph.axis.OffsetAxis'>),
                    ('y', <class 'music21.graph.axis.DynamicsAxis'>)]))]
-
 
     Just a couple of values:
 

--- a/music21/graph/plot.py
+++ b/music21/graph/plot.py
@@ -990,7 +990,6 @@ class WindowedKey(WindowedAnalysis):
     Stream plotting of windowed version of Krumhansl-Schmuckler analysis routine.
     See :class:`~music21.analysis.discrete.KrumhanslSchmuckler` for more details.
 
-
     >>> s = corpus.parse('bach/bwv66.6')
     >>> p = graph.plot.WindowedKey(s.parts[0])
     >>> p.doneAction = None #_DOCS_HIDE
@@ -1280,7 +1279,6 @@ class Dolan(HorizontalBarWeighted):
 
     Numerous parameters can be configured based on functionality encoded in
     the :class:`~music21.analysis.reduction.PartReduction` object.
-
 
     If the `fillByMeasure` parameter is True, and if measures are available, each part
     will segment by Measure divisions, and look for the target activity only once per

--- a/music21/graph/primitives.py
+++ b/music21/graph/primitives.py
@@ -615,7 +615,6 @@ class GraphColorGrid(Graph):
     Data is provided as a list of lists of colors, where colors are specified as a hex triplet,
     or the common HTML color codes, and based on analysis-specific mapping of colors to results.
 
-
     >>> #_DOCS_SHOW g = graph.primitives.GraphColorGrid()
     >>> g = graph.primitives.GraphColorGrid(doneAction=None) #_DOCS_HIDE
     >>> data = [['#55FF00', '#9b0000', '#009b00'],
@@ -1388,7 +1387,6 @@ class GraphHistogram(Graph):
     Data set is simply a list of x and y pairs, where there
     is only one of each x value, and y value is the count or magnitude
     of that value
-
 
     >>> import random
     >>> g = graph.primitives.GraphHistogram()

--- a/music21/harmony.py
+++ b/music21/harmony.py
@@ -403,7 +403,6 @@ class Harmony(chord.Chord):
         >>> [str(p) for p in h1.pitches]
         ['D-2', 'F-2', 'A-2', 'C-3', 'E-3', 'G-3']
 
-
         But it should change the .romanNumeral object:
 
         >>> y = harmony.ChordSymbol('F')
@@ -933,7 +932,6 @@ def chordSymbolFigureFromChord(inChord: chord.Chord, includeChordType=False):
     >>> harmony.chordSymbolFigureFromChord(c, True)
     ('CmaddD', 'minor')
 
-
     ELEVENTHS
 
     >>> c = chord.Chord(['E-3', 'G3', 'B-3', 'D-4', 'F3', 'A-3'] )
@@ -1095,7 +1093,6 @@ def chordSymbolFigureFromChord(inChord: chord.Chord, includeChordType=False):
     <music21.pitch.Pitch C3>
     >>> c.bass()
     <music21.pitch.Pitch C3>
-
 
     >>> c = chord.Chord(['C3', 'F3', 'G3'])
     >>> harmony.chordSymbolFigureFromChord(c, True)
@@ -1603,7 +1600,6 @@ class ChordSymbol(Harmony):
     >>> [[str(c.name) for c in c.pitches] for c in initialSymbols]
     [['F', 'A', 'C'], ['B-', 'D', 'F'], ['F', 'A', 'C'], ['C', 'E', 'G'], ['F', 'A', 'C']]
 
-
     Test creating an empty chordSymbol:
 
     >>> cs = harmony.ChordSymbol()
@@ -1689,7 +1685,6 @@ class ChordSymbol(Harmony):
                 intervals except for a minor seventh)
             if `alter` or `subtract`:
                 degree-alter is relative to degree already in the chord based on its kind element
-
 
         FROM XML DOCUMENTATION
 

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -976,7 +976,6 @@ class GlobalCommentLine(HumdrumLine):
     The constructor can be passed (lineNumber, contents); if contents begins with
     bangs, they are removed along with up to one space directly afterwards.
 
-
     >>> com1 = humdrum.spineParser.GlobalCommentLine(
     ...          lineNumber=4, contents='!! this comment is global')
     >>> com1

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -339,7 +339,7 @@ class Test(unittest.TestCase):
 
     def testDynamAttachedAligned(self):
         '''
-        **dynam events on the same line as a kern note attach at that note's
+        ``**dynam`` events on the same line as a kern note attach at that note's
         offset.  Sanity-check companion to testDynamAttachedMisaligned.
 
         Test is AI-assisted.
@@ -368,7 +368,7 @@ class Test(unittest.TestCase):
                    'SpineCollection.attachNonKernEvents.')
     def testDynamAttachedMisaligned(self):
         '''
-        A **dynam event on a line where the kern column has '.' (no new note
+        A ``**dynam`` event on a line where the kern column has '.' (no new note
         event) should still attach -- to the stream at the offset of the most
         recently-sounding note.  Currently fails: misaligned dynamics are
         silently dropped.  See TODO in `SpineCollection.attachNonKernEvents`.
@@ -402,7 +402,7 @@ class Test(unittest.TestCase):
                    'SpineCollection.attachNonKernEvents.')
     def testHarmAttachedMisaligned(self):
         '''
-        A **harm event on a line where the kern column has '.' should still
+        A ``**harm`` event on a line where the kern column has '.' should still
         attach -- to the stream at the offset of the most recently-sounding
         note.  Currently fails: misaligned harm events are silently dropped.
         See TODO in `SpineCollection.attachNonKernEvents`.
@@ -518,7 +518,7 @@ class Test(unittest.TestCase):
 
     def testLyricsCorrectlyAligned(self):
         '''
-        Verify that each lyric syllable from a **text spine attaches to the
+        Verify that each lyric syllable from a ``**text`` spine attaches to the
         kern note on the same line.  Existing testLyricsInSpine only checks
         the assembled lyric string; this checks the per-note mapping.
 

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -259,8 +259,6 @@ class Instrument(base.Music21Object):
         >>> used
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11]
 
-
-
         Unpitched percussion will be set to 9, so long as it's not in the filter list:
 
         >>> used = [0]
@@ -2346,7 +2344,6 @@ def fromString(instrumentString: str,
     >>> t3
     <music21.instrument.Flute 'flauto 2'>
 
-
     Excess information is ignored, and the useful information can be extracted
     correctly as long as it's sequential.
 
@@ -2379,7 +2376,6 @@ def fromString(instrumentString: str,
     >>> t8.transposition
     <music21.interval.Interval m3>
 
-
     Note that because of the ubiquity of B-flat clarinets and trumpets, and the
     rareness of B-natural forms of those instruments, this gives a B-flat, not
     B-natural clarinet, using the German form:
@@ -2392,7 +2388,6 @@ def fromString(instrumentString: str,
 
     Use "H" or "b-natural" to get an instrument in B-major.  Or donate one to me,
     and I'll change this back!
-
 
     Standard abbreviations are acceptable:
 
@@ -2408,7 +2403,6 @@ def fromString(instrumentString: str,
     >>> t11.__class__ == t10.__class__
     True
 
-
     Previously an exact instrument name was not always working:
 
     >>> instrument.fromString('Flute')
@@ -2418,7 +2412,6 @@ def fromString(instrumentString: str,
 
     >>> instrument.fromString('Choir (Aahs)')
     <music21.instrument.Choir 'Choir (Aahs)'>
-
 
     By default, this function searches over all stored instrument names.
     This includes multiple languages as well as the abbreviations

--- a/music21/interval.py
+++ b/music21/interval.py
@@ -218,7 +218,6 @@ class Specifier(enum.IntEnum):
         >>> Specifier.MINOR.semitonesAboveMajor()
         -1
 
-
         Diminished intervals are below minor:
 
         >>> Specifier.DIMINISHED.semitonesAboveMajor()
@@ -838,7 +837,6 @@ class GenericInterval(IntervalBase):
     >>> complement12.staffDistance
     3
 
-
     Note this illegal interval:
 
     >>> zeroth = interval.GenericInterval(0)
@@ -859,7 +857,6 @@ class GenericInterval(IntervalBase):
     a Perfect Unison or an Augmented Unison (or Augmented Prime as some prefer)?
     Thus, the illegal check will be moved to a higher level Interval object.
 
-
     A second is a step:
 
     >>> second = interval.GenericInterval(2)
@@ -875,7 +872,6 @@ class GenericInterval(IntervalBase):
     False
     >>> third.isStep
     False
-
 
     Intervals more than three octaves use numbers with abbreviations instead of names
 
@@ -1662,7 +1658,6 @@ class DiatonicInterval(IntervalBase):
     >>> dimDescending.direction
     <Direction.DESCENDING: -1>
 
-
     This raises an error:
 
     >>> interval.DiatonicInterval('Perfect', -1)
@@ -2166,7 +2161,6 @@ class DiatonicInterval(IntervalBase):
         >>> di.transposePitch(p, inPlace=True)
         >>> p
         <music21.pitch.Pitch F#5>
-
 
         * Changed in v6: added inPlace.
         '''
@@ -4077,7 +4071,6 @@ def subtract(intervalList):
     <music21.interval.Interval A7>
     >>> interval.subtract(['P8', 'A1'])
     <music21.interval.Interval d8>
-
 
     >>> a = interval.subtract(['P5', 'A5'])
     >>> a.niceName

--- a/music21/key.py
+++ b/music21/key.py
@@ -488,7 +488,6 @@ class KeySignature(base.Music21Object):
         >>> [str(p) for p in g.alteredPitches]
         ['B-', 'E-', 'A-', 'D-', 'G-', 'C-', 'F-', 'B--']
 
-
         Non-standard, non-traditional key signatures can set their own
         altered pitches cache.
 
@@ -908,7 +907,6 @@ class Key(KeySignature, scale.DiatonicScale):
     >>> fFlatMaj.accidentalByStep('B')
     <music21.pitch.Accidental double-flat>
 
-
     >>> eDor = key.Key('E', 'dorian')
     >>> eDor
     <music21.key.Key of E dorian>
@@ -1209,7 +1207,6 @@ class Key(KeySignature, scale.DiatonicScale):
 
         >>> k.alternateInterpretations[-1]
         <music21.key.Key of F# major>
-
 
         Note that this method only exists if the key has come from an analysis method. Otherwise
         it raises a KeySignatureException

--- a/music21/layout.py
+++ b/music21/layout.py
@@ -208,7 +208,6 @@ class PageLayout(LayoutBase):
 
     PageLayout objects may be found on Measure or Part Streams.
 
-
     >>> pl = layout.PageLayout(pageNumber=4, leftMargin=234, rightMargin=124,
     ...                        pageHeight=4000, pageWidth=3000, isNew=True)
     >>> pl.pageNumber
@@ -264,7 +263,6 @@ class SystemLayout(LayoutBase):
     Importantly, if isNew is True then this object
     indicates that a new system should start here.
 
-
     >>> sl = layout.SystemLayout(leftMargin=234, rightMargin=124, distance=3, isNew=True)
     >>> sl.distance
     3
@@ -308,7 +306,6 @@ class StaffLayout(LayoutBase):
     The musicxml equivalent <staff-layout> lives in
     the <defaults> and in <print> attributes.
 
-
     >>> sl = layout.StaffLayout(distance=3, staffNumber=1, staffSize=113, staffLines=5)
     >>> sl.distance
     3
@@ -334,7 +331,6 @@ class StaffLayout(LayoutBase):
     113.0
     >>> sl
     <music21.layout.StaffLayout distance 3, staffNumber 1, staffSize 113.0, staffLines 5>
-
 
     StaffLayout can also specify the staffType:
 
@@ -519,13 +515,11 @@ def divideByPages(
     (because our spanner gathering algorithm is currently O(n^2);
     something TODO: to fix.)
 
-
     >>> lt = corpus.parse('demos/layoutTest.xml')
     >>> len(lt.parts)
     3
     >>> len(lt.parts[0].getElementsByClass(stream.Measure))
     80
-
 
     Divide the score up into layout.Page objects
 
@@ -551,7 +545,6 @@ def divideByPages(
     <music21.layout.Page ...>
     >>> 'Opus' in lastPage.classes
     True
-
 
     Each page now has Systems not parts.
 
@@ -786,7 +779,6 @@ class LayoutScore(stream.Opus):
 
         Similarly, the first systemId on each page will be 0
 
-
         >>> lt = corpus.parse('demos/layoutTest.xml')
         >>> l = layout.divideByPages(lt, fastMeasures=True)
         >>> l.getPageAndSystemNumberFromMeasureNumber(80)
@@ -833,7 +825,6 @@ class LayoutScore(stream.Opus):
         margins for a given pageId in tenths
 
         Default of (100, 100, 100, 100, 850, 1100) if undefined
-
 
         >>> #_DOCS_SHOW g = corpus.parse('luca/gloria')
         >>> #_DOCS_SHOW m22 = g.parts[0].getElementsByClass(stream.Measure)[22]
@@ -1061,7 +1052,6 @@ class LayoutScore(stream.Opus):
         >>> ls.getPositionForStaff(0, 3, 2)
         (133.0, 173.0)
 
-
         Tests for a score with PartStaff objects:
         >>> lt = corpus.parse('demos/layoutTestMore.xml')
         >>> ls = layout.divideByPages(lt, fastMeasures = True)
@@ -1251,7 +1241,6 @@ class LayoutScore(stream.Opus):
         returns the staffLayout.hidden attribute for a staffId, or if it is not
         defined, recursively search through previous staves until one is found.
 
-
         >>> lt = corpus.parse('demos/layoutTestMore.xml')
         >>> ls = layout.divideByPages(lt, fastMeasures = True)
         >>> ls.getStaffHiddenAttribute(0, 0, 0)
@@ -1333,7 +1322,6 @@ class LayoutScore(stream.Opus):
         If returnFormat is "float", returns each as a number from 0 to 1 where 0 is the
         top or left of the page, and 1 is the bottom or right of the page.
 
-
         >>> lt = corpus.parse('demos/layoutTest.xml')
         >>> ls = layout.divideByPages(lt, fastMeasures = True)
 
@@ -1352,13 +1340,11 @@ class LayoutScore(stream.Opus):
         >>> ls.getPositionForStaffMeasure(2, 1)
         ((602.0, 170.0), (642.0, 417.0), 0)
 
-
         If float is requested for returning, then the numbers are the fraction of
         the distance across the page.
 
         >>> ls.getPositionForStaffMeasure(0, 1, returnFormat='float')
         ((0.152..., 0.0996...), (0.170..., 0.244...), 0)
-
 
         Moving over the page boundary:
 
@@ -1424,7 +1410,6 @@ class LayoutScore(stream.Opus):
         no staffId is needed since (at least for now) all measures begin and end at the same
         X position
 
-
         >>> l = corpus.parse('demos/layoutTest.xml')
         >>> ls = layout.divideByPages(l, fastMeasures = True)
         >>> ls.measurePositionWithinSystem(1, 0, 0)
@@ -1479,7 +1464,6 @@ class LayoutScore(stream.Opus):
         '''
         returns a list of dictionaries, where each dictionary gives the measure number
         and other information, etc. in the document.
-
 
         # >>> g = corpus.parse('luca/gloria')
         # >>> gl = layout.divideByPages(g)

--- a/music21/lily/lilyObjects.py
+++ b/music21/lily/lilyObjects.py
@@ -154,7 +154,6 @@ class LyObject(prebase.ProtoM21Object):
         Returns a dictionary and sets self.lilyAttributes to that dictionary, for a m21Object
         of class classLookup using the mapping of self.m21toLy[classLookup]
 
-
         >>> class Mock(base.Music21Object): pass
         >>> m = Mock()
         >>> lm = lily.lilyObjects.LyMock()
@@ -167,13 +166,11 @@ class LyObject(prebase.ProtoM21Object):
         mockAttribute: mock-attribute
         mockAttribute2: mock-attribute-2
 
-
         Some of these attributes have defaults:
 
         >>> for x in sorted(lm.defaultAttributes.keys()):
         ...    print(f'{x}: {lm.defaultAttributes[x]}')
         mockAttribute2: 7
-
 
         >>> m.mockAttribute = 'hello'
         >>> lilyAttributes = lm.setAttributesFromClassObject('Mock', m)
@@ -297,7 +294,6 @@ class LyLilypondTop(LyObject):
              | lilypond assignment
              | lilypond error
              | lilypond "\invalid"`
-
 
     error and \invalid are not defined by music21
     '''
@@ -542,7 +538,6 @@ class LyContextDefSpecBody(LyObject):
     >>> lyContextBody.stringOutput()
     'cdi'
 
-
     >>> embedScm = lily.lilyObjects.LyEmbeddedScm('#t')
     >>> lyContextBody = lily.lilyObjects.LyContextDefSpecBody(
     ...                 contextDefSpecBody='body', embeddedScm=embedScm)
@@ -667,7 +662,6 @@ class LyBookpartBody(LyObject):
        fullMarkupList
        lilypondHeader
        error
-
 
     >>> lyBookpartBody = lily.lilyObjects.LyBookpartBody(bookIdentifier='bookId')
     >>> lyBookpartBody.stringOutput()
@@ -874,7 +868,6 @@ class LyTempoEvent(LyObject):
     tempo_event: "\tempo" steno_duration '=' tempo_range
                | "\tempo" scalar steno_duration '=' tempo_range
                | "\tempo" scalar
-
 
     >>> lte = lily.lilyObjects.LyTempoEvent(scalar='40')
     >>> str(lte)
@@ -1470,9 +1463,7 @@ class LyPropertyOperation(LyObject):
 
     mandatory mode in ['set', 'unset', 'override', 'revert']
 
-
     also represents simple_music_property_def which has the same forms
-
 
     >>> lpo = lily.lilyObjects.LyPropertyOperation('unset', 'simple')
     >>> str(lpo)
@@ -1872,7 +1863,6 @@ class LyStenoDuration(LyObject):
 
     a duration number followed by one or more dots
 
-
     >>> lsd = lily.lilyObjects.LyStenoDuration('2', 2)
     >>> print(lsd)
     2..
@@ -1972,7 +1962,6 @@ class LySimpleElement(LyObject):
 class LyLyricElement(LyObject):
     r'''
     Object represents a single Lyric in lilypond.
-
 
     >>> lle = lily.lilyObjects.LyLyricElement('hel_')
     >>> lle

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -73,7 +73,6 @@ def makeLettersOnlyId(inputString):
         Takes an id and makes it purely letters by substituting
         letters for all other characters.
 
-
         >>> print(lily.translate.makeLettersOnlyId('rainbow123@@dfas'))
         rainbowxyzmmdfas
         '''
@@ -254,7 +253,6 @@ class LilypondConverter:
         r'''
         get a proper lilypond text file for writing from a music21 object
 
-
         >>> n = note.Note()
         >>> print(lily.translate.LilypondConverter().textFromMusic21Object(n))
         \version "2..."
@@ -321,7 +319,6 @@ class LilypondConverter:
         whose string representation accurately reflects all the Score objects
         in this Opus object.
 
-
         >>> #_DOCS_SHOW fifeOpus = corpus.parse('miscFolk/americanfifeopus.abc')
         >>> #_DOCS_SHOW lpc = lily.translate.LilypondConverter()
         >>> #_DOCS_SHOW lpc.loadObjectFromOpus(fifeOpus, makeNotation=False)
@@ -363,7 +360,6 @@ class LilypondConverter:
 
         creates a filled topLevelObject (lily.lilyObjects.LyLilypondTop)
         whose string representation accurately reflects this Score object.
-
 
         >>> lpc = lily.translate.LilypondConverter()
         >>> #_DOCS_SHOW b = corpus.parse('bach/bwv66.6')
@@ -427,7 +423,6 @@ class LilypondConverter:
         Takes in a score and returns a block that starts each part context and variant context
         with an identifier and {\stopStaff s1*n} (or s, whatever is needed for the duration)
         where n is the number of measures in the score.
-
 
         >>> import copy
 
@@ -567,7 +562,6 @@ class LilypondConverter:
         # noinspection PyShadowingNames
         r'''
         Creates a series of Spacer objects for the measures in a Stream Part.
-
 
         >>> m1 = stream.Measure(converter.parse('tinynotation: 3/4 a2.'))
         >>> m2 = stream.Measure(converter.parse('tinynotation: 3/4 b2.'))
@@ -942,7 +936,6 @@ class LilypondConverter:
 
         (should eventually replace the main Score parts finding tools)
 
-
         >>> lpc = lily.translate.LilypondConverter()
         >>> lpMusicList = lily.lilyObjects.LyMusicList()
         >>> lpc.context = lpMusicList
@@ -962,7 +955,6 @@ class LilypondConverter:
         des' 4
         eis' 4
         <BLANKLINE>
-
 
         >>> v1 = stream.Voice()
         >>> v1.append(note.Note('C5', quarterLength = 4.0))
@@ -1127,7 +1119,6 @@ class LilypondConverter:
         appends lySimpleMusicFromNoteOrRest to the
         current context.
 
-
         >>> n = note.Note('C#4')
         >>> lpc = lily.translate.LilypondConverter()
         >>> lpMusicList = lily.lilyObjects.LyMusicList()
@@ -1136,7 +1127,6 @@ class LilypondConverter:
         >>> print(lpMusicList)
         cis' 4
         <BLANKLINE>
-
 
         >>> n2 = note.Note('D#4')
         >>> n2.duration.quarterLength = 1/3
@@ -1194,7 +1184,6 @@ class LilypondConverter:
         appends lySimpleMusicFromChord to the
         current context.
 
-
         >>> c = chord.Chord(['C4', 'E4', 'G4'])
         >>> lpc = lily.translate.LilypondConverter()
         >>> lpMusicList = lily.lilyObjects.LyMusicList()
@@ -1203,7 +1192,6 @@ class LilypondConverter:
         >>> print(lpMusicList)
         < c' e' g'  > 4
         <BLANKLINE>
-
 
         >>> c2 = chord.Chord(['D4', 'F#4', 'A4'])
         >>> c2.duration.quarterLength = 1/3
@@ -1394,7 +1382,6 @@ class LilypondConverter:
         Adds an LyEmbeddedScm object to the context's contents if the object's stem direction
         is set (currently, only "up" and "down" are supported).
 
-
         >>> lpc = lily.translate.LilypondConverter()
         >>> lpMusicList = lily.lilyObjects.LyMusicList()
         >>> lpc.context = lpMusicList
@@ -1418,7 +1405,6 @@ class LilypondConverter:
 
     def lySimpleMusicFromChord(self, chordObj):
         '''
-
 
         >>> conv = lily.translate.LilypondConverter()
         >>> c1 = chord.Chord(['C#2', 'E4', 'D#5'])
@@ -1552,7 +1538,6 @@ class LilypondConverter:
         music21.lily.translate.LilyTranslateException: Cannot translate an object of
             zero duration <music21.duration.Duration 0.0>
 
-
         Does not work with complex durations:
 
         >>> d = duration.Duration(5.0)
@@ -1602,7 +1587,6 @@ class LilypondConverter:
         converts a Clef object to a
         lilyObjects.LyEmbeddedScm object
 
-
         >>> tc = clef.TrebleClef()
         >>> conv = lily.translate.LilypondConverter()
         >>> lpEmbeddedScm = conv.lyEmbeddedScmFromClef(tc)
@@ -1649,7 +1633,6 @@ class LilypondConverter:
         converts a Key or KeySignature object
         to a lilyObjects.LyEmbeddedScm object
 
-
         >>> d = key.Key('d')
         >>> conv = lily.translate.LilypondConverter()
         >>> lpEmbeddedScm = conv.lyEmbeddedScmFromKeySignature(d)
@@ -1686,7 +1669,6 @@ class LilypondConverter:
         r'''
         convert a :class:`~music21.meter.TimeSignature` object
         to a lilyObjects.LyEmbeddedScm object
-
 
         >>> ts = meter.TimeSignature('3/4')
         >>> conv = lily.translate.LilypondConverter()
@@ -1732,7 +1714,6 @@ class LilypondConverter:
         Returns an lpMusicList object contained in an lpSequentialMusic object
         in an lpPrefixCompositeMusic object which sets the times object to a particular
         fraction.
-
 
         >>> lpc = lily.translate.LilypondConverter()
         >>> lpc.context
@@ -1862,7 +1843,6 @@ class LilypondConverter:
         # noinspection PyShadowingNames
         r'''
 
-
         >>> s1 = converter.parse('tinynotation: 4/4 a4 a a a  a1')
         >>> s2 = converter.parse('tinynotation: 4/4 b4 b b b')
         >>> s3 = converter.parse('tinynotation: 4/4 c4 c c c')
@@ -1910,7 +1890,6 @@ class LilypondConverter:
         >>> for v in variantList :
         ...     v.groups = ['london']
         ...     activeSite.insert(0.0, v)
-
 
         >>> lpc = lily.translate.LilypondConverter()
 
@@ -2234,7 +2213,6 @@ class LilypondConverter:
     def lyOssiaMusicFromVariant(self, variantIn):
         r'''
         returns a LyOssiaMusic object from a stream
-
 
         >>> c = converter.parse('tinynotation: 3/4 C4 D E F2.')
         >>> v = variant.Variant(c.elements)

--- a/music21/mei/base.py
+++ b/music21/mei/base.py
@@ -999,7 +999,7 @@ def _processEmbeddedElements(
 
     If debugging is enabled for the previous example, this warning would be displayed:
 
-    ``mei.base: Found an unprocessed <rest> element in a <doctest>.
+    ``mei.base: Found an unprocessed <rest> element in a <doctest>.``
 
     The "beam" element holds "note" elements. All elements appear in a single level of the list:
 
@@ -3025,7 +3025,7 @@ def _correctMRestDurs(staves, targetLength):
                     del eachObject.m21wasMRest
 
 
-def _makeBarlines(elem, staves):
+def _makeBarlines(elem: Element, staves: dict) -> dict:
     '''
     This is a helper function for :func:`measureFromElement`, made independent only to improve
     that function's ease of testing.
@@ -3034,11 +3034,10 @@ def _makeBarlines(elem, staves):
     been processed, change the barlines of the :class:`Measure` objects in accordance with the
     element's @left and @right attributes.
 
-    :param :class:`~xml.etree.ElementTree.Element` elem: The ``<measure>`` tag to process.
-    :param dict staves: Dictionary where keys are @n attributes and values are corresponding
-        :class:`~music21.stream.Measure` objects.
-    :returns: The ``staves`` dictionary with properly-set barlines.
-    :rtype: dict
+    elem is the ``<measure>`` tag to process; staves maps @n attributes to their corresponding
+    :class:`~music21.stream.Measure` objects.
+
+    Returns the ``staves`` dictionary with properly-set barlines.
     '''
     if elem.get('left') is not None:
         bars = _barlineFromAttr(elem.get('left'))

--- a/music21/mei/test_base.py
+++ b/music21/mei/test_base.py
@@ -167,7 +167,7 @@ class Test(unittest.TestCase):
 
     def testSafePitch3(self):
         '''
-        safePitch(): when ``name`` is not given, but there are various **keywords
+        safePitch(): when ``name`` is not given, but there are various ``**keywords``
         '''
         expected = pitch.Pitch('D#6')
         actual = base.safePitch(name='D', accidental='#', octave='6')

--- a/music21/metadata/__init__.py
+++ b/music21/metadata/__init__.py
@@ -1144,7 +1144,6 @@ class Metadata(base.Music21Object):
         >>> md.search('opl(.*)cott')
         (True, 'composer')
 
-
         * New in v4: use a keyword argument to search that field directly:
 
         >>> md.search(composer='Joplin')
@@ -2345,7 +2344,6 @@ class Metadata(base.Music21Object):
 
         >>> metadata.Metadata.convertValue('title', 21.5)
         <music21.metadata.primitives.Text 21.5>
-
 
         If it is already the appropriate type, no change is made
 

--- a/music21/metadata/bundles.py
+++ b/music21/metadata/bundles.py
@@ -202,7 +202,6 @@ class MetadataBundle(prebase.ProtoM21Object):
     >>> resultsEntries
     <music21.metadata.bundles.MetadataBundle {40 entries}>
 
-
     Results are ordered by their source path:
 
     >>> resultsEntries[0]
@@ -218,13 +217,11 @@ class MetadataBundle(prebase.ProtoM21Object):
     >>> converter.parse(resultsEntries[0])
     <music21.stream.Score ...>
 
-
     A metadata bundle can be instantiated in three ways, (1) from a ``Corpus`` instance,
     or (2) a string indicating which corpus name to draw from, and then calling
     .read() or (3) by calling
     .metadataBundle on a corpus object.  This
     calls `.read()` automatically:
-
 
     Method 1:
 
@@ -254,8 +251,6 @@ class MetadataBundle(prebase.ProtoM21Object):
 
     >>> coreBundle
     <music21.metadata.bundles.MetadataBundle 'core': {151... entries}>
-
-
 
     Additionally, any two metadata bundles can be operated on together as
     though they were sets, allowing us to build up more complex searches:
@@ -425,7 +420,6 @@ class MetadataBundle(prebase.ProtoM21Object):
         True
         >>> coreBundle > coreBundle
         False
-
 
         Returns boolean.
         '''

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -410,11 +410,9 @@ class TimeSignature(TimeSignatureBase):
     >>> sixEight.symbol
     ''
 
-
     For complete details on using this object, see
     :ref:`User's Guide Chapter 14: Time Signatures <usersGuide_14_timeSignatures>` and
     :ref:`User's Guide Chapter 55: Advanced Meter <usersGuide_55_advancedMeter>` and
-
 
     That's it for the simple aspects of `TimeSignature` objects.  You know
     enough to get started now!
@@ -694,14 +692,12 @@ class TimeSignature(TimeSignatureBase):
         (for complex TimeSignatures, note that this comes from the .beamSequence
         of the TimeSignature)
 
-
         >>> ts = meter.TimeSignature('3/4')
         >>> ts.numerator
         3
         >>> ts.numerator = 5
         >>> ts
         <music21.meter.TimeSignature 5/4>
-
 
         In this case, the TimeSignature is silently being converted to 9/8
         to get a single digit numerator:
@@ -740,7 +736,6 @@ class TimeSignature(TimeSignatureBase):
         >>> ts.denominator = 8
         >>> ts.ratioString
         '3/8'
-
 
         In this following case, the TimeSignature is silently being converted to 9/8
         to get a single digit denominator:
@@ -1696,7 +1691,6 @@ class TimeSignature(TimeSignatureBase):
         returns a float of the average beat strength of all objects (or if notesOnly is True
         [default] only the notes) in the `Stream` specified as streamIn.
 
-
         >>> s = converter.parse('C4 D4 E8 F8', format='tinyNotation').flatten().notes.stream()
         >>> sixEight = meter.TimeSignature('6/8')
         >>> sixEight.averageBeatStrength(s)
@@ -1887,10 +1881,8 @@ class TimeSignature(TimeSignatureBase):
         it will work for asymmetrical meters, as the second
         example shows.
 
-
         Ex. 1: beat duration for 3/4 is always 1.0
         no matter where in the meter you query.
-
 
         >>> ts1 = meter.TimeSignature('3/4')
         >>> ts1.getBeatDuration(0.5)
@@ -1898,19 +1890,15 @@ class TimeSignature(TimeSignatureBase):
         >>> ts1.getBeatDuration(2.5)
         <music21.duration.Duration 1.0>
 
-
         Ex. 2: same for 6/8:
-
 
         >>> ts2 = meter.TimeSignature('6/8')
         >>> ts2.getBeatDuration(2.5)
         <music21.duration.Duration 1.5>
 
-
         Ex. 3: but for a compound meter of 3/8 + 2/8,
         where you ask for the beat duration
         will determine the length of the beat:
-
 
         >>> ts3 = meter.TimeSignature('3/8+2/8')  # will partition as 2 beat
         >>> ts3.getBeatDuration(0.5)
@@ -1923,7 +1911,6 @@ class TimeSignature(TimeSignatureBase):
     def getOffsetFromBeat(self, beat):
         '''
         Given a beat value, convert into an offset position.
-
 
         >>> ts1 = meter.TimeSignature('3/4')
         >>> ts1.getOffsetFromBeat(1)
@@ -1973,7 +1960,6 @@ class TimeSignature(TimeSignatureBase):
         1.0
         >>> ts3.getOffsetFromBeat(2.5)
         2.0
-
 
         Let's try this on a real piece, a 4/4 chorale with a one beat pickup.  Here we get the
         normal offset for beat 4 from the active TimeSignature, but we subtract out
@@ -2025,7 +2011,6 @@ class TimeSignature(TimeSignatureBase):
         (2, 0.0)
         >>> a.getBeatProgress(2.5)
         (3, 0.5)
-
 
         Works for specifically partitioned meters too:
 

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -668,7 +668,6 @@ class MeterSequence(MeterTerminal):
         >>> str(b)
         '{2/8+2/8+1/8}'
 
-
         Here we use loadDefault=True to get the default partition in case
         there is no known way to do this:
 
@@ -739,7 +738,6 @@ class MeterSequence(MeterTerminal):
         >>> a.partitionByList(['3/4', '1/8', '1/8'])
         >>> a
         <music21.meter.core.MeterSequence {3/4+1/8+1/8}>
-
 
         But the basics of the MeterSequence must be observed:
 
@@ -1175,7 +1173,6 @@ class MeterSequence(MeterTerminal):
         >>> ms.partitionStr
         '13-uple'
 
-
         Single partition:
 
         >>> ms = meter.MeterSequence('3/4', 1)
@@ -1352,7 +1349,6 @@ class MeterSequence(MeterTerminal):
         >>> accentSequence.weight = 1.0
         >>> (downbeat.weight, upbeat.weight)
         (0.5, 0.5)
-
 
         Assume this MeterSequence is a whole, not a part of some larger MeterSequence.
         Thus, we cannot use numerator/denominator relationship
@@ -1608,7 +1604,6 @@ class MeterSequence(MeterTerminal):
          <music21.meter.core.MeterSequence {1/8+1/8}>,
          <music21.meter.core.MeterTerminal 1/4>,
          <music21.meter.core.MeterSequence {{1/16+1/16}+1/8}>]
-
 
         >>> b.getLevelList(1, flat=False)
         [<music21.meter.core.MeterTerminal 1/4>,
@@ -1945,7 +1940,6 @@ class MeterSequence(MeterTerminal):
         If `permitMeterModulus` is True, quarter length positions
         greater than the duration of the Meter will be accepted
         as the modulus of the total meter duration.
-
 
         >>> a = meter.MeterSequence('3/4', 3)
         >>> a.offsetToSpan(0.5)

--- a/music21/midi/base.py
+++ b/music21/midi/base.py
@@ -98,7 +98,6 @@ def getNumber(midiBytes: bytes|int, length: int) -> tuple[int, bytes|int]:
     >>> midi.getNumber(b'test', 0)
     (0, b'test')
 
-
     The method can also take in an integer and return an integer and the remainder part.
     This usage might be deprecated in the future and has already been replaced within
     music21 internal code.
@@ -247,7 +246,6 @@ def putVariableLengthNumber(x: int) -> bytes:
     >>> bytes([255])
     b'\xff'
 
-
     This method can also deal with numbers > 255, which `bytes` cannot.
 
     >>> midi.putVariableLengthNumber(256)
@@ -327,7 +325,6 @@ def putNumbersAsList(numList: Iterable[int]) -> bytes:
 
     >>> bytes([0, 0, 0, 3])
     b'\x00\x00\x00\x03'
-
 
     If a number is < 0 then it wraps around from the top.  This is used in places
     like MIDI key signatures where flats are represented by `256 - flats`.
@@ -785,7 +782,6 @@ class MidiEvent(prebase.ProtoM21Object):
         >>> midBytes += b'hello'
         >>> midBytes
         b'\x92<xhello'
-
 
         Now see how parsing this ChannelVoiceMessage changes the MidiEvent
 

--- a/music21/midi/percussion.py
+++ b/music21/midi/percussion.py
@@ -127,7 +127,6 @@ class PercussionMapper:
         Traceback (most recent call last):
         music21.midi.percussion.MIDIPercussionException: 69 does not map to a valid instrument!
 
-
         Some music21 Instruments have more than one MidiPitch.  In this case you'll
         get the same Instrument object but with a different modifier
 
@@ -168,7 +167,6 @@ class PercussionMapper:
         '''
         Takes an instrument.Instrument object and returns a pitch object
         with the corresponding 1-indexed MIDI note, according to the GM Percussion Map.
-
 
         >>> pm = midi.percussion.PercussionMapper()
         >>> myCow = instrument.Cowbell()

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -86,7 +86,6 @@ def offsetToMidiTicks(o: OffsetQLIn, addStartDelay: bool = False) -> int:
     >>> defaults.ticksAtStart
     10080
 
-
     >>> midi.translate.offsetToMidiTicks(0)
     0
     >>> midi.translate.offsetToMidiTicks(0, addStartDelay=True)
@@ -111,7 +110,6 @@ def durationToMidiTicks(d: duration.Duration) -> int:
 
     Depends on *defaults.ticksPerQuarter*, Returns an int.
     Does not use defaults.ticksAtStart
-
 
     >>> n = note.Note()
     >>> n.duration.type = 'half'
@@ -386,7 +384,6 @@ def midiEventsToNote(
     >>> me1.type = midi.ChannelVoiceMessages.NOTE_ON
     >>> me1.pitch = 45
     >>> me1.velocity = 94
-
 
     This lasts until we send a NOTE_OFF event at offset 2.0.
 
@@ -1268,7 +1265,6 @@ def tempoToMidiEvents(
 
     >>> midi.translate.tempoToMidiEvents(mm, includeDeltaTime=False)
     [<music21.midi.MidiEvent SET_TEMPO...>]
-
 
     Test round-trip.  Note that for pure tempo numbers, by default
     we create a text name if there's an appropriate one:

--- a/music21/musedata/__init__.py
+++ b/music21/musedata/__init__.py
@@ -113,7 +113,6 @@ class MuseDataRecord(prebase.ProtoM21Object):
         >>> mdr.isTied()
         True
 
-
         >>> mdr = musedata.MuseDataRecord('C4     1        s     u  [[')
         >>> mdr.isTied()
         False
@@ -260,7 +259,6 @@ class MuseDataRecord(prebase.ProtoM21Object):
         'F#4'
         >>> p.accidental.displayStatus
         True
-
 
         Double sharps were giving octave problems.
 
@@ -1114,7 +1112,6 @@ class MuseDataPart(prebase.ProtoM21Object):
         The attributes record is not in a fixed position,
         but is the first line that starts with a $.
 
-
         >>> fp1 = (common.getSourceFilePath() / 'musedata' / 'testPrimitive'
         ...                    / 'test01' / '01.md')
         >>> mdw = musedata.MuseDataWork()
@@ -1310,7 +1307,6 @@ class MuseDataPart(prebase.ProtoM21Object):
     def _getTranspositionParameters(self):
         '''
         Get the transposition, if defined, from the Metadata header.
-
 
         >>> fp1 = (common.getSourceFilePath() / 'musedata' / 'testPrimitive'
         ...                    / 'test01' / '01.md')

--- a/music21/musedata/base40.py
+++ b/music21/musedata/base40.py
@@ -164,7 +164,6 @@ def base40DeltaToInterval(delta):
     instance, would return a diminished second, even though it's
     a quadruplely augmented unison) just would not occur.
 
-
     >>> musedata.base40.base40DeltaToInterval(4)
     <music21.interval.Interval d2>
     >>> musedata.base40.base40DeltaToInterval(11)
@@ -215,7 +214,6 @@ def base40ToPitch(base40Num):
     have an associated pitch name. There is one unassigned number
     each time the interval between two letters is a whole step.
 
-
     >>> musedata.base40.base40ToPitch(1)
     <music21.pitch.Pitch C--1>
     >>> musedata.base40.base40ToPitch(40)
@@ -246,7 +244,6 @@ def pitchToBase40(pitchToConvert):
     of pitches that Base40 can handle; for example, half flats
     and half sharps or triple flats and triple sharps.
 
-
     >>> musedata.base40.pitchToBase40(pitch.Pitch('C--5'))
     161
     >>> musedata.base40.pitchToBase40('F##4')
@@ -276,13 +273,11 @@ def base40Interval(base40NumA, base40NumB):
     to an interval in Base40, or if either base40 pitch
     number doesn't correspond to a pitch name.
 
-
     >>> musedata.base40.base40Interval(163, 191)
     <music21.interval.Interval m6>
 
     >>> musedata.base40.base40Interval(186, 174)      # Descending M3
     <music21.interval.Interval M-3>
-
 
     Base40 has limitations for intervals smaller than diminished or bigger than augmented.
 
@@ -335,7 +330,6 @@ def base40ActualInterval(base40NumA, base40NumB):
     numbers does not correspond to a pitch name or (b) If
     an unusual interval is encountered that can't be handled
     by music21.
-
 
     >>> musedata.base40.base40ActualInterval(163, 191)
     <music21.interval.Interval m6>

--- a/music21/musedata/translate.py
+++ b/music21/musedata/translate.py
@@ -13,7 +13,6 @@
 access computationally from music21.  This module is retained for anyone who has such access,
 however it is completely untested now and errors cannot and will not be fixed.**
 
-
 Functions for translating music21 objects and
 :class:`~music21.musedata.base.MuseDataHandler` instances. Mostly,
 these functions are for advanced, low level usage. For basic importing of MuseData

--- a/music21/musicxml/helpers.py
+++ b/music21/musicxml/helpers.py
@@ -317,7 +317,6 @@ def setM21AttributeFromAttribute(
     >>> pl.isNew
     'yes'
 
-
     Transform the pageNumber value to an int.
 
     >>> setb(pl, e, 'page-number', transform=int)
@@ -376,7 +375,6 @@ def setXMLAttributeFromAttribute(
     >>> setb(pl, e, 'new-page', 'isNew')
     >>> e.get('new-page')
     'True'
-
 
     Transform the isNew value to 'yes'.
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1057,7 +1057,6 @@ class XMLExporterBase:
           </page-layout>
         </print>
 
-
         >>> MP = musicxml.xmlToM21.MeasureParser()
         >>> pl2 = MP.xmlPrintToPageLayout(mxPrint)
         >>> pl2.isNew
@@ -1137,7 +1136,6 @@ class XMLExporterBase:
             <system-distance>55</system-distance>
           </system-layout>
         </print>
-
 
         Test return conversion
 
@@ -1268,7 +1266,6 @@ class XMLExporterBase:
         >>> acc.set('double-flat')
         >>> XB.dump(a2m(acc))
         <accidental>flat-flat</accidental>
-
 
         >>> acc.set('one-and-a-half-sharp')
         >>> XB.dump(a2m(acc, elName='accidental-mark'))
@@ -2148,7 +2145,6 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
 
         >>> mxPartGroup.set('number', str(1))
 
-
         What can we do with it?
 
         >>> firstStaffGroup.name = 'Voices'
@@ -2248,7 +2244,6 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
             <supports element="accidental" type="yes" />
           </encoding>
         </identification>
-
 
         Overriding the default:
 
@@ -4342,10 +4337,8 @@ class MeasureExporter(XMLExporterBase):
           <duration>30240</duration>
         </note>
 
-
         Note that if a measure has paddingLeft/paddingRight (such as a pickup)
         then a fullMeasure duration might not match the TimeSignature duration.
-
 
         The display-step and display-octave are set from a Rest's stepShift:
 
@@ -4474,7 +4467,6 @@ class MeasureExporter(XMLExporterBase):
           <duration>20160</duration>
           <type>half</type>
         </note>
-
 
         Test that notehead and style translation works:
 
@@ -5492,7 +5484,6 @@ class MeasureExporter(XMLExporterBase):
         >>> MEX.dump(mxTechnicalMark)
         <up-bow placement="below" />
 
-
         >>> f = articulations.Fingering(4)
         >>> f.substitution = True
         >>> mxFingering = MEX.articulationToXmlTechnical(f)
@@ -6377,7 +6368,6 @@ class MeasureExporter(XMLExporterBase):
           </direction-type>
         </direction>
 
-
         >>> mm = tempo.MetronomeMark('slow', 40, duration.Duration(quarterLength=1.5))
         >>> mxDirection = MEX.tempoIndicationToXml(mm)
         >>> MEX.dump(mxDirection)
@@ -6856,7 +6846,6 @@ class MeasureExporter(XMLExporterBase):
         '''
         Returns a list of <beam> tags
         from a :class:`~music21.beam.Beams` object
-
 
         >>> a = beam.Beams()
         >>> a.fill(2, type='start')
@@ -7488,7 +7477,6 @@ class MeasureExporter(XMLExporterBase):
           <chromatic>7</chromatic>
         </transpose>
 
-
         >>> i = interval.Interval('A13')
         >>> mxTranspose = ME.intervalToXmlTranspose(i)
         >>> ME.dump(mxTranspose)
@@ -7505,7 +7493,6 @@ class MeasureExporter(XMLExporterBase):
           <diatonic>-5</diatonic>
           <chromatic>-9</chromatic>
         </transpose>
-
 
         >>> i = interval.Interval('-M9')
         >>> mxTranspose = ME.intervalToXmlTranspose(i)

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -554,10 +554,8 @@ class XMLParserBase:
         Given an mxPrint object, set object data for
         the print section of a layout.PageLayout object
 
-
         >>> from xml.etree.ElementTree import fromstring as El
         >>> MP = musicxml.xmlToM21.MeasureParser()
-
 
         >>> mxPrint = El('<print new-page="yes" page-number="5">'
         ...    + '    <page-layout><page-height>4000</page-height>'
@@ -2170,7 +2168,6 @@ class PartParser(XMLParserBase):
         >>> pp2.lastTimeSignature
         <music21.meter.TimeSignature 4/4>
 
-
         For obscure reasons relating to how Finale gives suffixes
         to unnumbered measures, if a measure has the same number
         as the lastMeasureNumber, the lastNumberSuffix is not updated:
@@ -2993,7 +2990,6 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
         >>> n.articulations
         [<music21.articulations.Pizzicato>]
 
-
         >>> beams = EL('<beam>begin</beam>')
         >>> mxNote.append(beams)
         >>> n = MP.xmlToSimpleNote(mxNote)
@@ -3335,7 +3331,6 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
         'half-flat'
         >>> b.alter
         -0.5
-
 
         >>> a = EL('<accidental bracket="yes">sharp</accidental>')
         >>> b = MP.xmlToAccidental(a)
@@ -3901,7 +3896,6 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
 
         >>> f.fingerNumber
         5
-
 
         >>> mxTech = EL('<fingering alternate="yes">4-3</fingering>')
         >>> f = MP.xmlTechnicalToArticulation(mxTech)
@@ -4908,7 +4902,6 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
         >>> l2
         <music21.note.Lyric number=0 identifier='part2verse1' syllabic=single text='word'>
 
-
         Multiple texts can be created and result in composite lyrics
 
         >>> mxBianco = ET.fromstring('<lyric>'
@@ -5829,7 +5822,6 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
         >>> MP.xmlTransposeToInterval(t)
         <music21.interval.Interval M-6>
 
-
         Not mentioned in MusicXML XSD but supported in (Finale; MuseScore): octave-change
         refers to both diatonic and chromatic, so we will deal:
 
@@ -5945,7 +5937,6 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
         >>> mxSenza = ET.fromstring('<time><senza-misura>0</senza-misura></time>')
         >>> MP.xmlToTimeSignature(mxSenza)
         <music21.meter.SenzaMisuraTimeSignature 0>
-
 
         Small Duration Time Signatures
 
@@ -6109,13 +6100,11 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
         >>> MP.xmlToKeySignature(mxKey)
         <music21.key.KeySignature of 4 flats>
 
-
         >>> mxKey = ET.fromstring('<key><fifths>-4</fifths><mode>minor</mode></key>')
 
         >>> MP = musicxml.xmlToM21.MeasureParser()
         >>> MP.xmlToKeySignature(mxKey)
         <music21.key.Key of f minor>
-
 
         Invalid modes get ignored and returned as KeySignatures
 
@@ -6210,7 +6199,6 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
 
         >>> MP.xmlToKeySignature(mxKey)
         <music21.key.KeySignature of pitches: [E-]>
-
 
         Works with key-accidental also:
 

--- a/music21/note.py
+++ b/music21/note.py
@@ -710,7 +710,6 @@ class GeneralNote(base.Music21Object):
         [<music21.note.Lyric number=1 syllabic=single text='1. Hi'>,
          <music21.note.Lyric number=2 syllabic=single text='2. Bye'>]
 
-
         You can also set a lyric with a lyric object directly:
 
         >>> b = note.Note('B5')
@@ -1129,7 +1128,6 @@ class NotRest(GeneralNote):
         '''
         Get or set the notehead type of this NotRest object.
         Valid notehead type names are found in note.noteheadTypeNames (see below):
-
 
         >>> note.noteheadTypeNames
         ('arrow down', 'arrow up', 'back slashed', 'circle dot', 'circle-x', 'circled', 'cluster',
@@ -1735,7 +1733,6 @@ class Note(NotRest):
         >>> a
         <music21.note.Note C#>
 
-
         If the transposition value is an integer, take the KeySignature or Key context
         into account
 
@@ -1792,7 +1789,6 @@ class Note(NotRest):
         '''
         Return the most complete representation of this Note,
         providing duration and pitch information.
-
 
         >>> n = note.Note('A-', quarterLength=1.5)
         >>> n.fullName
@@ -1946,7 +1942,6 @@ class Rest(GeneralNote):
 
     >>> r.pitches
     ()
-
 
     All arguments to Duration are valid in constructing:
 

--- a/music21/noteworthy/binaryTranslate.py
+++ b/music21/noteworthy/binaryTranslate.py
@@ -187,7 +187,6 @@ This is very beta.  Much better would be to convert the file into .xml or .nwctx
             {0.0} <music21.chord.Chord F3 A3 C4>
             {3.0} <music21.note.Rest quarter>
 
-
 '''
 from __future__ import annotations
 

--- a/music21/noteworthy/translate.py
+++ b/music21/noteworthy/translate.py
@@ -135,8 +135,6 @@ class NoteworthyTranslator:
 
         Returns a :class:`~music21.stream.Score` object
 
-
-
         >>> data = []
         >>> data.append('!NoteWorthyComposer(2.0)\n')
         >>> data.append('|AddStaff|\n')
@@ -338,7 +336,6 @@ class NoteworthyTranslator:
         returns a list of pitch objects given the Pos:... info
         for a chord.
 
-
         >>> nwt = noteworthy.translate.NoteworthyTranslator()
         >>> nwt.currentClef = 'BASS'
         >>> pList = nwt.getMultiplePitchesFromPositionInfo('1,b3,5^')
@@ -456,8 +453,6 @@ class NoteworthyTranslator:
     def translateNote(self, attributes):
         r'''
         Translation of a music21 note from a NWC note.
-
-
 
         >>> measure = stream.Measure()
         >>> nwt = noteworthy.translate.NoteworthyTranslator()
@@ -604,8 +599,6 @@ class NoteworthyTranslator:
         r'''
         Translation of a music21 rest.  Adds the rest to the given measure.
 
-
-
         >>> measureIn = stream.Measure()
         >>> measureIn.append(note.Note('C#4', type='half'))
 
@@ -630,11 +623,8 @@ class NoteworthyTranslator:
         r'''
         Add a new clef to the current measure and return the currentClef.
 
-
         Clef lines should look like: \|Clef\|Type:ClefType  or
         \|Clef\|Type:ClefType\|OctaveShift:Octave Down (or Up)
-
-
 
         >>> nwt = noteworthy.translate.NoteworthyTranslator()
         >>> nwt.currentMeasure = stream.Measure()
@@ -653,10 +643,7 @@ class NoteworthyTranslator:
         {0.0} <music21.clef.Bass8vbClef>
         {0.0} <music21.clef.PercussionClef>
 
-
-
         If no clef can be found then it raises a NoteworthyTranslate exception
-
 
         >>> nwt.createClef({'Type' : 'OrangeClef'})
         Traceback (most recent call last):
@@ -751,7 +738,6 @@ class NoteworthyTranslator:
         r'''
         Adding a time signature in the score.
 
-
         >>> measure = stream.Measure()
         >>> nwt = noteworthy.translate.NoteworthyTranslator()
         >>> nwt.currentMeasure = measure
@@ -783,9 +769,6 @@ class NoteworthyTranslator:
     def createBarlines(self, attributes):
         r'''
         Translates bar lines into music21.
-
-
-
 
         >>> nwt = noteworthy.translate.NoteworthyTranslator()
         >>> nwt.currentPart = stream.Part()
@@ -859,7 +842,6 @@ class NoteworthyTranslator:
         r'''
         Repetitions like 'Coda', 'Segno' and some others.
 
-
         >>> nwt = noteworthy.translate.NoteworthyTranslator()
         >>> nwt.currentMeasure = stream.Measure()
         >>> nwt.createOtherRepetitions({'Style' : 'ToCoda', 'Pos': '8',
@@ -889,7 +871,6 @@ class NoteworthyTranslator:
         r'''
         Adding dynamics like "crescendo" to the measure.
 
-
         >>> nwt = noteworthy.translate.NoteworthyTranslator()
         >>> nwt.currentMeasure = stream.Measure()
         >>> nwt.createDynamicVariance({'Style' : 'Crescendo', 'Pos': '-6'})
@@ -911,7 +892,6 @@ class NoteworthyTranslator:
     def createDynamics(self, attributes):
         r'''
         Adding dynamics like "fff", "pp", ... to the measure.
-
 
         >>> nwt = noteworthy.translate.NoteworthyTranslator()
         >>> nwt.currentMeasure = stream.Measure()

--- a/music21/omr/correctors.py
+++ b/music21/omr/correctors.py
@@ -1111,7 +1111,6 @@ class MeasureHash:
         >>> mh.getProbabilityOnSubstitute('F', 'PP')
         0.0001485
 
-
         Take minimum length. Compare index to index. Any additional letters
         in the flagged measure get graded as additions. Any additional letters
         in the comparison measure get graded as omissions.
@@ -1161,7 +1160,6 @@ class MeasureHash:
 
         >>> mh.getProbabilityFromOneCharSub('P', 'V')
         0.009
-
 
         Dotted quarter note to quarter note:
 

--- a/music21/omr/evaluators.py
+++ b/music21/omr/evaluators.py
@@ -327,7 +327,6 @@ def autoCorrelationBestMeasure(inputScore):
     >>> print( float(totalUnflaggedWithMatches) / totalUnflagged )
     0.901...
 
-
     Schoenberg has low autoCorrelation.
 
     >>> c = corpus.parse('schoenberg/opus19/movement6')

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -355,7 +355,6 @@ def _convertPsToStep(
     >>> pitch._convertPsToStep(61.5)
     ('C', <music21.pitch.Accidental one-and-a-half-sharp>, <music21.pitch.Microtone (+0c)>, 0)
 
-
     Note that Microtones can have negative and positive zeros.
 
     >>> pitch._convertPsToStep(43.00001)
@@ -526,7 +525,6 @@ def _convertHarmonicToCents(value: int|float) -> int:
      4302, 4441, 4569, 4688, 4800, 4905, 5004, 5098, 5186, 5271, 5351,
      5428, 5502, 5573, 5641, 5706, 5769, 5830, 5888, 5945, 6000]
 
-
     Works with subHarmonics as well by specifying them as either 1/x or negative numbers.
     note that -2 is the first subharmonic, since -1 == 1:
 
@@ -662,7 +660,6 @@ def simplifyMultipleEnharmonics(pitches, criterion=_dissonanceScore, keyContext=
     >>> pitch.simplifyMultipleEnharmonics([6, 10, 1], keyContext=key.Key('C-'))
     [<music21.pitch.Pitch G->, <music21.pitch.Pitch B->, <music21.pitch.Pitch D->]
 
-
     Note that if there's no key context, then we won't simplify everything (at least
     for now; this behavior may change, ).
 
@@ -670,8 +667,6 @@ def simplifyMultipleEnharmonics(pitches, criterion=_dissonanceScore, keyContext=
     ...                                    pitch.Pitch('F-3'),
     ...                                    pitch.Pitch('A--3')])
     [<music21.pitch.Pitch D--3>, <music21.pitch.Pitch F-3>, <music21.pitch.Pitch A--3>]
-
-
 
     >>> pitch.simplifyMultipleEnharmonics([pitch.Pitch('D--3'),
     ...                                    pitch.Pitch('F-3'),
@@ -745,7 +740,6 @@ class Microtone(prebase.ProtoM21Object, SlottedObjectMixin):
 
     Microtones can be shifted according to the harmonic. Here we take the 3rd
     harmonic of the previous microtone
-
 
     >>> m.harmonicShift = 3
     >>> m.harmonicShift
@@ -1216,7 +1210,6 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
 
         This is the argument that .name and .alter use to allow non-standard names
 
-
         * Changed in v5: added allowNonStandardValue.
         '''
         if isinstance(name, str):
@@ -1640,7 +1633,6 @@ class Pitch(prebase.ProtoM21Object):
     >>> highEflat.nameWithOctave
     'E-6'
 
-
     `Pitch` objects represent themselves as the class name followed
     by the `.nameWithOctave`:
 
@@ -1673,7 +1665,6 @@ class Pitch(prebase.ProtoM21Object):
         AttributeError: 'NoneType' object has no attribute 'alter'
         >>> alters
         [1.0, -1.0]
-
 
     If a `Pitch` doesn't have an associated octave, then its
     `.octave` value is None.  This means that it represents
@@ -1711,7 +1702,6 @@ class Pitch(prebase.ProtoM21Object):
     >>> pitch.Pitch(65.5).accidental
     <music21.pitch.Accidental half-sharp>
 
-
     A `pitch.Pitch` object can also be created using only a number
     from 0-11, that number is taken to be a `pitchClass`, where
     0 = C, 1 = C#/D-, etc. and no octave is set.
@@ -1742,7 +1732,6 @@ class Pitch(prebase.ProtoM21Object):
     >>> lowE = pitch.Pitch(midi=3)
     >>> lowE.name, lowE.octave
     ('E-', -1)
-
 
     Instead of using a single string or integer for creating the object, a succession
     of named keywords can be used instead:
@@ -1822,7 +1811,6 @@ class Pitch(prebase.ProtoM21Object):
 
     >>> pitch.Pitch('C#5').ps == pitch.Pitch('D-5').ps
     True
-
 
     Advanced construction of pitch with keywords:
 
@@ -2342,7 +2330,6 @@ class Pitch(prebase.ProtoM21Object):
         >>> p.getCentShiftFromMidi()
         25
 
-
         >>> p = pitch.Pitch('c#4')
         >>> p.microtone = -25
         >>> p.ps
@@ -2566,7 +2553,6 @@ class Pitch(prebase.ProtoM21Object):
         <music21.pitch.Pitch A2>
         >>> a.ps
         45.0
-
 
         Notice that ps 61 represents both
         C# and D-flat.  Thus, "spellingIsInferred"
@@ -2854,7 +2840,6 @@ class Pitch(prebase.ProtoM21Object):
         Return or set the pitch name with an octave designation.
         If no octave as been set, no octave value is returned.
 
-
         >>> gSharp = pitch.Pitch('G#4')
         >>> gSharp.nameWithOctave
         'G#4'
@@ -2870,7 +2855,6 @@ class Pitch(prebase.ProtoM21Object):
         'C#'
         >>> dFlatFive.octave
         6
-
 
         N.B. -- it's generally better to set the name and octave separately, especially
         since you may at some point encounter very low pitches such as "A octave -1", which
@@ -3097,7 +3081,6 @@ class Pitch(prebase.ProtoM21Object):
         >>> pitch.Pitch(midi=p.midi).pitchClass
         1
 
-
         This means that pitchClass + microtone is NOT a good way to estimate the frequency
         of a pitch.  For instance, if we take a pitch that is 90% of the way between pitchClass
         0 (C) and pitchClass 1 (C#/D-flat), this formula gives an inaccurate answer of 1.9, not
@@ -3297,7 +3280,6 @@ class Pitch(prebase.ProtoM21Object):
         of a Pitch in the Italian system
         (F-sharp is fa diesis, C-flat is do bemolle, etc.)
         (Microtones and Quarter tones raise an error).
-
 
         >>> print(pitch.Pitch('B-').italian)
         si bemolle
@@ -3681,7 +3663,6 @@ class Pitch(prebase.ProtoM21Object):
         Example: G4 is the third harmonic of C3, albeit 2 cents flatter than
         the true 3rd harmonic.
 
-
         >>> p = pitch.Pitch('g4')
         >>> f = pitch.Pitch('c3')
         >>> p.harmonicFromFundamental(f)
@@ -3787,7 +3768,6 @@ class Pitch(prebase.ProtoM21Object):
         would use to play the harmonic on.  (Perhaps should be
         renamed).
 
-
         >>> pitch.Pitch('g4').harmonicString('c3')
         '3rdH(-2c)/C3'
 
@@ -3846,7 +3826,6 @@ class Pitch(prebase.ProtoM21Object):
         Given a Pitch that is a plausible target for a fundamental,
         return the harmonic number and a potentially shifted fundamental
         that describes this Pitch.
-
 
         >>> g4 = pitch.Pitch('g4')
         >>> g4.harmonicAndFundamentalFromPitch('c3')
@@ -4150,7 +4129,6 @@ class Pitch(prebase.ProtoM21Object):
         >>> print(p2)
         D#
 
-
         The lower enharmonic can have a different octave than
         the original.
 
@@ -4319,7 +4297,6 @@ class Pitch(prebase.ProtoM21Object):
         >>> p.getEnharmonic()
         <music21.pitch.Pitch C>
 
-
         Works with half-sharps, but converts them to microtones:
 
         >>> dHalfSharp = pitch.Pitch('D~')
@@ -4449,7 +4426,6 @@ class Pitch(prebase.ProtoM21Object):
 
         C4 (middleC) = 29, C#4 = 29, C##4 = 29, D-4 = 30, D4 = 30, etc.
 
-
         >>> c = pitch.Pitch('c4')
         >>> c.diatonicNoteNum
         29
@@ -4467,7 +4443,6 @@ class Pitch(prebase.ProtoM21Object):
         'double-flat'
         >>> d.diatonicNoteNum
         30
-
 
         >>> lowC = pitch.Pitch('c1')
         >>> lowC.diatonicNoteNum
@@ -4494,7 +4469,6 @@ class Pitch(prebase.ProtoM21Object):
         1
         >>> lowDSharp.name
         'D#'
-
 
         Negative diatonicNoteNums are possible,
         in case, like John Luther Adams, you want
@@ -4560,7 +4534,6 @@ class Pitch(prebase.ProtoM21Object):
         >>> cPitch
         <music21.pitch.Pitch C-5>
 
-
         An interval object can also be a certain number of semitones,
         in which case, the spelling of the resulting note (sharp or flat, etc.)
         is up to the system to choose.
@@ -4569,7 +4542,6 @@ class Pitch(prebase.ProtoM21Object):
         >>> bPitch = aPitch.transpose(aInterval)
         >>> bPitch
         <music21.pitch.Pitch C#4>
-
 
         Transpose fFlat down 5 semitones -- sort of like a Perfect 4th, but
         should be respelled:
@@ -4695,14 +4667,12 @@ class Pitch(prebase.ProtoM21Object):
         >>> higherG
         <music21.pitch.Pitch G5>
 
-
         To change the pitch itself, set inPlace to True:
 
         >>> p = pitch.Pitch('G5')
         >>> p.transposeBelowTarget(pitch.Pitch('C#4'), inPlace=True)
         >>> p
         <music21.pitch.Pitch G3>
-
 
         If already below the target, make no change:
 
@@ -4713,7 +4683,6 @@ class Pitch(prebase.ProtoM21Object):
 
         >>> pitch.Pitch('g#8').transposeBelowTarget(pitch.Pitch('g#1'))
         <music21.pitch.Pitch G#1>
-
 
         This does nothing because it is already low enough:
 
@@ -4786,7 +4755,6 @@ class Pitch(prebase.ProtoM21Object):
 
         >>> pitch.Pitch('d2').transposeAboveTarget(pitch.Pitch('e4'))
         <music21.pitch.Pitch D5>
-
 
         To change the pitch itself, set inPlace to True:
 

--- a/music21/prebase.py
+++ b/music21/prebase.py
@@ -45,7 +45,6 @@ class ProtoM21Object:
     >>> repr(pc)
     '<...PitchCounter no pitches>'
 
-
     ProtoM21Objects, like other Python primitives, cannot be put into streams --
     this is what base.Music21Object does.
 
@@ -96,7 +95,6 @@ class ProtoM21Object:
         >>> d = duration.Duration('half')
         >>> d.classes
         ('Duration', 'ProtoM21Object', 'SlottedObjectMixin', 'object')
-
 
         Having quick access to these things as strings makes it easier to do comparisons:
 

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -51,7 +51,6 @@ class RepeatMark(prebase.ProtoM21Object):
 
     The following demonstration shows how a user might see if a Stream has any repeats in it.
 
-
     >>> class PartialRepeat(repeat.RepeatMark, base.Music21Object):
     ...    def __init__(self, **keywords):
     ...        super().__init__(**keywords)
@@ -309,7 +308,6 @@ class DaCapoAlCoda(RepeatExpressionCommand):
     indicating that any repeats encountered on the
     Da Capo repeat not be repeated.
 
-
     >>> rm = repeat.DaCapoAlCoda()
     '''
 
@@ -419,7 +417,6 @@ def insertRepeatEnding(s, start, end, endingNumber: int = 1, *, inPlace=False):
 
     Example: create first and second endings over measures 4-6 and measures 11-13 of a chorale,
     respectively.
-
 
     >>> c1 = corpus.parse('bwv10.7.mxl')
     >>> repeat.insertRepeatEnding(c1,  4,  6, 1, inPlace=True)
@@ -824,7 +821,6 @@ class Expander(t.Generic[StreamType]):
         rather than just seeing
         what needs to be expanded and returning that.
 
-
         >>> s = converter.parse('tinynotation: 3/4 A2.  C4 D E   F2.    G4 a b   c2.')
         >>> s.makeMeasures(inPlace=True)
         >>> s.measure(2).leftBarline = bar.Repeat(direction='start')
@@ -1083,7 +1079,6 @@ class Expander(t.Generic[StreamType]):
         This is used to handle when there are more than
         one group of repeat brackets per Stream.
 
-
         >>> s = converter.parse('tinynotation: 3/4 A2.  C4 D E   F2.    G4 a b   c2.')
         >>> s.makeMeasures(inPlace=True)
         >>> s.measure(2).leftBarline = bar.Repeat(direction='start')
@@ -1243,7 +1238,6 @@ class Expander(t.Generic[StreamType]):
 
         The provided Stream must be a Stream only of Measures.
 
-
         >>> s = converter.parse('tinynotation: 3/4 A2.  C4 D E   F2.    G4 a b   c2.')
         >>> s.makeMeasures(inPlace=True)
         >>> s.measure(2).leftBarline = bar.Repeat(direction='start')
@@ -1309,7 +1303,6 @@ class Expander(t.Generic[StreamType]):
         placed on the left of a measure that is not actually
         being copied.
 
-
         The `index` parameter is the index of the last
         measure to be copied. The streamObj must only have Measures.
         '''
@@ -1353,7 +1346,6 @@ class Expander(t.Generic[StreamType]):
 
         If `returnExpansionOnly` is True, only the expanded portion is
         returned, the rest of the Stream is not retained.
-
 
         >>> s = converter.parse('tinynotation: 3/4 A2.  C4 D E   F2.    G4 a b   c2.')
         >>> s.makeMeasures(inPlace=True)
@@ -1429,7 +1421,6 @@ class Expander(t.Generic[StreamType]):
             {3.0} <music21.bar.Barline type=double>
         {21.0} <music21.stream.Measure 5 offset=21.0>
         ...
-
 
         Should work even if no start repeat is given:
 
@@ -1992,7 +1983,6 @@ class RepeatFinder:
         Raises an exception if RepeatFinder's internal stream is too short
         (i.e. fewer than 3 measures long)
 
-
         >>> noPickup = corpus.parse('bwv10.7.mxl')
         >>> repeat.RepeatFinder(noPickup).getQuarterLengthOfPickupMeasure()
         0.0
@@ -2394,18 +2384,14 @@ class RepeatFinder:
         ...    s.append(m)
         >>> #_DOCS_SHOW s.show()
 
-
         .. image:: images/repeat-RepeatFinderDSCH.*
             :width: 600
 
         >>> s2 = repeat.RepeatFinder(s).simplify()
         >>> #_DOCS_SHOW s2.show()
 
-
         .. image:: images/repeat-RepeatFinderDSCHsimplified.*
             :width: 600
-
-
 
         OMIT_FROM_DOCS
 

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -2056,7 +2056,8 @@ class RepeatFinder:
         .. image:: images/repeat-rf_hasPickup.*
            :width: 600
 
-        _OMIT_FROM_DOCS_
+        OMIT_FROM_DOCS
+
         >>> repeat.RepeatFinder(noPickup.parts[0].measures(1, 2)).hasPickup()
         Traceback (most recent call last):
         music21.repeat.InsufficientLengthException: Cannot determine length of pickup
@@ -2109,7 +2110,8 @@ class RepeatFinder:
         [[1, 2, 4, 5, 6, 8, 10], [2, 4, 5, 6, 8, 10], [4, 5, 6, 8, 10],
          [7, 9, 11], [5, 6, 8, 10], [6, 8, 10], [8, 10], [9, 11], [10], [11], [], []]
 
-        _OMIT_FROM_DOCS_
+        OMIT_FROM_DOCS
+
         >>> repeat.RepeatFinder().getMeasureSimilarityList()
         Traceback (most recent call last):
         music21.repeat.NoInternalStreamException: RepeatFinder must be initialized with a stream
@@ -2187,25 +2189,26 @@ class RepeatFinder:
         compareList=[compare, compare + 1, compare + 2, ...]), where
         measure sourceList[i] is the same as measure compareList[i]
 
-        Inputs:
-        measures -  A list returned from getMeasureSimilarityList.
-        source   -  The measure number which you are considering
-        compare  -  The measure number which is compared to the source measure
-                    (this is a repeat of the source measure)
-        resDict  -  A dictionary of memoized results where for each key (i,j),
-                    there is stored a tuple
-                    ([i, i + 1, i + 2, ...], [j, j + 1, j + 2, ...])
-                    where measures i and j are equal,
-                    and measure i + 1 and j + 1 are equal,
-                    and measures i + 2 and j + 2 are equal, etc.
-        useDict  -  A dictionary for each input that maps to False if
-                    and only if the function calls
-                    the same input m and i. Has the result that if resDict((i, j)) maps to
-                    something like ([i, i + 1, i + 2...],
-                    [j, j + 1, j + 2, ...]), then
-                    useDict(i,j) is only False if resDict(i - 1, j - 1) is
-                    something like ([i - 1, i, i + 1, ...],
-                    [j - 1, j, j + 1, ..])
+        Inputs::
+
+            measures -  A list returned from getMeasureSimilarityList.
+            source   -  The measure number which you are considering
+            compare  -  The measure number which is compared to the source measure
+                        (this is a repeat of the source measure)
+            resDict  -  A dictionary of memoized results where for each key (i,j),
+                        there is stored a tuple
+                        ([i, i + 1, i + 2, ...], [j, j + 1, j + 2, ...])
+                        where measures i and j are equal,
+                        and measure i + 1 and j + 1 are equal,
+                        and measures i + 2 and j + 2 are equal, etc.
+            useDict  -  A dictionary for each input that maps to False if
+                        and only if the function calls
+                        the same input m and i. Has the result that if resDict((i, j)) maps to
+                        something like ([i, i + 1, i + 2...],
+                        [j, j + 1, j + 2, ...]), then
+                        useDict(i,j) is only False if resDict(i - 1, j - 1) is
+                        something like ([i - 1, i, i + 1, ...],
+                        [j - 1, j, j + 1, ..])
 
         See getSimilarMeasureGroupsFromList documentation for tests.
         '''

--- a/music21/roman.py
+++ b/music21/roman.py
@@ -829,7 +829,6 @@ def romanNumeralFromChord(
     >>> romanNumeral10
     <music21.roman.RomanNumeral #iiiø7 in d minor>
 
-
     Augmented 6ths without key context
 
     >>> roman.romanNumeralFromChord(
@@ -926,7 +925,6 @@ def romanNumeralFromChord(
     ...     chord.Chord('E4 G4 B-4 C#5')
     ...     )
     <music21.roman.RomanNumeral io6b5b3 in c# minor>
-
 
     The preferSecondaryDominants option defaults to False, but if set to True,
     then certain rare figures are swapped with their
@@ -1038,7 +1036,6 @@ def romanNumeralFromChord(
 
     # >>> roman.romanNumeralFromChord(chord.Chord('B3 D3 E-3 G3'), key.Key('c'))
     # <music21.roman.RomanNumeral III+642 in c minor>
-
 
     These two are debatable -- is the harmonic minor or the natural minor used as the basis?
 
@@ -1414,7 +1411,6 @@ class RomanNumeral(harmony.Harmony):
     >>> roman.RomanNumeral('v64', 'c').pitches
     (<music21.pitch.Pitch D4>, <music21.pitch.Pitch G4>, <music21.pitch.Pitch B-4>)
 
-
     If no Key is given then it exists as a theoretical, keyless RomanNumeral;
     e.g., V in any key.  But when realized, keyless RomanNumerals are
     treated as if they are in C major.
@@ -1511,7 +1507,6 @@ class RomanNumeral(harmony.Harmony):
     >>> cp(minorSharpSix)
     ['C#5', 'E5', 'G#5']
 
-
     These rules can be changed by passing in a `sixthMinor` or `seventhMinor` parameter set to
     a member of :class:`music21.roman.Minor67Default`:
 
@@ -1530,7 +1525,6 @@ class RomanNumeral(harmony.Harmony):
     >>> majHarmonicSeven = roman.RomanNumeral('bVII', em, seventhMinor=roman.Minor67Default.SHARP)
     >>> cp(majHarmonicSeven)
     ['D5', 'F#5', 'A5']
-
 
     >>> majHarmonicSix = roman.RomanNumeral('VI', em, sixthMinor=roman.Minor67Default.FLAT)
     >>> cp(majHarmonicSix)
@@ -1775,7 +1769,6 @@ class RomanNumeral(harmony.Harmony):
     >>> r2.secondaryRomanNumeral.secondaryRomanNumeral
     <music21.roman.RomanNumeral vi in C major>
 
-
     The I64 chord can also be specified as Cad64, which
     simply parses as I64:
 
@@ -1798,7 +1791,6 @@ class RomanNumeral(harmony.Harmony):
     <music21.roman.RomanNumeral Cad64/V in c minor>
     >>> cp(r)
     ['D5', 'G5', 'B5']
-
 
     In a major context, i7 and iv7 and their inversions are treated as minor-7th
     chords:
@@ -1833,7 +1825,6 @@ class RomanNumeral(harmony.Harmony):
     >>> cp(roman.RomanNumeral('i#7', 'c'))
     ['C4', 'E-4', 'G4', 'B4']
 
-
     >>> cp(roman.RomanNumeral('i42[#7]', 'C'))
     ['B4', 'C5', 'E-5', 'G5']
 
@@ -1849,15 +1840,12 @@ class RomanNumeral(harmony.Harmony):
     >>> cp(roman.RomanNumeral('i7[#7]', 'c'))
     ['C4', 'E-4', 'G4', 'B4']
 
-
     Other inversions are the same as with major keys:
 
     >>> cp(roman.RomanNumeral('i65[#7]', 'c'))
     ['E-4', 'G4', 'B4', 'C5']
     >>> cp(roman.RomanNumeral('i43[#7]', 'c'))
     ['G4', 'B4', 'C5', 'E-5']
-
-
 
     The RomanNumeral constructor accepts a keyword 'updatePitches' which is
     passed to harmony.Harmony. By default, it
@@ -1902,7 +1890,6 @@ class RomanNumeral(harmony.Harmony):
     >>> rn7 = roman.RomanNumeral('N6', 'c')
     >>> rn5 == rn7
     False
-
 
     * Changed in v6.5: caseMatters is keyword only. It along with sixthMinor and
       seventhMinor are now the only allowable keywords to pass in.
@@ -2958,7 +2945,6 @@ class RomanNumeral(harmony.Harmony):
         '65'
         >>> rn.scaleDegreeWithAlteration
         (4, <music21.pitch.Accidental sharp>)
-
 
         Working figures might be changed to defaults:
 

--- a/music21/romanText/clercqTemperley.py
+++ b/music21/romanText/clercqTemperley.py
@@ -235,7 +235,6 @@ class CTSong(prebase.ProtoM21Object):
     >>> rule.sectionName
     'Introduction'
 
-
     With this object-oriented approach to parsing the clercq-temperley text file format,
     we now have the ability to analyze a large corpus (200 files) of popular music
     using the full suite of harmonic tools of music21. We can not only analyze each
@@ -299,7 +298,6 @@ class CTSong(prebase.ProtoM21Object):
                          text='S: [A] $In $Vr $Vr $Vr $Vr $Vr $Vr $Vrf
                                      % 3rd and 6th verses are instrumental'>)])
 
-
     >>> rule = s.rules['In']
     >>> rule.text
     'In: I | | | | | | V | |'
@@ -325,7 +323,6 @@ class CTSong(prebase.ProtoM21Object):
         Fadeout: I . . V | I . . V | I . . V |
         Co: [2/4] I | [4/4] . . . V | I . . V | $Fadeout
         S: [G] $In $Vr $Ch $In*2 $Ch $Vr2 $Ch $Ch $Co
-
 
     """
     _DOC_ORDER = ['text', 'toPart', 'title', 'homeTimeSig', 'homeKey', 'comments', 'rules']

--- a/music21/romanText/rtObjects.py
+++ b/music21/romanText/rtObjects.py
@@ -318,7 +318,6 @@ class RTTagged(RTToken):
         >>> tag.isKeySignature()
         False
 
-
         N.B.: this is not the same as a key definition found inside a
         Measure. These are represented by RTKey rtObjects, defined below, and are
         not RTTagged rtObjects, but RTAtom subclasses.
@@ -506,7 +505,6 @@ class RTMeasure(RTToken):
     ['a']
     >>> rtm.isMeasure()
     True
-
 
     '''
 
@@ -738,17 +736,14 @@ class RTBeat(RTAtom):
         >>> RTB('b1.2').getBeatFloatOrFrac()
         Fraction(6, 5)
 
-
         A third digit of 0.5 adds 1/2 of 1/DENOM of before.  Here DENOM is 3 (in 5/3) so
         we add 1/6 to 5/3 to get 11/6:
-
 
         >>> RTB('b1.66').getBeatFloatOrFrac()
         Fraction(5, 3)
 
         >>> RTB('b1.66.5').getBeatFloatOrFrac()
         Fraction(11, 6)
-
 
         Similarly 0.25 adds 1/4 of 1/DENOM, to get 21/12 or 7/4 or 1.75:
 

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -17,7 +17,6 @@ This module is really only needed for people extending the parser,
 for others it's simple to get Harmony, RomanNumeral, Key (or KeySignature)
 and other objects out of an rntxt file by running this:
 
-
 >>> monteverdi = corpus.parse('monteverdi/madrigal.3.1.rntxt')
 >>> monteverdi.show('text')
 {0.0} <music21.metadata.Metadata object at 0x...>
@@ -90,7 +89,6 @@ It's a little complex, but worth seeing in full:
 ...    i += 1
 >>> histogram.data = data
 
-
 These commands give nice labels for the data; optional:
 
 >>> histogram.setIntegerTicksFromData(values, 'y')
@@ -103,7 +101,6 @@ Now generate the histogram:
 
 .. image:: images/romanTranslatePitchDistribution.*
     :width: 600
-
 
 OMIT_FROM_DOCS
 
@@ -495,7 +492,6 @@ class PartTranslator:
         >>> pt.setMinorRootParse(tag)
         >>> print(pt.sixthMinor)
         Minor67Default.FLAT
-
 
         Unknown settings raise a `RomanTextTranslateException`
 

--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -1246,7 +1246,6 @@ class ConcreteScale(Scale):
     >>> [str(p) for p in myScale.getPitches('E-5', 'G-7')]
     ['E-5', 'G-5', 'A5', 'C6', 'E-6', 'G-6', 'A6', 'C7', 'E-7', 'G-7']
 
-
     A scale that lasts two octaves and uses quarter tones (D~)
 
     >>> complexScale = scale.ConcreteScale(
@@ -1271,8 +1270,6 @@ class ConcreteScale(Scale):
     Two ConcreteScales are the same if they satisfy all general Music21Object
     equality methods and their Abstract scales, their tonics, and their
     boundRanges are the same:
-
-
 
     OMIT_FROM_DOCS
 
@@ -1869,7 +1866,6 @@ class ConcreteScale(Scale):
         >>> cMaj.getScaleDegreeAndAccidentalFromPitch(pitch.Pitch('E-'))
         (3, <music21.pitch.Accidental flat>)
 
-
         The Direction of a melodic minor scale is significant
 
         >>> aMin = scale.MelodicMinorScale('a')
@@ -2362,7 +2358,6 @@ class ConcreteScale(Scale):
          (2, <music21.scale.ConcreteScale B Concrete>),
          (2, <music21.scale.ConcreteScale A Concrete>),
          (2, <music21.scale.ConcreteScale G# Concrete>)]
-
 
         >>> eConcrete = bestScales[0][1]
         >>> ' '.join([str(p) for p in eConcrete.pitches])
@@ -3002,7 +2997,6 @@ class OctaveRepeatingScale(ConcreteScale):
     '''
     A concrete cyclical scale, based on a cycle of intervals.
 
-
     >>> sc = scale.OctaveRepeatingScale('c4', ['m3', 'M3'])
     >>> sc.pitches
     [<music21.pitch.Pitch C4>, <music21.pitch.Pitch E-4>,
@@ -3062,7 +3056,6 @@ class CyclicalScale(ConcreteScale):
 class ChromaticScale(ConcreteScale):
     '''
     A concrete cyclical scale, based on a cycle of half steps.
-
 
     >>> sc = scale.ChromaticScale('g2')
     >>> [str(p) for p in sc.pitches]
@@ -3134,7 +3127,6 @@ class SieveScale(ConcreteScale):
     :class:`~music21.sieve.Sieve` object definition. The complete period of the
     sieve is realized as intervals and used to create a scale.
 
-
     >>> sc = scale.SieveScale('c4', '3@0')
     >>> sc.pitches
     [<music21.pitch.Pitch C4>, <music21.pitch.Pitch E-4>]
@@ -3144,7 +3136,6 @@ class SieveScale(ConcreteScale):
     >>> sc = scale.SieveScale('c2', '(-3@2 & 4) | (-3@1 & 4@1) | (3@2 & 4@2) | (-3 & 4@3)')
     >>> [str(p) for p in sc.pitches]
     ['C2', 'D2', 'E2', 'F2', 'G2', 'A2', 'B2', 'C3']
-
 
     OMIT_FROM_DOCS
 

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -514,7 +514,6 @@ class IntervalNetwork:
         >>> net.edges
         OrderedDict()
 
-
         >>> net.fillBiDirectedEdges(edgeList)
         >>> net.nodes
         OrderedDict([(Terminus.LOW, <music21.scale.intervalNetwork.Node id=Terminus.LOW>),
@@ -687,7 +686,6 @@ class IntervalNetwork:
                       'connections': ([0, Terminus.HIGH, Direction.BI],)
                       },
                     )
-
 
         >>> nodes = ({'id': scale.Terminus.LOW, 'degree': 1},
         ...          {'id': 0, 'degree': 2},
@@ -1228,7 +1226,6 @@ class IntervalNetwork:
 
         The `nodeName` parameter may be a :class:`~music21.scale.intervalNetwork.Node` object,
         a node degree, a Terminus Enum, or a None (indicating Terminus.LOW).
-
 
         >>> edgeList = ['M2', 'M2', 'm2', 'M2', 'M2', 'M2', 'm2']
         >>> net = scale.intervalNetwork.IntervalNetwork()
@@ -1980,7 +1977,6 @@ class IntervalNetwork:
         The nodeId, when a simple, linear network, can be used as a scale degree
         value starting from one.
 
-
         >>> edgeList = ['M2', 'M2', 'm2', 'M2', 'M2', 'M2', 'm2']
         >>> net = scale.intervalNetwork.IntervalNetwork()
         >>> net.fillBiDirectedEdges(edgeList)
@@ -2003,9 +1999,7 @@ class IntervalNetwork:
         >>> [str(p) for p in net.realizePitch(pitch.Pitch('a#2'), 7, 'c6', 'c7')]
         ['C#6', 'D#6', 'E6', 'F#6', 'G#6', 'A#6', 'B6']
 
-
         Circle of fifths
-
 
         >>> edgeList = ['P5'] * 6 + ['d6'] + ['P5'] * 5
         >>> net5ths = scale.intervalNetwork.IntervalNetwork()
@@ -2310,7 +2304,6 @@ class IntervalNetwork:
         If more than one node defines the same pitch, Node weights are used
         to select a single node.
 
-
         >>> edgeList = ['M2', 'M2', 'm2', 'M2', 'M2', 'M2', 'm2']
         >>> net = scale.intervalNetwork.IntervalNetwork(edgeList)
         >>> net.getRelativeNodeId('a', 1, 'a4')
@@ -2466,7 +2459,6 @@ class IntervalNetwork:
         equality.  Use `ps` (default) for post-tonal uses.  `name` for
         tonal, and `step` for diatonic.
 
-
         >>> edgeList = ['M2', 'M2', 'm2', 'M2', 'M2', 'M2', 'm2']
         >>> net = scale.intervalNetwork.IntervalNetwork(edgeList)
         >>> [str(p) for p in net.realizePitch(pitch.Pitch('e-2')) ]
@@ -2507,7 +2499,6 @@ class IntervalNetwork:
         1
         >>> net.getRelativeNodeDegree('e-3', 1, 'b-1')
         5
-
 
         >>> edgeList = ['p4', 'p4', 'p4']  # a non octave-repeating scale
         >>> net = scale.intervalNetwork.IntervalNetwork(edgeList)
@@ -2584,7 +2575,6 @@ class IntervalNetwork:
         <music21.pitch.Pitch F#4>
         >>> net.getPitchFromNodeDegree('e4', 1, 3, minPitch='c2', maxPitch='c3')
         <music21.pitch.Pitch G#2>
-
 
         This will always get the lowest pitch:
 
@@ -2883,7 +2873,6 @@ class IntervalNetwork:
         Given a collection of pitches, test all transpositions of a realized
         version of this network, and return the number of matches in each for
         each pitch assigned to the first node.
-
 
         >>> edgeList = ['M2', 'M2', 'm2', 'M2', 'M2', 'M2', 'm2']
         >>> net = scale.intervalNetwork.IntervalNetwork(edgeList)

--- a/music21/scale/scala/__init__.py
+++ b/music21/scale/scala/__init__.py
@@ -482,7 +482,6 @@ def parse(target):
     >>> ss.fileName
     'barbour_chrom1.scl'
 
-
     >>> ss = scale.scala.parse('blackj_gws.scl')
     >>> ss.description
     'Detempered Blackjack in 1/4 kleismic marvel tuning'

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -135,7 +135,6 @@ class StreamSearcher:
     >>> d = note.Note('D', quarterLength=0.5)
     >>> searchList = [c, d]
 
-
     Now create a StreamSearcher:
 
     >>> ss = search.StreamSearcher(thisStream, searchList)
@@ -163,7 +162,6 @@ class StreamSearcher:
     [<function StreamSearcher.wildcardAlgorithm at 0x111b6e340>,
      <function StreamSearcher.rhythmAlgorithm at 0x11200000>]
 
-
     Now run it:
 
     >>> results = ss.run()
@@ -175,7 +173,6 @@ class StreamSearcher:
     1
     >>> results[1].elStart.measureNumber
     2
-
 
     Wildcards can be useful:
 
@@ -193,7 +190,6 @@ class StreamSearcher:
     (<music21.note.Note D>, <music21.note.Note E>, <music21.note.Note G>)
     >>> [n.duration.quarterLength for n in results[0].els]
     [0.5, 1.0, 1.5]
-
 
     OMIT_FROM_DOCS
 
@@ -386,13 +382,10 @@ def rhythmicSearch(thisStreamOrIterator, searchList):
     {0.0} <music21.note.Note G>
     {1.5} <music21.note.Note A>
 
-
-
     Slightly more advanced search: we will look for any instances of eighth,
     followed by a note (or other element) of any length, followed by a dotted quarter
     note.  Again, we will find two instances; this time we will tag them both with
     a TextExpression of "*" and then show the original stream:
-
 
     >>> searchStream2 = stream.Stream()
     >>> searchStream2.append(note.Note(quarterLength=0.5))
@@ -405,7 +398,6 @@ def rhythmicSearch(thisStreamOrIterator, searchList):
     ...     thisStreamIter[found].lyric = '*'
     >>> #_DOCS_SHOW thisStream.show()
 
-
     .. image:: images/searchRhythmic1.*
         :width: 221
 
@@ -416,7 +408,6 @@ def rhythmicSearch(thisStreamOrIterator, searchList):
     is than the second (eighth, anything, dotted-quarter).  In fact, my hypothesis
     was wrong, and the second term is actually more common than the first! (n.b. rests
     are being counted here as well as notes)
-
 
     >>> grave = corpus.parse('corelli/opus3no1/1grave')
     >>> term1results = []
@@ -722,7 +713,6 @@ def translateDiatonicStreamToString(inputStreamOrIterator, returnMeasures=False)
     O-U = note of shorter length than previous
     Z = rest
 
-
     >>> s = converter.parse("tinynotation: 3/4 c4 d8~ d16 r16 FF8 F#8 a'8 b-2.")
     >>> streamString = search.translateDiatonicStreamToString(s.recurse().notesAndRests)
     >>> print(streamString)
@@ -796,7 +786,6 @@ def translateIntervalsAndSpeed(inputStream, returnMeasures=False):
     Skips all but the first note of tie. Skips multiple rests in a row
 
     Each note gets one byte and encodes up from -13 to 13 (all notes > octave are 13 or -13)
-
 
     >>> s = converter.parse("tinynotation: 3/4 c4 d8~ d16 r16 F8 F#8 F8 a'8 b-2")
     >>> sn = s.flatten().notesAndRests.stream()
@@ -1065,7 +1054,6 @@ def mostCommonMeasureRhythms(streamIn, transposeDiatonic=False):
     rhythm: the rhythm found (with the pitches of the first instance of the rhythm transposed to C5)
     measures: a list of measures containing the rhythm
     rhythmString: a string representation of the rhythm (see translateStreamToStringOnlyRhythm)
-
 
     >>> bach = corpus.parse('bwv1.6')
     >>> sortedRhythms = search.mostCommonMeasureRhythms(bach)

--- a/music21/search/segment.py
+++ b/music21/search/segment.py
@@ -66,7 +66,6 @@ def translateMonophonicPartToSegments(
     >>> segments[0:2]
     ['HJHEAAEHHCE@JHGECA@A>@A><A@AAE', '@A>@A><A@AAEEECGHJHGH@CAE@FECA']
 
-
     Segment zero begins at measure 1 and ends in m. 12.  Segment 1 spans m.7 - m.18:
 
     >>> measureLists[0:2]

--- a/music21/search/serial.py
+++ b/music21/search/serial.py
@@ -287,7 +287,6 @@ class ContiguousSegmentSearcher:
     [[<music21.note.Note G>, <music21.note.Note A>, <music21.note.Note B>],
      [<music21.note.Note A>, <music21.note.Note B>, <music21.note.Note C>]]
 
-
     In order to be considered repetition, the spellings of the notes
     in question must be exactly the same:
     enharmonic equivalents are not checked and notes with the
@@ -310,7 +309,6 @@ class ContiguousSegmentSearcher:
     >>> foundSegments = searcherNew.byLength(3)
     >>> [seg.segment for seg in foundSegments]
     [[<music21.note.Note C>, <music21.note.Note C>, <music21.note.Note B#>]]
-
 
     'rowsOnly' searches only for tone rows, in which all pitch classes
     in the segment must be distinct. Below,
@@ -847,7 +845,6 @@ class SegmentMatcher:
     matches at least one of the elements of the searchList,
     subject to the settings specified in reps and includeChords.
 
-
     >>> sc = stream.Score()
     >>> part = stream.Part()
     >>> sig = meter.TimeSignature('2/4')
@@ -920,7 +917,6 @@ class SegmentMatcher:
     >>> matcher = search.serial.SegmentMatcher(sc, reps='ignoreAll', includeChords=True)
     >>> [seg.segment for seg in matcher.find([[5, 7, 'B']])]
     [[<music21.note.Note F>, <music21.chord.Chord G4 B4>]]
-
 
     As expected, the pitch classes found segment are read
     in the order 5, 7, 11 ('B'), as the pitches
@@ -1213,7 +1209,6 @@ class TransposedSegmentMatcher(SegmentMatcher):
     least one of the elements of the searchList,
     subject to the settings specified in reps and includeChords.
 
-
     >>> part = stream.Part()
     >>> n1 = note.Note('e4')
     >>> n1.quarterLength = 6
@@ -1366,7 +1361,6 @@ class TransformedSegmentMatcher(SegmentMatcher):
     least one of the elements of the searchList,
     subject to the settings specified in reps and includeChords.
 
-
     >>> n1 = note.Note('c#4')
     >>> n2 = note.Note('e4')
     >>> n3 = note.Note('d#4')
@@ -1381,7 +1375,6 @@ class TransformedSegmentMatcher(SegmentMatcher):
 
     .. image:: images/serial-findTransformedSegments.png
         :width: 150
-
 
     >>> tsMatcher = search.serial.TransformedSegmentMatcher(part, 'rowsOnly',
     ...                 includeChords=False)
@@ -1577,7 +1570,6 @@ class MultisetSegmentMatcher(SegmentMatcher):
     matches at least one of the elements of the searchList,
     subject to the settings specified in reps and includeChords.
 
-
     >>> part = stream.Part()
     >>> n1 = note.Note('e4')
     >>> n1.quarterLength = 4
@@ -1615,7 +1607,6 @@ class MultisetSegmentMatcher(SegmentMatcher):
     .. image:: images/serial-findMultisets.png
         :width: 150
 
-
     Find all instances of the multiset [5, 4, 4] in the part
 
     >>> MSS = search.serial.MultisetSegmentMatcher(part, 'includeAll', includeChords=False)
@@ -1625,7 +1616,6 @@ class MultisetSegmentMatcher(SegmentMatcher):
      <music21.search.serial.ContiguousSegmentOfNotes ['E4', 'F4', 'E4']>]
     >>> [(seg.activeSegment, seg.startMeasureNumber) for seg in EEF]
     [([4, 4, 5], 1), ([4, 5, 4], 2)]
-
 
     >>> MSS = search.serial.MultisetSegmentMatcher(part, 'ignoreAll')
     >>> EF = MSS.find([5, 4])
@@ -1740,7 +1730,6 @@ class TransposedMultisetMatcher(SegmentMatcher):
     matches at least one of the elements of the searchList,
     subject to the settings specified in reps and includeChords.
 
-
     >>> part = stream.Part()
     >>> n1 = note.Note('c4')
     >>> n2 = note.Note('c#4')
@@ -1766,9 +1755,7 @@ class TransposedMultisetMatcher(SegmentMatcher):
     ([2, 4, 3], 3, [-9, -10, -11])
     ([3, 4, 2], 5, [-9, -10, -11])
 
-
     OMIT_FROM_DOCS
-
 
     >>> part2 = stream.Part()
     >>> n1 = chord.Chord(['c4', 'c5'])
@@ -1850,7 +1837,6 @@ class TransposedInvertedMultisetMatcher(TransposedMultisetMatcher):
     interpreted as a multiset,
     matches at least one of the elements of the searchList,
     subject to the settings specified in reps and includeChords.
-
 
     >>> s = stream.Stream()
     >>> n1 = note.Note('c4')
@@ -2240,7 +2226,6 @@ def labelMultisets(inputStream, multisetDict, reps='skipConsecutive', includeCho
     there will be more than six spanners active
     simultaneously, which may result in some
     spanners not showing correctly in XML format, or not at all.
-
 
     >>> part = stream.Part()
     >>> n1 = note.Note('e4')

--- a/music21/serial.py
+++ b/music21/serial.py
@@ -522,7 +522,6 @@ class ToneRow(stream.Stream):
         transform the row appropriately (without transposition), then transpose the resulting
         row by n semitones.
 
-
         >>> chromatic = serial.pcToToneRow(range(12))
         >>> chromatic.pitchClasses()
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
@@ -559,7 +558,6 @@ class ToneRow(stream.Stream):
 
         See :meth:`~music21.serial.ToneRow.zeroCenteredTransformation` for
         an explanation of this convention.
-
 
         >>> chromatic = serial.pcToToneRow([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 1])
         >>> reverseChromatic = serial.pcToToneRow([8, 7, 6, 5, 4, 3, 2, 1, 0, 11, 10, 9])
@@ -809,7 +807,6 @@ class TwelveToneRow(ToneRow):
         of the all-trichord hexachord. Note that the interval sets may be transformed.
 
         Named for John Link who discovered them.
-
 
         >>> bergLyric = serial.getHistoricalRowByName('BergLyricSuite')
         >>> bergLyric.pitchClasses()

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -33,15 +33,12 @@ The :class:`music21.sieve.Sieve` class permits generation segments in four forma
 >>> len(a.segment(segmentFormat='unit'))
 43
 
-
 A :class:`music21.sieve.CompressionSegment` can be used to derive a Sieve from a
 ny sequence of integers.
-
 
 >>> a = sieve.CompressionSegment([3, 4, 5, 6, 7, 8, 13, 19])
 >>> str(a)
 '6@1|7@6|8@5|9@4|10@3|11@8'
-
 
 The :class:`music21.sieve.PitchSieve` class provides a quick generation of
 :class:`music21.pitch.Pitch` lists from Sieves.
@@ -132,17 +129,14 @@ def eratosthenes(firstCandidate=2):
     To use this generator, create an instance and then call the .next() method
     on the instance.
 
-
     >>> a = sieve.eratosthenes()
     >>> next(a)
     2
     >>> next(a)
     3
 
-
     We can also specify a starting value for the sequence, skipping over
     initial primes smaller than this number:
-
 
     >>> a = sieve.eratosthenes(95)
     >>> next(a)
@@ -182,7 +176,6 @@ def rabinMiller(n):
     Rabin Miller primality test.
 
     See also here: http://www.4dsolutions.net/ocn/numeracy2.html
-
 
     >>> sieve.rabinMiller(234)
     False
@@ -255,7 +248,6 @@ def discreteBinaryPad(series: Iterable[int], fixRange=None) -> list[int]:
     the first entry (signifying 3), 0s for the next six entries (signifying
     4-9), a 1 (for 10), a 0 (for 11), and a 1 (for 12).
 
-
     >>> sieve.discreteBinaryPad([3, 10, 12])
     [1, 0, 0, 0, 0, 0, 0, 1, 0, 1]
 
@@ -293,18 +285,14 @@ def unitNormRange(series, fixRange=None):
     according to their distance between these two units.  For instance, for 0, 3, 4
     the middle entry will be 0.75 since 3 is 3/4 of the distance between 0 and 4:
 
-
     >>> sieve.unitNormRange([0, 3, 4])
     [0.0, 0.75, 1.0]
-
 
     but for [1, 3, 4], it will be 0.666... because 3 is 2/3 of the distance between
     1 and 4
 
-
     >>> sieve.unitNormRange([1, 3, 4])
     [0.0, 0.666..., 1.0]
-
 
     '''
     if fixRange is not None:
@@ -363,7 +351,6 @@ def unitNormStep(step, a=0, b=1, normalized=True):
     necessary to cover region.
 
     Note that returned values are, by default, normalized within the unit interval.
-
 
     >>> sieve.unitNormStep(0.5, 0, 1)
     [0.0, 0.5, 1]

--- a/music21/sieve.py
+++ b/music21/sieve.py
@@ -757,7 +757,7 @@ class Residual:
 
     def __or__(self, other):
         '''
-        |, not sure if this can be implemented
+        ``|``, not sure if this can be implemented
         i.e., a union of two Residual classes can not be expressed as a single
         Residual, that is intersections can always be reduced, whereas unions
         cannot be reduced.
@@ -1189,7 +1189,7 @@ class Sieve:
 
     def __or__(self, other):
         '''
-        |, produces a union
+        ``|``, produces a union
 
         >>> a = sieve.Sieve('3@11')
         >>> b = sieve.Sieve('2&4&8|5')
@@ -1300,11 +1300,13 @@ class Sieve:
 
     def _parseLogic(self, usrStr):
         '''
-        provide synonyms for logical symbols
-        intersection == and, &, *
-        union        == or, |, +
-        not          == not, -
-        the native format for str representation uses only &, |, -
+        provide synonyms for logical symbols::
+
+            intersection == and, &, *
+            union        == or, |, +
+            not          == not, -
+
+        the native format for str representation uses only ``&``, ``|``, ``-``;
         this method converts all other string representations
 
         all brackets and braces are replaced with parenthesis

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -376,7 +376,6 @@ class Spanner(base.Music21Object):
         Return all the elements of `.spannerStorage` for this Spanner
         as a list of Music21Objects.
 
-
         >>> n1 = note.Note('g')
         >>> n2 = note.Note('f#')
         >>> sl = spanner.Spanner()
@@ -1217,7 +1216,6 @@ class SpannerBundle(prebase.ProtoM21Object):
         class have been closed.  The example below demonstrates that the
         position of the contents of the spanner have no bearing on
         its idLocal (since we don't even put anything into the spanners).
-
 
         >>> su1 = spanner.Slur()
         >>> su2 = layout.StaffGroup()

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -10309,10 +10309,12 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
          <music21.note.Note B->, <music21.note.Note A->]
 
         * Changed in v7:
+
           - now finds notes in Voices without requiring `getOverlaps=True`
             and iterates over Parts rather than flattening.
           - If `noNone=False`, inserts `None`
             when backing up to scan a subsequent voice or part.
+
         * Changed in v8: all parameters are keyword only.
 
         OMIT_FROM_DOCS

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -546,7 +546,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> subslice[1].offset
         3.0
 
-
         If a class is given, then a :class:`~music21.stream.iterator.RecursiveIterator`
         of elements matching the requested class is returned, similar
         to `Stream().recurse().getElementsByClass()`.
@@ -600,7 +599,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         >>> list(s[layout.StaffLayout])
         []
-
 
         If the key is a string, it is treated as a `querySelector` as defined in
         :meth:`~music21.stream.iterator.getElementsByQuerySelector`, namely that bare strings
@@ -1172,7 +1170,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> m1.elements
         ()
 
-
         Only the time signature at offset 0 is found:
 
         >>> m2 = stream.Measure(number=2)
@@ -1712,7 +1709,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             {0.0} <music21.note.Note C>
         {4.0} <music21.stream.Measure 2 offset=4.0>
         <BLANKLINE>
-
 
         Can also remove elements stored at end:
 
@@ -3635,7 +3631,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> isinstance(foundStream, stream.Score)
         True
 
-
         Notice that we do not find elements that are in
         sub-streams of the main Stream.  We'll add 15 more rests
         in a sub-stream, and they won't be found:
@@ -3804,11 +3799,9 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         There are several attributes that govern how this range is
         determined:
 
-
         If `mustFinishInSpan` is True then an event that begins
         between offsetStart and offsetEnd but which ends after offsetEnd
         will not be included.  The default is False.
-
 
         For instance, a half note at offset 2.0 will be found in
         getElementsByOffset(1.5, 2.5) or getElementsByOffset(1.5, 2.5,
@@ -3849,7 +3842,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
             .. image:: images/getElementsByOffset.*
                 :width: 600
-
 
         >>> st1 = stream.Stream()
         >>> n0 = note.Note('C')
@@ -3893,7 +3885,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> [el.step for el in out7]
         ['C', 'D']
 
-
         Note, that elements that end at the start offset are included if mustBeginInSpan is False
 
         >>> out8 = st1.getElementsByOffset(2, 4, mustBeginInSpan=False)
@@ -3910,7 +3901,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         1
         >>> [el.step for el in out9]
         ['D']
-
 
         Note how zeroLengthSearches implicitly set includeElementsThatEndAtStart=False.
         These two are the same:
@@ -3939,8 +3929,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         1
         >>> out4[0] is n2
         True
-
-
 
         Testing multiple zero-length elements with mustBeginInSpan:
 
@@ -3971,7 +3959,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> len(c)
         10
 
-
         Same test as above, but with floats
 
         >>> out1 = st1.getElementsByOffset(2.0)
@@ -3998,7 +3985,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         1
         >>> out3b[0].step
         'C'
-
 
         >>> out4 = st1.getElementsByOffset(1.0, 2.0)
         >>> len(out4)
@@ -4086,7 +4072,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> b = stream1.getElementAtOrBefore(0.1)
         >>> b.offset, b.id
         (0.0, 'z')
-
 
         You can give a list of acceptable classes to return, and non-matching
         elements will be ignored
@@ -4283,7 +4268,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> t7 = st1.getElementAfterElement(r3)
         >>> t7 is None
         True
-
 
         If the element is not in the stream, it will raise a StreamException:
 
@@ -4747,7 +4731,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         {13.0} <music21.stream.Measure 4 offset=13.0>
         ...
 
-
         Really make empty with `fillWithRests=False`
 
         >>> alto = b.parts[1]
@@ -4766,7 +4749,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         {9.0} <music21.stream.Measure 3 offset=9.0>
             {0.0} <music21.layout.SystemLayout>
         ...
-
 
         `removeClasses` can be a list or set of classes to remove.  By default it is
         ['GeneralNote', 'Dynamic', 'Expression']
@@ -4851,7 +4833,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
                 {0.0} <music21.note.Rest dotted-half>
                 {3.0} <music21.bar.Barline type=final>
         {0.0} <music21.layout.StaffGroup ...>
-
 
         If `retainVoices` is False (default True) then Voice streams are treated
         differently from all other Streams and are removed.  All elements in the
@@ -5010,7 +4991,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         .. image:: images/streamMeasureOffsetMapBWV324.*
             :width: 572
-
 
         >>> chorale = corpus.parse('bach/bwv324.xml')
         >>> alto = chorale.parts['#alto']
@@ -5690,7 +5670,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> m3.getTimeSignatures(searchContext=False)[0]
         <music21.meter.TimeSignature 4/4>
 
-
         * Changed in v8: time signatures within recursed streams are found by default.
           Added recurse. Removed option for recurse=False and still getting the
           first time signature in the first measure.  This was wholly inconsistent.
@@ -6199,7 +6178,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         Helper method for makeChords and Chordify
         run on .flatten().notesAndRests
 
-
         >>> s = stream.Score()
         >>> p1 = stream.Part()
         >>> p1.insert(4, note.Note('C#'))
@@ -6540,7 +6518,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         (google "lambda functions in Python" for more information on
         what these powerful tools are).
 
-
         >>> stream1 = stream.Stream()
         >>> for x in range(30, 81):
         ...     n = note.Note()
@@ -6607,12 +6584,10 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         True
         >>> om[2].voiceIndex
 
-
         Needed for makeMeasures and a few other places.
 
         The Stream source of elements is self by default,
         unless a `srcObj` is provided.  (this will be removed in v.8)
-
 
         >>> s = stream.Stream()
         >>> s.repeatAppend(note.Note(), 8)
@@ -7663,7 +7638,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         If `force` is True, a sort will be attempted regardless of any other parameters.
 
-
         >>> n1 = note.Note('A')
         >>> n2 = note.Note('B')
         >>> s = stream.Stream()
@@ -7719,7 +7693,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         {1.0} <music21.note.Note D>
         {0.0} <music21.note.Note C>
 
-
         But a sorted version of the Stream puts the C first:
 
         >>> s.sorted().show('text')
@@ -7731,7 +7704,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> s.show('text')
         {1.0} <music21.note.Note D>
         {0.0} <music21.note.Note C>
-
 
         OMIT_FROM_DOCS
 
@@ -8487,15 +8459,11 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> stream1.lowestOffset
         3.0
 
-
         If the Stream is empty, then the lowest offset is 0.0:
-
 
         >>> stream2 = stream.Stream()
         >>> stream2.lowestOffset
         0.0
-
-
 
         >>> p = stream.Stream()
         >>> p.repeatInsert(note.Note('D5'), [0, 1, 2, 3, 4])
@@ -8710,7 +8678,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         Note that if other TempoIndication objects are defined,
         they will be converted to MetronomeMarks and returned here
-
 
         >>> s = stream.Stream()
         >>> s.repeatAppend(note.Note(), 8)
@@ -8973,7 +8940,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         method can be called on the relevant part.
 
         This algorithm should work even for weird time signatures such as 2+3+2/8.
-
 
         >>> bach = corpus.parse('bach/bwv1.6')
         >>> bach.parts[0].measure(2).getContextByClass(meter.TimeSignature)
@@ -9295,19 +9261,14 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         set to True, modifies the durations of each
         element within the stream.
 
-
         A number of 0.5 will halve the durations and relative
         offset positions; a number of 2 will double the
         durations and relative offset positions.
-
-
 
         Note that the default for inPlace is the opposite
         of what it is for augmentOrDiminish on a Duration.
         This is done purposely to reflect the most common
         usage.
-
-
 
         >>> s = stream.Stream()
         >>> n = note.Note()
@@ -9960,7 +9921,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> s.hasPartLikeStreams()
         False
 
-
         A stream with a single generic Stream substream at the beginning has part-like Streams:
 
         >>> s = stream.Score()
@@ -9969,7 +9929,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> s.append(m1)
         >>> s.hasPartLikeStreams()
         True
-
 
         Adding another though makes it not part-like.
 
@@ -10015,7 +9974,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         '''
         Return true if this Stream only employs twelve-tone equal-tempered pitch values.
 
-
         >>> s = stream.Stream()
         >>> s.append(note.Note('G#4'))
         >>> s.isTwelveTone()
@@ -10035,7 +9993,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         Return True if, given the context of this Stream or Stream subclass,
         contains what appears to be well-formed notation. This often means
         the formation of Measures, or a Score that contains Part with Measures.
-
 
         >>> s = corpus.parse('bwv66.6')
         >>> s.isWellFormedNotation()
@@ -10097,7 +10054,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         :class:`~music21.chord.Chord`,
         :class:`~music21.note.Rest`) but also their subclasses, such as
         `Harmony` objects (`ChordSymbols`, `FiguredBass`), etc.
-
 
         >>> s1 = stream.Stream()
         >>> k1 = key.KeySignature(0)  # key of C
@@ -10218,7 +10174,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         <music21.pitch.Pitch B4>
         >>> [str(p) for p in partOnePitches[0:10]]
         ['B4', 'D5', 'B4', 'B4', 'B4', 'B4', 'C5', 'B4', 'A4', 'A4']
-
 
         Note that the pitches returned above are
         objects, not text:
@@ -10359,7 +10314,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
           - If `noNone=False`, inserts `None`
             when backing up to scan a subsequent voice or part.
         * Changed in v8: all parameters are keyword only.
-
 
         OMIT_FROM_DOCS
 
@@ -10572,7 +10526,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         be considered an overlap. The includeCoincidentEnds parameter determines
         this behaviour, where ending and starting 3.0 being a type of overlap
         is set by the includeEndBoundary being True.
-
 
         >>> sc = stream.Stream()
         >>> sc._durSpanOverlap((0, 5), (4, 12), False)
@@ -10900,7 +10853,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         There are simultaneous attacks at offset 0.0 (the beginning) and at offset 3.0,
         but not at 1.0 or 2.0:
 
-
         >>> st1 = stream.Stream()
         >>> st2 = stream.Stream()
         >>> st1.append([note.Note(type='quarter'),
@@ -11107,7 +11059,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> fc.setOffsetBySite(s2, 20.6)
         >>> s1.playingWhenAttacked(fc)
         <music21.note.Note G#>
-
 
         Optionally, specify the site to get the offset from:
 
@@ -11692,12 +11643,10 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         By default, this method automatically
         recurses through measures, but not other container streams.
 
-
         >>> s = converter.parse('tinynotation: 4/4 a4 b c d   e f g a', makeNotation=False)
         >>> someLyrics = ['this', 'is', 'a', 'list', 'of', 'eight', 'lyric', 'words']
         >>> for n, lyric in zip(s.notes, someLyrics):
         ...     n.lyric = lyric
-
 
         >>> s.lyrics()
         {1: [<music21.note.Lyric number=1 syllabic=single text='this'>, ...,
@@ -11842,7 +11791,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> v1stream = converter.parse('tinynotation: 4/4 ' + v1Str, makeNotation=False)
         >>> v2stream1 = converter.parse('tinynotation: 4/4 ' + v2Str1, makeNotation=False)
         >>> v2stream2 = converter.parse('tinynotation: 4/4 ' + v2Str2, makeNotation=False)
-
 
         >>> v1 = variant.Variant()
         >>> v1measure = stream.Measure()
@@ -12304,7 +12252,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         ...    s.append(m)
         >>> s.insert(4.0, v)
 
-
         >>> deletedRegion, deletedMeasures, insertedMeasuresTuple = s._insertDeletionVariant(v)
         >>> deletedRegion
         (12.0, 4.0, [])
@@ -12395,7 +12342,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         Helper function for activateVariants. _removeOrExpandGaps must be called on the
         expanded regions before this function,
         or it will not work properly.
-
 
         >>> v = variant.Variant()
         >>> variantDataM1 = [('b', 'eighth'), ('c', 'eighth'), ('a', 'quarter'),
@@ -13295,7 +13241,6 @@ class Measure(Stream):
         >>> m.paddingLeft
         4.0
 
-
         Empty space at the beginning of the measure will not be taken in account:
 
         >>> m = stream.Measure()
@@ -13323,7 +13268,6 @@ class Measure(Stream):
         >>> m.show('text')
         {0.0} <music21.meter.TimeSignature 3/4>
         {0.0} <music21.note.Note C>
-
 
         Only initial rests count for useInitialRests:
 
@@ -13396,7 +13340,6 @@ class Measure(Stream):
         `barDuration` still gives a duration of 3.0, or a dotted quarter note,
         while `.duration` gives a whole note tied to a quarter.
 
-
         >>> m = stream.Measure()
         >>> m.timeSignature = meter.TimeSignature('3/4')
         >>> m.barDuration
@@ -13448,9 +13391,7 @@ class Measure(Stream):
 
         Note: this does not yet accommodate triplets.
 
-
         We create a simple stream that should be in 3/4
-
 
         >>> s = converter.parse('C4 D4 E8 F8', format='tinyNotation', makeNotation=False)
         >>> m = stream.Measure()
@@ -14203,7 +14144,6 @@ class Score(Stream):
         The `permitOneVoicePerPart` parameter, if True, will encode a
         single voice inside a single Part, rather than leaving it as
         a single Part alone, with no internal voices.
-
 
         >>> s = corpus.parse('bwv66.6')
         >>> len(s.flatten().notes)

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -596,7 +596,6 @@ class StreamCore(Music21Object):
         {0.0} <music21.note.Note C>
         {1.0} <music21.note.Note D>
 
-
         Now we'll remove the second note so not all elements of the Slur
         are present. This, by default, will not insert the Slur:
 
@@ -627,7 +626,6 @@ class StreamCore(Music21Object):
             {0.0} <music21.note.Note C>
             {1.0} <music21.note.Note D>
 
-
         But the default acts with recursion:
 
         >>> part.coreGatherMissingSpanners()
@@ -636,7 +634,6 @@ class StreamCore(Music21Object):
             {0.0} <music21.note.Note C>
             {1.0} <music21.note.Note D>
         {0.0} <music21.spanner.Slur <music21.note.Note C><music21.note.Note D>>
-
 
         Spanners already in the stream are not put there again:
 

--- a/music21/stream/filters.py
+++ b/music21/stream/filters.py
@@ -95,7 +95,6 @@ class IsFilter(StreamFilter):
 
     `.numToFind` is used so that once all elements are found, the iterator can short circuit.
 
-
     >>> for el in s.iter().addFilter(isFilter):
     ...     print(el is n)
     True
@@ -162,7 +161,6 @@ class IsNotFilter(IsFilter):
     ...     el
     <music21.key.KeySignature of 3 flats>
     <music21.note.Rest quarter>
-
 
     Using multiple filters:
 

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -824,7 +824,6 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         >>> s4.show('t')
         {0.0} <music21.bar.Barline type=regular>
 
-
         Note that this routine can create Streams that have elements that the original
         stream did not, in the case of recursion:
 
@@ -1042,7 +1041,6 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         ...     print(el)
         <music21.note.Rest quarter>
 
-
         ActiveSite is restored.
 
         >>> s2 = stream.Stream(id='s2')
@@ -1053,7 +1051,6 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         >>> for el in s.iter().getElementsByClass(note.Rest):
         ...     print(el.activeSite.id)
         s1
-
 
         Strings work in addition to classes, but your IDE will not know that
         `el` is a :class:`~music21.note.Rest` object.
@@ -1195,11 +1192,9 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         There are several attributes that govern how this range is
         determined:
 
-
         If `mustFinishInSpan` is True then an event that begins
         between offsetStart and offsetEnd but which ends after offsetEnd
         will not be included.  The default is False.
-
 
         For instance, a half note at offset 2.0 will be found in
         getElementsByOffset(1.5, 2.5) or getElementsByOffset(1.5, 2.5,
@@ -1361,7 +1356,6 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
         ...     print(el, el.offset, el.getOffsetInHierarchy(bwv66), el.activeSite)
         <music21.stream.Measure 1 offset=1.0> 1.0 1.0 <music21.stream.Part Soprano>
         <music21.note.Note B> 1.0 2.0 <music21.stream.Measure 1 offset=1.0>
-
 
         RecursiveIterators will probably want to use
         :meth:`~music21.stream.iterator.RecursiveIterator.getElementsByOffsetInHierarchy`
@@ -1541,7 +1535,6 @@ class OffsetIterator(StreamIterator, Sequence[list[M21ObjType]]):
     [<music21.note.Note E>]
     [<music21.note.Note F>, <music21.note.Note G>]
     [<music21.bar.Repeat direction=end>, <music21.clef.TrebleClef>]
-
 
     >>> for groupedElements in oIter.notes:
     ...     print(groupedElements)

--- a/music21/stream/makeNotation.py
+++ b/music21/stream/makeNotation.py
@@ -87,7 +87,6 @@ def makeBeams(
     2 <music21.beam.Beams <music21.beam.Beam 1/continue>/<music21.beam.Beam 2/start>>
     3 <music21.beam.Beams <music21.beam.Beam 1/stop>/<music21.beam.Beam 2/stop>>
 
-
     This was formerly a bug -- we could not have a partial-left beam at the start of a
     beam group.  Now merges across the archetypeSpan
 

--- a/music21/style.py
+++ b/music21/style.py
@@ -145,7 +145,6 @@ class Style(ProtoM21Object):
         music21.style.TextFormatException:
             Not a supported enclosure: 'parabola'
 
-
         OMIT_FROM_DOCS
 
         Similarly for non-strings:

--- a/music21/tempo.py
+++ b/music21/tempo.py
@@ -355,7 +355,6 @@ class MetronomeMark(TempoIndication):
     >>> print(a.text)
     slow
 
-
     Some text marks will automatically suggest a number.
 
     >>> mm = tempo.MetronomeMark('adagio')
@@ -634,7 +633,6 @@ class MetronomeMark(TempoIndication):
         BPM values are assumed to refer only to quarter notes; different beat values,
         if defined here, will be scaled
 
-
         >>> mm = tempo.MetronomeMark(number=60, referent='half')
         >>> mm.setQuarterBPM(240)  # set to 240 for a quarter
         >>> mm.number  # a half is half as fast
@@ -685,7 +683,6 @@ class MetronomeMark(TempoIndication):
 
         The `spread` value is a +/- shift around the default tempo
         indications defined in defaultTempoValues
-
 
         >>> mm = tempo.MetronomeMark()
         >>> mm._getDefaultText(92)
@@ -750,7 +747,6 @@ class MetronomeMark(TempoIndication):
         Return a new MetronomeMark object that has an equivalent speed but
         different number and referent values based on a supplied referent
         (given as a Duration type, quarterLength, or Duration object).
-
 
         >>> mm1 = tempo.MetronomeMark(number=60, referent=1.0)
         >>> mm1.getEquivalentByReferent(0.5)

--- a/music21/test/testRunner.py
+++ b/music21/test/testRunner.py
@@ -193,7 +193,6 @@ def mainTest(*testClasses, **keywords):
         if __name__ == '__main__':
             music21.mainTest(Test)
 
-
     This module tries to fix up some differences between python2 and python3 so
     that the same doctests can work.  These differences can now be removed, but
     I cannot remember what they are!

--- a/music21/text.py
+++ b/music21/text.py
@@ -205,7 +205,6 @@ def postpendArticle(src, language=None):
     Given a text string, if an article is found in a leading position,
     place it at the end with a comma.
 
-
     >>> text.postpendArticle('The Ale is Dear')
     'Ale is Dear, The'
     >>> text.postpendArticle('The Ale is Dear', 'en')

--- a/music21/tinyNotation.py
+++ b/music21/tinyNotation.py
@@ -764,67 +764,67 @@ def _getDefaultTokenMap() -> list[tuple[str, type[Token]]]:
     Returns the default tokenMap for TinyNotation.
 
     Based on the following grammar (in Extended Backus-Naur form)
-    (https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form)
+    (https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form)::
 
-    (* Items in parentheses are grouped *)
-    (* Items in curly braces appear zero or more times *)
-    (* Items in square brackets may appear exactly zero or one time *)
-    (* Items in double quotes are literal strings *)
-    (* Items between question marks should be interpreted as English *)
-    (* Each rule is ended by a semicolon *)
+        (* Items in parentheses are grouped *)
+        (* Items in curly braces appear zero or more times *)
+        (* Items in square brackets may appear exactly zero or one time *)
+        (* Items in double quotes are literal strings *)
+        (* Items between question marks should be interpreted as English *)
+        (* Each rule is ended by a semicolon *)
 
-    TINY-NOTATION = TOKEN, { WHITESPACE, TOKEN } ;
-    WHITESPACE = ( " " | ? Carriage return ? ) , { " " | ? Carriage return ? } ;
-    TOKEN = ( TIME-SIGNATURE | TUPLET | REST | NOTE );
-    TIME-SIGNATURE = INTEGER, "/", INTEGER ;
-    INTEGER = DIGIT, { DIGIT } ;
-    DIGIT = ( "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ) ;
-    TUPLET = ( "trip" | "quad" | ALPHANUMERIC ), "{",
-        [ WHITESPACE ],
-        ( REST | NOTE ),
-        { WHITESPACE, ( REST | NOTE ) },
-        [ WHITESPACE ],
-    "}" ;
-    REST = "r", [ DURATION ], [ MODIFIER ] ;
-    DURATION = ( EVEN-NUMBER, { "." } | { "." }, EVEN-NUMBER | ".", { "." } ) ;
-    EVEN-NUMBER = { INTEGER }, ( "0" | "2" | "4" | "6" | "8" ) ;
-    NOTE = PITCH, [ DURATION ], [ TIE ], { MODIFIER } ;
-    PITCH = (
-        ( LOW-A | LOW-B | LOW-C | LOW-D | LOW-E | LOW-F | LOW-G ), [ ACCIDENTAL ] |
-        ( "a" | "b" | "c" | "d" | "e" | "f" | "g" ), [ ACCIDENTAL ], { "'" } |
-        ( "a" | "b" | "c" | "d" | "e" | "f" | "g" ), { "'" }, [ ACCIDENTAL ]
-    ) ;
-    LOW-A = "A", { "A" } ;
-    LOW-B = "B", { "B" } ;
-    LOW-C = "C", { "C" } ;
-    LOW-D = "D", { "D" } ;
-    LOW-E = "E", { "E" } ;
-    LOW-F = "F", { "F" } ;
-    LOW-G = "G", { "G" } ;
-    ACCIDENTAL = ( EDITORIAL | SHARPS | FLATS | NATURAL ) ;
-    EDITORIAL = "(", ( SHARPS | FLATS | NATURAL ), ")" ;
-    SHARPS = "#", { "#" } ;
-    FLATS = "-", { "-" } ;
-    NATURAL = "n" ;
-    TIE = "~" ;
-    MODIFIER = (
-        EQUALS-MODIFIER |
-        UNDERSCORE-MODIFIER |
-        SQUARE-MODIFIER |
-        ANGLE-MODIFIER |
-        PARENS-MODIFIER |
-        STAR-MODIFIER
-    ) ;
-    EQUALS-MODIFIER = "=", EQUALS-DATA ;
-    UNDERSCORE-MODIFIER = "_", UNDERSCORE-DATA ;
-    SQUARE-MODIFIER = "[", ALPHANUMERIC, "]" ;
-    ANGLE-MODIFIER = "<", ALPHANUMERIC, ">" ;
-    PARENS-MODIFIER = "(", ALPHANUMERIC, ")" ;
-    STAR-MODIFIER = "*", ALPHANUMERIC, "*" ;
-    (* The following is just shorthand. *)
-    ALPHANUMERIC = ? At least one alphanumeric character. So "a-z", "A-Z", or "0-9" ? ;
-    EQUALS-DATA = ? At least one non-whitespace, non-"_" character. ? ;
-    UNDERSCORE-DATA = ? At least one non-whitespace, non-"=" character. ? ;
+        TINY-NOTATION = TOKEN, { WHITESPACE, TOKEN } ;
+        WHITESPACE = ( " " | ? Carriage return ? ) , { " " | ? Carriage return ? } ;
+        TOKEN = ( TIME-SIGNATURE | TUPLET | REST | NOTE );
+        TIME-SIGNATURE = INTEGER, "/", INTEGER ;
+        INTEGER = DIGIT, { DIGIT } ;
+        DIGIT = ( "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ) ;
+        TUPLET = ( "trip" | "quad" | ALPHANUMERIC ), "{",
+            [ WHITESPACE ],
+            ( REST | NOTE ),
+            { WHITESPACE, ( REST | NOTE ) },
+            [ WHITESPACE ],
+        "}" ;
+        REST = "r", [ DURATION ], [ MODIFIER ] ;
+        DURATION = ( EVEN-NUMBER, { "." } | { "." }, EVEN-NUMBER | ".", { "." } ) ;
+        EVEN-NUMBER = { INTEGER }, ( "0" | "2" | "4" | "6" | "8" ) ;
+        NOTE = PITCH, [ DURATION ], [ TIE ], { MODIFIER } ;
+        PITCH = (
+            ( LOW-A | LOW-B | LOW-C | LOW-D | LOW-E | LOW-F | LOW-G ), [ ACCIDENTAL ] |
+            ( "a" | "b" | "c" | "d" | "e" | "f" | "g" ), [ ACCIDENTAL ], { "'" } |
+            ( "a" | "b" | "c" | "d" | "e" | "f" | "g" ), { "'" }, [ ACCIDENTAL ]
+        ) ;
+        LOW-A = "A", { "A" } ;
+        LOW-B = "B", { "B" } ;
+        LOW-C = "C", { "C" } ;
+        LOW-D = "D", { "D" } ;
+        LOW-E = "E", { "E" } ;
+        LOW-F = "F", { "F" } ;
+        LOW-G = "G", { "G" } ;
+        ACCIDENTAL = ( EDITORIAL | SHARPS | FLATS | NATURAL ) ;
+        EDITORIAL = "(", ( SHARPS | FLATS | NATURAL ), ")" ;
+        SHARPS = "#", { "#" } ;
+        FLATS = "-", { "-" } ;
+        NATURAL = "n" ;
+        TIE = "~" ;
+        MODIFIER = (
+            EQUALS-MODIFIER |
+            UNDERSCORE-MODIFIER |
+            SQUARE-MODIFIER |
+            ANGLE-MODIFIER |
+            PARENS-MODIFIER |
+            STAR-MODIFIER
+        ) ;
+        EQUALS-MODIFIER = "=", EQUALS-DATA ;
+        UNDERSCORE-MODIFIER = "_", UNDERSCORE-DATA ;
+        SQUARE-MODIFIER = "[", ALPHANUMERIC, "]" ;
+        ANGLE-MODIFIER = "<", ALPHANUMERIC, ">" ;
+        PARENS-MODIFIER = "(", ALPHANUMERIC, ")" ;
+        STAR-MODIFIER = "*", ALPHANUMERIC, "*" ;
+        (* The following is just shorthand. *)
+        ALPHANUMERIC = ? At least one alphanumeric character. So "a-z", "A-Z", or "0-9" ? ;
+        EQUALS-DATA = ? At least one non-whitespace, non-"_" character. ? ;
+        UNDERSCORE-DATA = ? At least one non-whitespace, non-"=" character. ? ;
     '''
     sharpsFlatsOrNaturalRegex = r'#+|-+|n'
     editorialRegex = fr'\((?:{sharpsFlatsOrNaturalRegex})\)'

--- a/music21/tinyNotation.py
+++ b/music21/tinyNotation.py
@@ -14,7 +14,6 @@ options.  It was originally developed to notate trecento (medieval Italian)
 music, but it is pretty useful for a lot of short examples, so we have
 made it a generally supported music21 format.
 
-
 N.B.: TinyNotation is not meant to expand to cover every single case.  Instead,
 it is meant to be subclassable to extend to the cases *your* project needs.
 
@@ -101,8 +100,6 @@ Changing time signatures are supported:
     {0.0} <music21.note.Note C>
     {1.0} <music21.bar.Barline type=final>
 
-
-
 Here is an equivalent way of doing the example above, but using the lower level
 :class:`music21.tinyNotation.Converter` object:
 
@@ -160,7 +157,6 @@ The supported modifiers are:
     * `(data)` (`modifierParens`, no default action)
     * `*data*` (`modifierStar`, no default action)
 
-
 Another example: TinyNotation does not support key signatures -- well, no problem! Let's
 create a new Token type and add it to the tokenMap
 
@@ -182,7 +178,6 @@ create a new Token type and add it to the tokenMap
     {0.0} <music21.key.Key of f# minor>
     {0.0} <music21.note.Note A>
     {4.0} <music21.bar.Barline type=final>
-
 
 TokenMap should be passed a string, representing a regular expression with exactly one
 group (which can be the entire expression), and a subclass of :class:`~music21.tinyNotation.Token`
@@ -939,7 +934,6 @@ class Converter:
         {2.0} <music21.note.Note C>
         {4.0} <music21.bar.Barline type=final>
 
-
     Or, breaking down what Parse does bit by bit:
 
     >>> tnc = tinyNotation.Converter('4/4 C##4 D e-8 f~ f f# g4 trip{f8 e d} C2=hello')
@@ -1318,7 +1312,6 @@ class Converter:
         '~'
         >>> quadState.stateInfo
         'quad{'
-
 
         Note that the affected tokens haven't yet been added:
 

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -53,7 +53,6 @@ def listOfTreesByClass(
 
     This is used internally by `streamToTimespanTree`.
 
-
     >>> score = tree.examples.makeExampleScore()
 
     Get everything in the score

--- a/music21/tree/node.py
+++ b/music21/tree/node.py
@@ -74,14 +74,12 @@ class ElementNode(core.AVLNode):
     >>> m.offset
     0.0
 
-
     >>> rElNode.payloadElementIndex = 0
     >>> elNode.payloadElementIndex = 1
     >>> n2ElNode.payloadElementIndex = 2
 
     >>> elNode.updateIndices()
     >>> elNode.updateEndTimes()
-
 
     Now let's look at the ElementNode:
 
@@ -346,7 +344,6 @@ class OffsetNode(ElementNode):
     <music21.note.Note F>
     >>> rn.payload[0].element is sf[11]
     True
-
 
     We can look at the leftChild of the root node to get some more interesting cases:
 

--- a/music21/tree/spans.py
+++ b/music21/tree/spans.py
@@ -261,7 +261,6 @@ class ElementTimespan(Timespan):
     There are four PitchedTimespans in the verticality -- each representing
     a note.  The notes are arranged from lowest to highest.
 
-
     We can find all the PitchedTimespans that start exactly at 6.5. There's
     one.
 
@@ -587,7 +586,6 @@ class PitchedTimespan(ElementTimespan):
         >>> merged.part is timespan_one.part
         True
 
-
         Attempting to merge timespans which are not contiguous, or which do not
         have identical pitches will result in error:
 
@@ -595,13 +593,11 @@ class PitchedTimespan(ElementTimespan):
         (False, 'Cannot merge <PitchedTimespan (0.0 to 0.5) <music21.note.Note C#>>
              with <PitchedTimespan (9.5 to 10.0) <music21.note.Note B>>: not contiguous')
 
-
         >>> scoreTree[0].mergeWith(scoreTree[50])
         Traceback (most recent call last):
         music21.tree.spans.TimespanException: Cannot merge
                 <PitchedTimespan (0.0 to 0.5) <music21.note.Note C#>>
                 with <PitchedTimespan (9.5 to 10.0) <music21.note.Note B>>: not contiguous
-
 
         This is probably not what you want to do: get the next element timespan in
         the same score:

--- a/music21/tree/timespanTree.py
+++ b/music21/tree/timespanTree.py
@@ -130,7 +130,6 @@ class TimespanTree(trees.OffsetTree):
     ...             scoreTree.removeTimespan(horizontality[2])
     ...             scoreTree.insert(merged)
 
-
     >>> #_DOCS_SHOW newBach = tree.toStream.partwise(scoreTree, templateStream=bach)
     >>> #_DOCS_SHOW newBach.parts['#Alto'].measure(7).show('text')
     {0.0} <music21.chord.Chord F#4>
@@ -156,7 +155,6 @@ class TimespanTree(trees.OffsetTree):
         sorted.
 
     OMIT_FROM_DOCS
-
 
     TODO: Doc examples for all functions, including privates.
     '''
@@ -586,7 +584,6 @@ class TimespanTree(trees.OffsetTree):
             (36.0 {}),
             (36.0 {})
             ]>
-
 
         * Changed in v8: added padEnd.  Streams with fewer than n elements
             also return an empty sentinel entry.

--- a/music21/tree/trees.py
+++ b/music21/tree/trees.py
@@ -314,7 +314,6 @@ class ElementTree(core.AVLTree):
         <ElementNode: Start:2.0 <0.20...> Indices:(l:10 *10* r:11)
             Payload:<music21.note.Note F#>>
 
-
         >>> scoreTree[10:13]
         [<music21.note.Note F#>, <music21.note.Note F>, <music21.note.Note G>]
         >>> scoreTree[10:14:2] = [note.Note('E#'), note.Note('F-')]

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -54,13 +54,11 @@ class Verticality(prebase.ProtoM21Object):
     A collection of information about elements that are sounding at a given
     offset or just finished at that offset or are continuing from before, etc..
 
-
     Create a timespan-stream from a score:
 
     >>> score = corpus.parse('bwv66.6')
     >>> scoreTree = tree.fromStream.asTimespans(score, flatten=True,
     ...        classList=(note.Note, chord.Chord))
-
 
     Find the verticality at offset 6.5, or beat 2.5 of measure 2 (there's a one
     beat pickup)
@@ -69,10 +67,8 @@ class Verticality(prebase.ProtoM21Object):
     >>> verticality
     <music21.tree.verticality.Verticality 6.5 {E3 D4 G#4 B4}>
 
-
     The representation of a verticality gives the pitches from lowest to
     highest (in sounding notes).
-
 
     A verticality knows its offset, but because elements might end at
     different times, it doesn't know its endTime
@@ -82,7 +78,6 @@ class Verticality(prebase.ProtoM21Object):
     >>> verticality.endTime
     Traceback (most recent call last):
     AttributeError: 'Verticality' object has no attribute 'endTime'
-
 
     However, we can find when the next verticality starts by looking at the nextVerticality
 
@@ -297,7 +292,6 @@ class Verticality(prebase.ProtoM21Object):
         >>> verticality = scoreTree.getVerticalityAt(1.0)
         >>> verticality.beatStrength
         1.0
-
 
         Note that it will return None if there are no startTimespans at this point:
 
@@ -609,7 +603,6 @@ class Verticality(prebase.ProtoM21Object):
         >>> el.duration.fullName
         'Eighth Triplet (1/3 QL)'
 
-
         >>> n1 = note.Note('C4')
         >>> n2 = note.Note('C4')
         >>> s = stream.Score()
@@ -645,7 +638,6 @@ class Verticality(prebase.ProtoM21Object):
         >>> (n1.name, n2.name)
         ('F', 'G')
 
-
         gatherArticulations and gatherExpressions can be True, False, or (default) 'single'.
 
         * If False, no articulations (or expressions) are transferred to the chord.
@@ -670,7 +662,6 @@ class Verticality(prebase.ProtoM21Object):
         ...         super().__init__()
         ...         self.tieAttach = 'all'
 
-
         >>> n1.articulations.append(articulations.Accent())
         >>> n1.articulations.append(AllAttachArticulation())
         >>> n1.expressions.append(expressions.Fermata())
@@ -690,7 +681,6 @@ class Verticality(prebase.ProtoM21Object):
         [<music21.articulations.Accent>, <...AllAttachArticulation>]
 
         >>> verticality = scoreTree.getVerticalityAt(0.5)
-
 
         Here there will be no expressions, because there is no note ending
         at 0.75 and Fermatas attach to the last note:
@@ -1009,7 +999,6 @@ class Verticality(prebase.ProtoM21Object):
         >>> verticality22.getAllVoiceLeadingQuartets(includeOblique=False, includeRests=False)
         []
 
-
         Raw output, returns a 2-element tuple of 2-element tuples of PitchedTimespans
 
         >>> for vlqRaw in verticality22.getAllVoiceLeadingQuartets(returnObjects=False):
@@ -1135,7 +1124,6 @@ class Verticality(prebase.ProtoM21Object):
          <PitchedTimespan (22.0 to 23.0) <music21.note.Note F>>)
         (<PitchedTimespan (21.5 to 22.5) <music21.note.Note A>>,
          <PitchedTimespan (21.5 to 22.5) <music21.note.Note A>>)
-
 
         Oblique here means a pair that does not move (it could be called noMotion,
         because there's no motion

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -1896,7 +1896,7 @@ def _getRegionsFromStreams(streamX, streamY):
 
     >>> s1 = converter.parse("tinynotation: 2/4 d4 e8. f16 GG4 b'4 b-2 c4 d8. e16 FF4 a'4 b-2")
 
-                                                *0:Eq  *1:Rep        * *3:Eq             *6:In
+                                                ``*0:Eq  *1:Rep        * *3:Eq             *6:In``
 
     >>> s2 = converter.parse("tinynotation: 2/4 d4 e8. f16 FF4 b'4 c4 d8. e16 FF4 a'4 b-2 b-2")
     >>> s1m = s1.makeMeasures()

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -221,7 +221,6 @@ class Variant(base.Music21Object):
 
         This method must be overridden, otherwise Music21Object.show() is called.
 
-
         >>> v = variant.Variant()
         >>> v.repeatAppend(note.Note(quarterLength=0.25), 8)
         >>> v.show('t')
@@ -369,9 +368,7 @@ class Variant(base.Music21Object):
             {2.0} <music21.note.Note B->
             {3.0} <music21.note.Note A>
 
-
         A second example:
-
 
         >>> v = variant.Variant()
         >>> variantDataM1 = [('b', 'eighth'), ('c', 'eighth'), ('a', 'quarter'),
@@ -493,7 +490,6 @@ class Variant(base.Music21Object):
         '''
         remove replaced elements from a referenceStream or activeSite
 
-
         >>> v = variant.Variant()
         >>> variantDataM1 = [('b', 'eighth'), ('c', 'eighth'), ('a', 'quarter'),
         ...                  ('a', 'quarter'),('b', 'quarter')]
@@ -599,7 +595,6 @@ def mergeVariants(streamX, streamY, variantName='variant', *, inPlace=False):
     music21.variant.VariantException: Could not determine what merging method to use.
             Try using a more specific merging function.
 
-
     Example: Create a main score (aScore) and a variant score (vScore), each with
     two parts (ap1/vp1
     and ap2/vp2) and some small variants between ap1/vp1 and ap2/vp2, marked with * below.
@@ -662,7 +657,6 @@ def mergeVariants(streamX, streamY, variantName='variant', *, inPlace=False):
             {2.0} <music21.note.Note G>
             {3.0} <music21.note.Note F>
             {4.0} <music21.bar.Barline type=final>
-
 
     >>> mergedPart = variant.mergeVariants(ap2, vp2, variantName='docVariant', inPlace=False)
     >>> mergedPart.show('text')
@@ -773,7 +767,6 @@ def mergeVariantMeasureStreams(streamX, streamY, variantName='variant', *, inPla
     a new bar has been inserted between the
     original third and fourth bars, and two bars have been added at the end.
 
-
     >>> data1M1 = [('a', 'quarter'), ('b', 'eighth'), ('c', 'eighth'),
     ...            ('a', 'quarter'), ('a', 'quarter')]
     >>> data1M2 = [('b', 'eighth'), ('c', 'eighth'), ('a', 'quarter'),
@@ -820,12 +813,10 @@ def mergeVariantMeasureStreams(streamX, streamY, variantName='variant', *, inPla
     ...    stream2.append(m)
     >>> #_DOCS_SHOW stream1.show()
 
-
     .. image:: images/variant_measuresStreamMergeStream1.*
         :width: 600
 
     >>> #_DOCS_SHOW stream2.show()
-
 
     .. image:: images/variant_measuresStreamMergeStream2.*
         :width: 600
@@ -972,7 +963,6 @@ def mergeVariantsEqualDuration(streams, variantNames, *, inPlace=False):
     variant objects (i.e. more than once under different names).
     Also, note that a streams with bars of differing lengths will not behave properly.
 
-
     >>> stream1 = stream.Stream()
     >>> stream2paris = stream.Stream()
     >>> stream3london = stream.Stream()
@@ -1102,10 +1092,8 @@ def mergeVariantsEqualDuration(streams, variantNames, *, inPlace=False):
             {3.0} <music21.note.Note E>
     >>> #_DOCS_SHOW mergedStreams.show()
 
-
     .. image:: images/variant_measuresAndParts.*
         :width: 600
-
 
     >>> for p in mergedStreams.getElementsByClass(stream.Part):
     ...    for m in p.getElementsByClass(stream.Measure):
@@ -1133,7 +1121,6 @@ def mergeVariantsEqualDuration(streams, variantNames, *, inPlace=False):
             {2.0} <music21.note.Note A>
             {3.0} <music21.note.Note A>
     >>> #_DOCS_SHOW mergedStreams.show()
-
 
     .. image:: images/variant_measuresAndParts2.*
         :width: 600
@@ -1231,7 +1218,6 @@ def mergePartAsOssia(mainPart, ossiaPart, ossiaName,
     different duration than the segment of stream which it replaces
     because that information is not contained in the format of score this method is
     designed to deal with.
-
 
     >>> mainStream = converter.parse('tinynotation: 4/4   A4 B4 C4 D4   E1    F2 E2     E8 F8 F4 G2   G2 G4 F4   F4 F4 F4 F4   G1      ')
     >>> ossiaStream = converter.parse('tinynotation: 4/4  r1            r1    r1        E4 E4 F4 G4   r1         F2    F2      r1      ')
@@ -1385,7 +1371,6 @@ def addVariant(
     this is an insertion. If sVariant is
     None, this is a deletion.
 
-
     >>> data1M1 = [('a', 'quarter'), ('b', 'eighth'), ('c', 'eighth'),
     ...            ('a', 'quarter'), ('a', 'quarter')]
     >>> data1M3 = [('c', 'quarter'), ('d', 'quarter'), ('e', 'quarter'), ('e', 'quarter')]
@@ -1496,7 +1481,6 @@ def refineVariant(s, sVariant, *, inPlace=False):
     look at the documentation for _getBestListAndScore
 
     Note that this code does not work properly yet.
-
 
     >>> v = variant.Variant()
     >>> variantDataM1 = [('b', 'eighth'), ('c', 'eighth'), ('a', 'quarter'),
@@ -1764,7 +1748,6 @@ def _getBestListAndScore(streamX, streamY, badnessDict, listDict,
     in the list where this function has determined that the bar appearing
     in streamY does not have a counterpart in streamX anywhere and is an insertion.
 
-
     >>> badnessDict = {}
     >>> listDict = {}
     >>> stream1 = stream.Stream()
@@ -1883,7 +1866,6 @@ def _diffScore(measureX, measureY):
     isNone is true (i.e. testing when a bar does not associate with any existing bars the reference
     stream), is well-matched with the similarity scores generated by this function.
 
-
     >>> m1 = stream.Measure()
     >>> m2 = stream.Measure()
     >>> m1.append([note.Note('e'), note.Note('f'), note.Note('g'), note.Note('a')])
@@ -1911,7 +1893,6 @@ def _getRegionsFromStreams(streamX, streamY):
     '''
     Takes in two streams, returns a list of 5-tuples via difflib.get_opcodes()
     working on measure differences.
-
 
     >>> s1 = converter.parse("tinynotation: 2/4 d4 e8. f16 GG4 b'4 b-2 c4 d8. e16 FF4 a'4 b-2")
 
@@ -1945,7 +1926,6 @@ def _mergeVariants(streamA, streamB, *, variantName=None, inPlace=False):
     function will compare streamB to the streamA as well as the
     variant streams contained in streamA.
     Note that variant streams in streamB will be ignored and lost.
-
 
     >>> stream1 = stream.Stream()
     >>> stream2 = stream.Stream()
@@ -2262,7 +2242,6 @@ def _doVariantFixingOnStream(s, variantNames=None):
     (20.0, 'deletion', 8.0)
     (24.0, 'deletion', 8.0)
 
-
     This also works on streams with variants that contain notes and rests rather than measures.
 
     >>> s = converter.parse('tinyNotation: 4/4                     e4 b b b   f4 f f f   g4 a a a       ', makeNotation=False)
@@ -2355,7 +2334,6 @@ def _getNextElements(s, v, numberOfElements=1):
     This is a helper function for makeAllVariantsReplacements() which returns the next element in s
     of the type of elements found in the variant v so that it can be added to v.
 
-
     >>> #                                                   *                       *
     >>> s1 = converter.parse('tinyNotation: 4/4             b4 c d e    f4 g a b   d4 e f g   ', makeNotation=False)
     >>> s2 = converter.parse('tinyNotation: 4/4 e4 f g a    b4 c d e               d4 e f g   ', makeNotation=False)
@@ -2433,7 +2411,6 @@ def _getPreviousElement(s, v):
     This is a helper function for makeAllVariantsReplacements() which returns
     the previous element in s
     of the type of elements found in the variant v so that it can be added to v.
-
 
     >>> #                                                   *                       *
     >>> s1 = converter.parse('tinyNotation: 4/4 a4 b c d                b4 c d e    f4 g a b    ')

--- a/music21/voiceLeading.py
+++ b/music21/voiceLeading.py
@@ -356,7 +356,6 @@ class VoiceLeadingQuartet(base.Music21Object):
         >>> vl.motionType()
         <MotionType.noMotion: 'No Motion'>
 
-
         Anti-parallel motion has to be explicitly enabled to appear:
 
         >>> n1_a5 = note.Note('A5')
@@ -778,7 +777,6 @@ class VoiceLeadingQuartet(base.Music21Object):
         >>> vlq2a.parallelInterval(interval.Interval('P8'))
         True
 
-
         Non-parallel intervals are, of course, False
 
         >>> n12b = note.Note('B4')  # ascending 3rd
@@ -1047,7 +1045,6 @@ class VoiceLeadingQuartet(base.Music21Object):
             d5:     in by contrary motion to a third, with 7 resolving up to 1 in the bass
 
             m7:     Resolves to a third with a leap from 5 to 1 in the bass
-
 
         We will make the examples shorter with this abbreviation:
         >>> N = note.Note

--- a/music21/volpiano.py
+++ b/music21/volpiano.py
@@ -157,7 +157,6 @@ def toPart(volpianoText, *, breaksToLayout=False):
         {0.0} <music21.note.Note E>
         {1.0} <music21.bar.Barline type=double>
 
-
     As layout objects using breaksToLayout=True
 
     >>> breakTest = volpiano.toPart('1---e-7-e-77-e-777-e-3-e-4', breaksToLayout=True)
@@ -175,7 +174,6 @@ def toPart(volpianoText, *, breaksToLayout=False):
     {4.0} <music21.stream.Measure 0 offset=4.0>
         {0.0} <music21.note.Note E>
         {1.0} <music21.bar.Barline type=double>
-
 
     Liquescence test:
 


### PR DESCRIPTION
1. Make single backticks in docstrings function as `code` just like in markdown.
2. Collapse all double blank lines in docstrings to single blank lines
3. Fix RST markup errors in private/test functions that Sphinx had not found errors in.

AI-Assisted (Claude), Myke reviewed