### PR TITLE
humdrum: GraceNote improvements

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '11.0.0b2'
+__version__ = '11.0.0b3'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -26,7 +26,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'11.0.0b2'
+'11.0.0b3'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -2291,6 +2291,34 @@ def hdStringToNote(contents: str) -> note.GeneralNote:
     >>> n.duration.isGrace
     True
 
+    A grace note without duration is an eighth note.  If a duration, like ``16``,
+    is given, that type is preserved in the unlinked GraceDuration.  A single
+    ``q`` is a slashed grace note (acciaccatura):
+
+    >>> n = humdrum.spineParser.hdStringToNote('16ccq')
+    >>> n.duration
+    <music21.duration.GraceDuration unlinked type:16th quarterLength:0.0>
+    >>> n.duration.slash
+    True
+
+    Two ``q``\\s signify a grace note without a slash (or accented grace note):
+
+    >>> n = humdrum.spineParser.hdStringToNote('16ccqq')
+    >>> n.duration.type
+    '16th'
+    >>> n.duration.slash
+    False
+
+    .. note::
+
+        A capital ``Q`` was the original Humdrum way of signifying these notes
+        (gruppettos).  Some post-2020 encodings use ``Q`` to mean a cue-sized
+        note.  Given no way of distinguishing these interpretations, music21
+        will remain with the original version; so ``Q`` and ``qq`` are synonyms.
+
+    * Changed in v11: grace notes keep their written duration, and ``qq`` is
+      parsed as an unslashed grace note.
+
     >>> humdrum.spineParser.flavors['JRP'] = storedFlavors  #_DOCS_HIDE
 
     '''
@@ -2468,15 +2496,17 @@ def hdStringToNote(contents: str) -> note.GeneralNote:
             # call Duration.TupletFixer after to correct this.
 
     # 3.2.9 Grace Notes and Groupettos
-    if 'q' in contents:
+    # A single `q` is a slashed grace note; `qq` or `Q` is an unslashed grace note.
+    # A grace note keeps its written duration; with none written it defaults to an eighth.
+    qCount = contents.count('q')
+    if qCount or 'Q' in contents:
         thisObject = thisObject.getGrace()
-        thisObject.duration.type = 'eighth'
-    elif 'Q' in contents:
-        thisObject = thisObject.getGrace()
-        dur = thisObject.duration
-        assert isinstance(dur, GraceDuration)
-        dur.slash = False
-        dur.type = 'eighth'
+        if foundNumber is None:
+            thisObject.duration.type = 'eighth'
+        # != 1: number of q's == 0 (because it's a capital Q) or 2+ (== qq)
+        if qCount != 1:
+            graceDuration = t.cast(GraceDuration, thisObject.duration)
+            graceDuration.slash = False
     elif 'P' in contents:
         thisObject = thisObject.getGrace(appoggiatura=True)
     elif 'p' in contents:

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -84,9 +84,6 @@ class Test(unittest.TestCase):
     def testGraceNoteKeepsWrittenDuration(self):
         '''
         A single `q` is a slashed grace note that keeps its written duration
-        rather than always becoming an eighth.
-
-        Test is AI-assisted.
         '''
         n = SpineEvent('16ccq').toNote()
         self.assertTrue(n.duration.isGrace)
@@ -95,9 +92,7 @@ class Test(unittest.TestCase):
 
     def testUnslashedGraceNote(self):
         '''
-        `qq` or `Q` marks an unslashed grace note.
-
-        Test is AI-assisted.
+        `qq` or `Q` marks two kinds of unslashed grace note.
         '''
         for contents in ('16ccqq', '16ccQ'):
             n = SpineEvent(contents).toNote()
@@ -108,8 +103,6 @@ class Test(unittest.TestCase):
     def testGraceNoteWithoutDurationDefaultsToEighth(self):
         '''
         With no written duration a grace note defaults to an eighth.
-
-        Test is AI-assisted.
         '''
         n = SpineEvent('ccq').toNote()
         self.assertTrue(n.duration.isGrace)
@@ -234,8 +227,6 @@ class Test(unittest.TestCase):
         spines (split indicator immediately *after* the =2 barline) with a half
         note on each, merges back to one spine before =3, and m3 has a single
         half note.
-
-        Test is AI-assisted.
         '''
         krn = re.sub(r'\s\s\s\s+', '\t', r'''
 **kern
@@ -279,8 +270,6 @@ class Test(unittest.TestCase):
         *before* the =2 barline (the barline therefore appears within both new
         spines).  Humdrum syntax permits this; only adjacency rules constrain
         spine path indicators.
-
-        Test is AI-assisted.
         '''
         krn = re.sub(r'\s\s\s\s+', '\t', r'''
 **kern
@@ -328,8 +317,6 @@ class Test(unittest.TestCase):
         Expected layout: one Part with three Measures, each two quarters long;
         m1 has no voices, m2 and m3 each have two voices with one half note
         each.
-
-        Test is AI-assisted.
         '''
         krn = re.sub(r'\s\s\s\s+', '\t', r'''
 **kern
@@ -376,8 +363,6 @@ class Test(unittest.TestCase):
         '''
         ``**dynam`` events on the same line as a kern note attach at that note's
         offset.  Sanity-check companion to testDynamAttachedMisaligned.
-
-        Test is AI-assisted.
         '''
         krn = re.sub(r'\s\s\s\s+', '\t', r'''
 **kern    **dynam
@@ -407,8 +392,6 @@ class Test(unittest.TestCase):
         event) should still attach -- to the stream at the offset of the most
         recently-sounding note.  Currently fails: misaligned dynamics are
         silently dropped.  See TODO in `SpineCollection.attachNonKernEvents`.
-
-        Test is AI-assisted.
         '''
         krn = re.sub(r'\s\s\s\s+', '\t', r'''
 **kern    **dynam
@@ -441,8 +424,6 @@ class Test(unittest.TestCase):
         attach -- to the stream at the offset of the most recently-sounding
         note.  Currently fails: misaligned harm events are silently dropped.
         See TODO in `SpineCollection.attachNonKernEvents`.
-
-        Test is AI-assisted.
         '''
         krn = re.sub(r'\s\s\s\s+', '\t', r'''
 **kern    **harm
@@ -474,8 +455,6 @@ class Test(unittest.TestCase):
         '''
         Blank lines should not affect parsing.  Same shape as
         testSplitAfterBarline but with blank lines sprinkled throughout.
-
-        Test is AI-assisted.
         '''
         krn = re.sub(r'\s\s\s\s+', '\t', r'''
 
@@ -517,8 +496,6 @@ class Test(unittest.TestCase):
         '''
         Blank lines mixed into a kern + dynam + harm piece should not affect
         which events attach where.
-
-        Test is AI-assisted.
         '''
         krn = re.sub(r'\s\s\s\s+', '\t', r'''
 **kern    **dynam    **harm
@@ -556,8 +533,6 @@ class Test(unittest.TestCase):
         Verify that each lyric syllable from a ``**text`` spine attaches to the
         kern note on the same line.  Existing testLyricsInSpine only checks
         the assembled lyric string; this checks the per-note mapping.
-
-        Test is AI-assisted.
         '''
         krn = re.sub(r'\s\s\s\s+', '\t', r'''
 **kern    **text

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -81,6 +81,41 @@ class Test(unittest.TestCase):
         self.assertEqual(b.duration.dots, 0)
         self.assertEqual(b.duration.tuplets[0].durationNormal.dots, 2)
 
+    def testGraceNoteKeepsWrittenDuration(self):
+        '''
+        A single `q` is a slashed grace note that keeps its written duration
+        rather than always becoming an eighth.
+
+        Test is AI-assisted.
+        '''
+        n = SpineEvent('16ccq').toNote()
+        self.assertTrue(n.duration.isGrace)
+        self.assertEqual(n.duration.type, '16th')
+        self.assertTrue(n.duration.slash)
+
+    def testUnslashedGraceNote(self):
+        '''
+        `qq` or `Q` marks an unslashed grace note.
+
+        Test is AI-assisted.
+        '''
+        for contents in ('16ccqq', '16ccQ'):
+            n = SpineEvent(contents).toNote()
+            self.assertTrue(n.duration.isGrace)
+            self.assertEqual(n.duration.type, '16th')
+            self.assertFalse(n.duration.slash)
+
+    def testGraceNoteWithoutDurationDefaultsToEighth(self):
+        '''
+        With no written duration a grace note defaults to an eighth.
+
+        Test is AI-assisted.
+        '''
+        n = SpineEvent('ccq').toNote()
+        self.assertTrue(n.duration.isGrace)
+        self.assertEqual(n.duration.type, 'eighth')
+        self.assertTrue(n.duration.slash)
+
     def testMeasureBoundaries(self):
         m0 = stream.Measure()
         m1 = hdStringToMeasure('=29a;:|:', m0)


### PR DESCRIPTION
Branching off from @alexandermorgan 's PR #1706 to keep to one thing at a time.

In kern import, a grace note previously always became an eighth note, discarding its written duration.  It now keeps the written duration (falling back to an eighth only when none is given).  

In addition to `Q` now, two mark an unslashed grace note.  Use `typing.cast()` to set GraceDuration rather than type: ignore or asserts.  Bump version.

AI-assisted (Claude). - Myke reviewed.