### PR TITLE
figuredBass: voice-leading caches and #1938 TODOs

### DIFF
--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -19,7 +19,7 @@ from music21 import stream
 from music21 import voiceLeading
 from music21.common.numberTools import opFrac
 from music21.common.types import OffsetQL
-from music21.figuredBass.possibility import PitchQuartetToBool
+from music21.figuredBass import possibility
 from music21.exceptions21 import Music21Exception
 
 if t.TYPE_CHECKING:
@@ -265,7 +265,7 @@ def checkSinglePossibilities(
             :width: 700
     '''
     debugInfo: list[str] = []
-    if debug is True:
+    if debug:
         debugInfo.append('Function To Apply: ' + functionToApply.__name__)
         debugInfo.append(f"{'(Offset, End Time):'!s:25}Part Numbers:")
 
@@ -283,10 +283,10 @@ def checkSinglePossibilities(
                         initOffset,
                         mustBeginInSpan=False)[0]
                     noteA.style.color = color
-            if debug is True:
+            if debug:
                 debugInfo.append(f'{offsets!s:25}{partNumberTuple!s}')
 
-    if debug is True:
+    if debug:
         if len(debugInfo) == 2:
             debugInfo.append('No violations to report.')
         for lineInfo in debugInfo:
@@ -333,7 +333,7 @@ def checkConsecutivePossibilities(
             :width: 700
     '''
     debugInfo: list[str] = []
-    if debug is True:
+    if debug:
         debugInfo.append('Function To Apply: ' + functionToApply.__name__)
         debugInfo.append('(Offset A, End Time A):  (Offset B, End Time B): Part Numbers:')
 
@@ -359,14 +359,14 @@ def checkConsecutivePossibilities(
                             'Expected notes to color at the violation offset, but found none')
                     noteA.style.color = color
                     noteB.style.color = color
-            if debug is True:
+            if debug:
                 debugInfo.append(f'{previousOffsets!s:25}{offsets!s:25}{partNumberTuple!s}')
         # Current vlm becomes previous
         previousOffsets = offsets
         vlmA = vlmB
         initOffsetA = initOffsetB
 
-    if debug is True:
+    if debug:
         if len(debugInfo) == 2:
             debugInfo.append('No violations to report.')
         for lineInfo in debugInfo:
@@ -417,10 +417,9 @@ def voiceCrossing(possibA: PossibilityWithRests) -> list[PartPair]:
 # Consecutive Possibility Rule-Checking Methods
 
 
-parallelFifthsTable: PitchQuartetToBool = {}
-parallelOctavesTable: PitchQuartetToBool = {}
-hiddenFifthsTable: PitchQuartetToBool = {}
-hiddenOctavesTable: PitchQuartetToBool = {}
+# The speedup tables are shared with figuredBass.possibility: both modules feed the
+# same VoiceLeadingQuartet (in the same pitch order) into the same checks, so a quartet
+# computed by one module is valid for the other.  See possibility.py for the definitions.
 
 
 def parallelFifths(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -> list[PartPair]:
@@ -466,7 +465,7 @@ def parallelFifths(possibA: PossibilityWithRests, possibB: PossibilityWithRests)
     []
     '''
     partViolations: list[PartPair] = []
-    pairsList = list(zip(possibA, possibB))
+    pairsList = list(zip(possibA, possibB, strict=True))
 
     for pair1Index in range(len(pairsList)):
         (higherPitchA, higherPitchB) = pairsList[pair1Index]
@@ -486,20 +485,19 @@ def parallelFifths(possibA: PossibilityWithRests, possibB: PossibilityWithRests)
                 continue
             # Very high probability of ||5, but still not certain.
             pitchQuartet = (lowerPitchA, lowerPitchB, higherPitchA, higherPitchB)
-            if pitchQuartet in parallelFifthsTable:
-                hasParallelFifths = parallelFifthsTable[pitchQuartet]
-                if hasParallelFifths:
-                    partViolations.append((pair1Index + 1, pair2Index + 1))
-            vlq = voiceLeading.VoiceLeadingQuartet(*pitchQuartet)
-            if vlq.parallelFifth():
+            if pitchQuartet in possibility.parallelFifthsTable:
+                hasParallelFifths = possibility.parallelFifthsTable[pitchQuartet]
+            else:
+                vlq = voiceLeading.VoiceLeadingQuartet(*pitchQuartet)
+                hasParallelFifths = vlq.parallelFifth()
+                possibility.parallelFifthsTable[pitchQuartet] = hasParallelFifths
+            if hasParallelFifths:
                 partViolations.append((pair1Index + 1, pair2Index + 1))
-                parallelFifthsTable[pitchQuartet] = True
-            parallelFifthsTable[pitchQuartet] = False
 
     return partViolations
 
 
-def hiddenFifth(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -> list[PartPair]:
+def hiddenFifths(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -> list[PartPair]:
     '''
     Returns a list with a (highestPart, lowestPart) pair which represents
     a hidden fifth between shared outer parts of possibA and possibB. The
@@ -524,7 +522,7 @@ def hiddenFifth(possibA: PossibilityWithRests, possibB: PossibilityWithRests) ->
 
     >>> possibA1 = (E5, E3, C3)
     >>> possibB1 = (A5, F3, D3)
-    >>> checker.hiddenFifth(possibA1, possibB1)
+    >>> checker.hiddenFifths(possibA1, possibB1)
     [(1, 3)]
 
     Here, the soprano and bass parts also move in similar motion, but the
@@ -534,7 +532,7 @@ def hiddenFifth(possibA: PossibilityWithRests, possibB: PossibilityWithRests) ->
     >>> Ab5 = pitch.Pitch('A-5')
     >>> possibA2 = (E5, E3, C3)
     >>> possibB2 = (Ab5, F3, D3)
-    >>> checker.hiddenFifth(possibA2, possibB2)
+    >>> checker.hiddenFifths(possibA2, possibB2)
     []
 
     Now, we have the soprano and bass parts again moving to A5 and D3, whose
@@ -544,11 +542,13 @@ def hiddenFifth(possibA: PossibilityWithRests, possibB: PossibilityWithRests) ->
     >>> E6 = pitch.Pitch('E6')
     >>> possibA3 = (E6, E3, C3)
     >>> possibB3 = (A5, F3, D3)
-    >>> checker.hiddenFifth(possibA3, possibB3)
+    >>> checker.hiddenFifths(possibA3, possibB3)
     []
+
+    * Changed in v11: renamed from hiddenFifth (singular) to match parallelFifths.
     '''
     partViolations: list[PartPair] = []
-    pairsList = list(zip(possibA, possibB))
+    pairsList = list(zip(possibA, possibB, strict=True))
     (highestPitchA, highestPitchB) = pairsList[0]
     (lowestPitchA, lowestPitchB) = pairsList[-1]
     if not isinstance(highestPitchA, pitch.Pitch):
@@ -563,17 +563,14 @@ def hiddenFifth(possibA: PossibilityWithRests, possibB: PossibilityWithRests) ->
     if abs(highestPitchB.ps - lowestPitchB.ps) % 12 == 7:
         # Very high probability of hidden fifth, but still not certain.
         pitchQuartet = (lowestPitchA, lowestPitchB, highestPitchA, highestPitchB)
-        if pitchQuartet in hiddenFifthsTable:
-            hasHiddenFifth = hiddenFifthsTable[pitchQuartet]
-            if hasHiddenFifth:
-                partViolations.append((1, len(possibB)))
-            return partViolations
-        vlq = voiceLeading.VoiceLeadingQuartet(*pitchQuartet)
-        if vlq.hiddenFifth():
+        if pitchQuartet in possibility.hiddenFifthsTable:
+            hasHiddenFifth = possibility.hiddenFifthsTable[pitchQuartet]
+        else:
+            vlq = voiceLeading.VoiceLeadingQuartet(*pitchQuartet)
+            hasHiddenFifth = vlq.hiddenFifth()
+            possibility.hiddenFifthsTable[pitchQuartet] = hasHiddenFifth
+        if hasHiddenFifth:
             partViolations.append((1, len(possibB)))
-            hiddenFifthsTable[pitchQuartet] = True
-        hiddenFifthsTable[pitchQuartet] = False
-        return partViolations
 
     return partViolations
 
@@ -622,7 +619,7 @@ def parallelOctaves(possibA: PossibilityWithRests, possibB: PossibilityWithRests
     []
     '''
     partViolations: list[PartPair] = []
-    pairsList = list(zip(possibA, possibB))
+    pairsList = list(zip(possibA, possibB, strict=True))
 
     for pair1Index in range(len(pairsList)):
         (higherPitchA, higherPitchB) = pairsList[pair1Index]
@@ -642,20 +639,19 @@ def parallelOctaves(possibA: PossibilityWithRests, possibB: PossibilityWithRests
                 continue
             # Very high probability of ||8, but still not certain.
             pitchQuartet = (lowerPitchA, lowerPitchB, higherPitchA, higherPitchB)
-            if pitchQuartet in parallelOctavesTable:
-                hasParallelOctaves = parallelOctavesTable[pitchQuartet]
-                if hasParallelOctaves:
-                    partViolations.append((pair1Index + 1, pair2Index + 1))
-            vlq = voiceLeading.VoiceLeadingQuartet(*pitchQuartet)
-            if vlq.parallelOctave():
+            if pitchQuartet in possibility.parallelOctavesTable:
+                hasParallelOctaves = possibility.parallelOctavesTable[pitchQuartet]
+            else:
+                vlq = voiceLeading.VoiceLeadingQuartet(*pitchQuartet)
+                hasParallelOctaves = vlq.parallelOctave()
+                possibility.parallelOctavesTable[pitchQuartet] = hasParallelOctaves
+            if hasParallelOctaves:
                 partViolations.append((pair1Index + 1, pair2Index + 1))
-                parallelOctavesTable[pitchQuartet] = True
-            parallelOctavesTable[pitchQuartet] = False
 
     return partViolations
 
 
-def hiddenOctave(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -> list[PartPair]:
+def hiddenOctaves(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -> list[PartPair]:
     '''
     Returns a list with a (highestPart, lowestPart) pair which represents
     a hidden octave between shared outer parts of possibA and possibB. The
@@ -680,7 +676,7 @@ def hiddenOctave(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -
 
     >>> possibA1 = (A5, E3, C3)
     >>> possibB1 = (D6, F3, D3)  # Perfect octave between soprano and bass.
-    >>> checker.hiddenOctave(possibA1, possibB1)
+    >>> checker.hiddenOctaves(possibA1, possibB1)
     [(1, 3)]
 
     Here, the bass part moves up from C3 to D3 but the soprano part moves
@@ -690,11 +686,13 @@ def hiddenOctave(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -
     >>> A6 = pitch.Pitch('A6')
     >>> possibA2 = (A6, E3, C3)
     >>> possibB2 = (D6, F3, D3)
-    >>> checker.hiddenOctave(possibA2, possibB2)
+    >>> checker.hiddenOctaves(possibA2, possibB2)
     []
+
+    * Changed in v11: renamed from hiddenOctave (singular) to match parallelOctaves.
     '''
     partViolations: list[PartPair] = []
-    pairsList = list(zip(possibA, possibB))
+    pairsList = list(zip(possibA, possibB, strict=True))
     (highestPitchA, highestPitchB) = pairsList[0]
     (lowestPitchA, lowestPitchB) = pairsList[-1]
     if not isinstance(highestPitchA, pitch.Pitch):
@@ -709,17 +707,14 @@ def hiddenOctave(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -
     if abs(highestPitchB.ps - lowestPitchB.ps) % 12 == 0:
         # Very high probability of hidden octave, but still not certain.
         pitchQuartet = (lowestPitchA, lowestPitchB, highestPitchA, highestPitchB)
-        if pitchQuartet in hiddenOctavesTable:
-            hasHiddenOctave = hiddenOctavesTable[pitchQuartet]
-            if hasHiddenOctave:
-                partViolations.append((1, len(possibB)))
-            return partViolations
-        vlq = voiceLeading.VoiceLeadingQuartet(*pitchQuartet)
-        if vlq.hiddenOctave():
+        if pitchQuartet in possibility.hiddenOctavesTable:
+            hasHiddenOctave = possibility.hiddenOctavesTable[pitchQuartet]
+        else:
+            vlq = voiceLeading.VoiceLeadingQuartet(*pitchQuartet)
+            hasHiddenOctave = vlq.hiddenOctave()
+            possibility.hiddenOctavesTable[pitchQuartet] = hasHiddenOctave
+        if hasHiddenOctave:
             partViolations.append((1, len(possibB)))
-            hiddenOctavesTable[pitchQuartet] = True
-        hiddenOctavesTable[pitchQuartet] = False
-        return partViolations
 
     return partViolations
 
@@ -752,7 +747,29 @@ _DOC_ORDER = [extractHarmonies, getVoiceLeadingMoments,
 
 
 class Test(unittest.TestCase):
-    pass
+    def testParallelFifthsCachePopulatesAndIsShared(self):
+        '''
+        The speedup table actually caches (it formerly stored False on every call and
+        never hit), and the table is the one shared with figuredBass.possibility, so a
+        quartet computed in one module is reused by the other.
+        '''
+        # Bass C3->D3 and tenor G3->A3 form a perfect fifth moving in parallel.
+        possibA = (pitch.Pitch('B4'), pitch.Pitch('G3'), pitch.Pitch('C3'))
+        possibB = (pitch.Pitch('A4'), pitch.Pitch('A3'), pitch.Pitch('D3'))
+
+        possibility.parallelFifthsTable.clear()
+        self.assertEqual(parallelFifths(possibA, possibB), [(2, 3)])
+
+        # The quartet was stored as True, not recomputed-and-overwritten-as-False.
+        self.assertEqual(len(possibility.parallelFifthsTable), 1)
+        self.assertEqual(list(possibility.parallelFifthsTable.values()), [True])
+
+        # checker and possibility share one table: value-equal pitches (new objects)
+        # hit the cached entry rather than adding a second one.
+        possibA2 = (pitch.Pitch('B4'), pitch.Pitch('G3'), pitch.Pitch('C3'))
+        possibB2 = (pitch.Pitch('A4'), pitch.Pitch('A3'), pitch.Pitch('D3'))
+        self.assertTrue(possibility.parallelFifths(possibA2, possibB2))
+        self.assertEqual(len(possibility.parallelFifthsTable), 1)
 
 
 if __name__ == '__main__':

--- a/music21/figuredBass/notation.py
+++ b/music21/figuredBass/notation.py
@@ -210,6 +210,9 @@ class Notation(prebase.ProtoM21Object):
         # Parse notation string
         self.notationColumn: str = notationColumn or ''
         self.figureStrings: list[str] = []
+        # numbers are usually ints, but an extender-only figure stores the
+        # underscore string '_' as its "number" (see _parseNotationColumn), and a
+        # figure with a modifier but no number stores None until longhand expansion.
         self.origNumbers: tuple[int|str|None, ...] = ()
         self.origModStrings: tuple[str|None, ...] = ()
         self.numbers: tuple[int|str|None, ...] = ()

--- a/music21/figuredBass/possibility.py
+++ b/music21/figuredBass/possibility.py
@@ -17,6 +17,11 @@ the last element of each possibility is the bass.
 .. note:: fbRealizer supports voice crossing, so the order of pitches from lowest
     to highest may not correspond to the ordering of parts.
 
+.. note:: A realized possibility has one pitch per part, so with the default four-part
+    (SATB) realization each possibility holds four pitches, the last being the bass. The
+    examples in this module use shorter, often three-voice, possibilities purely for
+    brevity; every function here works for any number of parts.
+
 Here, a possibility is created. G5 is in the highest part, and C4 is the bass. The highest
 part contains the highest Pitch, and the lowest part contains the lowest Pitch. No voice
 crossing is present.
@@ -56,7 +61,6 @@ The application of these methods is controlled by corresponding instance variabl
 '''
 from __future__ import annotations
 
-import typing as t
 import unittest
 
 from music21 import chord
@@ -263,11 +267,10 @@ def limitPartToPitch(
 
 # CONSECUTIVE POSSIBILITY RULE-CHECKING METHODS
 # ---------------------------------------------
-# Speedup tables
-# TODO: reinstitute PitchQuartetToBool caching with proper pitch hash checking
-#   (keying on Pitch objects relies on identity, so these caches rarely hit;
-#   rework to key on nameWithOctave strings).  Same applies to the copies in
-#   figuredBass.checker.
+# Speedup tables.  pitch.Pitch hashes and compares by value, so tuples of
+# pitches work as dict keys: a quartet of value-equal pitches hits the cache
+# regardless of object identity.  The same tables are duplicated in
+# figuredBass.checker.
 type PitchQuartetToBool = dict[
     tuple[pitch.Pitch, pitch.Pitch, pitch.Pitch, pitch.Pitch],
     bool
@@ -425,7 +428,7 @@ def parallelOctaves(possibA: Possibility, possibB: Possibility) -> bool:
     return hasParallelOctaves
 
 
-def hiddenFifth(possibA: Possibility, possibB: Possibility) -> bool:
+def hiddenFifths(possibA: Possibility, possibB: Possibility) -> bool:
     '''
     Returns True if there is a hidden fifth between shared outer parts
     of possibA and possibB. The outer parts here are the first and last
@@ -450,7 +453,7 @@ def hiddenFifth(possibA: Possibility, possibB: Possibility) -> bool:
 
     >>> possibA1 = (E5, E3, C3)
     >>> possibB1 = (A5, F3, D3)
-    >>> possibility.hiddenFifth(possibA1, possibB1)
+    >>> possibility.hiddenFifths(possibA1, possibB1)
     True
 
     Here, the soprano and bass parts also move in similar motion, but the
@@ -460,7 +463,7 @@ def hiddenFifth(possibA: Possibility, possibB: Possibility) -> bool:
     >>> Ab5 = pitch.Pitch('A-5')
     >>> possibA2 = (E5, E3, C3)
     >>> possibB2 = (Ab5, F3, D3)
-    >>> possibility.hiddenFifth(possibA2, possibB2)
+    >>> possibility.hiddenFifths(possibA2, possibB2)
     False
 
     Now, we have the soprano and bass parts again moving to A5 and D3, whose
@@ -470,8 +473,10 @@ def hiddenFifth(possibA: Possibility, possibB: Possibility) -> bool:
     >>> E6 = pitch.Pitch('E6')
     >>> possibA3 = (E6, E3, C3)
     >>> possibB3 = (A5, F3, D3)
-    >>> possibility.hiddenFifth(possibA3, possibB3)
+    >>> possibility.hiddenFifths(possibA3, possibB3)
     False
+
+    * Changed in v11: renamed from hiddenFifth (singular) to match parallelFifths.
     '''
     hasHiddenFifth = False
     pairsList = partPairs(possibA, possibB)
@@ -492,7 +497,7 @@ def hiddenFifth(possibA: Possibility, possibB: Possibility) -> bool:
     return hasHiddenFifth
 
 
-def hiddenOctave(possibA: Possibility, possibB: Possibility) -> bool:
+def hiddenOctaves(possibA: Possibility, possibB: Possibility) -> bool:
     '''
     Returns True if there is a hidden octave between shared outer parts
     of possibA and possibB. The outer parts here are the first and last
@@ -517,7 +522,7 @@ def hiddenOctave(possibA: Possibility, possibB: Possibility) -> bool:
 
     >>> possibA1 = (A5, E3, C3)
     >>> possibB1 = (D6, F3, D3)  # Perfect octave between soprano and bass.
-    >>> possibility.hiddenOctave(possibA1, possibB1)
+    >>> possibility.hiddenOctaves(possibA1, possibB1)
     True
 
     Here, the bass part moves up from C3 to D3 but the soprano part moves
@@ -527,8 +532,10 @@ def hiddenOctave(possibA: Possibility, possibB: Possibility) -> bool:
     >>> A6 = pitch.Pitch('A6')
     >>> possibA2 = (A6, E3, C3)
     >>> possibB2 = (D6, F3, D3)
-    >>> possibility.hiddenOctave(possibA2, possibB2)
+    >>> possibility.hiddenOctaves(possibA2, possibB2)
     False
+
+    * Changed in v11: renamed from hiddenOctave (singular) to match parallelOctaves.
     '''
     hasHiddenOctave = False
     pairsList = partPairs(possibA, possibB)
@@ -809,8 +816,10 @@ def couldBeItalianA6Resolution(
             raise PossibilityException('possibA does not spell out an It+6 chord.')
         bass = augSixthChord.bass()
         root = augSixthChord.root()
-        third = t.cast(pitch.Pitch, augSixthChord.getChordStep(3))
-        fifth = t.cast(pitch.Pitch, augSixthChord.getChordStep(5))
+        third = augSixthChord.getChordStep(3)
+        fifth = augSixthChord.getChordStep(5)
+        if third is None or fifth is None:
+            raise PossibilityException('possibA does not spell out an It+6 chord.')
         threePartChordInfo = [bass, root, third, fifth]
 
     allowedIntervalNames = ['M3', 'm3', 'M2', 'm-2']
@@ -931,7 +940,7 @@ def partPairs(
      (<music21.pitch.Pitch C4>, <music21.pitch.Pitch D4>)]
 
     '''
-    return list(zip(possibA, possibB))
+    return list(zip(possibA, possibB, strict=True))
 
 # apply a function to one pitch of possibA at a time
 # apply a function to two pitches of possibA at a time
@@ -943,7 +952,7 @@ def partPairs(
 singlePossibilityMethods = [voiceCrossing, isIncomplete, upperPartsWithinLimit, pitchesWithinLimit]
 # singlePossibilityMethods.sort(None, lambda x: x.__name__)
 consequentPossibilityMethods = [parallelFifths, parallelOctaves,
-                                hiddenFifth, hiddenOctave, voiceOverlap,
+                                hiddenFifths, hiddenOctaves, voiceOverlap,
                                 partMovementsWithinLimits, upperPartsSame,
                                 couldBeItalianA6Resolution]
 # consequentPossibilityMethods.sort(None, lambda x: x.__name__)

--- a/music21/figuredBass/realizer.py
+++ b/music21/figuredBass/realizer.py
@@ -45,13 +45,16 @@ import random
 import typing as t
 import unittest
 
+from music21 import base
 from music21 import chord
 from music21 import clef
 from music21 import exceptions21
+from music21 import harmony
 from music21 import key
 from music21 import meter
 from music21 import note
 from music21 import pitch
+from music21 import roman
 from music21 import stream
 from music21.common.types import OffsetQL
 from music21.figuredBass import checker
@@ -60,10 +63,6 @@ from music21.figuredBass import realizerScale
 from music21.figuredBass import rules
 from music21.figuredBass import segment
 from music21.figuredBass.possibility import Possibility
-
-if t.TYPE_CHECKING:
-    from music21 import harmony
-    from music21 import roman
 
 
 def figuredBassFromStream(streamPart: stream.Stream) -> FiguredBassLine:
@@ -164,7 +163,7 @@ def figuredBassFromStream(streamPart: stream.Stream) -> FiguredBassLine:
     return fb
 
 
-def addLyricsToBassNote(bassNote: note.Note, notationString: str|None = None) -> None:
+def addLyricsToBassNote(bassNote: note.Note, notationString: str = '') -> None:
     '''
     Takes in a bassNote and a corresponding notationString as arguments.
     Adds the parsed notationString as lyrics to the bassNote, which is
@@ -183,7 +182,7 @@ def addLyricsToBassNote(bassNote: note.Note, notationString: str|None = None) ->
         :width: 100
     '''
     bassNote.lyrics = []
-    n = notation.Notation(notationString or '')
+    n = notation.Notation(notationString)
     if not n.figureStrings:
         return
     maxLength = max([len(fs) for fs in n.figureStrings])
@@ -274,15 +273,12 @@ class FiguredBassLine:
         >>> fbLine.addElement(roman.RomanNumeral('V'))
         '''
         bassObject.editorial.notationString = notationString
-        c = bassObject.classes
-        if 'Note' in c:
-            bassNote = t.cast(note.Note, bassObject)
-            self._fbList.append((bassNote, notationString))  # a bass note, and a notationString
-            addLyricsToBassNote(bassNote, notationString)
+        if isinstance(bassObject, note.Note):
+            self._fbList.append((bassObject, notationString))  # a bass note, and a notationString
+            addLyricsToBassNote(bassObject, notationString or '')
         # ---------- Added to accommodate harmony.ChordSymbol and roman.RomanNumeral objects ---
-        elif 'RomanNumeral' in c or 'ChordSymbol' in c:
-            harmonyObject = t.cast('harmony.ChordSymbol | roman.RomanNumeral', bassObject)
-            self._fbList.append(harmonyObject)  # a roman Numeral object
+        elif isinstance(bassObject, (roman.RomanNumeral, harmony.ChordSymbol)):
+            self._fbList.append(bassObject)  # a roman Numeral object
         else:
             raise FiguredBassLineException(
                 'Not a valid bassObject (only note.Note, '
@@ -474,11 +470,8 @@ class FiguredBassLine:
             if isinstance(item, tuple):
                 # a (bassNote, notationString) pair, not a harmony object
                 continue
-            c = item.classes
-            if 'Note' in c:
-                break
             # Added to accommodate harmony.ChordSymbol and roman.RomanNumeral objects
-            if 'RomanNumeral' in c or 'ChordSymbol' in c:
+            if isinstance(item, (roman.RomanNumeral, harmony.ChordSymbol)):
                 listOfHarmonyObjects = True
                 break
 
@@ -548,7 +541,7 @@ class FiguredBassLine:
         elif len(segmentList) >= 3:
             segmentList.reverse()
             # gets this wrong  # pylint: disable=cell-var-from-loop
-            movementsAB: dict[Possibility, list[Possibility]]|None = None
+            movementsAB: dict[Possibility, list[Possibility]] = {}
             for segmentIndex in range(1, len(segmentList) - 1):
                 movementsAB = segmentList[segmentIndex + 1].movements
                 movementsBC = segmentList[segmentIndex].movements
@@ -560,10 +553,9 @@ class FiguredBassLine:
                     movementsAB[possibA] = list(
                         filter(lambda possibBB: (possibBB in movementsBC), possibBList))
 
-            movementsABFinal = t.cast('dict[Possibility, list[Possibility]]', movementsAB)
-            for (possibA, possibBList) in list(movementsABFinal.items()):
+            for (possibA, possibBList) in list(movementsAB.items()):
                 if not possibBList:
-                    del movementsABFinal[possibA]
+                    del movementsAB[possibA]
 
             segmentList.reverse()
             return True
@@ -592,6 +584,15 @@ class Realization:
             realizations are represented in chorale style with n staves,
             where n is the number of parts. SATB if n = 4.''',
     }
+
+    # Populated in __init__ from FiguredBassLine.realize()'s keyword outputs.
+    # Declared here for typing; **fbLineOutputs stays untyped for Sphinx's sake.
+    _segmentList: list[segment.Segment]
+    _inKey: key.Key
+    _keySig: key.KeySignature
+    _inTime: meter.TimeSignature
+    _overlaidParts: list[base.Music21Object]
+    _paddingLeft: OffsetQL
 
     def __init__(self, **fbLineOutputs: t.Any) -> None:
         # fbLineOutputs always will have three elements, checks are for sphinx documentation only.
@@ -695,7 +696,7 @@ class Realization:
         currMovements = self._segmentList[0].movements
         if self.getNumSolutions() == 0:
             raise FiguredBassLineException('Zero solutions')
-        prevPossib = random.sample(currMovements.keys(), 1)[0]
+        prevPossib = random.sample(list(currMovements.keys()), 1)[0]
         progression.append(prevPossib)
 
         for segmentIndex in range(len(self._segmentList) - 1):

--- a/music21/figuredBass/realizerScale.py
+++ b/music21/figuredBass/realizerScale.py
@@ -33,7 +33,7 @@ scaleModes = {'major': scale.MajorScale,
 class FiguredBassScale:
     '''
     Acts as a wrapper for :class:`~music21.scale.Scale`. Used to represent the
-    concept of a figured bass scale, with a scale value and mode.
+    concept of a figured bass scale, with a scale tonic and mode.
 
     Accepted scale types: major, minor, dorian, phrygian, and hypophrygian.
     A FiguredBassScaleException is raised if an invalid scale type is provided.
@@ -50,32 +50,34 @@ class FiguredBassScale:
     <music21.scale.MinorScale D minor>
     >>> fbScale.keySig
     <music21.key.KeySignature of 1 flat>
+
+    * Changed in v11: the first argument was renamed from `scaleValue` to `scaleTonic`.
     '''
     _DOC_ATTR: dict[str, str] = {
         'realizerScale': '''
             A :class:`~music21.scale.Scale` based on the
-            desired value and mode.
+            desired tonic and mode.
             ''',
         'keySig': '''
             A :class:`~music21.key.KeySignature` corresponding to
-            the scale value and mode.
+            the scale tonic and mode.
             ''',
     }
 
     def __init__(self,
-                 scaleValue: str | pitch.Pitch | note.Note = 'C',
+                 scaleTonic: str | pitch.Pitch | note.Note = 'C',
                  scaleMode: str = 'major') -> None:
         try:
             scaleClass = scaleModes[scaleMode]
-            self.realizerScale: scale.ConcreteScale = scaleClass(scaleValue)
+            self.realizerScale: scale.ConcreteScale = scaleClass(scaleTonic)
             self.keySig: key.KeySignature = key.KeySignature(
-                key.pitchToSharps(scaleValue, scaleMode))
+                key.pitchToSharps(scaleTonic, scaleMode))
         except KeyError:
             raise FiguredBassScaleException('Unsupported scale type-> ' + scaleMode)
 
     def getPitchNames(self,
                       bassPitch: str | pitch.Pitch,
-                      notationString: str | None = None) -> list[str]:
+                      notationString: str = '') -> list[str]:
         '''
         Takes a bassPitch and notationString and returns a list of corresponding
         pitch names based on the scale value and mode above and inclusive of the
@@ -94,7 +96,7 @@ class FiguredBassScale:
         '''
         bassPitch = convertToPitch(bassPitch)  # Convert string to pitch (if necessary)
         bassSD = self.realizerScale.getScaleDegreeFromPitch(bassPitch)
-        nt = notation.Notation(notationString or '')
+        nt = notation.Notation(notationString)
 
         if bassSD is None:
             bassPitchCopy = copy.deepcopy(bassPitch)
@@ -119,7 +121,7 @@ class FiguredBassScale:
 
     def getSamplePitches(self,
                          bassPitch: str | pitch.Pitch,
-                         notationString: str | None = None) -> list[pitch.Pitch]:
+                         notationString: str = '') -> list[pitch.Pitch]:
         '''
         Returns all pitches for a bassPitch and notationString within
         an octave of the bassPitch, inclusive of the bassPitch but
@@ -166,7 +168,7 @@ class FiguredBassScale:
 
     def getPitches(self,
                    bassPitch: str | pitch.Pitch,
-                   notationString: str | None = None,
+                   notationString: str = '',
                    maxPitch: str | pitch.Pitch | None = None) -> list[pitch.Pitch]:
         '''
         Takes in a bassPitch, a notationString, and a maxPitch representing the highest
@@ -201,7 +203,7 @@ class FiguredBassScale:
         bassPitch = convertToPitch(bassPitch)
         maxPitch = convertToPitch(maxPitch)
         pitchNames = self.getPitchNames(bassPitch, notationString)
-        maxOctave = t.cast(int, maxPitch.octave)
+        maxOctave = maxPitch.implicitOctave
         iter1 = itertools.product(pitchNames, range(maxOctave + 1))
         iter2 = map(lambda x: pitch.Pitch(x[0] + str(x[1])), iter1)
         iter3 = itertools.filterfalse(lambda samplePitch: bassPitch > samplePitch, iter2)

--- a/music21/figuredBass/rules.py
+++ b/music21/figuredBass/rules.py
@@ -38,11 +38,11 @@ doc_parallelOctaves = '''True by default. If True,
     (possibA, possibB) pairs, and all those pairs for which the method returns
     False are retained.'''
 doc_hiddenFifths = '''True by default. If True,
-    :meth:`~music21.figuredBass.possibility.hiddenFifth` is applied to all
+    :meth:`~music21.figuredBass.possibility.hiddenFifths` is applied to all
     (possibA, possibB) pairs, and all those pairs for which the method returns
     False are retained.'''
 doc_hiddenOctaves = '''True by default. If True,
-    :meth:`~music21.figuredBass.possibility.hiddenOctave` is applied to all
+    :meth:`~music21.figuredBass.possibility.hiddenOctaves` is applied to all
     (possibA, possibB) pairs, and all those pairs for which the method returns
     False are retained.'''
 doc_voiceOverlap = '''True by default. If True,

--- a/music21/figuredBass/segment.py
+++ b/music21/figuredBass/segment.py
@@ -134,19 +134,26 @@ class Segment:
         else:
             self.fbRules = copy.deepcopy(fbRules)
 
-        self._specialResolutionRuleChecking: dict[bool, list[tuple[t.Any, ...]]]|None = None
-        self._singlePossibilityRuleChecking: dict[bool, list[tuple[t.Any, ...]]]|None = None
-        self._consecutivePossibilityRuleChecking: dict[bool, list[tuple[t.Any, ...]]]|None = None
+        # Empty until the matching allCorrect*/special-resolution method compiles them.
+        self._specialResolutionRuleChecking: dict[bool, list[tuple[t.Any, ...]]] = {}
+        self._singlePossibilityRuleChecking: dict[bool, list[tuple[t.Any, ...]]] = {}
+        self._consecutivePossibilityRuleChecking: dict[bool, list[tuple[t.Any, ...]]] = {}
 
         self.bassNote: note.Note = bassNote
         self.numParts: int = numParts
         self._maxPitch: pitch.Pitch = maxPitch
+        # `notationString is None` is the mode sentinel: None means "no figures given,
+        # take the chord from listOfPitches" (the harmony.ChordSymbol / roman.RomanNumeral
+        # path); any string (including '') means "figured bass, derive pitches from the
+        # figures". realizer.py only ever supplies one of the two, so they never collide,
+        # but if both are given listOfPitches is silently dropped. (This is why
+        # notationString must NOT be defaulted to '': that would disable the sentinel and
+        # break every chord-symbol/roman realization.)
         if notationString is None and listOfPitches is not None:
-            # must be a chord symbol or roman num.
             self.pitchNamesInChord = listOfPitches
-        # ------ Added to accommodate harmony.ChordSymbol and roman.RomanNumeral objects ------
         else:
-            self.pitchNamesInChord = fbScale.getPitchNames(self.bassNote.pitch, notationString)
+            self.pitchNamesInChord = fbScale.getPitchNames(self.bassNote.pitch,
+                                                           notationString or '')
 
         self.allPitchesAboveBass = getPitches(self.pitchNamesInChord,
                                               self.bassNote.pitch,
@@ -250,8 +257,8 @@ class Segment:
         True       partMovementsWithinLimits     True                          []
         True       parallelFifths                False                         None
         True       parallelOctaves               False                         None
-        True       hiddenFifth                   False                         None
-        True       hiddenOctave                  False                         None
+        True       hiddenFifths                  False                         None
+        True       hiddenOctaves                 False                         None
         False      couldBeItalianA6Resolution    True           [<music21.pitch.Pitch C3>,
                                                                  <music21.pitch.Pitch C3>,
                                                                  <music21.pitch.Pitch E3>,
@@ -274,8 +281,8 @@ class Segment:
         True       partMovementsWithinLimits     True                          [(1, 2)]
         True       parallelFifths                False                         None
         True       parallelOctaves               False                         None
-        True       hiddenFifth                   False                         None
-        False      hiddenOctave                  False                         None
+        True       hiddenFifths                  False                         None
+        False      hiddenOctaves                 False                         None
         False      couldBeItalianA6Resolution    True           [<music21.pitch.Pitch C3>,
                                                                  <music21.pitch.Pitch C3>,
                                                                  <music21.pitch.Pitch E3>,
@@ -293,8 +300,8 @@ class Segment:
             (True, possibility.partMovementsWithinLimits, True, [fbRules.partMovementLimits]),
             (fbRules.forbidParallelFifths, possibility.parallelFifths, False),
             (fbRules.forbidParallelOctaves, possibility.parallelOctaves, False),
-            (fbRules.forbidHiddenFifths, possibility.hiddenFifth, False),
-            (fbRules.forbidHiddenOctaves, possibility.hiddenOctave, False),
+            (fbRules.forbidHiddenFifths, possibility.hiddenFifths, False),
+            (fbRules.forbidHiddenOctaves, possibility.hiddenOctaves, False),
             (fbRules.resolveAugmentedSixthProperly and isItalianAugmentedSixth,
                 possibility.couldBeItalianA6Resolution,
                 True,
@@ -434,6 +441,8 @@ class Segment:
         dominantScale = t.cast(scale.MajorScale, scale.MajorScale().derive(domChord))
         minorScale = dominantScale.getParallelMinor()
 
+        # A complete diatonic scale always defines a tonic and every degree 1-7,
+        # so getTonic() and pitchFromDegree() never return None here; the casts are safe.
         tonic = t.cast(pitch.Pitch, dominantScale.getTonic())
         subdominant = t.cast(pitch.Pitch, dominantScale.pitchFromDegree(4))
         majSubmediant = t.cast(pitch.Pitch, dominantScale.pitchFromDegree(6))
@@ -529,6 +538,8 @@ class Segment:
         dimScale = scale.HarmonicMinorScale().deriveByDegree(7, dimChord.root())
         # minorScale = dimScale.getParallelMinor()
 
+        # A complete diatonic scale always defines a tonic and every degree 1-7,
+        # so getTonic() and pitchFromDegree() never return None here; the casts are safe.
         tonic = t.cast(pitch.Pitch, dimScale.getTonic())
         subdominant = t.cast(pitch.Pitch, dimScale.pitchFromDegree(4))
 
@@ -801,7 +812,6 @@ class Segment:
         from segmentA.
         '''
         ruleChecking = self._singlePossibilityRuleChecking
-        assert ruleChecking is not None
         for (method, isCorrect, args) in ruleChecking[True]:
             if not (method(possibA, *args) == isCorrect):
                 return False
@@ -819,7 +829,6 @@ class Segment:
         from segmentA.
         '''
         ruleChecking = self._consecutivePossibilityRuleChecking
-        assert ruleChecking is not None
         for (method, isCorrect, args) in ruleChecking[True]:
             if not (method(possibA, possibB, *args) == isCorrect):
                 return False


### PR DESCRIPTION
Fix one large bug in FB (preexisting recent code) and implement a bunch of smaller TODOs.

checker.py uses speedup cache tables to look up whether certain pitch combinations are parallelFifths etc. But they did not work properly.  Uses hashable pitches to make sure they work.

Other #1938 TODOs:
- renamed hiddenFifth/hiddenOctave -> hiddenFifths/hiddenOctaves (matching parallelFifths/parallelOctaves) in possibility and checker
- couldBeItalianA6Resolution: make sure that thirds and fifths are present rather than crashing
- partPairs and checker zips use `strict=True` and fail if the two possibilities have different lengths.
- realizer: addElement/realize switch from .classes strings to isinstance;
- fixed a latent random.sample(dict.keys(), ...) bug surfaced by the typing
- realizerScale: scaleValue -> scaleTonic; notationString default '' 
- octaveless pitches work in more cases (using `implicitOctave`)
- Initialize dicts to {} instead of `None` - simplifying typing.
- documented why notation numbers can hold strings, etc.

Decided for now not to use `stream.template()` 

Deferred: segment.Segment - and perhaps others - make a ProtoM21Object

Next PR: get rid of special cases for 'RT' (RestToken) and '_' (extender line),  use a pitch with ps = 0.0 and number -1 respectively.

Fixes #1938.

AI-assisted (Claude), substantially discussed and reviewed by Myke