### PR TITLE
Type Narrowing: Use cast instead of if TYPE_CHECKING isinstance 

### DIFF
--- a/.agents/skills/bump-version/SKILL.md
+++ b/.agents/skills/bump-version/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: bump-version
+description: >-
+  When and how to bump music21's version number. Use this whenever a change
+  warrants a new version — especially any change to a parsing format or parser
+  (musicxml, abc, MIDI, noteworthy/NWC, humdrum, etc.), since those invalidate
+  the pickled-stream cache — as well as new features and bug fixes. Covers which
+  digit to change, the even/odd minor and beta-suffix conventions, the TWO files
+  to edit, and the `Changed in`/`New in` docstring markers.
+---
+
+# Bumping music21's version
+
+The version lives in **`music21/_version.py`** as
+`__version__ = 'MAJOR.MINOR.PATCHsuffix'` (e.g. `'11.0.0b2'`). The
+`__version_info__` tuple is derived from it automatically — only edit the
+string.
+
+## Two files to change, always together
+
+1. `music21/_version.py` — the `__version__` string.
+2. `music21/base.py` — the single version doctest:
+   ```
+   >>> music21.VERSION_STR
+   '11.0.0b2'
+   ```
+   This test exists specifically to force you to remember the bump. If you change
+   `_version.py` without it, the doctest fails.
+
+Verify both with:
+```bash
+uv run pytest --doctest-modules music21/base.py music21/_version.py
+```
+(or `uv run python -c "import music21; print(music21.VERSION_STR)"`).
+
+## When to bump
+
+- **Parsing-format / parser changes (most common reason).** Any change to how a
+  format is read or written — musicxml, abc, MIDI, noteworthy/NWC, humdrum,
+  etc. — should bump the version, even a refactor, because the version is baked
+  into the **pickled-stream cache** (cached parsed files). Bumping invalidates
+  stale pickles so users don't get results from the old parser. This is the rule
+  in AGENTS.md ("Changes to parsing formats … need to update the patch version").
+- **New feature** → bump (see digit rules below); mark it in docstrings with
+  `* New in vX: …`.
+- **Bug fix** → bump the patch; if it changes public behavior, mark
+  `* Changed in vX: …`.
+- **Pure internal refactor with no behavioral/pickle impact** → usually no bump.
+
+## Which part to change
+
+music21 follows semver-ish rules (see the `_version.py` docstring for the full
+rationale):
+
+- **MAJOR (X)** — breaks old features. Rare.
+- **MINOR (Y)** — new features. **Even Y = alpha/beta, odd Y = release.**
+  `X.0` (e.g. `11.0`) are development releases that can still change until `X.1`.
+- **PATCH (Z)** — bug fixes and parsing/pickle-invalidating changes.
+- **beta suffix (`bN`)** — successive pre-release builds of the same
+  `MAJOR.MINOR.PATCH`. To cut another beta without otherwise changing the
+  number, increment it: `11.0.0b1` → `11.0.0b2`. (This is what a
+  parser change during a `…b1` cycle does.)
+
+## `Changed in` / `New in` docstring markers
+
+When a bump accompanies a public-interface change, annotate the affected
+method/class docstring:
+- `* Changed in vX: one-line explanation.`
+- `* New in vX: one-line explanation.`
+
+Pick `X` from the AGENTS.md rule: if the current version is `MAJOR.0…`, use
+`Changed in vMAJOR`; if it's `MAJOR.[even]`, use the **next odd** minor (e.g. at
+`10.2`, write `Changed in 10.3`); if it's already odd, use the following odd
+number. (Humans remove the AI-assisted note on review; leave the version marker.)
+
+## Checklist
+
+1. Edit `__version__` in `music21/_version.py`.
+2. Edit the `VERSION_STR` doctest in `music21/base.py` to match.
+3. Add/update `Changed in` / `New in` markers on any changed public API.
+4. `uv run pytest --doctest-modules music21/base.py music21/_version.py`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,14 @@
   if on a single core machine.)
 - Run `uv run ruff check music21` before making PRs or pushes to open PRs.
 - Run `uv run mypy music21` before making PRs or pushes to open PRs.
+- Never commit `forceSource=True` to a test or doctest (it re-parses from source every
+  run and slows the suite for everyone). The ONLY exception is the one test that exercises
+  `forceSource` itself. If you hit a stale-parse problem while developing:
+  - If it is local-only (e.g. you just changed a parser and a cached pickle is stale),
+    clear the music21 temp cache (the `*.p.gz` files under `environment.Environment().getRootTempDir()`).
+  - If the stale result could have spread to other users/devs, increment the music21
+    patch/beta version (see "PRs and Issues" below) — bumping the version invalidates all
+    caches everywhere.
 
 # Setup
 

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '11.0.0b1'
+__version__ = '11.0.0b2'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -26,7 +26,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'11.0.0b1'
+'11.0.0b2'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4069,7 +4069,7 @@ class Chord(ChordBase):
                 if p.step not in usedSteps:
                     usedSteps.append(p.step)
                 else:
-                    p.octave = t.cast(int, p.octave) + 1
+                    p.octave = p.implicitOctave + 1
                     newRemainingPitches.append(p)
             remainingPitches = newRemainingPitches
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4056,11 +4056,11 @@ class Chord(ChordBase):
         if inPlace is True:
             c2 = self
 
-        # c2 behaves as both a Chord and a Stream here; cast to Any to keep
-        # access to members of both (formerly a TYPE_CHECKING isinstance assertion).
-        c2 = t.cast(t.Any, c2)
+        # closedPosition() only returns None when inPlace=True, in which case c2
+        # is overwritten with self above, so c2 is always a non-None Chord here.
+        c2 = t.cast(t.Self, c2)
         # startOctave = c2.bass().octave
-        remainingPitches = copy.copy(c2.pitches)  # no deepcopy needed
+        remainingPitches = list(c2.pitches)  # no deepcopy needed
 
         while remainingPitches:
             usedSteps = []
@@ -4069,7 +4069,7 @@ class Chord(ChordBase):
                 if p.step not in usedSteps:
                     usedSteps.append(p.step)
                 else:
-                    p.octave += 1
+                    p.octave = t.cast(int, p.octave) + 1
                     newRemainingPitches.append(p)
             remainingPitches = newRemainingPitches
 

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -47,9 +47,6 @@ from music21.chord import tables
 from music21.chord import tools
 
 
-if t.TYPE_CHECKING:
-    from music21 import stream
-
 environLocal = environment.Environment('chord')
 
 # ------------------------------------------------------------------------------
@@ -4059,8 +4056,9 @@ class Chord(ChordBase):
         if inPlace is True:
             c2 = self
 
-        if t.TYPE_CHECKING:
-            assert isinstance(c2, stream.Stream)
+        # c2 behaves as both a Chord and a Stream here; cast to Any to keep
+        # access to members of both (formerly a TYPE_CHECKING isinstance assertion).
+        c2 = t.cast(t.Any, c2)
         # startOctave = c2.bass().octave
         remainingPitches = copy.copy(c2.pitches)  # no deepcopy needed
 
@@ -5040,9 +5038,7 @@ class Chord(ChordBase):
             pitchZeroDuration = self._notes[0].duration
             self._duration = pitchZeroDuration
 
-        d_out = self._duration
-        if t.TYPE_CHECKING:
-            assert isinstance(d_out, Duration)
+        d_out = t.cast(Duration, self._duration)
         return d_out
 
     @duration.setter

--- a/music21/converter/__init__.py
+++ b/music21/converter/__init__.py
@@ -565,12 +565,11 @@ class Converter:
         if useFormat is None:
             useFormat = self.getFormatFromFileExtension(fpPathlib)
         self.setSubConverterFromFormat(useFormat)
-        if t.TYPE_CHECKING:
-            assert isinstance(self.subConverter, subConverters.SubConverter)
+        subConverter = t.cast(subConverters.SubConverter, self.subConverter)
 
-        self.subConverter.keywords = keywords
+        subConverter.keywords = keywords
         try:
-            self.subConverter.parseFile(
+            subConverter.parseFile(
                 fp,
                 number=number,
                 **keywords
@@ -578,14 +577,13 @@ class Converter:
         except NotImplementedError:
             raise ConverterFileException(f'File is not in a correct format: {fp}')
 
-        if t.TYPE_CHECKING:
-            assert isinstance(self.stream, stream.Stream)
+        parsedStream = t.cast(stream.Stream, self.stream)
 
-        if not self.stream.metadata:
-            self.stream.metadata = metadata.Metadata()
-        self.stream.metadata.filePath = str(fpPathlib)
-        self.stream.metadata.fileNumber = number
-        self.stream.metadata.fileFormat = useFormat
+        if not parsedStream.metadata:
+            parsedStream.metadata = metadata.Metadata()
+        parsedStream.metadata.filePath = str(fpPathlib)
+        parsedStream.metadata.fileNumber = number
+        parsedStream.metadata.fileFormat = useFormat
 
     def getFormatFromFileExtension(self, fp):
         # noinspection PyShadowingNames
@@ -723,10 +721,9 @@ class Converter:
                 )
 
         self.setSubConverterFromFormat(useFormat)
-        if t.TYPE_CHECKING:
-            assert isinstance(self.subConverter, subConverters.SubConverter)
-        self.subConverter.keywords = keywords
-        self.subConverter.parseData(dataStr, number=number)
+        subConverter = t.cast(subConverters.SubConverter, self.subConverter)
+        subConverter.keywords = keywords
+        subConverter.parseData(dataStr, number=number)
 
     def parseURL(
         self,
@@ -1248,9 +1245,8 @@ def parseFile(fp,
     v = Converter()
     fp = common.cleanpath(fp, returnPathlib=True)
     v.parseFile(fp, number=number, format=format, forceSource=forceSource, **keywords)
-    if t.TYPE_CHECKING:
-        assert isinstance(v.stream, (stream.Score, stream.Part, stream.Opus))
-    return v.stream
+    vStream = t.cast(stream.Score | stream.Part | stream.Opus, v.stream)
+    return vStream
 
 # pylint: disable=redefined-builtin
 # noinspection PyShadowingBuiltins
@@ -1264,9 +1260,8 @@ def parseData(dataStr,
     '''
     v = Converter()
     v.parseData(dataStr, number=number, format=format, **keywords)
-    if t.TYPE_CHECKING:
-        assert isinstance(v.stream, (stream.Score, stream.Part, stream.Opus))
-    return v.stream
+    vStream = t.cast(stream.Score | stream.Part | stream.Opus, v.stream)
+    return vStream
 
 # pylint: disable=redefined-builtin
 # noinspection PyShadowingBuiltins
@@ -1285,9 +1280,8 @@ def parseURL(url,
     '''
     v = Converter()
     v.parseURL(url, format=format, forceSource=forceSource, **keywords)
-    if t.TYPE_CHECKING:
-        assert isinstance(v.stream, (stream.Score, stream.Part, stream.Opus))
-    return v.stream
+    vStream = t.cast(stream.Score | stream.Part | stream.Opus, v.stream)
+    return vStream
 
 
 def parse(value: bundles.MetadataEntry|bytes|str|pathlib.Path|list|tuple,

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -387,11 +387,10 @@ class ConverterIPython(SubConverter):
             )
             return None
         elif helperFormat == 'midi':
-            if t.TYPE_CHECKING:
-                assert isinstance(helperSubConverter, ConverterMidi)
+            midiSubConverter = t.cast(ConverterMidi, helperSubConverter)
             return ip21_converters.displayMusic21jMIDI(
                 obj,
-                subConverter=helperSubConverter,
+                subConverter=midiSubConverter,
                 fmt=helperFormat,
                 subformats=helperSubformats,
                 **keywords,

--- a/music21/expressions.py
+++ b/music21/expressions.py
@@ -632,9 +632,8 @@ class Ornament(Expression):
         # TODO: remove expressions
         # secondNote.expressions = None
         if isTransposed:
-            if t.TYPE_CHECKING:
-                assert isinstance(secondNote, note.Note)
-            secondNote.transpose(transposeInterval, inPlace=True)
+            secondNoteObj = t.cast('note.Note', secondNote)
+            secondNoteObj.transpose(transposeInterval, inPlace=True)
 
         fillObjects.append(firstNote)
         fillObjects.append(secondNote)
@@ -968,11 +967,10 @@ class GeneralMordent(Ornament):
             # second (middle) note might need an accidental from the keysig (but
             # only if it doesn't already have an accidental, from self.accidental)
             for noteIdx, n in enumerate(mordNotes):
-                if t.TYPE_CHECKING:
-                    assert isinstance(n, note.Note)
+                noteObj = t.cast('note.Note', n)
                 noteNum: int = noteIdx + 1
-                if n.pitch.accidental is None and noteNum == 2:
-                    n.pitch.accidental = currentKeySig.accidentalByStep(n.pitch.step)
+                if noteObj.pitch.accidental is None and noteNum == 2:
+                    noteObj.pitch.accidental = currentKeySig.accidentalByStep(noteObj.pitch.step)
 
         inExpressions = -1
         if self in srcObj.expressions:
@@ -1714,15 +1712,14 @@ class Trill(Ornament):
             setAccidentalFromKeySig = self._setAccidentalFromKeySig
             if setAccidentalFromKeySig:
                 for n in trillNotes:
-                    if t.TYPE_CHECKING:
-                        assert isinstance(n, note.Note)
-                        assert isinstance(srcObj, note.Note)
-                    if n.pitch.nameWithOctave != srcObj.pitch.nameWithOctave:
+                    noteObj = t.cast('note.Note', n)
+                    srcNote = t.cast('note.Note', srcObj)
+                    if noteObj.pitch.nameWithOctave != srcNote.pitch.nameWithOctave:
                         # do not correct original note, no matter what.
-                        if n.pitch.accidental is None:
+                        if noteObj.pitch.accidental is None:
                             # correct if there isn't already an accidental (from self.accidental)
-                            n.pitch.accidental = (
-                                currentKeySig.accidentalByStep(n.step)
+                            noteObj.pitch.accidental = (
+                                currentKeySig.accidentalByStep(noteObj.step)
                             )
 
         if inPlace and self in srcObj.expressions:
@@ -1737,16 +1734,15 @@ class Trill(Ornament):
             secondNoteNachschlag.expressions = []
             secondNoteNachschlag.duration.quarterLength = useQL
             if isTransposed:
-                if t.TYPE_CHECKING:
-                    assert isinstance(secondNoteNachschlag, note.Note)
-                    assert isinstance(firstNoteNachschlag, note.Note)
-                secondNoteNachschlag.transpose(transposeIntervalReverse,
-                                                inPlace=True)
+                secondNoteNachschlagObj = t.cast('note.Note', secondNoteNachschlag)
+                firstNoteNachschlagObj = t.cast('note.Note', firstNoteNachschlag)
+                secondNoteNachschlagObj.transpose(transposeIntervalReverse,
+                                                  inPlace=True)
                 if setAccidentalFromKeySig and currentKeySig:
-                    firstNoteNachschlag.pitch.accidental = currentKeySig.accidentalByStep(
-                        firstNoteNachschlag.step)
-                    secondNoteNachschlag.pitch.accidental = currentKeySig.accidentalByStep(
-                        secondNoteNachschlag.step)
+                    firstNoteNachschlagObj.pitch.accidental = currentKeySig.accidentalByStep(
+                        firstNoteNachschlagObj.step)
+                    secondNoteNachschlagObj.pitch.accidental = currentKeySig.accidentalByStep(
+                        secondNoteNachschlagObj.step)
 
             nachschlag = [firstNoteNachschlag, secondNoteNachschlag]
 
@@ -2356,9 +2352,7 @@ class Turn(Ornament):
             # half the duration of the srcObj note
             remainderDuration = opFrac(srcObj.duration.quarterLength / 2)
         else:
-            theDelay = self.delay
-            if t.TYPE_CHECKING:
-                assert isinstance(theDelay, (float, Fraction))
+            theDelay = t.cast(float | Fraction, self.delay)
             remainderDuration = theDelay
 
         turnDuration = srcObj.duration.quarterLength - remainderDuration
@@ -2388,9 +2382,8 @@ class Turn(Ornament):
         firstNote.expressions = []
         firstNote.duration.quarterLength = useQL
         if isTransposed:
-            if t.TYPE_CHECKING:
-                assert isinstance(firstNote, note.Note)
-            firstNote.transpose(firstTransposeInterval, inPlace=True)
+            firstNoteObj = t.cast('note.Note', firstNote)
+            firstNoteObj.transpose(firstTransposeInterval, inPlace=True)
 
         secondNote = copy.deepcopy(srcObj)
         secondNote.expressions = []
@@ -2400,9 +2393,8 @@ class Turn(Ornament):
         thirdNote.expressions = []
         thirdNote.duration.quarterLength = useQL
         if isTransposed:
-            if t.TYPE_CHECKING:
-                assert isinstance(thirdNote, note.Note)
-            thirdNote.transpose(secondTransposeInterval, inPlace=True)
+            thirdNoteObj = t.cast('note.Note', thirdNote)
+            thirdNoteObj.transpose(secondTransposeInterval, inPlace=True)
 
         fourthNote = copy.deepcopy(srcObj)
         fourthNote.expressions = []
@@ -2420,11 +2412,10 @@ class Turn(Ornament):
             # first note and third note might need an accidental from the keySig (but
             # only if they don't already have an accidental from upper/lowerAccidental)
             for noteIdx, n in enumerate(turnNotes):
-                if t.TYPE_CHECKING:
-                    assert isinstance(n, note.Note)
+                noteObj = t.cast('note.Note', n)
                 noteNum: int = noteIdx + 1
-                if n.pitch.accidental is None and noteNum in (1, 3):
-                    n.pitch.accidental = currentKeySig.accidentalByStep(n.pitch.step)
+                if noteObj.pitch.accidental is None and noteNum in (1, 3):
+                    noteObj.pitch.accidental = currentKeySig.accidentalByStep(noteObj.pitch.step)
 
         inExpressions = -1
         if self in srcObj.expressions:
@@ -2505,9 +2496,8 @@ class GeneralAppoggiatura(Ornament):
         appoggiaturaNote.duration.quarterLength = newDuration
         isTransposed: bool = not isUnison(transposeInterval)
         if isTransposed:
-            if t.TYPE_CHECKING:
-                assert isinstance(appoggiaturaNote, note.Note)
-            appoggiaturaNote.transpose(transposeInterval, inPlace=True)
+            appoggiaturaNoteObj = t.cast('note.Note', appoggiaturaNote)
+            appoggiaturaNoteObj.transpose(transposeInterval, inPlace=True)
 
         inExpressions = -1
         if self in srcObj.expressions:

--- a/music21/figuredBass/resolution.py
+++ b/music21/figuredBass/resolution.py
@@ -106,11 +106,10 @@ def augmentedSixthToDominant(
     else:
         raise ResolutionException(f'Unknown augSixthType: {augSixthType!r}')
 
-    if t.TYPE_CHECKING:
-        assert isinstance(bass, pitch.Pitch)
-        assert isinstance(root, pitch.Pitch)
-        assert isinstance(fifth, pitch.Pitch)
-        assert isinstance(other, pitch.Pitch)
+    bass = t.cast(pitch.Pitch, bass)
+    root = t.cast(pitch.Pitch, root)
+    fifth = t.cast(pitch.Pitch, fifth)
+    other = t.cast(pitch.Pitch, other)
 
     howToResolve = [(lambda p: p and bass and p.name == bass.name, '-m2'),
                     (lambda p: p and root and p.name == root.name, 'm2'),
@@ -189,11 +188,10 @@ def augmentedSixthToMajorTonic(
     else:
         raise ResolutionException(f'Unknown augSixthType: {augSixthType!r}')
 
-    if t.TYPE_CHECKING:
-        assert isinstance(bass, pitch.Pitch)
-        assert isinstance(root, pitch.Pitch)
-        assert isinstance(fifth, pitch.Pitch)
-        assert isinstance(other, pitch.Pitch)
+    bass = t.cast(pitch.Pitch, bass)
+    root = t.cast(pitch.Pitch, root)
+    fifth = t.cast(pitch.Pitch, fifth)
+    other = t.cast(pitch.Pitch, other)
 
     howToResolve = [(lambda p: p and bass and p.name == bass.name, '-m2'),
                     (lambda p: p and root and p.name == root.name, 'm2'),
@@ -273,11 +271,10 @@ def augmentedSixthToMinorTonic(
     else:
         raise ResolutionException(f'Unknown augSixthType: {augSixthType!r}')
 
-    if t.TYPE_CHECKING:
-        assert isinstance(bass, pitch.Pitch)
-        assert isinstance(root, pitch.Pitch)
-        assert isinstance(fifth, pitch.Pitch)
-        assert isinstance(other, pitch.Pitch)
+    bass = t.cast(pitch.Pitch, bass)
+    root = t.cast(pitch.Pitch, root)
+    fifth = t.cast(pitch.Pitch, fifth)
+    other = t.cast(pitch.Pitch, other)
 
     howToResolve = [(lambda p: p and bass and p.name == bass.name, '-m2'),
                     (lambda p: p and root and p.name == root.name, 'm2'),

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -1434,9 +1434,7 @@ class TimeSignature(TimeSignatureBase):
             beams = beamsList[i]
             if beams is None:
                 return
-
-            if t.TYPE_CHECKING:
-                assert isinstance(beams, beam.Beams)
+            beams = t.cast(beam.Beams, beams)
 
             beamNumber = depth + 1
             # see if there is a component defined for this beam number

--- a/music21/midi/translate.py
+++ b/music21/midi/translate.py
@@ -2640,9 +2640,8 @@ def updatePacketStorageWithChannelInfo(
         elif isinstance(instObj, instrument.Conductor):
             initCh = None
         else:  # keys are midi program
-            if t.TYPE_CHECKING:
-                assert isinstance(instObj, instrument.Instrument)
-            initCh = channelByInstrument[instObj.midiProgram]
+            instObjInstrument = t.cast(instrument.Instrument, instObj)
+            initCh = channelByInstrument[instObjInstrument.midiProgram]
         bundle['initChannel'] = initCh  # set for bundle too
 
         for rawPacket in bundle['rawPackets']:

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1533,8 +1533,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         music21.musicxml.xmlObjects.MusicXMLExportException:
         Exporting scores nested inside scores is not supported
         '''
-        s = self.stream
-        s = t.cast(stream.Score, s)
+        s = t.cast(stream.Score, self.stream)
 
         # environLocal.printDebug('streamToMx(): interpreting multipart')
         streamOfStreams = s.getElementsByClass(stream.Stream)
@@ -1805,8 +1804,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         # TODO: link/bookmark in credit-words
         self.setPrintStyleAlign(mxCreditWords, textBox)
         if textBox.hasStyleInformation:
-            sty = textBox.style
-            sty = t.cast(style.TextStyle, sty)
+            sty = t.cast(style.TextStyle, textBox.style)
             if sty.justify is not None:
                 mxCreditWords.set('justify', sty.justify)
         mxCredit.append(mxCreditWords)
@@ -2741,8 +2739,8 @@ class PartExporter(XMLExporterBase):
         else:
             # get a default instrument if not assigned
             self.instrumentStream = self.stream.getInstruments(returnDefault=True, recurse=True)
-        firstInstrumentObject = self.instrumentStream[0]  # store first, as handled differently
-        firstInstrumentObject = t.cast(instrument.Instrument, firstInstrumentObject)
+        # store first, as handled differently
+        firstInstrumentObject = t.cast(instrument.Instrument, self.instrumentStream[0])
         self.firstInstrumentObject = firstInstrumentObject
 
         if self.parent is not None:

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -1534,8 +1534,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         Exporting scores nested inside scores is not supported
         '''
         s = self.stream
-        if t.TYPE_CHECKING:
-            assert isinstance(s, stream.Score)
+        s = t.cast(stream.Score, s)
 
         # environLocal.printDebug('streamToMx(): interpreting multipart')
         streamOfStreams = s.getElementsByClass(stream.Stream)
@@ -1807,8 +1806,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
         self.setPrintStyleAlign(mxCreditWords, textBox)
         if textBox.hasStyleInformation:
             sty = textBox.style
-            if t.TYPE_CHECKING:
-                assert isinstance(sty, style.TextStyle)
+            sty = t.cast(style.TextStyle, sty)
             if sty.justify is not None:
                 mxCreditWords.set('justify', sty.justify)
         mxCredit.append(mxCreditWords)
@@ -2744,8 +2742,7 @@ class PartExporter(XMLExporterBase):
             # get a default instrument if not assigned
             self.instrumentStream = self.stream.getInstruments(returnDefault=True, recurse=True)
         firstInstrumentObject = self.instrumentStream[0]  # store first, as handled differently
-        if t.TYPE_CHECKING:
-            assert isinstance(firstInstrumentObject, instrument.Instrument)
+        firstInstrumentObject = t.cast(instrument.Instrument, firstInstrumentObject)
         self.firstInstrumentObject = firstInstrumentObject
 
         if self.parent is not None:
@@ -3551,11 +3548,10 @@ class MeasureExporter(XMLExporterBase):
 
                     if m21spannerClass == 'PedalMark' and posSub == 'first':
                         # check to see if we also need to start a line
-                        if t.TYPE_CHECKING:
-                            assert isinstance(thisSpanner, expressions.PedalMark)
-                        if thisSpanner.pedalForm == expressions.PedalForm.SymbolLine:
+                        pedalMark = t.cast(expressions.PedalMark, thisSpanner)
+                        if pedalMark.pedalForm == expressions.PedalForm.SymbolLine:
                             mxPedalLine = (
-                                self.makePedalResumeLineXml(thisSpanner)
+                                self.makePedalResumeLineXml(pedalMark)
                             )
                             preList.append(mxPedalLine)
 
@@ -3596,42 +3592,38 @@ class MeasureExporter(XMLExporterBase):
         '''
         post: dict[str, t.Any] = {'type': 'start'}
         if spannerClass == 'Ottava':
-            if t.TYPE_CHECKING:
-                assert isinstance(sp, spanner.Ottava)
-            post['size'] = sp.shiftMagnitude()
-            post['type'] = sp.shiftDirection(reverse=True)  # up or down
+            ottava = t.cast(spanner.Ottava, sp)
+            post['size'] = ottava.shiftMagnitude()
+            post['type'] = ottava.shiftDirection(reverse=True)  # up or down
         elif spannerClass == 'Line':
-            if t.TYPE_CHECKING:
-                assert isinstance(sp, spanner.Line)
-            post['line-end'] = sp.startTick
-            post['end-length'] = sp.startHeight
+            line = t.cast(spanner.Line, sp)
+            post['line-end'] = line.startTick
+            post['end-length'] = line.startHeight
         elif spannerClass == 'DynamicWedge':
-            if t.TYPE_CHECKING:
-                assert isinstance(sp, dynamics.DynamicWedge)
-            post['type'] = sp.type
-            if sp.type == 'crescendo':
+            wedge = t.cast(dynamics.DynamicWedge, sp)
+            post['type'] = wedge.type
+            if wedge.type == 'crescendo':
                 post['spread'] = 0
-                if sp.niente:
+                if wedge.niente:
                     post['niente'] = 'yes'
             else:
-                post['spread'] = sp.spread
+                post['spread'] = wedge.spread
         elif spannerClass == 'PedalMark':
-            if t.TYPE_CHECKING:
-                assert isinstance(sp, expressions.PedalMark)
-            if sp.pedalType == expressions.PedalType.Sostenuto:
+            pedalMark = t.cast(expressions.PedalMark, sp)
+            if pedalMark.pedalType == expressions.PedalType.Sostenuto:
                 post['type'] = 'sostenuto'
             else:
-                # non-Sostenuto sp.pedalType might be Sustain, Soft, or Silent.
+                # non-Sostenuto pedalMark.pedalType might be Sustain, Soft, or Silent.
                 # But MusicXML only has 'start', which implies Sustain,
                 # so that's what we do here, hoping there is a text
                 # direction describing which pedal to use.
                 post['type'] = 'start'
-            if sp.pedalForm == expressions.PedalForm.Line:
+            if pedalMark.pedalForm == expressions.PedalForm.Line:
                 post['line'] = 'yes'
             else:
                 # 'symbol', 'altsymbol', and 'symline' all start with a sign
                 post['sign'] = 'yes'
-            if sp.abbreviated:
+            if pedalMark.abbreviated:
                 post['abbreviated'] = 'yes'
         return post
 
@@ -3649,27 +3641,25 @@ class MeasureExporter(XMLExporterBase):
         '''
         post: dict[str, t.Any] = {'type': 'stop'}
         if spannerClass == 'Ottava':
-            if t.TYPE_CHECKING:
-                assert isinstance(sp, spanner.Ottava)
-            post['size'] = sp.shiftMagnitude()
+            ottava = t.cast(spanner.Ottava, sp)
+            post['size'] = ottava.shiftMagnitude()
         elif spannerClass == 'Line':
-            if t.TYPE_CHECKING:
-                assert isinstance(sp, spanner.Line)
-            post['line-end'] = sp.endTick
-            post['end-length'] = sp.endHeight
+            line = t.cast(spanner.Line, sp)
+            post['line-end'] = line.endTick
+            post['end-length'] = line.endHeight
         elif spannerClass == 'DynamicWedge':
-            if t.TYPE_CHECKING:
-                assert isinstance(sp, dynamics.DynamicWedge)
-            if sp.type == 'crescendo':
-                post['spread'] = sp.spread
+            wedge = t.cast(dynamics.DynamicWedge, sp)
+            if wedge.type == 'crescendo':
+                post['spread'] = wedge.spread
             else:
                 post['spread'] = 0
-                if sp.niente:
+                if wedge.niente:
                     post['niente'] = 'yes'
         elif spannerClass == 'PedalMark':
-            if t.TYPE_CHECKING:
-                assert isinstance(sp, expressions.PedalMark)
-            if sp.pedalForm in (expressions.PedalForm.Line, expressions.PedalForm.SymbolLine):
+            pedalMark = t.cast(expressions.PedalMark, sp)
+            if pedalMark.pedalForm in (
+                expressions.PedalForm.Line, expressions.PedalForm.SymbolLine
+            ):
                 post['line'] = 'yes'
             else:
                 # 'symbol', 'altsymbol' both end with a sign
@@ -4404,8 +4394,7 @@ class MeasureExporter(XMLExporterBase):
                 currentClef = clef.TrebleClef()
                 # this should not be common enough to
                 # worry about the overhead
-            if t.TYPE_CHECKING:
-                assert isinstance(currentClef, clef.PitchClef)
+            currentClef = t.cast(clef.PitchClef, currentClef)
             midLineDNN = currentClef.lowestLine + 4
             restObjectPseudoDNN = midLineDNN + r.stepShift
             tempPitch = pitch.Pitch()
@@ -5441,16 +5430,14 @@ class MeasureExporter(XMLExporterBase):
             mxArticulationMark.set('placement', articulationMark.placement)
         self.setPrintStyle(mxArticulationMark, articulationMark)
         if musicXMLArticulationName == 'strong-accent':
-            if t.TYPE_CHECKING:
-                assert isinstance(articulationMark, articulations.StrongAccent)
-            mxArticulationMark.set('type', articulationMark.pointDirection)
+            strongAccent = t.cast(articulations.StrongAccent, articulationMark)
+            mxArticulationMark.set('type', strongAccent.pointDirection)
         if musicXMLArticulationName in ('doit', 'falloff', 'plop', 'scoop'):
             self.setLineStyle(mxArticulationMark, articulationMark)
         if musicXMLArticulationName == 'breath-mark':
-            if t.TYPE_CHECKING:
-                assert isinstance(articulationMark, articulations.BreathMark)
-            if articulationMark.symbol is not None:
-                mxArticulationMark.text = articulationMark.symbol
+            breathMark = t.cast(articulations.BreathMark, articulationMark)
+            if breathMark.symbol is not None:
+                mxArticulationMark.text = breathMark.symbol
         if (musicXMLArticulationName == 'other-articulation'
                 and articulationMark.displayText is not None):
             mxArticulationMark.text = articulationMark.displayText
@@ -5537,11 +5524,10 @@ class MeasureExporter(XMLExporterBase):
         if articulationMark.placement is not None:
             mxTechnicalMark.set('placement', articulationMark.placement)
         if musicXMLTechnicalName == 'fingering':
-            if t.TYPE_CHECKING:
-                assert isinstance(articulationMark, articulations.Fingering)
-            mxTechnicalMark.text = str(articulationMark.fingerNumber)
+            fingering = t.cast(articulations.Fingering, articulationMark)
+            mxTechnicalMark.text = str(fingering.fingerNumber)
             mxTechnicalMark.set('alternate',
-                                xmlObjects.booleanToYesNo(articulationMark.alternate))
+                                xmlObjects.booleanToYesNo(fingering.alternate))
         if (musicXMLTechnicalName in ('handbell', 'other-technical')
                 and articulationMark.displayText is not None):
             #     The handbell element represents notation for various
@@ -5557,23 +5543,19 @@ class MeasureExporter(XMLExporterBase):
             mxTechnicalMark.set('substitution',
                                 xmlObjects.booleanToYesNo(articulationMark.substitution))
         if musicXMLTechnicalName == 'string':
-            if t.TYPE_CHECKING:
-                assert isinstance(articulationMark, articulations.StringIndication)
-            mxTechnicalMark.text = str(articulationMark.number)
+            stringIndication = t.cast(articulations.StringIndication, articulationMark)
+            mxTechnicalMark.text = str(stringIndication.number)
         if musicXMLTechnicalName == 'fret':
-            if t.TYPE_CHECKING:
-                assert isinstance(articulationMark, articulations.FretIndication)
-            mxTechnicalMark.text = str(articulationMark.number)
+            fretIndication = t.cast(articulations.FretIndication, articulationMark)
+            mxTechnicalMark.text = str(fretIndication.number)
         if musicXMLTechnicalName == 'bend':
-            if t.TYPE_CHECKING:
-                assert isinstance(articulationMark, articulations.FretBend)
-            self.setBend(mxTechnicalMark, articulationMark)
+            fretBend = t.cast(articulations.FretBend, articulationMark)
+            self.setBend(mxTechnicalMark, fretBend)
         # harmonic needs to check for whether it is artificial or natural, and
         # whether it is base-pitch, sounding-pitch, or touching-pitch
         if musicXMLTechnicalName == 'harmonic':
-            if t.TYPE_CHECKING:
-                assert isinstance(articulationMark, articulations.StringHarmonic)
-            self.setHarmonic(mxTechnicalMark, articulationMark)
+            stringHarmonic = t.cast(articulations.StringHarmonic, articulationMark)
+            self.setHarmonic(mxTechnicalMark, stringHarmonic)
 
         if (musicXMLTechnicalName == 'other-technical'
                 and articulationMark.displayText is not None):

--- a/music21/musicxml/partStaffExporter.py
+++ b/music21/musicxml/partStaffExporter.py
@@ -433,8 +433,7 @@ class PartStaffExporterMixin:
                    and helpers.measureNumberComesBefore(sourceNumber, targetNumber)):
                 if i not in insertions:
                     insertions[i] = []
-                if t.TYPE_CHECKING:
-                    assert isinstance(sourceNumber, str)
+                sourceNumber = t.cast(str, sourceNumber)
                 insertions[i] += [makeDivider(sourceNumber), sourceMeasure]
                 try:
                     sourceMeasure = next(sourceMeasures)
@@ -456,8 +455,7 @@ class PartStaffExporterMixin:
             idx = len(target)
             if idx not in insertions:
                 insertions[idx] = []
-            if t.TYPE_CHECKING:
-                assert isinstance(sourceNumber, str)
+            sourceNumber = t.cast(str, sourceNumber)
 
             insertions[idx] += [makeDivider(sourceNumber), remaining]
         return insertions

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -66,6 +66,20 @@ def xmlSound(mp: MeasureParser, mxSound: ET.Element) -> None:
     <music21.tempo.MetronomeMark Quarter=128 (playback only)>
     >>> mm.offset
     2.0
+
+    A <sound> tag may also carry its own <offset> child, which is measured in
+    MusicXML *divisions* and shifts the mark relative to the current position.
+    `mp.divisions` is the number of divisions per quarter note, so with 8
+    divisions per quarter an <offset> of 4 is half a quarter note -- an eighth
+    note -- and the mark lands an eighth later than `.offsetMeasureNote`:
+
+    >>> mp = musicxml.xmlToM21.MeasureParser()
+    >>> mp.divisions = 8
+    >>> mp.offsetMeasureNote = 2.0
+    >>> xmlSound(mp, EL('<sound tempo="108"><offset>4</offset></sound>'))
+    >>> mp.stream.coreElementsChanged()
+    >>> mp.stream[tempo.MetronomeMark].first().offset
+    2.5
     '''
     # sound tags can specify an offset that begin at, relative to current position.
     offsetDirection = mp.xmlToOffset(mxSound)
@@ -195,6 +209,23 @@ class Test(unittest.TestCase):
             mp.stream.coreElementsChanged()
         self.assertEqual(
             len(mp.stream.getElementsByClass(tempo.MetronomeMark)), 0)
+
+    def testNegativeOffsetShiftsEarlier(self):
+        '''
+        A negative <offset> child inside a <sound> tag shifts the mark earlier.
+        Here, at 8 divisions per quarter, an <offset> of -4 is an eighth note,
+        so the mark lands an eighth before `.offsetMeasureNote`.
+        '''
+        from xml.etree.ElementTree import fromstring as EL
+        from music21.musicxml.xmlToM21 import MeasureParser
+
+        mp = MeasureParser()
+        mp.divisions = 8
+        mp.offsetMeasureNote = 2.0
+        xmlSound(mp, EL('<sound tempo="84"><offset>-4</offset></sound>'))
+        mp.stream.coreElementsChanged()
+        mm = mp.stream[tempo.MetronomeMark].first()
+        self.assertEqual(mm.offset, 1.5)
 
 
 if __name__ == '__main__':

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -41,18 +41,18 @@ class SoundTagMixin:
         (presently just MetronomeMark),
         and add it or them to the core and staffReference.
         '''
-        self = t.cast('MeasureParser', self)
-
+        # this mixin is only ever mixed into MeasureParser
+        mp = t.cast('MeasureParser', self)
         # offset is out of order because we need to know it before direction-type
-        offsetDirection = self.xmlToOffset(mxSound)
-        totalOffset = offsetDirection + self.offsetMeasureNote
+        offsetDirection = mp.xmlToOffset(mxSound)
+        totalOffset = offsetDirection + mp.offsetMeasureNote
 
-        staffKey = self.getStaffNumber(mxSound)
+        staffKey = mp.getStaffNumber(mxSound)
 
-        self.setSound(mxSound,
-                      None,
-                      staffKey,
-                      totalOffset)
+        mp.setSound(mxSound,
+                    None,
+                    staffKey,
+                    totalOffset)
 
     def setSound(
         self,
@@ -67,7 +67,6 @@ class SoundTagMixin:
         If the <sound> tag is a child of a <direction> tag, the direction information
         is used to set the placement of the MetronomeMark.
         '''
-        self = t.cast('MeasureParser', self)
         # TODO: coda
         # TODO: dacapo
         # TODO: dalsegno
@@ -87,7 +86,8 @@ class SoundTagMixin:
         # TODO: musicxml4: instrument-change: instrument-sound, solo or ensemble or none
         #                                     virtual-instrument
         if 'tempo' in mxSound.attrib:
-            self.setSoundTempo(mxSound, mxDir, staffKey, totalOffset)
+            mp = t.cast('MeasureParser', self)
+            mp.setSoundTempo(mxSound, mxDir, staffKey, totalOffset)
 
 
     def setSoundTempo(
@@ -100,8 +100,7 @@ class SoundTagMixin:
         '''
         Add a metronome mark from the tempo attribute of a <sound> tag.
         '''
-        self = t.cast('MeasureParser', self)
-
+        mp = t.cast('MeasureParser', self)
         qpm = common.numToIntOrFloat(float(mxSound.get('tempo', 0)))
         if qpm == 0:
             warnings.warn('0 qpm tempo tag found, skipping.', stacklevel=2)
@@ -111,14 +110,14 @@ class SoundTagMixin:
                                  numberSounding=qpm,
                                  )
         helpers.synchronizeIdsToM21(mxSound, mm)
-        self.setPrintObject(mxSound, mm)
-        self.setPosition(mxSound, mm)
+        mp.setPrintObject(mxSound, mm)
+        mp.setPosition(mxSound, mm)
         if mxDir is not None:
             helpers.setM21AttributeFromAttribute(
                 mm, mxDir, 'placement', 'placement'
             )
-            self.setEditorial(mxDir, mm)
-        self.insertCoreAndRef(totalOffset, staffKey, mm)
+            mp.setEditorial(mxDir, mm)
+        mp.insertCoreAndRef(totalOffset, staffKey, mm)
 
 
 if __name__ == '__main__':

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -88,8 +88,12 @@ def setSound(
     '''
     Takes a <sound> tag and creates objects from it on the MeasureParser `mp`.
     Presently only handles <sound tempo='x'> events and inserts them as MetronomeMarks.
+
     If the <sound> tag is a child of a <direction> tag, the direction information
-    is used to set the placement of the MetronomeMark.
+    is used to set the placement of the MetronomeMark.  (`xmlToM21` calls this routine
+    directly in that circumstance.)
+
+    Setup:
 
     >>> from music21.musicxml.xmlSoundParser import setSound
     >>> from xml.etree.ElementTree import fromstring as EL
@@ -97,13 +101,13 @@ def setSound(
 
     A <sound> with a tempo attribute inserts a MetronomeMark:
 
-    >>> setSound(mp, EL('<sound tempo="144"/>'), mxDir=None, totalOffset=0.0)
+    >>> setSound(mp, EL('<sound tempo="144"/>'), mxDir=None, totalOffset=2.0)
     >>> mp.stream.coreElementsChanged()
     >>> mp.stream.getElementsByClass(tempo.MetronomeMark).first()
     <music21.tempo.MetronomeMark Quarter=144 (playback only)>
 
     A <sound> without a tempo attribute is (currently) a no-op, so no second
-    mark is added:
+    mark is added.  This should change soon.
 
     >>> setSound(mp, EL('<sound dynamics="70"/>'), mxDir=None, totalOffset=0.0)
     >>> mp.stream.coreElementsChanged()

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -8,10 +8,15 @@
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
-Functions that convert <sound> tag to the many music21
+Functions that convert the <sound> tag to the many music21
 objects that this tag might represent.
 
-Pulled out because xmlToM21 is getting way too big.
+Pulled out because xmlToM21 is getting way too big. These are plain functions
+(not methods/a mixin) that take the owning :class:`MeasureParser` as their first
+argument, like the functions in :mod:`~music21.stream.makeNotation`. Only
+:func:`xmlSound` is exposed on MeasureParser (as a thin method), so that no
+per-measure helper object is created for the common case of a measure with no
+<sound> tag.
 '''
 from __future__ import annotations
 
@@ -29,98 +34,141 @@ if t.TYPE_CHECKING:
     from music21.musicxml.xmlToM21 import MeasureParser
 
 
-class SoundTagParser:
+def xmlSound(mp: MeasureParser, mxSound: ET.Element) -> None:
     '''
-    Parses the <sound> tag on behalf of a :class:`MeasureParser`.
+    Convert a <sound> tag to one or more relevant objects
+    (presently just MetronomeMark),
+    and add it or them to the core and staffReference of the MeasureParser `mp`.
 
-    Held by the MeasureParser (as ``.soundParser``) rather than mixed in,
-    because there is still a lot to write here and xmlToM21.py is getting
-    too big. Reaches back into the owning MeasureParser via ``self.measureParser``.
+    Unlike :func:`setSound`, the offset is read from `mp` (it is not passed in),
+    so the mark lands at the parser's current position in the measure:
+
+    >>> from music21.musicxml.xmlSoundParser import xmlSound
+    >>> from xml.etree.ElementTree import fromstring as EL
+    >>> mp = musicxml.xmlToM21.MeasureParser()
+    >>> mp.offsetMeasureNote = 2.0
+    >>> xmlSound(mp, EL('<sound tempo="120"/>'))
+    >>> mm = mp.stream.getElementsByClass(tempo.MetronomeMark).first()
+    >>> mm
+    <music21.tempo.MetronomeMark Quarter=120 (playback only)>
+    >>> mm.offset
+    2.0
     '''
-    def __init__(self, measureParser: MeasureParser):
-        self.measureParser = measureParser
+    # offset is out of order because we need to know it before direction-type
+    offsetDirection = mp.xmlToOffset(mxSound)
+    totalOffset = offsetDirection + mp.offsetMeasureNote
 
-    def xmlSound(self, mxSound: ET.Element) -> None:
-        '''
-        Convert a <sound> tag to one or more relevant objects
-        (presently just MetronomeMark),
-        and add it or them to the core and staffReference.
-        '''
-        mp = self.measureParser
-        # offset is out of order because we need to know it before direction-type
-        offsetDirection = mp.xmlToOffset(mxSound)
-        totalOffset = offsetDirection + mp.offsetMeasureNote
+    staffKey = mp.getStaffNumber(mxSound)
 
-        staffKey = mp.getStaffNumber(mxSound)
-
-        self.setSound(mxSound,
-                      None,
-                      staffKey,
-                      totalOffset)
-
-    def setSound(
-        self,
-        mxSound: ET.Element,
-        mxDir: ET.Element|None,
-        staffKey: int,
-        totalOffset: float
-    ) -> None:
-        '''
-        Takes a <sound> tag and creates objects from it.
-        Presently only handles <sound tempo='x'> events and inserts them as MetronomeMarks.
-        If the <sound> tag is a child of a <direction> tag, the direction information
-        is used to set the placement of the MetronomeMark.
-        '''
-        # TODO: coda
-        # TODO: dacapo
-        # TODO: dalsegno
-        # TODO: damper-pedal
-        # TODO: divisions
-        # TODO: dynamics
-        # TODO: fine
-        # TODO: forward-repeat
-        # TODO: id
-        # TODO: pizzicato
-        # TODO: segno
-        # TODO: soft-pedal
-        # TODO: sostenuto-pedal
-        # TODO: time-only
-        # TODO: tocoda
-        # TODO: musicxml4: swing: straight or first/second/swing-type, swing-style
-        # TODO: musicxml4: instrument-change: instrument-sound, solo or ensemble or none
-        #                                     virtual-instrument
-        if 'tempo' in mxSound.attrib:
-            self.setSoundTempo(mxSound, mxDir, staffKey, totalOffset)
+    setSound(mp,
+             mxSound,
+             None,
+             staffKey,
+             totalOffset)
 
 
-    def setSoundTempo(
-        self,
-        mxSound: ET.Element,
-        mxDir: ET.Element|None,
-        staffKey: int,
-        totalOffset: float
-    ) -> None:
-        '''
-        Add a metronome mark from the tempo attribute of a <sound> tag.
-        '''
-        mp = self.measureParser
-        qpm = common.numToIntOrFloat(float(mxSound.get('tempo', 0)))
-        if qpm == 0:
-            warnings.warn('0 qpm tempo tag found, skipping.', stacklevel=2)
-            return
-        mm = tempo.MetronomeMark(referent=duration.Duration(type='quarter'),
-                                 number=None,
-                                 numberSounding=qpm,
-                                 )
-        helpers.synchronizeIdsToM21(mxSound, mm)
-        mp.setPrintObject(mxSound, mm)
-        mp.setPosition(mxSound, mm)
-        if mxDir is not None:
-            helpers.setM21AttributeFromAttribute(
-                mm, mxDir, 'placement', 'placement'
-            )
-            mp.setEditorial(mxDir, mm)
-        mp.insertCoreAndRef(totalOffset, staffKey, mm)
+def setSound(
+    mp: MeasureParser,
+    mxSound: ET.Element,
+    mxDir: ET.Element|None,
+    staffKey: int,
+    totalOffset: float
+) -> None:
+    '''
+    Takes a <sound> tag and creates objects from it on the MeasureParser `mp`.
+    Presently only handles <sound tempo='x'> events and inserts them as MetronomeMarks.
+    If the <sound> tag is a child of a <direction> tag, the direction information
+    is used to set the placement of the MetronomeMark.
+
+    >>> from music21.musicxml.xmlSoundParser import setSound
+    >>> from xml.etree.ElementTree import fromstring as EL
+    >>> mp = musicxml.xmlToM21.MeasureParser()
+
+    A <sound> with a tempo attribute inserts a MetronomeMark:
+
+    >>> setSound(mp, EL('<sound tempo="144"/>'), None, 1, 0.0)
+    >>> mp.stream.getElementsByClass(tempo.MetronomeMark).first()
+    <music21.tempo.MetronomeMark Quarter=144 (playback only)>
+
+    A <sound> without a tempo attribute is (currently) a no-op, so no second
+    mark is added:
+
+    >>> setSound(mp, EL('<sound dynamics="70"/>'), None, 1, 0.0)
+    >>> len(mp.stream.getElementsByClass(tempo.MetronomeMark))
+    1
+    '''
+    # TODO: coda
+    # TODO: dacapo
+    # TODO: dalsegno
+    # TODO: damper-pedal
+    # TODO: divisions
+    # TODO: dynamics
+    # TODO: fine
+    # TODO: forward-repeat
+    # TODO: id
+    # TODO: pizzicato
+    # TODO: segno
+    # TODO: soft-pedal
+    # TODO: sostenuto-pedal
+    # TODO: time-only
+    # TODO: tocoda
+    # TODO: musicxml4: swing: straight or first/second/swing-type, swing-style
+    # TODO: musicxml4: instrument-change: instrument-sound, solo or ensemble or none
+    #                                     virtual-instrument
+    if 'tempo' in mxSound.attrib:
+        setSoundTempo(mp, mxSound, mxDir, staffKey, totalOffset)
+
+
+def setSoundTempo(
+    mp: MeasureParser,
+    mxSound: ET.Element,
+    mxDir: ET.Element|None,
+    staffKey: int,
+    totalOffset: float
+) -> None:
+    '''
+    Add a metronome mark from the tempo attribute of a <sound> tag to the
+    MeasureParser `mp`.
+
+    >>> from music21.musicxml.xmlSoundParser import setSoundTempo
+    >>> from xml.etree.ElementTree import fromstring as EL
+    >>> mp = musicxml.xmlToM21.MeasureParser()
+    >>> setSoundTempo(mp, EL('<sound tempo="90"/>'), None, 1, 0.0)
+    >>> mm = mp.stream.getElementsByClass(tempo.MetronomeMark).first()
+    >>> mm
+    <music21.tempo.MetronomeMark Quarter=90 (playback only)>
+    >>> mm.numberSounding
+    90
+    >>> mm.number is None
+    True
+
+    A tempo of zero is skipped (with a warning) and nothing is inserted, so the
+    count stays at the one mark from above:
+
+    >>> import warnings
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter('ignore')
+    ...     setSoundTempo(mp, EL('<sound tempo="0"/>'), None, 1, 0.0)
+    >>> len(mp.stream.getElementsByClass(tempo.MetronomeMark))
+    1
+    '''
+    qpm = common.numToIntOrFloat(float(mxSound.get('tempo', 0)))
+    if qpm == 0:
+        warnings.warn('0 qpm tempo tag found, skipping.', stacklevel=2)
+        return
+    mm = tempo.MetronomeMark(referent=duration.Duration(type='quarter'),
+                             number=None,
+                             numberSounding=qpm,
+                             )
+    helpers.synchronizeIdsToM21(mxSound, mm)
+    mp.setPrintObject(mxSound, mm)
+    mp.setPosition(mxSound, mm)
+    if mxDir is not None:
+        helpers.setM21AttributeFromAttribute(
+            mm, mxDir, 'placement', 'placement'
+        )
+        mp.setEditorial(mxDir, mm)
+    mp.insertCoreAndRef(totalOffset, staffKey, mm)
 
 
 if __name__ == '__main__':

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -4,19 +4,16 @@
 #
 # Authors:      Michael Scott Asato Cuthbert
 #
-# Copyright:    Copyright © 2016-22 Michael Scott Asato Cuthbert
+# Copyright:    Copyright © 2016-26 Michael Scott Asato Cuthbert
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
 Functions that convert the <sound> tag to the many music21
 objects that this tag might represent.
 
-Pulled out because xmlToM21 is getting way too big. These are plain functions
+Pulled out because xmlToM21 got way too big. These are plain functions
 (not methods/a mixin) that take the owning :class:`MeasureParser` as their first
-argument, like the functions in :mod:`~music21.stream.makeNotation`. Only
-:func:`xmlSound` is exposed on MeasureParser (as a thin method), so that no
-per-measure helper object is created for the common case of a measure with no
-<sound> tag.
+argument (like in :mod:`~music21.stream.makeNotation`).
 '''
 from __future__ import annotations
 
@@ -41,38 +38,51 @@ def xmlSound(mp: MeasureParser, mxSound: ET.Element) -> None:
     (presently just MetronomeMark),
     and add it or them to the core and staffReference of the MeasureParser `mp`.
 
-    Unlike :func:`setSound`, the offset is read from `mp` (it is not passed in),
-    so the mark lands at the parser's current position in the measure:
+    Reads offset is from `mp` via `.offsetMeasureNote` so the mark lands at the
+    current position in the measure.
+
+    Set up everything:
 
     >>> from music21.musicxml.xmlSoundParser import xmlSound
     >>> from xml.etree.ElementTree import fromstring as EL
     >>> mp = musicxml.xmlToM21.MeasureParser()
     >>> mp.offsetMeasureNote = 2.0
-    >>> xmlSound(mp, EL('<sound tempo="120"/>'))
-    >>> mm = mp.stream.getElementsByClass(tempo.MetronomeMark).first()
+    >>> len(mp.stream[tempo.MetronomeMark])
+    0
+
+    Now call the routine.
+
+    >>> xmlSound(mp, EL('<sound tempo="128"/>'))
+
+    Nothing is returned, but the stream inside the MeasureParser now has a metronomeMark
+    at the `.offsetMeasureNote` of `mp`.  Because all the routines in this module
+    are optimized for speed, we first need to call `coreElementsChanged`
+    before querying the stream for each of them (normally the MeasureParser
+    does this for us after parsing the entire measure).
+
+    >>> mp.stream.coreElementsChanged()
+    >>> mm = mp.stream[tempo.MetronomeMark].first()
     >>> mm
-    <music21.tempo.MetronomeMark Quarter=120 (playback only)>
+    <music21.tempo.MetronomeMark Quarter=128 (playback only)>
     >>> mm.offset
     2.0
     '''
-    # offset is out of order because we need to know it before direction-type
+    # sound tags can specify an offset that begin at, relative to current position.
     offsetDirection = mp.xmlToOffset(mxSound)
+    # we put offsetDirection + mp.offsetMeasureNote to force conversion of Fraction to float
     totalOffset = offsetDirection + mp.offsetMeasureNote
 
-    staffKey = mp.getStaffNumber(mxSound)
-
     setSound(mp,
-             mxSound,
-             None,
-             staffKey,
-             totalOffset)
+             mxSound=mxSound,
+             mxDir=None,
+             totalOffset=totalOffset)
 
 
 def setSound(
     mp: MeasureParser,
     mxSound: ET.Element,
+    *,
     mxDir: ET.Element|None,
-    staffKey: int,
     totalOffset: float
 ) -> None:
     '''
@@ -87,17 +97,23 @@ def setSound(
 
     A <sound> with a tempo attribute inserts a MetronomeMark:
 
-    >>> setSound(mp, EL('<sound tempo="144"/>'), mxDir=None, staffKey=1, totalOffset=0.0)
+    >>> setSound(mp, EL('<sound tempo="144"/>'), mxDir=None, totalOffset=0.0)
+    >>> mp.stream.coreElementsChanged()
     >>> mp.stream.getElementsByClass(tempo.MetronomeMark).first()
     <music21.tempo.MetronomeMark Quarter=144 (playback only)>
 
     A <sound> without a tempo attribute is (currently) a no-op, so no second
     mark is added:
 
-    >>> setSound(mp, EL('<sound dynamics="70"/>'), mxDir=None, staffKey=1, totalOffset=0.0)
-    >>> len(mp.stream.getElementsByClass(tempo.MetronomeMark))
+    >>> setSound(mp, EL('<sound dynamics="70"/>'), mxDir=None, totalOffset=0.0)
+    >>> mp.stream.coreElementsChanged()
+    >>> len(mp.stream[tempo.MetronomeMark])
     1
     '''
+    # extract the staffKey once since it will be the same for all the rest.
+    staffKey = mp.getStaffNumber(mxSound)
+    attrib = mxSound.attrib
+
     # TODO: coda
     # TODO: dacapo
     # TODO: dalsegno
@@ -116,13 +132,14 @@ def setSound(
     # TODO: musicxml4: swing: straight or first/second/swing-type, swing-style
     # TODO: musicxml4: instrument-change: instrument-sound, solo or ensemble or none
     #                                     virtual-instrument
-    if 'tempo' in mxSound.attrib:
-        setSoundTempo(mp, mxSound, mxDir, staffKey, totalOffset)
+    if 'tempo' in attrib:
+        setSoundTempo(mp, mxSound, mxDir=mxDir, staffKey=staffKey, totalOffset=totalOffset)
 
 
 def setSoundTempo(
     mp: MeasureParser,
     mxSound: ET.Element,
+    *,
     mxDir: ET.Element|None,
     staffKey: int,
     totalOffset: float
@@ -134,12 +151,13 @@ def setSoundTempo(
     >>> from music21.musicxml.xmlSoundParser import setSoundTempo
     >>> from xml.etree.ElementTree import fromstring as EL
     >>> mp = musicxml.xmlToM21.MeasureParser()
-    >>> setSoundTempo(mp, EL('<sound tempo="90"/>'), mxDir=None, staffKey=1, totalOffset=0.0)
-    >>> mm = mp.stream.getElementsByClass(tempo.MetronomeMark).first()
+    >>> setSoundTempo(mp, EL('<sound tempo="92"/>'), mxDir=None, staffKey=1, totalOffset=0.0)
+    >>> mp.stream.coreElementsChanged()
+    >>> mm = mp.stream[tempo.MetronomeMark].first()
     >>> mm
-    <music21.tempo.MetronomeMark Quarter=90 (playback only)>
+    <music21.tempo.MetronomeMark Quarter=92 (playback only)>
     >>> mm.numberSounding
-    90
+    92
     >>> mm.number is None
     True
     '''
@@ -174,6 +192,7 @@ class Test(unittest.TestCase):
         with self.assertWarns(UserWarning):
             setSoundTempo(mp, EL('<sound tempo="0"/>'),
                           mxDir=None, staffKey=1, totalOffset=0.0)
+            mp.stream.coreElementsChanged()
         self.assertEqual(
             len(mp.stream.getElementsByClass(tempo.MetronomeMark)), 0)
 

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -21,6 +21,7 @@ per-measure helper object is created for the common case of a measure with no
 from __future__ import annotations
 
 import typing as t
+import unittest
 import xml.etree.ElementTree as ET
 import warnings
 
@@ -141,16 +142,6 @@ def setSoundTempo(
     90
     >>> mm.number is None
     True
-
-    A tempo of zero is skipped (with a warning) and nothing is inserted, so the
-    count stays at the one mark from above:
-
-    >>> import warnings
-    >>> with warnings.catch_warnings():
-    ...     warnings.simplefilter('ignore')
-    ...     setSoundTempo(mp, EL('<sound tempo="0"/>'), mxDir=None, staffKey=1, totalOffset=0.0)
-    >>> len(mp.stream.getElementsByClass(tempo.MetronomeMark))
-    1
     '''
     qpm = common.numToIntOrFloat(float(mxSound.get('tempo', 0)))
     if qpm == 0:
@@ -171,6 +162,22 @@ def setSoundTempo(
     mp.insertCoreAndRef(totalOffset, staffKey, mm)
 
 
+class Test(unittest.TestCase):
+    def testSetSoundTempoZeroIsSkipped(self):
+        '''
+        A <sound> tag with tempo='0' warns and inserts no MetronomeMark.
+        '''
+        from xml.etree.ElementTree import fromstring as EL
+        from music21.musicxml.xmlToM21 import MeasureParser
+
+        mp = MeasureParser()
+        with self.assertWarns(UserWarning):
+            setSoundTempo(mp, EL('<sound tempo="0"/>'),
+                          mxDir=None, staffKey=1, totalOffset=0.0)
+        self.assertEqual(
+            len(mp.stream.getElementsByClass(tempo.MetronomeMark)), 0)
+
+
 if __name__ == '__main__':
     import music21
-    music21.mainTest()  # doctests only
+    music21.mainTest(Test)

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -29,30 +29,34 @@ if t.TYPE_CHECKING:
     from music21.musicxml.xmlToM21 import MeasureParser
 
 
-class SoundTagMixin:
+class SoundTagParser:
     '''
-    This Mixin is applied to MeasureParser -- it is moved
-    out from there because there is still a lot to write
-    here and xmlToM21.py is getting too big.
+    Parses the <sound> tag on behalf of a :class:`MeasureParser`.
+
+    Held by the MeasureParser (as ``.soundParser``) rather than mixed in,
+    because there is still a lot to write here and xmlToM21.py is getting
+    too big. Reaches back into the owning MeasureParser via ``self.measureParser``.
     '''
+    def __init__(self, measureParser: MeasureParser):
+        self.measureParser = measureParser
+
     def xmlSound(self, mxSound: ET.Element) -> None:
         '''
         Convert a <sound> tag to one or more relevant objects
         (presently just MetronomeMark),
         and add it or them to the core and staffReference.
         '''
-        # this mixin is only ever mixed into MeasureParser
-        mp = t.cast('MeasureParser', self)
+        mp = self.measureParser
         # offset is out of order because we need to know it before direction-type
         offsetDirection = mp.xmlToOffset(mxSound)
         totalOffset = offsetDirection + mp.offsetMeasureNote
 
         staffKey = mp.getStaffNumber(mxSound)
 
-        mp.setSound(mxSound,
-                    None,
-                    staffKey,
-                    totalOffset)
+        self.setSound(mxSound,
+                      None,
+                      staffKey,
+                      totalOffset)
 
     def setSound(
         self,
@@ -86,8 +90,7 @@ class SoundTagMixin:
         # TODO: musicxml4: instrument-change: instrument-sound, solo or ensemble or none
         #                                     virtual-instrument
         if 'tempo' in mxSound.attrib:
-            mp = t.cast('MeasureParser', self)
-            mp.setSoundTempo(mxSound, mxDir, staffKey, totalOffset)
+            self.setSoundTempo(mxSound, mxDir, staffKey, totalOffset)
 
 
     def setSoundTempo(
@@ -100,7 +103,7 @@ class SoundTagMixin:
         '''
         Add a metronome mark from the tempo attribute of a <sound> tag.
         '''
-        mp = t.cast('MeasureParser', self)
+        mp = self.measureParser
         qpm = common.numToIntOrFloat(float(mxSound.get('tempo', 0)))
         if qpm == 0:
             warnings.warn('0 qpm tempo tag found, skipping.', stacklevel=2)

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -86,14 +86,14 @@ def setSound(
 
     A <sound> with a tempo attribute inserts a MetronomeMark:
 
-    >>> setSound(mp, EL('<sound tempo="144"/>'), None, 1, 0.0)
+    >>> setSound(mp, EL('<sound tempo="144"/>'), mxDir=None, staffKey=1, totalOffset=0.0)
     >>> mp.stream.getElementsByClass(tempo.MetronomeMark).first()
     <music21.tempo.MetronomeMark Quarter=144 (playback only)>
 
     A <sound> without a tempo attribute is (currently) a no-op, so no second
     mark is added:
 
-    >>> setSound(mp, EL('<sound dynamics="70"/>'), None, 1, 0.0)
+    >>> setSound(mp, EL('<sound dynamics="70"/>'), mxDir=None, staffKey=1, totalOffset=0.0)
     >>> len(mp.stream.getElementsByClass(tempo.MetronomeMark))
     1
     '''
@@ -133,7 +133,7 @@ def setSoundTempo(
     >>> from music21.musicxml.xmlSoundParser import setSoundTempo
     >>> from xml.etree.ElementTree import fromstring as EL
     >>> mp = musicxml.xmlToM21.MeasureParser()
-    >>> setSoundTempo(mp, EL('<sound tempo="90"/>'), None, 1, 0.0)
+    >>> setSoundTempo(mp, EL('<sound tempo="90"/>'), mxDir=None, staffKey=1, totalOffset=0.0)
     >>> mm = mp.stream.getElementsByClass(tempo.MetronomeMark).first()
     >>> mm
     <music21.tempo.MetronomeMark Quarter=90 (playback only)>
@@ -148,7 +148,7 @@ def setSoundTempo(
     >>> import warnings
     >>> with warnings.catch_warnings():
     ...     warnings.simplefilter('ignore')
-    ...     setSoundTempo(mp, EL('<sound tempo="0"/>'), None, 1, 0.0)
+    ...     setSoundTempo(mp, EL('<sound tempo="0"/>'), mxDir=None, staffKey=1, totalOffset=0.0)
     >>> len(mp.stream.getElementsByClass(tempo.MetronomeMark))
     1
     '''

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -129,7 +129,10 @@ def setSound(
     1
     '''
     # extract the staffKey once since it will be the same for all the rest.
-    staffKey = mp.getStaffNumber(mxSound)
+    # When the <sound> is inside a <direction>, the <staff> lives on the
+    # <direction>, not on the <sound> -- read it from there so the mark is
+    # assigned to the right staff (otherwise it goes to every staff).
+    staffKey = mp.getStaffNumber(mxDir if mxDir is not None else mxSound)
     attrib = mxSound.attrib
 
     # TODO: coda

--- a/music21/musicxml/xmlSoundParser.py
+++ b/music21/musicxml/xmlSoundParser.py
@@ -41,8 +41,7 @@ class SoundTagMixin:
         (presently just MetronomeMark),
         and add it or them to the core and staffReference.
         '''
-        if t.TYPE_CHECKING:
-            assert isinstance(self, MeasureParser) and isinstance(self, SoundTagMixin)
+        self = t.cast('MeasureParser', self)
 
         # offset is out of order because we need to know it before direction-type
         offsetDirection = self.xmlToOffset(mxSound)
@@ -68,8 +67,7 @@ class SoundTagMixin:
         If the <sound> tag is a child of a <direction> tag, the direction information
         is used to set the placement of the MetronomeMark.
         '''
-        if t.TYPE_CHECKING:
-            assert isinstance(self, MeasureParser) and isinstance(self, SoundTagMixin)
+        self = t.cast('MeasureParser', self)
         # TODO: coda
         # TODO: dacapo
         # TODO: dalsegno
@@ -102,8 +100,7 @@ class SoundTagMixin:
         '''
         Add a metronome mark from the tempo attribute of a <sound> tag.
         '''
-        if t.TYPE_CHECKING:
-            assert isinstance(self, MeasureParser) and isinstance(self, SoundTagMixin)
+        self = t.cast('MeasureParser', self)
 
         qpm = common.numToIntOrFloat(float(mxSound.get('tempo', 0)))
         if qpm == 0:

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -2850,14 +2850,12 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
             n = self.xmlToRest(mxNote)
 
         if isChord is False:  # normal note or rest
-            if t.TYPE_CHECKING:
-                assert isinstance(n, note.GeneralNote)
-
-            self.updateLyricsFromList(n, mxNote.findall('lyric'))
-            self.addToStaffReference(mxNote, n)
-            self.insertInMeasureOrVoice(mxNote, n)
-            offsetIncrement = n.duration.quarterLength
-            self.nLast = n  # update
+            generalNote = t.cast(note.GeneralNote, n)
+            self.updateLyricsFromList(generalNote, mxNote.findall('lyric'))
+            self.addToStaffReference(mxNote, generalNote)
+            self.insertInMeasureOrVoice(mxNote, generalNote)
+            offsetIncrement = generalNote.duration.quarterLength
+            self.nLast = generalNote  # update
 
         # if we have notes in the note list and the next
         # note either does not exist or is not a chord, we

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -5527,9 +5527,8 @@ class MeasureParser(XMLParserBase):
                 # setSound is defined in xmlSoundParser.py
                 xmlSoundParser.setSound(self,
                                         mxSound,
-                                        mxDirection,
-                                        staffKey,
-                                        totalOffset)
+                                        mxDir=mxDirection,
+                                        totalOffset=totalOffset)
                 break
 
         # TODO: musicxml 4:listening

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -58,7 +58,7 @@ from music21 import tie
 
 from music21.musicxml import xmlObjects
 from music21.musicxml import helpers
-from music21.musicxml.xmlSoundParser import SoundTagMixin
+from music21.musicxml.xmlSoundParser import SoundTagParser
 from music21.musicxml.xmlObjects import MusicXMLImportException, MusicXMLWarning
 
 synchronizeIds = helpers.synchronizeIdsToM21
@@ -2348,7 +2348,7 @@ class PartParser(XMLParserBase):
 
 
 # -----------------------------------------------------------------------------
-class MeasureParser(SoundTagMixin, XMLParserBase):
+class MeasureParser(XMLParserBase):
     '''
     parser to work with a single <measure> tag.
 
@@ -2469,6 +2469,16 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
         # inserted into a Stream).
         # key is PedalMark; value is OffsetQL
         self.pedalToStartOffset: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+        # parses <sound> tags; pulled out to keep this file smaller (see xmlSoundParser)
+        self.soundParser = SoundTagParser(self)
+
+    def xmlSound(self, mxSound: ET.Element) -> None:
+        '''
+        Convert a <sound> tag; delegates to
+        :class:`~music21.musicxml.xmlSoundParser.SoundTagParser`.
+        '''
+        self.soundParser.xmlSound(mxSound)
 
     @staticmethod
     def getStaffNumber(mxObject: ET.Element|int|None) -> int:
@@ -5516,11 +5526,11 @@ class MeasureParser(SoundTagMixin, XMLParserBase):
             for mxSound in mxDirection.findall('sound'):
                 if 'tempo' not in mxSound.attrib:
                     continue
-                # setSoundTempo is defined in xmlSoundParser.py
-                self.setSound(mxSound,
-                              mxDirection,
-                              staffKey,
-                              totalOffset)
+                # setSound is defined in xmlSoundParser.py
+                self.soundParser.setSound(mxSound,
+                                          mxDirection,
+                                          staffKey,
+                                          totalOffset)
                 break
 
         # TODO: musicxml 4:listening

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -58,7 +58,7 @@ from music21 import tie
 
 from music21.musicxml import xmlObjects
 from music21.musicxml import helpers
-from music21.musicxml.xmlSoundParser import SoundTagParser
+from music21.musicxml import xmlSoundParser
 from music21.musicxml.xmlObjects import MusicXMLImportException, MusicXMLWarning
 
 synchronizeIds = helpers.synchronizeIdsToM21
@@ -2470,15 +2470,13 @@ class MeasureParser(XMLParserBase):
         # key is PedalMark; value is OffsetQL
         self.pedalToStartOffset: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
-        # parses <sound> tags; pulled out to keep this file smaller (see xmlSoundParser)
-        self.soundParser = SoundTagParser(self)
-
     def xmlSound(self, mxSound: ET.Element) -> None:
         '''
         Convert a <sound> tag; delegates to
-        :class:`~music21.musicxml.xmlSoundParser.SoundTagParser`.
+        :func:`~music21.musicxml.xmlSoundParser.xmlSound`, which is pulled out to
+        keep this file smaller.
         '''
-        self.soundParser.xmlSound(mxSound)
+        xmlSoundParser.xmlSound(self, mxSound)
 
     @staticmethod
     def getStaffNumber(mxObject: ET.Element|int|None) -> int:
@@ -5527,10 +5525,11 @@ class MeasureParser(XMLParserBase):
                 if 'tempo' not in mxSound.attrib:
                     continue
                 # setSound is defined in xmlSoundParser.py
-                self.soundParser.setSound(mxSound,
-                                          mxDirection,
-                                          staffKey,
-                                          totalOffset)
+                xmlSoundParser.setSound(self,
+                                        mxSound,
+                                        mxDirection,
+                                        staffKey,
+                                        totalOffset)
                 break
 
         # TODO: musicxml 4:listening

--- a/music21/noteworthy/binaryTranslate.py
+++ b/music21/noteworthy/binaryTranslate.py
@@ -1146,9 +1146,8 @@ class NWCObject:
             self.stemLength = 7
 
         self.data2 = []
-        self = t.cast(NWCStaff, self)
         for i in range(numberOfNotes):
-            chordNote = NWCObject(staffParent=self, parserParent=p)
+            chordNote = NWCObject(staffParent=t.cast(NWCStaff, self), parserParent=p)
             chordNote.parse()
             self.data2.append(chordNote)
 
@@ -1291,8 +1290,7 @@ class NWCObject:
         '''
         self.noteChordMember()
         self.type = 'RestChordMember'
-        self = t.cast(NWCStaff, self)
-        rest = NWCObject(staffParent=self, parserParent=self.parserParent)
+        rest = NWCObject(staffParent=t.cast(NWCStaff, self), parserParent=self.parserParent)
         rest.duration = self.data1[0]
         rest.data2 = self.data1
         rest.durationStr = rest.setDurationForObject()

--- a/music21/noteworthy/binaryTranslate.py
+++ b/music21/noteworthy/binaryTranslate.py
@@ -192,7 +192,6 @@ from __future__ import annotations
 
 import pathlib
 import struct
-import typing as t
 from typing import TypedDict
 
 from music21 import environment
@@ -736,7 +735,7 @@ class NWCStaff:
 
         # print('Number of objects: ', self.numberOfObjects)
         for i in range(self.numberOfObjects):
-            thisObject = NWCObject(staffParent=self, parserParent=p)
+            thisObject = NWCObject(parserParent=p)
             thisObject.parse()
             objects.append(thisObject)
         self.objects = objects
@@ -753,8 +752,7 @@ class NWCObject:
     Each parsing method should set up the 'dumpMethod' method that return the nwctxt version
     of the object.
     '''
-    def __init__(self, staffParent: NWCStaff, parserParent: NWCConverter):
-        self.staffParent: NWCStaff = staffParent
+    def __init__(self, parserParent: NWCConverter):
         self.parserParent: NWCConverter = parserParent
         self.type = None
         self.placement = 0
@@ -1147,7 +1145,7 @@ class NWCObject:
 
         self.data2 = []
         for i in range(numberOfNotes):
-            chordNote = NWCObject(staffParent=t.cast(NWCStaff, self), parserParent=p)
+            chordNote = NWCObject(parserParent=p)
             chordNote.parse()
             self.data2.append(chordNote)
 
@@ -1290,7 +1288,7 @@ class NWCObject:
         '''
         self.noteChordMember()
         self.type = 'RestChordMember'
-        rest = NWCObject(staffParent=t.cast(NWCStaff, self), parserParent=self.parserParent)
+        rest = NWCObject(parserParent=self.parserParent)
         rest.duration = self.data1[0]
         rest.data2 = self.data1
         rest.durationStr = rest.setDurationForObject()

--- a/music21/noteworthy/binaryTranslate.py
+++ b/music21/noteworthy/binaryTranslate.py
@@ -1146,8 +1146,7 @@ class NWCObject:
             self.stemLength = 7
 
         self.data2 = []
-        if t.TYPE_CHECKING:
-            assert isinstance(self, NWCStaff)
+        self = t.cast(NWCStaff, self)
         for i in range(numberOfNotes):
             chordNote = NWCObject(staffParent=self, parserParent=p)
             chordNote.parse()
@@ -1292,8 +1291,7 @@ class NWCObject:
         '''
         self.noteChordMember()
         self.type = 'RestChordMember'
-        if t.TYPE_CHECKING:
-            assert isinstance(self, NWCStaff)
+        self = t.cast(NWCStaff, self)
         rest = NWCObject(staffParent=self, parserParent=self.parserParent)
         rest.duration = self.data1[0]
         rest.data2 = self.data1

--- a/music21/romanText/translate.py
+++ b/music21/romanText/translate.py
@@ -407,9 +407,8 @@ class PartTranslator:
 
         # most common case first
         if lineToken.isMeasure():
-            if t.TYPE_CHECKING:
-                assert isinstance(lineToken, rtObjects.RTMeasure)
-            self.translateMeasureLineToken(lineToken)
+            measureToken = t.cast(rtObjects.RTMeasure, lineToken)
+            self.translateMeasureLineToken(measureToken)
 
         elif lineToken.isTitle():
             md.add('title', lineToken.data)

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -870,24 +870,23 @@ class M21toTSV:
                 thisEntry.numeral = '@none'
                 thisEntry.chord = '@none'
             else:
-                if t.TYPE_CHECKING:
-                    assert isinstance(thisRN, roman.RomanNumeral)
-                local_key = localKeyAsRn(thisRN.key, global_key_obj)
+                thisRomanNumeral = t.cast(roman.RomanNumeral, thisRN)
+                local_key = localKeyAsRn(thisRomanNumeral.key, global_key_obj)
                 relativeroot = None
-                if thisRN.secondaryRomanNumeral:
-                    relativeroot = thisRN.secondaryRomanNumeral.figure
+                if thisRomanNumeral.secondaryRomanNumeral:
+                    relativeroot = thisRomanNumeral.secondaryRomanNumeral.figure
                     relativeroot = characterSwaps(
                         relativeroot, isMinor(local_key), direction='m21-DCML'
                     )
                 # We replace the "d" annotation for Mm7 chords on degrees other than
                 #   V because it is not used by the DCML standard
                 # NB: slightly different from DCML: no key.
-                thisEntry.chord = thisRN.figure.replace('d', '', 1)
+                thisEntry.chord = thisRomanNumeral.figure.replace('d', '', 1)
                 thisEntry.pedal = None
-                thisEntry.numeral = thisRN.romanNumeral
-                thisEntry.form = getForm(thisRN)
+                thisEntry.numeral = thisRomanNumeral.romanNumeral
+                thisEntry.form = getForm(thisRomanNumeral)
                 # Strip any leading non-digits from figbass (e.g., M43 -> 43)
-                fig_bass_m = re.match(r'^\D*(\d.*|)', thisRN.figuresWritten)
+                fig_bass_m = re.match(r'^\D*(\d.*|)', thisRomanNumeral.figuresWritten)
                 # implementing the following check according to the review
                 # at https://github.com/cuthbertLab/music21/pull/1267/
                 # but the match should always exist because either:

--- a/music21/romanText/tsvConverter.py
+++ b/music21/romanText/tsvConverter.py
@@ -870,23 +870,23 @@ class M21toTSV:
                 thisEntry.numeral = '@none'
                 thisEntry.chord = '@none'
             else:
-                thisRomanNumeral = t.cast(roman.RomanNumeral, thisRN)
-                local_key = localKeyAsRn(thisRomanNumeral.key, global_key_obj)
+                thisRN = t.cast(roman.RomanNumeral, thisRN)
+                local_key = localKeyAsRn(thisRN.key, global_key_obj)
                 relativeroot = None
-                if thisRomanNumeral.secondaryRomanNumeral:
-                    relativeroot = thisRomanNumeral.secondaryRomanNumeral.figure
+                if thisRN.secondaryRomanNumeral:
+                    relativeroot = thisRN.secondaryRomanNumeral.figure
                     relativeroot = characterSwaps(
                         relativeroot, isMinor(local_key), direction='m21-DCML'
                     )
                 # We replace the "d" annotation for Mm7 chords on degrees other than
                 #   V because it is not used by the DCML standard
                 # NB: slightly different from DCML: no key.
-                thisEntry.chord = thisRomanNumeral.figure.replace('d', '', 1)
+                thisEntry.chord = thisRN.figure.replace('d', '', 1)
                 thisEntry.pedal = None
-                thisEntry.numeral = thisRomanNumeral.romanNumeral
-                thisEntry.form = getForm(thisRomanNumeral)
+                thisEntry.numeral = thisRN.romanNumeral
+                thisEntry.form = getForm(thisRN)
                 # Strip any leading non-digits from figbass (e.g., M43 -> 43)
-                fig_bass_m = re.match(r'^\D*(\d.*|)', thisRomanNumeral.figuresWritten)
+                fig_bass_m = re.match(r'^\D*(\d.*|)', thisRN.figuresWritten)
                 # implementing the following check according to the review
                 # at https://github.com/cuthbertLab/music21/pull/1267/
                 # but the match should always exist because either:

--- a/music21/spanner.py
+++ b/music21/spanner.py
@@ -649,8 +649,7 @@ class Spanner(base.Music21Object):
                     'Spanner.fill() requires a searchStream or getFirst().activeSite'
                 )
 
-        if t.TYPE_CHECKING:
-            assert isinstance(searchStream, stream.Stream)
+        searchStream = t.cast('stream.Stream', searchStream)
 
         endElement: base.Music21Object|None = self.getLast()
         if endElement is startElement:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -1718,9 +1718,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
 
         targetList: list[base.Music21Object]
         if not common.isListLike(targetOrList):
-            if t.TYPE_CHECKING:
-                assert isinstance(targetOrList, base.Music21Object)
-            targetList = [targetOrList]
+            targetObj = t.cast(base.Music21Object, targetOrList)
+            targetList = [targetObj]
         elif isinstance(targetOrList, Sequence) and len(targetOrList) > 1:
             if t.TYPE_CHECKING:
                 assert not isinstance(targetOrList, base.Music21Object)
@@ -5534,9 +5533,8 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         if returnObj.hasPartLikeStreams() or 'Opus' in returnObj.classes:
             for partLike in returnObj.getElementsByClass('Stream'):
                 # call on each part
-                if t.TYPE_CHECKING:
-                    assert isinstance(partLike, Stream)
-                partLike.toWrittenPitch(
+                partStream = t.cast(Stream, partLike)
+                partStream.toWrittenPitch(
                     inPlace=True,
                     ottavasToSounding=ottavasToSounding,
                     preserveAccidentalDisplay=preserveAccidentalDisplay
@@ -9105,9 +9103,7 @@ class Stream(core.StreamCore, t.Generic[M21ObjType]):
         elif isinstance(value, interval.DiatonicInterval):
             intv = interval.Interval(diatonic=value)
         else:
-            if t.TYPE_CHECKING:
-                assert isinstance(value, (interval.GenericInterval, interval.Interval))
-            intv = value
+            intv = t.cast(interval.GenericInterval | interval.Interval, value)
 
         # for p in post.pitches:  # includes chords
         #     # do inplace transpositions on the deepcopy

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -525,8 +525,7 @@ class StreamCore(Music21Object):
         >>> scoreTree
         <ElementTree {20} (0.0 <0.-25...> to 8.0) <music21.stream.Score exampleScore>>
         '''
-        if t.TYPE_CHECKING:
-            assert isinstance(self, Stream)
+        self = t.cast('Stream', self)
         hashedAttributes = hash((tuple(classList or ()),
                                  flatten,
                                  useTimespans,

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -525,14 +525,13 @@ class StreamCore(Music21Object):
         >>> scoreTree
         <ElementTree {20} (0.0 <0.-25...> to 8.0) <music21.stream.Score exampleScore>>
         '''
-        self = t.cast('Stream', self)
         hashedAttributes = hash((tuple(classList or ()),
                                  flatten,
                                  useTimespans,
                                  groupOffsets))
         cacheKey = 'elementTree' + str(hashedAttributes)
         if cacheKey not in self._cache or self._cache[cacheKey] is None:
-            hashedElementTree = tree.fromStream.asTree(self,
+            hashedElementTree = tree.fromStream.asTree(t.cast('Stream', self),
                                                        flatten=flatten,
                                                        classList=classList,
                                                        useTimespans=useTimespans,

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -739,9 +739,8 @@ class StreamIterator(prebase.ProtoM21Object, Sequence[M21ObjType]):
                     if f(e, self) is False:
                         return False
                 except TypeError:  # one element filters are acceptable.
-                    if t.TYPE_CHECKING:
-                        assert isinstance(f, filters.StreamFilter)
-                    if f(e) is False:
+                    streamFilter = t.cast(filters.StreamFilter, f)
+                    if streamFilter(e) is False:
                         return False
             except StopIteration:  # pylint: disable=try-except-raise
                 raise  # clearer this way to see that this can happen
@@ -1811,11 +1810,9 @@ class RecursiveIterator(StreamIterator[M21ObjType], Sequence[M21ObjType]):
             # in a recursive filter, the stream does not need to match the filter,
             # only the internal elements.
             if e.isStream:
-                if t.TYPE_CHECKING:
-                    assert isinstance(e, streamModule.Stream)
-
+                eStream = t.cast('streamModule.Stream', e)
                 childRecursiveIterator: RecursiveIterator[M21ObjType] = RecursiveIterator(
-                    srcStream=e,
+                    srcStream=eStream,
                     restoreActiveSites=self.restoreActiveSites,
                     filterList=self.filters,  # shared list
                     activeInformation=self.activeInformation,  # shared dict

--- a/music21/tree/fromStream.py
+++ b/music21/tree/fromStream.py
@@ -372,9 +372,7 @@ def asTimespans(
                                              flatten=flatten,
                                              classLists=classLists,
                                              useTimespans=True)
-    timespanTreeFirst = listOfTimespanTrees[0]
-    if t.TYPE_CHECKING:
-        assert isinstance(timespanTreeFirst, timespanTree.TimespanTree)
+    timespanTreeFirst = t.cast(timespanTree.TimespanTree, listOfTimespanTrees[0])
     return timespanTreeFirst
 
 


### PR DESCRIPTION
I learned a mistaken idiom sometime in the past decade.  To narrow type, it is now frowned upon to do

```
x: int|str = 4
if TYPE_CHECKING:
    assert isinstance(x, int)
y = x + 2
```

What we should be doing is:

```
x: int|str = 4
y = cast(int, x) + 2
```

Fixed many places this occurred.  Also:

* fix a bug in chord.semiclosedPosition where the typing of the return variable was mistakenly typed as Stream(!)
* fix a bug in the same method where a pitch without octave could crash in theory.
* substantial legibility improvements in m21ToXml.py 
* Add a skill for `bump-version`.

The failed casts for StreamCore, SoundTagMixin, and NoteworthyComposer's binaryTranslate needed some more substantial changes:
* put bandaids on StreamCore for now -- will want to do a real refactor to .core... at some point.
* SoundTagMixin -- exists mainly to make the class less complex, etc.  -- make it its own subparser via separate functions (like we did with Stream's makeNotation methods a while back).  Add doc tests for the first time!
* Remove unused parent references (staffParent) in NoteworthyComposer binaryTranslate.

AI-Assisted (Claude)