### PR TITLE
Fix parsing MIDI from URL

### DIFF
--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -798,17 +798,21 @@ class Converter:
             raise ConverterException(f'Cannot automatically find a format for {fp!r}')
 
         self.setSubConverterFromFormat(useFormat)
-        if t.TYPE_CHECKING:
-            assert isinstance(self.subConverter, subConverters.SubConverter)
 
-        self.subConverter.keywords = keywords
-        self.subConverter.parseFile(fp, number=number)
+        subConverter = t.cast(subConverters.SubConverter, self.subConverter)
+        subConverter.keywords = keywords
+        subConverter.parseFile(fp, number=number)
 
-        if self.stream is None:
+        s = self.stream
+        if s is None:
             raise ConverterException('Could not create a Stream via a subConverter.')
-        self.stream.metadata.filePath = fp
-        self.stream.metadata.fileNumber = number
-        self.stream.metadata.fileFormat = useFormat
+
+        if not s.metadata:
+            s.metadata = metadata.Metadata()
+
+        s.metadata.filePath = fp
+        s.metadata.fileNumber = number
+        s.metadata.fileFormat = useFormat
 
 
     # -----------------------------------------------------------------------#

--- a/music21/features/base.py
+++ b/music21/features/base.py
@@ -87,7 +87,7 @@ class Feature:
 
     def __init__(self):
         # these values will be filled by the extractor
-        self.dimensions = None  # number of dimensions
+        self.dimensions: int = 1  # number of dimensions
         # data storage; possibly use numpy array
         self.vector = None
 
@@ -553,12 +553,12 @@ class DataInstance:
         # or metadata title
         if id is not None:
             self._id = id
-        elif (self.stream is not None
-              and hasattr(self.stream, 'metadata')
-              and self.stream.metadata is not None
-              and self.stream.metadata.title is not None
+        elif ((s := self.stream) is not None
+              and hasattr(s, 'metadata')
+              and (md := s.metadata) is not None
+              and md.title is not None
               ):
-            self._id = self.stream.metadata.title
+            self._id = md.title
         elif self.stream is not None and hasattr(self.stream, 'sourcePath'):
             self._id = self.stream.sourcePath
         elif self.streamPath is not None:
@@ -1077,8 +1077,11 @@ class DataSet:
         '''
         if format is None and fp is not None:
             outputFormat = self._getOutputFormatFromFilePath(fp)
+        elif format is None:
+            raise ValueError('Specify a format or a file path')
         else:
             outputFormat = self._getOutputFormat(format)
+
         if outputFormat is None:
             raise DataSetException('no output format could be defined from file path '
                                    f'{fp} or format {format}')


### PR DESCRIPTION
parseURL assumed that the stream created a metadata object.  MIDI Converter did not.

Fixes #1914

```
>>> from music21 import *
>>> converter.parse('https://scrime-apps.labri.fr/gp-provider/file?path=midi/the_last_year.mid', format='midi')
<music21.stream.Score 0x104035be0>
```

Also clean up metadata assignments in features.DataSet -- that one had no bugs, but now typecheckers can know that.  And give a default value to Features.dimensions.  (Yeah, probably should have "split into two PRs" but time=$ and I'm doing my own reviews)