### PR TITLE
humdrum: Chord Duration improvements

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '11.0.0b3'
+__version__ = '11.0.0b4'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -26,7 +26,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'11.0.0b3'
+'11.0.0b4'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -1423,12 +1423,26 @@ class KernSpine(HumdrumSpine):
         # multipleNotes
         notesToProcess = eventC.split()
         chordNotes: list[note.Note] = []
+        # A note after the first that omits a duration, or just repeats the first
+        # note's, shares its Duration object.  A note with a genuinely different
+        # duration (the held `2g` in `4G 4e 2g`) keeps its own.
+        firstDuration: duration.Duration|None = None
+        firstDurationChars = ''
         for noteToProcess in notesToProcess:
-            thisNote = hdStringToNote(noteToProcess)
+            durationChars = ''.join(c for c in noteToProcess if c in '0123456789.%')
+            if firstDuration is not None and durationChars in ('', firstDurationChars):
+                # drop the repeated duration so the note reuses firstDuration
+                bareContents = re.sub(r'[0-9.%]', '', noteToProcess)
+                thisNote = hdStringToNote(bareContents, firstDuration)
+            else:
+                thisNote = hdStringToNote(noteToProcess)
+                if firstDuration is None:
+                    firstDuration = thisNote.duration
+                    firstDurationChars = durationChars
             if isinstance(thisNote, note.Note):
                 chordNotes.append(thisNote)
-        eventChord = chord.Chord(chordNotes, beams=chordNotes[-1].beams)
-        eventChord.duration = chordNotes[0].duration
+        eventChord = chord.Chord(chordNotes, beams=chordNotes[-1].beams,
+                                 duration=firstDuration)
 
         self.setBeamsForNote(eventChord)
         self.setTupletTypeForNote(eventChord)
@@ -2217,11 +2231,23 @@ class EventCollection(prebase.ProtoM21Object):
         return retEvents
 
 
-def hdStringToNote(contents: str) -> note.GeneralNote:
+def hdStringToNote(
+    contents: str,
+    defaultDurationOrNone: duration.Duration|None = None,
+) -> note.GeneralNote:
     '''
     returns a :class:`~music21.note.Note` (or Rest or Unpitched, etc.)
     matching the current SpineEvent.
     Does not check to see that it is sane or part of a :samp:`**kern` spine, etc.
+
+    If `contents` has no written duration, the note takes `defaultDurationOrNone`
+    when one is given, otherwise a quarter note.  This is used for chords whose
+    notes after the first omit a duration, e.g. the `E` and `G` in `8C E G`.
+    (In practice, all chords with notes of the same duration, such as
+    `16.C 16.E 16.G`, will be parsed as if the subsequent notes omit their
+    durations, e.g. as `16.C E G`, since processChordEvent removes duration
+    markers from the second and succeeding chord pitches whose durations are
+    identical to the first.)
 
     New rhythmic extensions formerly defined in
     `wiki.humdrum.org/index.php/Rational_rhythms`
@@ -2331,8 +2357,11 @@ def hdStringToNote(contents: str) -> note.GeneralNote:
     # Detect rests first, because rests can contain manual positioning information,
     # which is also detected by the `matchedNote` variable above.
     thisObject: note.GeneralNote
+    # Build with defaultDurationOrNone (None gives the usual default).  A note
+    # that omits its own duration then shares this exact Duration object rather
+    # than allocating a copy; one that has its own duration replaces it below.
     if 'r' in contents:
-        thisObject = note.Rest()
+        thisObject = note.Rest(duration=defaultDurationOrNone)
 
     elif matchedNote:
         kernNoteName = matchedNote.group(1)
@@ -2341,7 +2370,7 @@ def hdStringToNote(contents: str) -> note.GeneralNote:
             octave = 3 + len(kernNoteName)
         else:  # below middle C
             octave = 4 - len(kernNoteName)
-        builtNote = note.Note(octave=octave)
+        builtNote = note.Note(octave=octave, duration=defaultDurationOrNone)
         builtNote.step = step  # type: ignore[assignment]
         thisObject = builtNote
 
@@ -2444,6 +2473,12 @@ def hdStringToNote(contents: str) -> note.GeneralNote:
     # TODO: SPEEDUP -- only search for rational after foundNumber.
     foundRational = re.search(r'(\d+)%(\d+)', contents)
     foundNumber = re.search(r'(\d+)', contents)
+
+    if (foundRational or foundNumber) and defaultDurationOrNone is not None:
+        # we will be manipulating the duration, so we should give this object
+        # its own duration object
+        thisObject.duration = duration.Duration(1.0)
+
     if foundRational:
         durationFirst = int(foundRational.group(1))
         durationSecond = int(foundRational.group(2))

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -34,6 +34,7 @@ from music21.humdrum.spineParser import (
     SpineEvent,
     flavors,
     hdStringToMeasure,
+    hdStringToNote,
     kernTandemToObject,
 )
 
@@ -108,6 +109,78 @@ class Test(unittest.TestCase):
         self.assertTrue(n.duration.isGrace)
         self.assertEqual(n.duration.type, 'eighth')
         self.assertTrue(n.duration.slash)
+
+    def testChordNoteInheritsDefaultDuration(self):
+        '''
+        A note with no written duration takes the given defaultDurationOrNone
+        (the first note's duration in a chord), sharing the same Duration object;
+        a note with its own written duration ignores it.
+        '''
+        first = hdStringToNote('8C')
+        inherited = hdStringToNote('E', first.duration)
+        self.assertEqual(inherited.duration.type, 'eighth')
+        self.assertIs(inherited.duration, first.duration)
+
+        ownDuration = hdStringToNote('2G', first.duration)
+        self.assertEqual(ownDuration.duration.type, 'half')
+
+    def testPartiallyNotatedChordDurations(self):
+        '''
+        In a kern chord whose later notes omit a duration (`8C E G`), every note
+        takes the first note's duration instead of defaulting to a quarter; a
+        chord that notates each duration (`8C 2E 2G`) keeps them.
+        '''
+        krn = re.sub(r'\s\s\s\s+', '\t', r'''
+**kern
+*M4/4
+=1
+8C E G
+8C 2E 2G
+2r
+*-
+''')
+        hdc = HumdrumDataCollection(krn)
+        hdc.parse()
+        chords = list(hdc.stream.recurse().getElementsByClass('Chord'))
+        self.assertEqual(len(chords), 2)
+        partial, fullyNotated = chords
+        self.assertEqual([n.duration.type for n in partial],
+                         ['eighth', 'eighth', 'eighth'])
+        self.assertEqual([n.duration.type for n in fullyNotated],
+                         ['eighth', 'half', 'half'])
+
+    def testChordSharesMatchingDurationObjects(self):
+        '''
+        Chord notes that omit or repeat the first note's duration share its
+        Duration object; a note with a different duration keeps its own (e.g. the
+        held top voice in `4G 4e 2g`).
+        '''
+        krn = re.sub(r'\s\s\s\s+', '\t', r'''
+**kern
+*M4/4
+=1
+8C 8E 8G
+4G 4e 2g
+2r
+*-
+''')
+        hdc = HumdrumDataCollection(krn)
+        hdc.parse()
+        chords = list(hdc.stream.recurse().getElementsByClass('Chord'))
+        self.assertEqual(len(chords), 2)
+        matched, mixed = chords
+
+        # 8C 8E 8G: all three notes share one Duration object
+        matchedDurations = [n.duration for n in matched.notes]
+        self.assertEqual(len({id(d) for d in matchedDurations}), 1)
+
+        # 4G 4e 2g: the two quarters share one object, the half is its own
+        mixedDurations = [n.duration for n in mixed.notes]
+        quarters = [d for d in mixedDurations if d.type == 'quarter']
+        halves = [d for d in mixedDurations if d.type == 'half']
+        self.assertEqual(len(quarters), 2)
+        self.assertEqual(len(halves), 1)
+        self.assertEqual(len({id(d) for d in quarters}), 1)
 
     def testMeasureBoundaries(self):
         m0 = stream.Measure()


### PR DESCRIPTION
Method proposed by @alexandermorgan in #1706 and #1684 -- broken out so that the indentation didn't need to change to minimize the diffs.

1. In kern, a chord may notate the duration only on its first note (`8C E G`).   Existing bug: this becomes a Chord of duration 8th, with Notes C=eighth (linked duration), E=quarter!, G=quarter!.

2. Chords, now, like notes have already done, are also constructed so they generate only one duration object for the normal case of all matching durations.  Chords that notate each duration (`8C 2E 2G`) are unchanged.  hdStringToNote gains a `fallbackDuration` argument to pass in durations.

AI-assisted (Claude).  Reviewed by Myke.  Co-Authored by Alexander Morgan.