### PR TITLE
StandardizePython 2/3 doctest ellipses

### DIFF
--- a/music21/alpha/analysis/hasher.py
+++ b/music21/alpha/analysis/hasher.py
@@ -577,7 +577,7 @@ class NoteHash(tuple):
     >>> b
     2
     >>> nh.__class__
-    <... 'music21.alpha.analysis.hasher.NoteHash'>
+    <class 'music21.alpha.analysis.hasher.NoteHash'>
     '''
     def __new__(cls, tupEls):
         return super(NoteHash, cls).__new__(cls, tuple(tupEls))

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -1015,7 +1015,7 @@ def toRoman(num: int) -> str:
 
     >>> common.toRoman('hi')
     Traceback (most recent call last):
-    TypeError: expected integer, got <... 'str'>
+    TypeError: expected integer, got <class 'str'>
 
     >>> common.toRoman(0)
     Traceback (most recent call last):

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -632,7 +632,7 @@ class Segment:
         >>> segmentA = segment.Segment()
         >>> allPossib = segmentA.allSinglePossibilities()
         >>> allPossib.__class__
-        <... 'itertools.product'>
+        <class 'itertools.product'>
 
         The number of naive possibilities is always the length of
         :attr:`~music21.figuredBass.segment.Segment.allPitchesAboveBass`

--- a/music21/lily/lilyObjects.py
+++ b/music21/lily/lilyObjects.py
@@ -122,7 +122,7 @@ class LyObject(prebase.ProtoM21Object):
         to LyMock.lilyAttributes:
 
         >>> print(lm.supportedClasses)
-        [...'Mock', ...'Mocker']
+        ['Mock', 'Mocker']
 
         Thus, we can get attributes from the Mock class (see `setAttributesFromClassObject`):
 

--- a/music21/romanText/rtObjects.py
+++ b/music21/romanText/rtObjects.py
@@ -1066,7 +1066,7 @@ class RTRepeatStart(RTRepeat):
     '''
     >>> repeat = romanText.rtObjects.RTRepeatStart()
     >>> repeat
-    <music21.romanText.rtObjects.RTRepeatStart ...'||:'>
+    <music21.romanText.rtObjects.RTRepeatStart '||:'>
     '''
 
     def __init__(self, src='||:', container=None):
@@ -1077,7 +1077,7 @@ class RTRepeatStop(RTRepeat):
     '''
     >>> repeat = romanText.rtObjects.RTRepeatStop()
     >>> repeat
-    <music21.romanText.rtObjects.RTRepeatStop ...':||'>
+    <music21.romanText.rtObjects.RTRepeatStop ':||'>
     '''
 
     def __init__(self, src=':||', container=None):


### PR DESCRIPTION
Remove old doctest ellipses that existed only to bridge Python 2 vs 3 repr differences

- '<... 'X'>' bridged Py2 '<type 'X'>' vs Py3 '<class 'X'>' 
- '...'literal'' bridged the Py2 'u'...'' unicode prefix vs Py3 '...' 

AI-assisted (Claude)