### PR TITLE
Add more typing to ABC Module

### DIFF
--- a/.agents/skills/running-tests/SKILL.md
+++ b/.agents/skills/running-tests/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: running-tests
+description: >-
+  How to correctly run music21's tests and doctests with pytest. Use this
+  whenever you need to run, verify, or judge the pass/fail of tests or doctests
+  in this repo — confirming a change works, checking that doctests still pass,
+  running a single module's tests, or sanity-checking before a PR or push.
+  Especially consult this before concluding that a doctest "fails": the repo's
+  pytest plugin normalizes object addresses and injects the doctest namespace,
+  and running doctests any other way (e.g. raw doctest.testmod) produces FALSE
+  failures.
+---
+
+# Running music21 tests and doctests
+
+The reliable way to run tests/doctests for a music21 module is plain pytest with
+explicit file paths:
+
+```bash
+uv run pytest music21/abcFormat/__init__.py music21/abcFormat/translate.py
+```
+
+`pyproject.toml` `[tool.pytest.ini_options]` already wires up everything that
+makes this work:
+
+```
+addopts = ['--doctest-modules', '-p', 'music21.test.pytest_plugin']
+doctest_optionflags = ['NORMALIZE_WHITESPACE', 'ELLIPSIS']
+```
+
+So you do not pass `--doctest-modules` yourself — doctests in every `.py` are
+collected automatically, and `music21/test/pytest_plugin.py` is loaded.
+
+## Why the plugin matters (and why not to use raw doctest)
+
+The plugin does two things that make doctests pass the way the project intends:
+
+- It runs `stripAddresses(example.want, '0x...')` (from
+  `music21.test.testRunner`) on every doctest, so docstrings that hardcode a
+  repr like `<music21.abcFormat.ABCHandler object at 0x10b0cf5f8>` are
+  normalized and DO pass. The literal hex address in the docstring is expected
+  and fine.
+- It injects the `music21.__all__` names plus `music21` itself into the doctest
+  namespace, so examples can reference `meter`, `key`, `corpus`, etc. without
+  importing them.
+
+This is why you must judge doctest pass/fail **through pytest**. Do NOT use
+`doctest.testmod(...)` or `doctest.DocTestSuite(...)` directly to decide whether
+doctests pass: that path applies neither the address normalizer nor the
+namespace injection, so it manufactures false failures on any docstring that
+prints a `<... object at 0x...>` repr or relies on the injected names. If you
+ever see only an object-address example "failing," that is the tell that you
+ran doctests the wrong way — rerun through pytest.
+
+## Pass explicit file paths, not a bare directory
+
+Use explicit file paths so the in-module `Test(unittest.TestCase)` classes run
+too, not just doctests. `python_files = ['test_*.py', '*_test.py', 'tests.py']`,
+so for a module that keeps its `Test` class inside `__init__.py` /
+`translate.py` (e.g. `abcFormat`), pointing pytest at the directory
+(`uv run pytest music21/abcFormat/`) collects ONLY its doctests and silently
+skips the unittest classes.
+
+Concretely, for `abcFormat`:
+- `uv run pytest music21/abcFormat/` → ~43 items (doctests only)
+- `uv run pytest music21/abcFormat/__init__.py music21/abcFormat/translate.py`
+  → ~82 items (doctests **and** `Test` methods)
+
+Both apply the address normalizer; only the explicit-paths form also runs the
+unittest classes. When a module's tests live in a `tests.py` file (much of
+music21's house style), the directory form already picks those up — the gotcha
+is specifically modules that keep `Test` inside a non-`tests.py` file.
+
+## Whole suite and the other gates
+
+- Full suite: `python music21/test/multiprocessTest.py` (or
+  `music21/test/testSingleCoreAll.py` on a single-core machine).
+- Before a PR or a push to an open PR, also run the lint and type gates:
+  `uv run ruff check music21` and `uv run mypy music21`.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -101,6 +101,7 @@ if t.TYPE_CHECKING:
     from music21 import dynamics
     from music21 import key
     from music21 import meter
+    from music21 import note
     from music21 import tempo
     from music21 import spanner
 
@@ -181,10 +182,10 @@ class ABCToken(prebase.ProtoM21Object, common.objects.EqualSlottedObjectMixin):
     '''
     __slots__ = ('src',)
 
-    def __init__(self, src: str = ''):
+    def __init__(self, src: str = '') -> None:
         self.src: str = src  # store source character sequence
 
-    def _reprInternal(self):
+    def _reprInternal(self) -> str:
         return repr(self.src)
 
     @staticmethod
@@ -213,14 +214,14 @@ class ABCToken(prebase.ProtoM21Object, common.objects.EqualSlottedObjectMixin):
             return strSrc.split('%')[0]
         return strSrc
 
-    def preParse(self):
+    def preParse(self) -> None:
         '''
         Dummy method that is called before contextual adjustments.
         Designed to be subclassed or overridden.
         '''
         pass
 
-    def parse(self):
+    def parse(self) -> None:
         '''
         Dummy method that reads self.src and loads attributes.
         It is called after contextual adjustments.
@@ -256,7 +257,7 @@ class ABCMetadata(ABCToken):
 
     # given a logical unit, create an object
     # may be a chord, notes, metadata, bars
-    def __init__(self, src: str = ''):
+    def __init__(self, src: str = '') -> None:
         super().__init__(src)
         self.tag: str = ''
         self.data: str = ''
@@ -280,7 +281,7 @@ class ABCMetadata(ABCToken):
             self.tag = strSrc[:div - 1]  # do not get the colon
             self.data = strSrc[div:].strip()  # remove leading/trailing
 
-    def parse(self):
+    def parse(self) -> None:
         pass
 
     def isDefaultNoteLength(self) -> bool:
@@ -835,7 +836,7 @@ class ABCBar(ABCToken):
     # may be a chord, notes, metadata, bars
     __slots__ = ('barType', 'barStyle', 'repeatForm')
 
-    def __init__(self, src):
+    def __init__(self, src: str = '') -> None:
         super().__init__(src)
         self.barType = ''  # repeat or barline
         self.barStyle = ''  # regular, heavy-light, etc
@@ -989,7 +990,7 @@ class ABCTuplet(ABCToken):
     '''
     __slots__ = ('noteCount', 'numberNotesActual', 'numberNotesNormal', 'tupletObj')
 
-    def __init__(self, src: str = ''):
+    def __init__(self, src: str = '') -> None:
         super().__init__(src)
 
         # self.qlRemain = None  # how many ql are left of this tuplets activity
@@ -1179,9 +1180,9 @@ class ABCTie(ABCToken):
     '''
     __slots__ = ('noteObj',)
 
-    def __init__(self, src=''):
+    def __init__(self, src: str = '') -> None:
         super().__init__(src)
-        self.noteObj = None
+        self.noteObj: note.Note|None = None
 
 
 class ABCSlurStart(ABCToken):
@@ -1191,11 +1192,11 @@ class ABCSlurStart(ABCToken):
     '''
     __slots__ = ('slurObj',)
 
-    def __init__(self, src: str = ''):
+    def __init__(self, src: str = '') -> None:
         super().__init__(src)
         self.slurObj: spanner.Slur|None = None
 
-    def fillSlur(self):
+    def fillSlur(self) -> None:
         '''
         Creates a spanner object for each open paren associated with a slur;
         these slurs are filled with notes until end parens are read.
@@ -1220,7 +1221,7 @@ class ABCCrescStart(ABCToken):
     '''
     __slots__ = ('crescObj',)
 
-    def __init__(self, src: str = ''):
+    def __init__(self, src: str = '') -> None:
         super().__init__(src)
         self.crescObj: dynamics.Crescendo|None = None
 
@@ -1236,11 +1237,11 @@ class ABCDimStart(ABCToken):
     '''
     __slots__ = ('dimObj',)
 
-    def __init__(self, src: str = ''):
+    def __init__(self, src: str = '') -> None:
         super().__init__(src)
         self.dimObj: dynamics.Diminuendo|None = None
 
-    def fillDim(self):
+    def fillDim(self) -> None:
         from music21 import dynamics
         self.dimObj = dynamics.Diminuendo()
 
@@ -1315,11 +1316,11 @@ class ABCBrokenRhythmMarker(ABCToken):
     '''
     __slots__ = ('data',)
 
-    def __init__(self, src: str = ''):
+    def __init__(self, src: str = '') -> None:
         super().__init__(src)
         self.data: str = ''
 
-    def preParse(self):
+    def preParse(self) -> None:
         '''
         Called before context adjustments: need to have access to data
 
@@ -1352,7 +1353,7 @@ class ABCNote(ABCToken):
                  'articulations', 'accidentalDisplayStatus', 'isRest',
                  'pitchName', 'quarterLength',)
 
-    def __init__(self, src='', carriedAccidental: str = ''):
+    def __init__(self, src: str = '', carriedAccidental: str = '') -> None:
         super().__init__(src)
 
         # store the ABC accidental string propagated in the measure that
@@ -1431,7 +1432,7 @@ class ABCNote(ABCToken):
     def getPitchName(
         self,
         strSrc: str,
-        forceKeySignature=None
+        forceKeySignature: key.KeySignature|None = None
     ) -> tuple[str|None, bool|None]:
         '''
         Given a note or rest string without a chord symbol,
@@ -1502,6 +1503,7 @@ class ABCNote(ABCToken):
         if name == 'z':
             return (None, None)  # designates a rest
 
+        activeKeySignature: key.KeySignature|None
         if forceKeySignature is not None:
             activeKeySignature = forceKeySignature
         else:  # may be None
@@ -1763,7 +1765,7 @@ class ABCChord(ABCNote):
     A subclass of ABCNote.
     '''
 
-    def __init__(self, src: str = ''):
+    def __init__(self, src: str = '') -> None:
         super().__init__(src)
         # store a list of component objects
         self.subTokens: list[ABCToken] = []
@@ -1772,7 +1774,7 @@ class ABCChord(ABCNote):
         self,
         forceDefaultQuarterLength: float|None = None,
         forceKeySignature: key.KeySignature|None = None
-    ):
+    ) -> None:
         '''
         Handles the following types of chords:
 
@@ -1864,7 +1866,7 @@ class ABCHandler:
     '''
     def __init__(self,
                  abcVersion: tuple[int, ...] = defaults.abcVersionDefault,
-                 lineBreaksDefinePhrases=False):
+                 lineBreaksDefinePhrases: bool = False) -> None:
         # tokens are ABC objects import n a linear stream
         self.abcVersion: tuple[int, ...] = abcVersion
         self.abcDirectives: dict[str, str] = {}
@@ -2070,7 +2072,7 @@ class ABCHandler:
             abcPatch = 0
         return (abcMajor, abcMinor, abcPatch)
 
-    def processComment(self):
+    def processComment(self) -> None:
         r'''
         Processes the comment at self.pos in self.strSrc, setting self.skipAhead
         and self.abcDirectives for the directiveKey.
@@ -2753,10 +2755,10 @@ class ABCHandler:
     # --------------------------------------------------------------------------
     # access tokens
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.tokens)
 
-    def __add__(self, other):
+    def __add__(self, other: ABCHandler) -> ABCHandler:
         '''
         Return a new handler adding the tokens in both
 
@@ -2792,7 +2794,7 @@ class ABCHandler:
     # --------------------------------------------------------------------------
     # utility methods for post-processing
 
-    def definesReferenceNumbers(self):
+    def definesReferenceNumbers(self) -> bool:
         '''
         Return True if this token structure defines more than 1 reference number,
         usually implying multiple pieces encoded in one file.
@@ -2932,7 +2934,7 @@ class ABCHandler:
 
         return ahDict
 
-    def getReferenceNumber(self):
+    def getReferenceNumber(self) -> str|None:
         '''
         If tokens are processed, get the first
         reference number defined.
@@ -2951,7 +2953,7 @@ class ABCHandler:
                     return token.data
         return None
 
-    def definesMeasures(self):
+    def definesMeasures(self) -> bool:
         '''
         Returns True if this token structure defines Measures in a normal Measure form.
         Otherwise False
@@ -3331,7 +3333,7 @@ class ABCHandlerBar(ABCHandler):
         self.leftBarToken: ABCBar|None = None
         self.rightBarToken: ABCBar|None = None
 
-    def __add__(self, other):
+    def __add__(self, other: ABCHandler) -> ABCHandlerBar:
         ah = self.__class__()  # will get the same class type
         ah.tokens = self.tokens + other.tokens
         # get defined tokens
@@ -3412,12 +3414,12 @@ class ABCFile(prebase.ProtoM21Object):
 
     If not set, default ABC 1.3 parsing is performed.
     '''
-    def __init__(self, abcVersion: tuple[int, int, int] = defaults.abcVersionDefault):
+    def __init__(self, abcVersion: tuple[int, int, int] = defaults.abcVersionDefault) -> None:
         self.abcVersion: tuple[int, int, int] = abcVersion
         self.file: t.IO|None = None
         self.filename: str|pathlib.Path = ''
 
-    def open(self, filename: str|pathlib.Path):
+    def open(self, filename: str|pathlib.Path) -> None:
         '''
         Open a file for reading
         '''
@@ -3427,7 +3429,7 @@ class ABCFile(prebase.ProtoM21Object):
         # self.file = io.open(filename, encoding='latin-1')
         self.filename = filename
 
-    def openFileLike(self, fileLike):
+    def openFileLike(self, fileLike: t.IO) -> None:
         '''
         Assign a file-like object, such as those provided by
         StringIO, as an open file object.
@@ -3437,20 +3439,24 @@ class ABCFile(prebase.ProtoM21Object):
         '''
         self.file = fileLike  # already 'open'
 
-    def _reprInternal(self):
+    def _reprInternal(self) -> str:
         return ''
 
-    def close(self):
-        self.file.close()
+    def close(self) -> None:
+        if self.file is not None:
+            self.file.close()
 
-    def read(self, number=None):
+    def read(self, number: int|None = None) -> ABCHandler:
         '''
         Read a file. Note that this calls readstr,
         which processes all tokens.
 
         If `number` is given, a work number will be extracted if possible.
         '''
-        return self.readstr(self.file.read(), number)
+        file = self.file
+        if file is None:
+            raise ABCFileException('cannot read; no file or file-like object is open')
+        return self.readstr(file.read(), number)
 
     @staticmethod
     def extractReferenceNumber(strSrc: str, number: int) -> str:

--- a/music21/abcFormat/__init__.py
+++ b/music21/abcFormat/__init__.py
@@ -178,7 +178,7 @@ class ABCToken(prebase.ProtoM21Object, common.objects.EqualSlottedObjectMixin):
     The source ABC string itself is stored in self.src.
 
     Because of how copying ABCTokens works, all tokens must have default parameters in their
-    initializers
+    initializers.
     '''
     __slots__ = ('src',)
 
@@ -755,7 +755,7 @@ class ABCMetadata(ABCToken):
 
     def getDefaultQuarterLength(self) -> float:
         r'''
-        If there is a quarter length representation available, return it as a floating point value
+        If there is a quarter length representation available, return it as a floating point value.
 
         >>> am = abcFormat.ABCMetadata('L:1/2')
         >>> am.preParse()
@@ -812,7 +812,7 @@ class ABCMetadata(ABCToken):
             return n * 4 / d
 
         elif self.isMeter():
-            # if meter auto-set a default not length
+            # if meter, auto-set a default note length
             parameters = self.getTimeSignatureParameters()
             if parameters is None:
                 return 0.5  # TODO: assume default, need to configure
@@ -840,7 +840,7 @@ class ABCBar(ABCToken):
         super().__init__(src)
         self.barType = ''  # repeat or barline
         self.barStyle = ''  # regular, heavy-light, etc
-        self.repeatForm = ''  # end, start, bidrectional, first, second
+        self.repeatForm = ''  # end, start, bidirectional, first, second
 
     def parse(self) -> None:
         '''
@@ -1156,7 +1156,7 @@ class ABCTuplet(ABCToken):
         if self.numberNotesActual == -1:
             raise ABCTokenException('must set numberNotesActual with updateRatio()')
 
-        # nee dto
+        # need to create the tuplet object
         from music21 import duration
         self.tupletObj = duration.Tuplet(
             numberNotesActual=self.numberNotesActual,
@@ -1406,7 +1406,7 @@ class ABCNote(ABCToken):
     def _splitChordSymbols(strSrc: str) -> tuple[list[str], str]:
         '''
         Splits chord symbols from other string characteristics.
-        Returns a 2-tuple of a list of chord symbols, and clean remaining chars
+        Returns a 2-tuple of a list of chord symbols, and clean remaining chars.
 
         Staticmethod:
 
@@ -1481,7 +1481,7 @@ class ABCNote(ABCToken):
         >>> an.getPitchName('c')
         ('C#5', False)
 
-        Illegal pitch names raise an ABCHandlerException
+        Illegal pitch names raise an ABCHandlerException:
 
         >>> an.getPitchName('x')
         Traceback (most recent call last):
@@ -1596,7 +1596,7 @@ class ABCNote(ABCToken):
                          strSrc: str,
                          forceDefaultQuarterLength: float|None = None) -> OffsetQL:
         '''
-        Called with parse(), after context processing, to calculate duration
+        Called with parse(), after context processing, to calculate duration.
 
         >>> an = abcFormat.ABCNote()
         >>> an.activeDefaultQuarterLength = 0.5
@@ -1729,7 +1729,7 @@ class ABCNote(ABCToken):
     ) -> None:
         # environLocal.printDebug(['parse', self.src])
         self.chordSymbols, nonChordSymStr = self._splitChordSymbols(self.src)
-        # get pitch name form remaining string
+        # get pitch name from remaining string
         # rests will have a pitch name of None
 
         pn: str|None
@@ -1852,22 +1852,22 @@ class ABCChord(ABCNote):
 # ------------------------------------------------------------------------------
 class ABCHandler:
     '''
-    An ABCHandler is able to divide elements of a character stream into objects and handle
-    store in a list, and passes global information to components
+    An ABCHandler is able to divide elements of a character stream into objects,
+    store them in a list, and pass global information to components.
 
     Optionally, specify the (major, minor, patch) version of ABC to process--
     e.g., (1.2.0). If not set, default ABC 1.3 parsing is performed.
 
     If lineBreaksDefinePhrases is True then new lines within music elements
     define new phrases.  This is useful for parsing extra information from
-    the Essen Folksong repertory
+    the Essen Folksong repertory.
 
     * New in v6.3: lineBreaksDefinePhrases -- does not yet do anything.
     '''
     def __init__(self,
                  abcVersion: tuple[int, ...] = defaults.abcVersionDefault,
                  lineBreaksDefinePhrases: bool = False) -> None:
-        # tokens are ABC objects import n a linear stream
+        # tokens are ABC objects in a linear stream
         self.abcVersion: tuple[int, ...] = abcVersion
         self.abcDirectives: dict[str, str] = {}
         self.tokens: list[ABCToken] = []
@@ -2144,11 +2144,11 @@ class ABCHandler:
         False
 
         Pipe after colon indicates not metadata (bar info).
-        For example need to not misinterpret repeat bars as metadata
+        For example, we need to avoid misinterpreting repeat bars as metadata,
         e.g. `dAG FED:|2 dAG FGA|`
 
-        this is incorrect, but we can avoid it by
-        looking for a leading pipe and returning False
+        This is incorrect, but we can avoid it by
+        looking for a leading pipe and returning False.
 
         >>> ah.startsMetadata('A', ':', '|')
         False
@@ -2314,7 +2314,7 @@ class ABCHandler:
                     j += 1
                 self.currentCollectStr = self.strSrc[self.pos:j]
                 # environLocal.printDebug(
-                #     ['got bidrectional rhythm mod:', repr(self.currentCollectStr)])
+                #     ['got bidirectional rhythm mod:', repr(self.currentCollectStr)])
                 self.tokens.append(ABCBrokenRhythmMarker(self.currentCollectStr))
                 self.skipAhead = j - (self.pos + 1)
                 continue
@@ -2629,7 +2629,7 @@ class ABCHandler:
             if isinstance(token, ABCTuplet):
                 token.updateRatio(lastTimeSignatureObj)
                 # set number of notes that will be altered
-                # might need to do this with ql values, or look ahead to nxt
+                # might need to do this with ql values, or look ahead to next
                 # token
                 token.updateNoteCount()
                 lastTupletToken = token
@@ -2994,7 +2994,7 @@ class ABCHandler:
         Given a processed token list, look for voices. If voices exist,
         split into parts: common metadata, then next voice, next voice, etc.
 
-        Each part is returned as a ABCHandler instance.
+        Each part is returned as an ABCHandler instance.
 
         >>> abcStr = ('M:6/8\\nL:1/8\\nK:G\\nV:1 name="Whistle" '
         ...           'snm="wh"\\nB3 A3 | G6 | B3 A3 | G6 ||\\nV:2 name="violin" '
@@ -3093,7 +3093,7 @@ class ABCHandler:
         Given a list of indices of a list marking the position of
         each barline or implied barline, and the last valid index,
         return a list of two-element lists, each indicating
-        the start and positions of a measure.
+        the start and end positions of a measure.
 
         Here's an easy case that makes this method look worthless:
 
@@ -3144,7 +3144,7 @@ class ABCHandler:
         as an empty bar. This is often done with leading metadata.
 
         Returns a list of ABCHandlerBar instances.
-        The first usually defines only Metadata
+        The first usually defines only Metadata.
 
         TODO: Test and examples
         '''
@@ -3277,7 +3277,7 @@ class ABCHandler:
     def hasNotes(self) -> bool:
         '''
         If tokens are processed, return True if ABCNote or
-        ABCChord classes are defined
+        ABCChord classes are defined.
 
         >>> abcStr = 'M:6/8\\nL:1/8\\nK:G\\n'
         >>> ah1 = abcFormat.ABCHandler()
@@ -3440,6 +3440,30 @@ class ABCFile(prebase.ProtoM21Object):
         self.file = fileLike  # already 'open'
 
     def _reprInternal(self) -> str:
+        '''
+        Return the filename if one is set, otherwise a placeholder for an
+        open file-like object, otherwise the empty string.
+
+        >>> abcFile = abcFormat.ABCFile()
+        >>> abcFile
+        <music21.abcFormat.ABCFile>
+
+        >>> abcFile.filename = 'tune.abc'
+        >>> abcFile
+        <music21.abcFormat.ABCFile tune.abc>
+
+        A file-like object with no filename shows a generic placeholder:
+
+        >>> from io import StringIO
+        >>> abcFile2 = abcFormat.ABCFile()
+        >>> abcFile2.openFileLike(StringIO('X:1'))
+        >>> abcFile2
+        <music21.abcFormat.ABCFile <filelike-object>>
+        '''
+        if self.filename:
+            return str(self.filename)
+        if self.file is not None:
+            return '<filelike-object>'
         return ''
 
     def close(self) -> None:
@@ -3528,7 +3552,7 @@ class ABCFile(prebase.ProtoM21Object):
     def readstr(self, strSrc: str, number: int|None = None) -> ABCHandler:
         '''
         Read a string and process all Tokens.
-        Returns a ABCHandler instance.
+        Returns an ABCHandler instance.
         '''
         if number is not None:
             # will raise exception if number cannot be found

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -443,7 +443,10 @@ def metadataToM21Object(
     return postTransposition, clefSet
 
 
-def abcToStreamScore(abcHandler, inputM21=None):
+def abcToStreamScore(
+    abcHandler: abcFormat.ABCHandler,
+    inputM21: stream.Score|None = None
+) -> stream.Score:
     '''
     Given an abcHandler object, build into a
     multi-part :class:`~music21.stream.Score` with metadata.
@@ -472,12 +475,11 @@ def abcToStreamScore(abcHandler, inputM21=None):
         if isinstance(t, abcFormat.ABCMetadata):
             if t.isVersion():
                 v = t.data.replace('abc-version', '').strip()
-                try:
+                versionMatch = re.match(r'(\d+).(\d+).?(\d+)?', v)
+                if versionMatch is not None:
                     abcHandler.abcVersion = abcHandler.returnAbcVersionFromMatch(
-                        re.match(r'(\d+).(\d+).?(\d+)?', v)
+                        versionMatch
                     )
-                except AttributeError:
-                    pass
 
             elif t.isTitle():
                 if titleCount == 0:  # first
@@ -530,13 +532,18 @@ def abcToStreamScore(abcHandler, inputM21=None):
     s.coreElementsChanged()
     return s
 
-def abcToStreamOpus(abcHandler, inputM21=None, number=None):
+def abcToStreamOpus(
+    abcHandler: abcFormat.ABCHandler,
+    inputM21: stream.Opus|None = None,
+    number: int|None = None
+) -> stream.Score|stream.Opus:
     '''
     Convert a multi-work stream into one or more complete works packed into an Opus Stream.
 
     If a `number` argument is given, and a work is defined by
     that number, that work is returned.
     '''
+    opus: stream.Score|stream.Opus
     if inputM21 is None:
         opus = stream.Opus()
     else:
@@ -569,7 +576,7 @@ def abcToStreamOpus(abcHandler, inputM21=None, number=None):
     return opus
 
 
-def reBar(music21Part, *, inPlace=False):
+def reBar(music21Part: stream.Part, *, inPlace: bool = False) -> stream.Part|None:
     # noinspection PyShadowingNames,SpellCheckingInspection
     '''
     Re-bar overflow measures using the last known time signature.

--- a/music21/abcFormat/translate.py
+++ b/music21/abcFormat/translate.py
@@ -63,7 +63,7 @@ def abcToStreamPart(
     '''
     Handler conversion of a single Part of a Score with multiple Parts.
     Results are added into the provided inputM21 object
-    or a newly created Part object
+    or a newly created Part object.
 
     The part object is then returned.
     '''
@@ -122,7 +122,7 @@ def abcToStreamPart(
             # environLocal.printDebug(['abcToStreamPart', 'useMeasures',
             #    useMeasures, 'mh.hasNotes()', mh.hasNotes()])
             dst = stream.Measure()
-            # bar tokens are already extracted form token list and are available
+            # bar tokens are already extracted from token list and are available
             # as attributes on the handler object
             # may return None for a regular barline
 
@@ -256,7 +256,7 @@ def parseTokens(
     useMeasures: bool
 ) -> tuple[int, bool]:
     '''
-    parses all the tokens in a measure or part.
+    Parses all the tokens in a measure or part.
     '''
     # in case need to transpose due to clef indication
     from music21 import abcFormat
@@ -536,14 +536,15 @@ def abcToStreamOpus(
     abcHandler: abcFormat.ABCHandler,
     inputM21: stream.Opus|None = None,
     number: int|None = None
-) -> stream.Score|stream.Opus:
+) -> stream.Opus:
     '''
     Convert a multi-work stream into one or more complete works packed into an Opus Stream.
 
     If a `number` argument is given, and a work is defined by
-    that number, that work is returned.
+    that number, an Opus containing just that single work is returned.
+
+    * Changed in v11: always returns an Opus even if only a single number is given.
     '''
-    opus: stream.Score|stream.Opus
     if inputM21 is None:
         opus = stream.Opus()
     else:
@@ -555,8 +556,8 @@ def abcToStreamOpus(
     if abcHandler.definesReferenceNumbers():
         abcDict = abcHandler.splitByReferenceNumber()
         if number is not None and number in abcDict:
-            # get number from dictionary; set to new score
-            opus = abcToStreamScore(abcDict[number])  # return a score, not an opus
+            # get the single requested work, but still wrap it in an Opus
+            opus.append(abcToStreamScore(abcDict[number]))
         else:  # build entire opus into an opus stream
             scoreList = []
             for key, value in sorted(abcDict.items()):
@@ -574,6 +575,16 @@ def abcToStreamOpus(
     else:  # just return single entry in opus object
         opus.append(abcToStreamScore(abcHandler))
     return opus
+
+
+@typing.overload
+def reBar(music21Part: stream.Part, *, inPlace: typing.Literal[True]) -> None:
+    ...
+
+
+@typing.overload
+def reBar(music21Part: stream.Part, *, inPlace: typing.Literal[False] = False) -> stream.Part:
+    ...
 
 
 def reBar(music21Part: stream.Part, *, inPlace: bool = False) -> stream.Part|None:


### PR DESCRIPTION
* Add lots of typing to ABC Module
* Fixes grammar and typos etc.
* Changes ABCtoStreamOpus to always return an Opus, even if it's just a single score
* Add a better `__repr__` for ABCFile
* Better error if calling read on a closed or non existent file.
* Adds an AI skill for running-tests for other user's agents.

AI-Assisted (Claude)