### PR TITLE
Remove v11 deprecations, and update pending deprecations

### DIFF
--- a/music21/chord/tables.py
+++ b/music21/chord/tables.py
@@ -970,7 +970,7 @@ forteNumberWithInversionToTnIndex = {
 # http://solo1.home.mindspring.com/pcsets.htm
 # Larry Solomon, 1997, 2000
 # Larry Solomon's 'The List of Chords, Their Properties and Use in Analysis,'
-# in Interface, Journal of New Music Research , 1982, v11/2.
+# in _Interface, Journal of New Music Research_ 11.2 (1982).
 # http://www.sweb.cz/vladimir_ladma/english/music/structs/mus_rot.htm
 # Vladimir Ladma, Czech Republic
 
@@ -1263,7 +1263,7 @@ tnIndexToChordInfo = {
     (6, 35,  0): {'name': ('whole tone scale',
                            '6 equal part division',
                            'F all-combinatorial (P1, P3, P5, P7, P9, P11, I1, I3, I5, I7, '
-                              + 'I9, I11, R2, R4, R6, R8, R10, RI2, RI4, RI6, RI8, RI10)',
+                           + 'I9, I11, R2, R4, R6, R8, R10, RI2, RI4, RI6, RI8, RI10)',
                            "Messiaen's mode 1",
                            'sixth-order all combinatorial')},
     (6, 36,  1): {},

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -874,19 +874,6 @@ def instrumentToMidiEvents(
 # ------------------------------------------------------------------------------
 # Meta events
 
-@common.deprecated('v10', 'v11', 'passing a list was never used; use midiEventToInstrument instead')
-def midiEventsToInstrument(
-    eventList: MidiEvent|tuple[int, MidiEvent],
-    *,
-    encoding: str = 'utf-8',
-) -> instrument.Instrument:
-    if not common.isListLike(eventList):
-        event = t.cast(MidiEvent, eventList)
-    else:  # get the second event; first is delta time
-        event = eventList[1]
-    return midiEventToInstrument(event, encoding=encoding)
-
-
 def midiEventToInstrument(
     event: MidiEvent,
     *,

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -1259,8 +1259,6 @@ class MusicXMLImporter(XMLParserBase):
         <miscellaneous> tags etc., add this information to the
         :class:`~music21.metadata.Metadata` object passed in.
 
-        (Replaces identificationToMetadata which is now deprecated.)
-
         Not supported: source, relation
 
         Only the first <rights> tag is supported
@@ -1304,26 +1302,6 @@ class MusicXMLImporter(XMLParserBase):
                     # We didn't recognize miscFieldName? Add as custom metadata,
                     # so nothing is lost.
                     md.addCustom(miscFieldName, miscFieldValue)
-
-    @common.deprecated('use addIdentificationToMetadata', 'v10', 'v11')
-    def identificationToMetadata(
-        self,
-        identification: ET.Element,
-        inputM21: metadata.Metadata|None = None
-    ) -> metadata.Metadata|None:
-        '''
-        Deprecated -- use addIdentificationToMetadata instead and always
-        pass in a metadata object.
-        '''
-        if inputM21 is not None:
-            md = inputM21
-        else:
-            md = metadata.Metadata()
-        self.addIdentificationToMetadata(identification, md)
-        if inputM21 is not None:
-            return md
-        return None
-
 
     @staticmethod
     def isRecognizableMetadataKey(miscFieldName: str) -> bool:
@@ -1427,7 +1405,7 @@ class MusicXMLImporter(XMLParserBase):
             # We don't check against metadata.Contributor.roleNames here.
             # Custom roles/creatorTypes are allowed, and will be stored in
             # the metadata with uniqueName 'otherContributor' (see code in
-            # identificationToMetadata that does this).
+            # addIdentificationToMetadata that does this).
             c.role = creatorType
 
         creatorText = creator.text
@@ -2541,21 +2519,9 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
         True
         >>> mp.getStaffNumber(1)
         1
-
-        Deprecation notice: getting staff number from a string is deprecated
-            and will be removed in v11 (this sort of lazy conversion is frowned upon).
-
-        OMIT_FROM_DOCS
-
-        Stop dealing with and documenting this silliness in v11
-
-        >>> mp.getStaffNumber('2')
-        2
         '''
         if isinstance(mxObject, int):
             return mxObject
-        elif isinstance(mxObject, str):
-            return int(mxObject)
         elif mxObject is None:
             return NO_STAFF_ASSIGNED
         tag = mxObject.tag

--- a/music21/sites.py
+++ b/music21/sites.py
@@ -694,7 +694,7 @@ class Sites(common.SlottedObjectMixin):
                 # environLocal.printDebug(
                 #    ['\tY: skipping flat stream that does not contain object:'])
                 if obj.sites.getSiteCount() == 0:  # is top level; no more to search
-                    if not obj.hasElementOfClass(className, forceFlat=True):
+                    if not obj.getElementsByClass(className):
                         continue  # skip, not in this stream
 
             # if after trying to match name, look in the defined contexts'

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -3640,6 +3640,27 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> totalFound
         25
 
+        To test merely whether any element of a class is present, just use
+        `if` or `bool()` around the getElementsByClass call.  It will
+        scan through until it finds the first element with that class.
+        (It is a replacement for the older :meth:`hasElementOfClass`)
+
+        >>> bool(a.getElementsByClass(note.Note))
+        True
+        >>> if a.getElementsByClass(stream.Measure):
+        ...     print('has measures')
+        ... else:
+        ...     print('no measures')
+        no measures
+
+        Use `recurse()` to search nested streams as well, or the `[X]` shorthand
+        for `.recurse().getElementsByClass(X)`:
+
+        >>> bool(a.recurse().getElementsByClass(note.Rest))
+        True
+        >>> bool(a[note.Note])
+        True
+
         The class name of the Stream created is usually the same as the original:
 
         >>> found = a.getElementsByClass(note.Note).stream()
@@ -3658,28 +3679,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> foundList = list(a.recurse().getElementsByClass(note.Rest))
         >>> len(foundList)
         25
-
-        To test merely whether *any* element of a class is present, take the
-        `bool()` of the resulting iterator, or use it directly in an `if`
-        statement.  Since an empty iterator is falsy and a non-empty one is
-        truthy, this is the preferred replacement for the deprecated
-        :meth:`hasElementOfClass`:
-
-        >>> bool(a.getElementsByClass(note.Note))
-        True
-        >>> if a.getElementsByClass(stream.Measure):
-        ...     print('has measures')
-        ... else:
-        ...     print('no measures')
-        no measures
-
-        Use `recurse()` to search nested streams as well, or the `[]` operator
-        as a shorthand for `getElementsByClass`:
-
-        >>> bool(a.recurse().getElementsByClass(note.Rest))
-        True
-        >>> bool(a[note.Note])
-        True
         '''
         return self.iter().getElementsByClass(classFilterList)
 

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1415,19 +1415,11 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
             if hasattr(other, attr):
                 setattr(self, attr, getattr(other, attr))
 
-    @common.deprecated('v9.3', 'v11', 'Use `el in stream` instead of '
-                       '`stream.hasElement(el)`')
-    def hasElement(self, obj: base.Music21Object) -> bool:
-        '''
-        DEPRECATED: just use `el in stream` instead of `stream.hasElement(el)`
-
-        Return True if an element, provided as an argument, is contained in
-        this Stream.
-        '''
-        return obj in self
-
+    @common.deprecated('v11', 'v12', 'use `bool(s.getElementsByClass(className))` instead')
     def hasElementOfClass(self, className, forceFlat=False):
         '''
+        Deprecated: use `bool(s.getElementsByClass(className))` instead.
+
         Given a single class name as string,
         return True or False if an element with the
         specified class is found.
@@ -1438,13 +1430,6 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> s.append(meter.TimeSignature('5/8'))
         >>> s.append(note.Note('d-2'))
         >>> s.insert(dynamics.Dynamic('fff'))
-        >>> s.hasElementOfClass(meter.TimeSignature)
-        True
-        >>> s.hasElementOfClass('Measure')
-        False
-
-        To be deprecated in v11 -- to be removed in v12, use:
-
         >>> bool(s.getElementsByClass(meter.TimeSignature))
         True
         >>> bool(s.getElementsByClass(stream.Measure))
@@ -1452,11 +1437,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         forceFlat does nothing, while getElementsByClass can be done on recurse()
         '''
-        # environLocal.printDebug(['calling hasElementOfClass()', className])
-        for e in self.elements:
-            if className in e.classSet:
-                return True
-        return False
+        return bool(self.getElementsByClass(className))
 
     def mergeElements(self, other, classFilterList=None):
         '''
@@ -3677,6 +3658,28 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         >>> foundList = list(a.recurse().getElementsByClass(note.Rest))
         >>> len(foundList)
         25
+
+        To test merely whether *any* element of a class is present, take the
+        `bool()` of the resulting iterator, or use it directly in an `if`
+        statement.  Since an empty iterator is falsy and a non-empty one is
+        truthy, this is the preferred replacement for the deprecated
+        :meth:`hasElementOfClass`:
+
+        >>> bool(a.getElementsByClass(note.Note))
+        True
+        >>> if a.getElementsByClass(stream.Measure):
+        ...     print('has measures')
+        ... else:
+        ...     print('no measures')
+        no measures
+
+        Use `recurse()` to search nested streams as well, or the `[]` operator
+        as a shorthand for `getElementsByClass`:
+
+        >>> bool(a.recurse().getElementsByClass(note.Rest))
+        True
+        >>> bool(a[note.Note])
+        True
         '''
         return self.iter().getElementsByClass(classFilterList)
 

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -40,7 +40,7 @@ def listOfTreesByClass(
 ) -> list[trees.OffsetTree|timespanTree.TimespanTree]:
     # noinspection PyShadowingNames
     r'''
-    To be DEPRECATED in v11: this is no faster than calling streamToTimespanTree
+    To be DEPRECATED in v12: this is no faster than calling streamToTimespanTree
     multiple times with different classLists.
 
     Recurses through `inputStream`, and constructs TimespanTrees for each

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -25,6 +25,7 @@ from collections.abc import Sequence
 import copy
 import difflib
 import unittest
+import warnings
 
 from music21 import base
 from music21 import clef
@@ -297,6 +298,11 @@ class Variant(base.Music21Object):
         return self.replacementQuarterLength
 
     def _setReplacementDuration(self, value):
+        warnings.warn(
+            "'replacementDuration' is deprecated as of v11 and will be removed in v12; "
+            + 'use the synonym replacementQuarterLength instead.',
+            exceptions21.Music21DeprecationWarning,
+            stacklevel=2)
         self.replacementQuarterLength = value
 
     replacementDuration = property(
@@ -307,9 +313,9 @@ class Variant(base.Music21Object):
 
         .. note::
 
-            ``replacementDuration`` is pending deprecation as of v10.3 (music21
-            avoids referring to an offset/quarterLength value as a "Duration"). It will be
-            fully deprecated in v11 and removed in v12.  Use
+            ``replacementDuration`` is deprecated as of v11 (music21
+            avoids referring to an offset/quarterLength value as a "Duration").
+            Setting it raises a deprecation warning, and it will be removed in v12.  Use
             :attr:`replacementQuarterLength` instead.
         ''')
 
@@ -1400,8 +1406,9 @@ def addVariant(
     None, this is a deletion.
 
     * Changed in v10.3: the ``replacementDuration`` keyword renamed to
-      ``replacementQuarterLength``.  The old name is pending deprecation:
-      will warn in v11 and be removed in v12.
+      ``replacementQuarterLength``.
+    * Changed in v11: passing the old ``replacementDuration`` keyword now raises a
+      deprecation warning; it will be removed in v12.
 
     >>> data1M1 = [('a', 'quarter'), ('b', 'eighth'), ('c', 'eighth'),
     ...            ('a', 'quarter'), ('a', 'quarter')]
@@ -1468,7 +1475,13 @@ def addVariant(
     '''
     if replacementDuration is not None:
         # 'replacementDuration' was renamed to 'replacementQuarterLength' in v10.3.
-        # Pending deprecation: still accepted in v10, will warn in v11, be removed in v12.
+        # Deprecated as of v11, to be removed in v12.
+        warnings.warn(
+            "addVariant()'s 'replacementDuration' keyword was renamed to "
+            + "'replacementQuarterLength' in v10.3; 'replacementDuration' is deprecated "
+            + 'and will be removed in v12.',
+            exceptions21.Music21DeprecationWarning,
+            stacklevel=2)
         if replacementQuarterLength is not None:
             raise TypeError(
                 "addVariant() received both 'replacementQuarterLength' and its former "
@@ -2593,7 +2606,7 @@ class Test(unittest.TestCase):
         self.assertEqual(v.highestTime, 0.0)
 
         self.assertEqual(len(v.notes), 2)
-        self.assertTrue(v.hasElementOfClass('Note'))
+        self.assertTrue(v.getElementsByClass('Note'))
         v.pop(1)  # remove the last item
 
         self.assertEqual(v.highestOffset, 0.0)
@@ -2620,8 +2633,8 @@ class Test(unittest.TestCase):
 
         self.assertIn('Variant', v1.classes)
 
-        self.assertFalse(v1.hasElementOfClass(Variant))
-        self.assertTrue(v1.hasElementOfClass(stream.Measure))
+        self.assertFalse(v1.getElementsByClass(Variant))
+        self.assertTrue(v1.getElementsByClass(stream.Measure))
 
     def testDeepCopyVariantA(self):
         from music21 import variant


### PR DESCRIPTION
## Removed (were deprecated for removal in v11)
- `midi.translate.midiEventsToInstrument` — use `midiEventToInstrument`
- `stream.Stream.hasElement` — use `el in stream`
- `musicxml.xmlToM21.MeasureParser.identificationToMetadata` — use
  `addIdentificationToMetadata`
- string input to `MeasureParser.getStaffNumber` (the lazy `int(str)` coercion)

## Deprecations now active in v11
- `stream.Stream.hasElementOfClass` — use `if self.getElementsByClass(className):`
- `variant.addVariant`'s `replacementDuration` keyword and
  `Variant._setReplacementDuration`

AI-assisted (Claude)