### PR TITLE
Suppress spurious tuplet bracket on between-note tremolo round-trip.

### DIFF
--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -1082,26 +1082,71 @@ class Test(unittest.TestCase):
 
     def testTremoloImpliedTuplet(self):
         '''
-        Test that between-note tremolos with time-modification of 2:1 do not get tuplets with show-number None, as they should not be drawn as tuplets.
+        Test that between-note tremolos with time-modification of 2:1 do not
+        get tuplets with show-number None, as they should not be drawn as
+        tuplets.
         '''
         from music21 import converter
 
         mxString = '''<?xml version="1.0" encoding="UTF-8"?>
-        <score-partwise version="4.0">
-        <part-list><score-part id="P1"><part-name>P</part-name></score-part></part-list>
-        <part id="P1"><measure number="1">
-            <attributes><divisions>256</divisions>
-            <time><beats>2</beats><beat-type>2</beat-type></time>
-            <clef><sign>F</sign><line>4</line></clef></attributes>
-            <note><pitch><step>E</step><octave>3</octave></pitch>
-            <duration>512</duration><voice>1</voice><type>whole</type>
-            <time-modification><actual-notes>2</actual-notes><normal-notes>1</normal-notes></time-modification>
-            <notations><ornaments><tremolo type="start">4</tremolo></ornaments></notations></note>
-            <note><pitch><step>G</step><octave>3</octave></pitch>
-            <duration>512</duration><voice>1</voice><type>whole</type>
-            <time-modification><actual-notes>2</actual-notes><normal-notes>1</normal-notes></time-modification>
-            <notations><ornaments><tremolo type="stop">4</tremolo></ornaments></notations></note>
-        </measure></part></score-partwise>'''
+                    <score-partwise version="4.0">
+                    <part-list>
+                        <score-part id="P1">
+                        <part-name>P</part-name>
+                        </score-part>
+                    </part-list>
+                    <part id="P1">
+                        <measure number="1">
+                        <attributes>
+                            <divisions>256</divisions>
+                            <time>
+                            <beats>2</beats>
+                            <beat-type>2</beat-type>
+                            </time>
+                            <clef>
+                            <sign>F</sign>
+                            <line>4</line>
+                            </clef>
+                        </attributes>
+                        <note>
+                            <pitch>
+                            <step>E</step>
+                            <octave>3</octave>
+                            </pitch>
+                            <duration>512</duration>
+                            <voice>1</voice>
+                            <type>whole</type>
+                            <time-modification>
+                            <actual-notes>2</actual-notes>
+                            <normal-notes>1</normal-notes>
+                            </time-modification>
+                            <notations>
+                            <ornaments>
+                                <tremolo type="start">4</tremolo>
+                            </ornaments>
+                            </notations>
+                        </note>
+                        <note>
+                            <pitch>
+                            <step>G</step>
+                            <octave>3</octave>
+                            </pitch>
+                            <duration>512</duration>
+                            <voice>1</voice>
+                            <type>whole</type>
+                            <time-modification>
+                            <actual-notes>2</actual-notes>
+                            <normal-notes>1</normal-notes>
+                            </time-modification>
+                            <notations>
+                            <ornaments>
+                                <tremolo type="stop">4</tremolo>
+                            </ornaments>
+                            </notations>
+                        </note>
+                        </measure>
+                    </part>
+                    </score-partwise>'''
 
         s = converter.parse(mxString, format='musicxml')
         tuplets = [n.duration.tuplets[0] for n in s.recurse().notes]

--- a/music21/musicxml/test_xmlToM21.py
+++ b/music21/musicxml/test_xmlToM21.py
@@ -1080,6 +1080,34 @@ class Test(unittest.TestCase):
         tuplets = [n.duration.tuplets[0] for n in s.recurse().notes]
         self.assertEqual([tup.bracket for tup in tuplets], [True, True, True, False, False, False])
 
+    def testTremoloImpliedTuplet(self):
+        '''
+        Test that between-note tremolos with time-modification of 2:1 do not get tuplets with show-number None, as they should not be drawn as tuplets.
+        '''
+        from music21 import converter
+
+        mxString = '''<?xml version="1.0" encoding="UTF-8"?>
+        <score-partwise version="4.0">
+        <part-list><score-part id="P1"><part-name>P</part-name></score-part></part-list>
+        <part id="P1"><measure number="1">
+            <attributes><divisions>256</divisions>
+            <time><beats>2</beats><beat-type>2</beat-type></time>
+            <clef><sign>F</sign><line>4</line></clef></attributes>
+            <note><pitch><step>E</step><octave>3</octave></pitch>
+            <duration>512</duration><voice>1</voice><type>whole</type>
+            <time-modification><actual-notes>2</actual-notes><normal-notes>1</normal-notes></time-modification>
+            <notations><ornaments><tremolo type="start">4</tremolo></ornaments></notations></note>
+            <note><pitch><step>G</step><octave>3</octave></pitch>
+            <duration>512</duration><voice>1</voice><type>whole</type>
+            <time-modification><actual-notes>2</actual-notes><normal-notes>1</normal-notes></time-modification>
+            <notations><ornaments><tremolo type="stop">4</tremolo></ornaments></notations></note>
+        </measure></part></score-partwise>'''
+
+        s = converter.parse(mxString, format='musicxml')
+        tuplets = [n.duration.tuplets[0] for n in s.recurse().notes]
+        self.assertEqual([tup.bracket for tup in tuplets], [False, False])
+        self.assertEqual([tup.tupletActualShow for tup in tuplets], [None, None])
+
     def test34MeasureRestWithoutTag(self):
         from xml.etree.ElementTree import fromstring as EL
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -4833,6 +4833,9 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
                                               remainderFraction.numerator)
             remainderTuplet.durationNormal = timeModTup.durationNormal
             remainderTuplet.durationActual = timeModTup.durationActual
+            remainderTuplet.bracket = False
+            remainderTuplet.tupletActualShow = None
+            remainderTuplet.tupletNormalShow = None
             returnTuplets[-1] = remainderTuplet
 
         # now we can remove stops for future notes.


### PR DESCRIPTION
A time-modification with no matching tuplet was importing with a visible tuplet bracket and number, which has been fixed by setting the bracket and number not to show Added a regression test `testTremoloImpliedTuple` and confirmed via reconstructed musicxml and imported into music notation software to verify visual fix.

Fixes #1907