### PR TITLE
humdrum: separate Duration parsing, improve docs, typing

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '11.0.0b5'
+__version__ = '11.0.0b6'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -26,7 +26,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'11.0.0b5'
+'11.0.0b6'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -1697,7 +1697,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
 
     # SPECIAL METHODS #
-    
+
     def __eq__(self, other):
         '''
         Two durations are the same if their type, dots, tuplets, and

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -1271,7 +1271,7 @@ class Tuplet(prebase.ProtoM21Object):
 
         '''
         self._checkFrozen()
-        if common.isNum(durType) and not isinstance(durType, str):
+        if not isinstance(durType, str):
             durType = convertQuarterLengthToType(durType)
 
         self.durationActual = durationTupleFromTypeDots(durType, dots)
@@ -1633,7 +1633,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
                  /,
                  *,
                  type: str|None = None,  # pylint: disable=redefined-builtin
-                 dots: int|None = 0,
+                 dots: int = 0,
                  quarterLength: OffsetQLIn|None = None,
                  durationTuple: DurationTuple|None = None,
                  components: Iterable[DurationTuple]|None = None,
@@ -1697,6 +1697,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
 
 
     # SPECIAL METHODS #
+    
     def __eq__(self, other):
         '''
         Two durations are the same if their type, dots, tuplets, and

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -872,7 +872,7 @@ def durationTupleFromQuarterLength(ql=1.0) -> DurationTuple:
             return DurationTuple('inexpressible', 0, ql)
 
 
-def durationTupleFromTypeDots(durType='quarter', dots=0):
+def durationTupleFromTypeDots(durType: str = 'quarter', dots: int = 0) -> DurationTuple:
     '''
     Returns a DurationTuple (which knows its quarterLength) for
     a given type and dots (no tuplets)

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -2590,7 +2590,8 @@ def hdStringToNote(
         d = overrideDuration or hdStringToDuration(contents)
     except HumdrumException:
         d = duration.Duration(1.0)
-        warnings.warn(f'Could not find a duration in {contents}, using quarter note.')
+        warnings.warn(f'Could not find a duration in {contents}, using quarter note.',
+                      stacklevel=2)
 
     # 3.2.1 Pitches and 3.3 Rests
 

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -61,6 +61,7 @@ import math
 import re
 import typing as t
 import unittest
+import warnings
 import weakref
 
 from music21.common.numberTools import opFrac
@@ -69,6 +70,7 @@ from music21.common.types import OffsetQL
 from music21 import articulations
 from music21 import bar
 from music21 import base
+from music21 import beam  # cast only, can use 'beam' if it ever becomes circular.
 from music21 import chord
 from music21 import clef
 from music21 import common
@@ -1310,15 +1312,15 @@ class HumdrumSpine(prebase.ProtoM21Object):
         '''
         Extract duration characters from a token, returning what is left.
 
-        >>> humdrum.KernSpine.extractDuration('2cc.')
+        >>> humdrum.spineParser.KernSpine.extractDuration('2cc.')
         ('2.', 'cc')
 
         available on all Humdrum spines, since they might need duration
         information from other spines.
 
-        >>> humdrum.HumdrumSpine.extractDuration('3%2D')
+        >>> humdrum.spineParser.HumdrumSpine.extractDuration('3%2D')
         ('3%2', 'D')
-        >>> humdrum.HarmSpine.extractDuration('B#')
+        >>> humdrum.spineParser.HarmSpine.extractDuration('B#')
         ('', 'B#')
 
         For ``**kern``, this routine should be run separately for each component of a chord.
@@ -1333,7 +1335,6 @@ class HumdrumSpine(prebase.ProtoM21Object):
             else:
                 remain.append(c)
         return (''.join(d), ''.join(remain))
-
 
     def parse(self) -> None:
         '''
@@ -1467,13 +1468,19 @@ class KernSpine(HumdrumSpine):
 
     def processChordEvent(self, eventC: str) -> chord.Chord:
         '''
-        Process a single chord event
+        Process a single chord event.
 
         Like processNoteEvent, stores information about current beam and tuplet state.
+
+        The same duration object is normally used for each member of the chord
+        whether they write their duration out ('8C 8E 8G') or others omit them
+        ('8C E G' - not in spec, but often seen).  Humdrum spec does not technically
+        allow different durations ('8C 8E 4G'), but it is seen (Bach) so we support it.
         '''
         # multipleNotes
         notesToProcess = eventC.split()
         chordNotes: list[note.Note] = []
+
         # A note after the first that omits a duration, or just repeats the first
         # note's, shares its Duration object.  A note with a genuinely different
         # duration (the held `2g` in `4G 4e 2g`) keeps its own.
@@ -1482,17 +1489,24 @@ class KernSpine(HumdrumSpine):
         for noteToProcess in notesToProcess:
             durationChars, bareContents = self.extractDuration(noteToProcess)
             if firstDuration is not None and durationChars in ('', firstDurationChars):
-                thisNote = hdStringToNote(bareContents, firstDuration)
+                thisNote = hdStringToNote(bareContents, overrideDuration=firstDuration)
             else:
                 thisNote = hdStringToNote(noteToProcess)
                 if firstDuration is None:
                     firstDuration = thisNote.duration
                     firstDurationChars = durationChars
-            if isinstance(thisNote, note.Note):
+            if isinstance(thisNote, note.Note):  # perhaps unpitched maybe also?
                 chordNotes.append(thisNote)
-        eventChord = chord.Chord(chordNotes, beams=chordNotes[-1].beams,
-                                 duration=firstDuration)
+            # else -- error?
 
+        if not chordNotes:  # pragma: no cover
+            # for typing.
+            raise HumdrumException(
+                'Do not call processChordEvent unless there is at least one note'
+            )
+        eventChord = chord.Chord(chordNotes,
+                                 beams=chordNotes[-1].beams,
+                                 duration=firstDuration)
         self.setBeamsForNote(eventChord)
         self.setTupletTypeForNote(eventChord)
         self.lastNote = eventChord
@@ -1506,17 +1520,18 @@ class KernSpine(HumdrumSpine):
 
         Safe enough to use on elements such as rests that don't have beam info.
         '''
-        if not hasattr(n, 'beams'):
+        if not isinstance(n, note.NotRest):
             return None
 
-        if self.currentBeamNumbers != 0 and not n.beams.beamsList:
+        n_beams = t.cast(beam.Beams, n.beams)
+        if self.currentBeamNumbers != 0 and not n_beams.beamsList:
             for unused_counter in range(self.currentBeamNumbers):
-                n.beams.append('continue')
-        elif n.beams.beamsList:
-            if n.beams.beamsList[0].type == 'stop':
+                n_beams.append('continue')
+        elif n_beams.beamsList:
+            if n_beams.beamsList[0].type == 'stop':
                 self.currentBeamNumbers = 0
             else:
-                for thisBeam in n.beams.beamsList:
+                for thisBeam in n_beams.beamsList:
                     if thisBeam.type != 'stop':
                         self.currentBeamNumbers += 1
 
@@ -2282,109 +2297,62 @@ class EventCollection(prebase.ProtoM21Object):
             retEvents.append(self.getSpineOccurring(i))
         return retEvents
 
-
-def hdStringToNote(
-    contents: str,
-    overrideDuration: duration.Duration|None = None,
-) -> note.GeneralNote:
+def hdStringToDuration(contents: str) -> duration.Duration:
     '''
-    returns a :class:`~music21.note.Note` (or Rest or Unpitched, etc.)
-    matching the current SpineEvent.
-    Does not check to see that it is sane or part of a :samp:`**kern` spine, etc.
+    Convert ``contents`` to a :class:`~music21.duration.Duration` object.
 
-    If `contents` has no written duration, the note takes `overrideDuration`
-    when one is given, otherwise a quarter note.  This is used for chords whose
-    notes after the first omit a duration, e.g. the `E` and `G` in `8C E G`.
-    (In practice, all chords with notes of the same duration, such as
-    `16.C 16.E 16.G`, will be parsed as if the subsequent notes omit their
-    durations, e.g. as `16.C E G`, since processChordEvent removes duration
-    markers from the second and succeeding chord pitches whose durations are
-    identical to the first.)
+    >>> d = humdrum.spineParser.hdStringToDuration('32')
+    >>> d
+    <music21.duration.Duration 0.125>
+    >>> d.type
+    '32nd'
 
-    New rhythmic extensions formerly defined in
-    `wiki.humdrum.org/index.php/Rational_rhythms`
-    and now at https://extras.humdrum.org/man/rscale/
-    are fully implemented:
+    Other information such as pitch can be passed here (and in practice is passed here)
+    without affecting parsing, such as the ``C#`` here.
 
-    >>> n = humdrum.spineParser.hdStringToNote('CC3%2')
-    >>> n.duration.quarterLength
-    Fraction(8, 3)
-    >>> n.duration.fullName
-    'Whole Triplet (2 2/3 QL)'
-
-    >>> n = humdrum.spineParser.hdStringToNote('e-00.')
-    >>> n.pitch
-    <music21.pitch.Pitch E-4>
-    >>> n.duration.quarterLength
-    24.0
-    >>> n.duration.fullName
-    'Perfect Longa'
-
-    >>> n = humdrum.spineParser.hdStringToNote('F#000')
-    >>> n.duration.quarterLength
-    32.0
-    >>> n.duration.fullName
-    'Imperfect Maxima'
-
-    Note that the following example is interpreted as one note in the time of a
-    double-dotted quarter not a double-dotted quarter-note triplet.
-
-    I believe that the latter definition, though used in
-    https://kern.humdrum.org/cgi-bin/ksdata?l=musedata/mozart/quartet&file=k421-01.krn&f=kern
-    and the Josquin Research Project [JRP] is incorrect, seeing as it
-    contradicts the specification in
-    https://web.archive.org/web/20100203144730/http://www.music-cog.ohio-state.edu/Humdrum/representations/kern.html#N-Tuplets
-
-    >>> storedFlavors = humdrum.spineParser.flavors['JRP']  #_DOCS_HIDE
-
-    This is the default:
-
-    >>> humdrum.spineParser.flavors['JRP'] = False
-
-    >>> n = humdrum.spineParser.hdStringToNote('6..fff')
-    >>> n.duration.quarterLength
-    Fraction(7, 6)
-
-    >>> n.duration.dots
-    0
-
-    >>> n.duration.tuplets[0].durationNormal.dots
+    >>> d = humdrum.spineParser.hdStringToDuration('8C#..')
+    >>> d.type
+    'eighth'
+    >>> d.dots
     2
 
-    If you want the JRP definition, set humdrum.spineParser.flavors['JRP'] = True
-    before calling converter.parse() or anything like that:
+    Tuplets are represented with the number of them in a whole note, such as 12 for
+    eighth-note triplets:
 
-    >>> humdrum.spineParser.flavors['JRP'] = True
-    >>> n = humdrum.spineParser.hdStringToNote('6..fff')
-    >>> n.duration.quarterLength
-    Fraction(7, 6)
-    >>> n.duration.dots
-    2
-    >>> n.duration.tuplets[0].durationNormal.dots
-    0
+    >>> d = humdrum.spineParser.hdStringToDuration('12')
+    >>> d.fullName
+    'Eighth Triplet (1/3 QL)'
+    >>> d.type
+    'eighth'
+    >>> d.tuplets
+    (<music21.duration.Tuplet 3/2/eighth>,)
 
-    >>> n = humdrum.spineParser.hdStringToNote('gg#q/LL')
-    >>> n.duration
+    Grace notes are represented by ``q``.  A grace note without duration is an eighth note:
+
+    >>> d = humdrum.spineParser.hdStringToDuration('gg#q/LL')
+    >>> d
     <music21.duration.GraceDuration unlinked type:eighth quarterLength:0.0>
-    >>> n.duration.isGrace
+    >>> d.isGrace
     True
 
-    A grace note without duration is an eighth note.  If a duration, like ``16``,
-    is given, that type is preserved in the unlinked GraceDuration.  A single
-    ``q`` is a slashed grace note (acciaccatura):
+    If a duration, like ``16``, is given, that type is preserved in the
+    unlinked GraceDuration.
 
-    >>> n = humdrum.spineParser.hdStringToNote('16ccq')
-    >>> n.duration
+    >>> d = humdrum.spineParser.hdStringToDuration('16ccq')
+    >>> d
     <music21.duration.GraceDuration unlinked type:16th quarterLength:0.0>
-    >>> n.duration.slash
+
+    A single ``q`` is a slashed grace note (acciaccatura):
+
+    >>> d.slash
     True
 
     Two ``q``\\s signify a grace note without a slash (or accented grace note):
 
-    >>> n = humdrum.spineParser.hdStringToNote('16ccqq')
-    >>> n.duration.type
+    >>> d = humdrum.spineParser.hdStringToDuration('16ccqq')
+    >>> d.type
     '16th'
-    >>> n.duration.slash
+    >>> d.slash
     False
 
     .. note::
@@ -2394,14 +2362,235 @@ def hdStringToNote(
         note.  Given no way of distinguishing these interpretations, music21
         will remain with the original version; so ``Q`` and ``qq`` are synonyms.
 
-    * Changed in v11: grace notes keep their written duration, and ``qq`` is
-      parsed as an unslashed grace note.
+    New rhythmic extensions formerly defined in
+    `wiki.humdrum.org/index.php/Rational_rhythms`
+    and now at https://extras.humdrum.org/man/rscale/
+    are fully implemented:
 
-    >>> humdrum.spineParser.flavors['JRP'] = storedFlavors  #_DOCS_HIDE
+    >>> d = humdrum.spineParser.hdStringToDuration('CC3%2')
+    >>> d.quarterLength
+    Fraction(8, 3)
+    >>> d.fullName
+    'Whole Triplet (2 2/3 QL)'
 
+    >>> d = humdrum.spineParser.hdStringToDuration('e-00.')
+    >>> d.quarterLength
+    24.0
+    >>> d.fullName
+    'Perfect Longa'
+
+    >>> d = humdrum.spineParser.hdStringToDuration('F#000')
+    >>> d.quarterLength
+    32.0
+    >>> d.fullName
+    'Imperfect Maxima'
+
+    Note that the following example is interpreted as one note in the time of a
+    double-dotted quarter (not a double-dotted quarter-note triplet).
+
+    >>> stored_JRP_Flavor = humdrum.spineParser.flavors['JRP']  #_DOCS_HIDE
+    >>> humdrum.spineParser.flavors['JRP'] = False  #_DOCS_HIDE
+
+    >>> d = humdrum.spineParser.hdStringToDuration('6..fff')
+    >>> d.quarterLength
+    Fraction(7, 6)
+    >>> d.dots
+    0
+    >>> d.tuplets[0].durationNormal.dots
+    2
+    >>> d.tuplets[0].totalTupletLength()
+    3.5
+
+    The latter definition (a double-dotted quarter-note triplet) though used in
+    https://kern.humdrum.org/cgi-bin/ksdata?l=musedata/mozart/quartet&file=k421-01.krn&f=kern
+    and the Josquin Research Project (JRP) is incorrect, seeing as it
+    contradicts the specification in
+    https://www.humdrum.org/Humdrum/representations/kern.html#N-Tuplets
+    (_"92.." is the correct ``**kern`` encoding for a note whose duration is
+    23 notes in the time of a doubly-dotted quarter._)
+
+    We will call the second interpretation the "JRP Flavor". The default JRP Flavor is False::
+
+    >>> humdrum.spineParser.flavors['JRP']
+    False
+
+    If you want the JRP definition, where dots apply to the note, not tuplet,
+    set humdrum.spineParser.flavors['JRP'] = True before calling converter.parse()
+    or anything other parsing routine like hdStringToDuration:
+
+    >>> humdrum.spineParser.flavors['JRP'] = True
+    >>> d = humdrum.spineParser.hdStringToDuration('6..fff')
+
+    Note that the quarter length of the individual note is the same:
+
+    >>> d.quarterLength
+    Fraction(7, 6)
+
+    But the representation of how many dots are on the note as opposed to
+    the total tuplet duration is quite different.
+
+    >>> d.dots
+    2
+    >>> d.tuplets[0].durationNormal.dots
+    0
+    >>> d.tuplets[0].totalTupletLength()
+    2.0
+
+    >>> humdrum.spineParser.flavors['JRP'] = stored_JRP_Flavor  #_DOCS_HIDE
+
+    If no duration number can be found and this is not a grace note (which gets
+    a default eighth-note duration), then a HumdrumException is raised.
+
+    >>> humdrum.spineParser.hdStringToDuration('nada')
+    Traceback (most recent call last):
+    music21.humdrum.spineParser.HumdrumException: Could not find a duration in 'nada'
+
+    * Changed in v11: Duration extraction moved to hdStringToDuration.
+        Grace notes keep their written duration, and ``qq`` is
+        parsed as an unslashed grace note.
     '''
 
+    # 3.2.7 Duration and
+    # 3.2.8 N-Tuplets
+
+    # Rational durations are rare, and require a '%'; skip the regex without one.
+    foundRational = re.search(r'(\d+)%(\d+)', contents) if '%' in contents else None
+    foundNumber = re.search(r'(\d+)', contents)
+
+    numDots = contents.count('.')
+    hasGrace = 'q' in contents or 'Q' in contents
+
+    d: duration.Duration
+    if foundRational:
+        durationFirst = int(foundRational.group(1))
+        durationSecond = int(foundRational.group(2))
+        d = duration.Duration(
+            quarterLength=opFrac(4 * durationSecond / durationFirst),
+        )
+        # append dots after the quarterLength has been computed.
+        d.dots = numDots
+
+    elif foundNumber:
+        humdrumDurationNumber = int(foundNumber.group(1))
+        d_type: str
+        if humdrumDurationNumber == 0:
+            durationString = foundNumber.group(1)
+            if durationString == '000':
+                # for larger values, see https://extras.humdrum.org/man/rscale/
+                d_type = 'maxima'
+            elif durationString == '00':
+                # for larger values, see https://extras.humdrum.org/man/rscale/
+                d_type = 'longa'
+            else:
+                d_type = 'breve'
+            d = duration.Duration(type=d_type, dots=numDots)
+        elif humdrumDurationNumber in duration.typeFromNumDict:
+            d_type = duration.typeFromNumDict[humdrumDurationNumber]
+            d = duration.Duration(type=d_type, dots=numDots)
+        else:
+            exponents = math.floor(math.log2(humdrumDurationNumber))
+            baseValue = t.cast(int, 2 ** exponents)
+            d_type = duration.typeFromNumDict[baseValue]
+            newTup = duration.Tuplet()
+            newTup.durationActual = duration.durationTupleFromTypeDots(d_type, 0)
+            newTup.durationNormal = newTup.durationActual
+
+            gcd = math.gcd(humdrumDurationNumber, baseValue)
+            newTup.numberNotesActual = humdrumDurationNumber // gcd
+            newTup.numberNotesNormal = baseValue // gcd
+
+            # The Josquin Research Project uses a definition of
+            # Humdrum tuplets that breaks normal usage.
+            JRP = flavors['JRP']
+            if not JRP and numDots:
+                # normal Humdrum way of interpreting dots -- they apply to the tuplet
+                newTup.durationNormal = duration.durationTupleFromTypeDots(d_type, numDots)
+            d = duration.Duration(type=d_type)
+            d.appendTuplet(newTup)
+            if JRP and numDots:
+                d.dots = numDots
+            # call Duration.TupletFixer after to correct this.
+    elif hasGrace:
+        d = duration.Duration(type='eighth')
+    else:
+        raise HumdrumException(f'Could not find a duration in {contents!r}')
+
+    # 3.2.9 Grace Notes and Groupettos
+    # A single `q` is a slashed grace note; `qq` or `Q` is an unslashed grace note.
+    # A grace note keeps its written duration; with none written it defaults to an eighth.
+    if hasGrace:
+        d = d.getGraceDuration(appoggiatura=False)
+        if foundNumber is None:
+            d.type = 'eighth'
+        # != 1: number of q's == 0 (because it's a capital Q) or 2+ (== qq)
+        if contents.count('q') != 1:
+            t.cast(GraceDuration, d).slash = False
+    elif 'P' in contents:
+        d = d.getGraceDuration(appoggiatura=True)
+    elif 'p' in contents:
+        pass  # end appoggiatura duration -- not recorded in music21...
+
+    return d
+
+
+def hdStringToNote(
+    contents: str,
+    *,
+    overrideDuration: duration.Duration|None = None,
+) -> note.GeneralNote:
+    '''
+    returns a :class:`~music21.note.Note` (or Rest or Unpitched, etc.)
+    matching the current SpineEvent.
+
+    Does not check to see that it is sane or part of a :samp:`**kern` spine, etc.
+
+    If `contents` has no written duration, the note should have had `overrideDuration`
+    given, as happens with chord members.
+
+    >>> n = humdrum.spineParser.hdStringToNote('4CC.')
+    >>> n.fullName
+    'C in octave 2 Dotted Quarter Note'
+
+    >>> n = humdrum.spineParser.hdStringToNote('12dd##')
+    >>> n.fullName
+    'D-double-sharp in octave 5 Eighth Triplet (1/3 QL) Note'
+
+    If `overrideDuration` is passed in as a Duration object, that is used no matter what::
+
+    >>> n = humdrum.spineParser.hdStringToNote('12dd##',
+    ...         overrideDuration=duration.Duration('whole'))
+    >>> n.duration
+    <music21.duration.Duration 4.0>
+    >>> n.duration.type
+    'whole'
+
+    The `overrideDuration` is needed if a note is not a grace note. For instance, for
+    chord members after the first one.
+
+    >>> n = humdrum.spineParser.hdStringToNote('BBB--',
+    ...         overrideDuration=duration.Duration('eighth'))
+    >>> n.fullName
+    'B-double-flat in octave 1 Eighth Note'
+
+    Otherwise, it uses a quarter note and gives a warning.  This may become an error in
+    future versions::
+
+    >>> import warnings
+    >>> with warnings.catch_warnings(record=True) as w:
+    ...      n = humdrum.spineParser.hdStringToNote('B-')
+    ...      n.fullName
+    'B-flat in octave 3 Quarter Note'
+    >>> w[0].message
+    UserWarning('Could not find a duration in B-, using quarter note.')
+    '''
     # http://www.lib.virginia.edu/artsandmedia/dmmc/Music/Humdrum/kern_hlp.html#kern
+
+    # Get duration early
+    try:
+        d = overrideDuration or hdStringToDuration(contents)
+    except HumdrumException:
+        d = duration.Duration(1.0)
+        warnings.warn(f'Could not find a duration in {contents}, using quarter note.')
 
     # 3.2.1 Pitches and 3.3 Rests
 
@@ -2410,7 +2599,7 @@ def hdStringToNote(
     # need that search at all.
     thisObject: note.GeneralNote
     if 'r' in contents:
-        thisObject = note.Rest(duration=overrideDuration)
+        thisObject = note.Rest(duration=d)
 
     elif matchedNote := re.search('([a-gA-G]+)', contents):
         kernNoteName = matchedNote.group(1)
@@ -2419,7 +2608,7 @@ def hdStringToNote(
             octave = 3 + len(kernNoteName)
         else:  # below middle C
             octave = 4 - len(kernNoteName)
-        builtNote = note.Note(octave=octave, duration=overrideDuration)
+        builtNote = note.Note(octave=octave, duration=d)
         builtNote.step = step  # type: ignore[assignment]
         thisObject = builtNote
 
@@ -2514,87 +2703,6 @@ def hdStringToNote(
             thisObject.stemDirection = 'up'
         elif '\\' in contents:
             thisObject.stemDirection = 'down'
-
-    # 3.2.7 Duration and
-    # 3.2.8 N-Tuplets
-
-    # Rational durations are rare, and require a '%'; skip the regex without one.
-    foundRational = re.search(r'(\d+)%(\d+)', contents) if '%' in contents else None
-    foundNumber = re.search(r'(\d+)', contents)
-
-    if overrideDuration is not None and foundNumber:
-        # we will be manipulating the duration, so we should give this object
-        # its own duration object (foundRational implies foundNumber, so this
-        # also covers rational durations)
-        thisObject.duration = duration.Duration(1.0)
-
-    if foundRational:
-        durationFirst = int(foundRational.group(1))
-        durationSecond = int(foundRational.group(2))
-        thisObject.duration.quarterLength = opFrac(4 * durationSecond / durationFirst)
-        if '.' in contents:
-            thisObject.duration.dots = contents.count('.')
-
-    elif foundNumber:
-        durationType = int(foundNumber.group(1))
-        if durationType == 0:
-            durationString = foundNumber.group(1)
-            if durationString == '000':
-                # for larger values, see https://extras.humdrum.org/man/rscale/
-                thisObject.duration.type = 'maxima'
-            elif durationString == '00':
-                # for larger values, see https://extras.humdrum.org/man/rscale/
-                thisObject.duration.type = 'longa'
-            else:
-                thisObject.duration.type = 'breve'
-            if '.' in contents:
-                thisObject.duration.dots = contents.count('.')
-        elif durationType in duration.typeFromNumDict:
-            thisObject.duration.type = duration.typeFromNumDict[durationType]
-            if '.' in contents:
-                thisObject.duration.dots = contents.count('.')
-        else:
-            dT = int(durationType) + 0.0
-            (unused_remainder, exponents) = math.modf(math.log2(dT))
-            baseValue = 2 ** exponents
-            thisObject.duration.type = duration.typeFromNumDict[int(baseValue)]
-            newTup = duration.Tuplet()
-            newTup.durationActual = duration.durationTupleFromTypeDots(thisObject.duration.type, 0)
-            newTup.durationNormal = duration.durationTupleFromTypeDots(thisObject.duration.type, 0)
-
-            gcd = math.gcd(int(dT), int(baseValue))
-            newTup.numberNotesActual = int(dT / gcd)
-            newTup.numberNotesNormal = int(float(baseValue) / gcd)
-
-            # The Josquin Research Project uses an incorrect definition of
-            # Humdrum tuplets that breaks normal usage.  TODO: Refactor adding a Flavor = 'JRP'
-            # code that uses this other method.
-            JRP = flavors['JRP']
-            if not JRP and '.' in contents:
-                newTup.durationNormal = duration.durationTupleFromTypeDots(
-                    newTup.durationNormal.type, contents.count('.'))
-
-            thisObject.duration.appendTuplet(newTup)
-            if JRP and '.' in contents:
-                thisObject.duration.dots = contents.count('.')
-            # call Duration.TupletFixer after to correct this.
-
-    # 3.2.9 Grace Notes and Groupettos
-    # A single `q` is a slashed grace note; `qq` or `Q` is an unslashed grace note.
-    # A grace note keeps its written duration; with none written it defaults to an eighth.
-    qCount = contents.count('q')
-    if qCount or 'Q' in contents:
-        thisObject = thisObject.getGrace()
-        if foundNumber is None:
-            thisObject.duration.type = 'eighth'
-        # != 1: number of q's == 0 (because it's a capital Q) or 2+ (== qq)
-        if qCount != 1:
-            graceDuration = t.cast(GraceDuration, thisObject.duration)
-            graceDuration.slash = False
-    elif 'P' in contents:
-        thisObject = thisObject.getGrace(appoggiatura=True)
-    elif 'p' in contents:
-        pass  # end appoggiatura duration -- not needed in music21...
 
     # 3.2.10 Beaming
     if isinstance(thisObject, note.NotRest):
@@ -3048,6 +3156,9 @@ class GlobalReference(base.Music21Object):
 
     def _reprInternal(self) -> str:
         return f'{self.code} {self.value!r}'
+
+
+# -----------------------------------------------------------------------------
 
 
 class Test(unittest.TestCase):

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -44,16 +44,15 @@ SpineParsing consists of several steps.
 
 * Changed in v10: flag attributes `isSpineLine, isComment, isGlobal, isReference` have been
     removed from HumdrumLine and all subclasses. `isinstance(...)` is a bit slower than
-    checking these, but adds correct typing.  Nothing is stored with weakrefs.  `.iterIndex`
-    and hand rolled iterator/generators are gone now (could've gone when Python 2.4 became
+    checking these, but adds correct typing.  `.iterIndex` and hand rolled iterator/generators
+    are gone now (they could've gone away when Python 2.4 became
     the minimum version).  `HumdrumDataCollection.parsePositionInStream` is gone (was
     duplicating `numLines`); `HumdrumDataCollection.fileLength` is now the read-only
     property `numLines` (= `len(self.dataStream)`); `HumdrumLine.position` and
     `SpineEvent.position` were both renamed to `lineNumber` and now hold the 1-based
-    source line number (was eventList index for SpineEvent),
-    advancing on blank lines too.  Blank lines now produce `BlankLine` HumdrumLine
-    entries rather than being skipped, so `eventList[lineNumber - 1]` always
-    resolves to the line at that source position.
+    source line number (was eventList index for SpineEvent), advancing on blank lines too.
+    Blank lines now produce `BlankLine` HumdrumLine entries rather than being skipped,
+    in order that `eventList[lineNumber - 1]` always resolve to the line at that source position.
 '''
 from __future__ import annotations
 
@@ -159,7 +158,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         if isinstance(dataStream, str):
             dataStream = dataStream.splitlines()
 
-        self.dataStream: list[str] = dataStream
+        self.dataStream = t.cast(list[str], dataStream)
         # Defaults to a Score; parseOpusDataCollections will replace it with
         # an Opus if the input turns out to be a multipart file.
         self.stream: stream.Score|stream.Opus = stream.Score()
@@ -204,11 +203,12 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         self.parseEventListFromDataStream(dataStream)  # sets self.eventList
         self.parseProtoSpinesAndEventCollections()
         self.spineCollection = self.createHumdrumSpines()
-        self.spineCollection.createMusic21Streams()
+        spineCollection = t.cast(SpineCollection, self.spineCollection)
+        spineCollection.createMusic21Streams()
         self.insertGlobalEvents()
-        for thisSpine in self.spineCollection:
+        for thisSpine in spineCollection:
             thisSpine.stream.id = 'spine_' + str(thisSpine.id)
-        for thisSpine in self.spineCollection:
+        for thisSpine in spineCollection:
             if thisSpine.parentSpine is None and thisSpine.spineType == 'kern':
                 score.insert(thisSpine.stream)
 
@@ -1670,6 +1670,9 @@ class SpineEvent(prebase.ProtoM21Object):
         <music21.note.Note D#>
         >>> n.octave
         2
+
+        Default duration is a quarter note.
+
         >>> n.duration.type
         'quarter'
         '''

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -109,7 +109,7 @@ These are unfortunately not usually indicated in the scores themselves
 Music21 currently supports one flavor type, ``JRP`` for Stanford's
 Josquin Research Project, which interprets dots on tuplets differently
 from other parts of the Humdrum community (in a way that is more typically
-seen in early music).  Switch ``music21.humdrum.flavors['JRP'] = True` to
+seen in early music).  Switch ``music21.humdrum.flavors['JRP'] = True`` to
 get that behavior before parsing.
 '''
 
@@ -1307,35 +1307,6 @@ class HumdrumSpine(prebase.ProtoM21Object):
 
         return streamOut
 
-    @staticmethod
-    def extractDuration(eventC: str) -> tuple[str, str]:
-        '''
-        Extract duration characters from a token, returning what is left.
-
-        >>> humdrum.spineParser.KernSpine.extractDuration('2cc.')
-        ('2.', 'cc')
-
-        available on all Humdrum spines, since they might need duration
-        information from other spines.
-
-        >>> humdrum.spineParser.HumdrumSpine.extractDuration('3%2D')
-        ('3%2', 'D')
-        >>> humdrum.spineParser.HarmSpine.extractDuration('B#')
-        ('', 'B#')
-
-        For ``**kern``, this routine should be run separately for each component of a chord.
-
-        New in v11.
-        '''
-        d = []
-        remain = []
-        for c in eventC:
-            if c in '0123456789.%':
-                d.append(c)
-            else:
-                remain.append(c)
-        return (''.join(d), ''.join(remain))
-
     def parse(self) -> None:
         '''
         Dummy method that pushes all these objects to HumdrumSpine.stream
@@ -1487,7 +1458,7 @@ class KernSpine(HumdrumSpine):
         firstDuration: duration.Duration|None = None
         firstDurationChars = ''
         for noteToProcess in notesToProcess:
-            durationChars, bareContents = self.extractDuration(noteToProcess)
+            durationChars, bareContents = extractDuration(noteToProcess)
             if firstDuration is not None and durationChars in ('', firstDurationChars):
                 thisNote = hdStringToNote(bareContents, overrideDuration=firstDuration)
             else:
@@ -2297,6 +2268,32 @@ class EventCollection(prebase.ProtoM21Object):
             retEvents.append(self.getSpineOccurring(i))
         return retEvents
 
+
+def extractDuration(eventC: str) -> tuple[str, str]:
+    '''
+    Extract duration characters from a token, returning what is left.
+
+    >>> humdrum.spineParser.extractDuration('2cc.')
+    ('2.', 'cc')
+    >>> humdrum.spineParser.extractDuration('3%2D')
+    ('3%2', 'D')
+    >>> humdrum.spineParser.extractDuration('B#')
+    ('', 'B#')
+
+    For ``**kern``, this routine should be run separately for each component of a chord.
+
+    New in v11.
+    '''
+    d = []
+    remain = []
+    for c in eventC:
+        if c in '0123456789.%':
+            d.append(c)
+        else:
+            remain.append(c)
+    return (''.join(d), ''.join(remain))
+
+
 def hdStringToDuration(contents: str) -> duration.Duration:
     '''
     Convert ``contents`` to a :class:`~music21.duration.Duration` object.
@@ -2577,11 +2574,14 @@ def hdStringToNote(
 
     >>> import warnings
     >>> with warnings.catch_warnings(record=True) as w:
+    ...      warnings.simplefilter('always')  # _DOCS_HIDE
     ...      n = humdrum.spineParser.hdStringToNote('B-')
     ...      n.fullName
     'B-flat in octave 3 Quarter Note'
     >>> w[0].message
-    UserWarning('Could not find a duration in B-, using quarter note.')
+    UserWarning("Could not find a duration in 'B-', using quarter note.")
+
+    * Changed in v11: give a warning if no duration can be found and a quarter default was used.
     '''
     # http://www.lib.virginia.edu/artsandmedia/dmmc/Music/Humdrum/kern_hlp.html#kern
 
@@ -2590,7 +2590,7 @@ def hdStringToNote(
         d = overrideDuration or hdStringToDuration(contents)
     except HumdrumException:
         d = duration.Duration(1.0)
-        warnings.warn(f'Could not find a duration in {contents}, using quarter note.',
+        warnings.warn(f'Could not find a duration in {contents!r}, using quarter note.',
                       stacklevel=2)
 
     # 3.2.1 Pitches and 3.3 Rests

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -99,6 +99,18 @@ if t.TYPE_CHECKING:
 environLocal = environment.Environment('humdrum.spineParser')
 
 flavors = {'JRP': False}
+'''
+Humdrum has developed several "flavors" or local varieties of parsing.
+These are unfortunately not usually indicated in the scores themselves
+(since communities mostly work within their own flavor groups).
+
+Music21 currently supports one flavor type, ``JRP`` for Stanford's
+Josquin Research Project, which interprets dots on tuplets differently
+from other parts of the Humdrum community (in a way that is more typically
+seen in early music).  Switch ``music21.humdrum.flavors['JRP'] = True` to
+get that behavior before parsing.
+'''
+
 
 spinePathIndicators = ['*+', '*-', '*^', '*v', '*x', '*']
 
@@ -115,7 +127,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
     .. note:: Most users should not need to be here.  Just run `converter.parse('file.krn')`
         and it will give you a stream.Score instead.
         Intermediate users who want to get into the guts of Humdrum are still
-        probably better off running humdrum.parseFile("filename")
+        probably better off running humdrum.parseFile('filename')
         which returns a humdrum.SpineCollection directly.
 
     A HumdrumDataCollection takes in a mandatory list where each element
@@ -128,10 +140,10 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
     have it as a string.
 
     LIMITATIONS:
-    (1) Spines cannot change definition (\*\*exclusive interpretations) mid-spine.
+    (1) Spines cannot change definition (``**exclusive`` interpretations) mid-spine.
 
-        So if you start off with \*\*kern, the rest of the spine needs to be
-        \*\*kern (actually, the first exclusive interpretation for a spine is
+        So if you start off with ``**kern``, the rest of the spine needs to be
+        ``**kern`` (actually, the first exclusive interpretation for a spine is
         used throughout).
 
         Note that, even though changing exclusive interpretations mid-spine
@@ -140,13 +152,12 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         definitions mid-spine, so I don't think this limitation is a problem.
         (Craig Stuart Sapp confirmed this to me.)
 
-        The Aarden/Miller Palestrina dataset uses `\*-` followed by `\*\*kern`
+        The Aarden/Miller Palestrina dataset uses ``\*-`` followed by ``**kern``
         at the changes of sections thus some parsing of multiple exclusive
         interpretations in a protospine may be necessary.  But none change definition.
 
     (2) Split spines are assumed to be voices in a single spine staff.
     '''
-
     def __init__(self, dataStream: str|list[str]) -> None:
         # attributes
         self.eventList: list[HumdrumLine] = []
@@ -1056,10 +1067,10 @@ class ProtoSpine(prebase.ProtoM21Object):
 class HumdrumSpine(prebase.ProtoM21Object):
     r'''
     A HumdrumSpine is a representation of a generic HumdrumSpine
-    regardless of \*\*definition after spine path indicators have
+    regardless of ``**definition`` after spine path indicators have
     been simplified.
 
-    A subclass of HumdrumSpine should be defined for each \*\*type. Those
+    A subclass of HumdrumSpine should be defined for each ``**type``. Those
     subclasses cannot redefine `__init__()`
 
     A HumdrumSpine is a collection of events arranged vertically that have a
@@ -1294,6 +1305,36 @@ class HumdrumSpine(prebase.ProtoM21Object):
 
         return streamOut
 
+    @staticmethod
+    def extractDuration(eventC: str) -> tuple[str, str]:
+        '''
+        Extract duration characters from a token, returning what is left.
+
+        >>> humdrum.KernSpine.extractDuration('2cc.')
+        ('2.', 'cc')
+
+        available on all Humdrum spines, since they might need duration
+        information from other spines.
+
+        >>> humdrum.HumdrumSpine.extractDuration('3%2D')
+        ('3%2', 'D')
+        >>> humdrum.HarmSpine.extractDuration('B#')
+        ('', 'B#')
+
+        For ``**kern``, this routine should be run separately for each component of a chord.
+
+        New in v11.
+        '''
+        d = []
+        remain = []
+        for c in eventC:
+            if c in '0123456789.%':
+                d.append(c)
+            else:
+                remain.append(c)
+        return (''.join(d), ''.join(remain))
+
+
     def parse(self) -> None:
         '''
         Dummy method that pushes all these objects to HumdrumSpine.stream
@@ -1328,7 +1369,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
 
 class KernSpine(HumdrumSpine):
     r'''
-    A KernSpine is a type of Humdrum spine with the \*\*kern
+    A KernSpine is a type of Humdrum spine with the ``**kern``
     attribute set and thus events are processed as if they
     are kern notes.
 
@@ -1348,14 +1389,23 @@ class KernSpine(HumdrumSpine):
     currentTupletQL: OffsetQL
     desiredTupletQL: OffsetQL
 
-    def parse(self) -> None:
-        humdrumLineNumbers = self.parentSpineCollection.humdrumLineNumbers
+    def setup(self) -> None:
+        '''
+        Pre-parse setup routines for KernSpine.
+
+        These set defaults for attributes which would normally be defined in __init__
+        if we weren't reclassing spines.
+        '''
         self.lastContainer = hdStringToMeasure('=0')
         self.inTuplet = False
         self.lastNote = None
         self.currentBeamNumbers = 0
         self.currentTupletQL = 0.0
         self.desiredTupletQL = 0.0
+
+    def parse(self) -> None:
+        self.setup()
+        humdrumLineNumbers = self.parentSpineCollection.humdrumLineNumbers
 
         for event in self.eventList:
             # event is a SpineEvent object
@@ -1430,10 +1480,8 @@ class KernSpine(HumdrumSpine):
         firstDuration: duration.Duration|None = None
         firstDurationChars = ''
         for noteToProcess in notesToProcess:
-            durationChars = ''.join(c for c in noteToProcess if c in '0123456789.%')
+            durationChars, bareContents = self.extractDuration(noteToProcess)
             if firstDuration is not None and durationChars in ('', firstDurationChars):
-                # drop the repeated duration so the note reuses firstDuration
-                bareContents = re.sub(r'[0-9.%]', '', noteToProcess)
                 thisNote = hdStringToNote(bareContents, firstDuration)
             else:
                 thisNote = hdStringToNote(noteToProcess)
@@ -1503,7 +1551,7 @@ class KernSpine(HumdrumSpine):
 
 class DynamSpine(HumdrumSpine):
     r'''
-    A DynamSpine is a type of Humdrum spine with the \*\*dynam
+    A DynamSpine is a type of Humdrum spine with the ``**dynam``
     attribute set and thus events are processed as if they
     are dynamics.
     '''
@@ -1552,12 +1600,12 @@ class DynamSpine(HumdrumSpine):
 
 class HarmSpine(HumdrumSpine):
     r'''
-    A HarmSpine is a type of Humdrum spine with the \*\*harm
+    A HarmSpine is a type of Humdrum spine with the ``**harm``
     attribute set and thus events are processed as if they
     are harmonic analysis annotations in the "harm" syntax.
 
     The harm roman numeral annotations are parsed using
-    a superset of the original \*\*harm Humdrum representation, written
+    a superset of the original ``**harm`` Humdrum representation, written
     for python and extending the syntax based on other projects like the
     RomanText and the MuseScore roman numeral notations.
     '''
@@ -1661,7 +1709,7 @@ class SpineEvent(prebase.ProtoM21Object):
 
     def toNote(self, convertString: str|None = None) -> note.GeneralNote:
         r'''
-        parse the object as a \*\*kern note and return a
+        parse the object as a ``**kern`` note and return a
         :class:`~music21.note.Note` object (or Rest, or Chord)
 
         >>> se = humdrum.spineParser.SpineEvent('DD#4')
@@ -1926,7 +1974,7 @@ class SpineCollection(prebase.ProtoM21Object):
         r'''
         Changes the classes of HumdrumSpines to more specific types
         (KernSpine, DynamicSpine)
-        according to their spineType (e.g., \*\*kern, \*\*dynam)
+        according to their spineType (e.g., ``**kern``, ``**dynam``)
         '''
         for thisSpine in self.spines:
             if thisSpine.spineType == 'kern':
@@ -2237,14 +2285,14 @@ class EventCollection(prebase.ProtoM21Object):
 
 def hdStringToNote(
     contents: str,
-    defaultDurationOrNone: duration.Duration|None = None,
+    overrideDuration: duration.Duration|None = None,
 ) -> note.GeneralNote:
     '''
     returns a :class:`~music21.note.Note` (or Rest or Unpitched, etc.)
     matching the current SpineEvent.
     Does not check to see that it is sane or part of a :samp:`**kern` spine, etc.
 
-    If `contents` has no written duration, the note takes `defaultDurationOrNone`
+    If `contents` has no written duration, the note takes `overrideDuration`
     when one is given, otherwise a quarter note.  This is used for chords whose
     notes after the first omit a duration, e.g. the `E` and `G` in `8C E G`.
     (In practice, all chords with notes of the same duration, such as
@@ -2360,13 +2408,9 @@ def hdStringToNote(
     # Detect rests first, because rests can contain manual positioning information
     # (a pitch letter) that the note search would otherwise pick up; only notes
     # need that search at all.
-    #
-    # Build with defaultDurationOrNone (None gives the usual default).  A note
-    # that omits its own duration then shares this exact Duration object rather
-    # than allocating a copy; one that has its own duration replaces it below.
     thisObject: note.GeneralNote
     if 'r' in contents:
-        thisObject = note.Rest(duration=defaultDurationOrNone)
+        thisObject = note.Rest(duration=overrideDuration)
 
     elif matchedNote := re.search('([a-gA-G]+)', contents):
         kernNoteName = matchedNote.group(1)
@@ -2375,7 +2419,7 @@ def hdStringToNote(
             octave = 3 + len(kernNoteName)
         else:  # below middle C
             octave = 4 - len(kernNoteName)
-        builtNote = note.Note(octave=octave, duration=defaultDurationOrNone)
+        builtNote = note.Note(octave=octave, duration=overrideDuration)
         builtNote.step = step  # type: ignore[assignment]
         thisObject = builtNote
 
@@ -2385,9 +2429,9 @@ def hdStringToNote(
     # The count of '#' (or '-') gives the number of sharps (or flats) directly,
     # which is also the Accidental's alteration -- no regex needed.
     if isinstance(thisObject, note.Note):
-        if (sharps := contents.count('#')):
+        if sharps := contents.count('#'):
             thisObject.pitch.accidental = pitch.Accidental(sharps)
-        elif (flats := contents.count('-')):
+        elif flats := contents.count('-'):
             thisObject.pitch.accidental = pitch.Accidental(-flats)
         elif 'n' in contents:
             thisObject.pitch.accidental = pitch.Accidental('n')
@@ -2478,7 +2522,7 @@ def hdStringToNote(
     foundRational = re.search(r'(\d+)%(\d+)', contents) if '%' in contents else None
     foundNumber = re.search(r'(\d+)', contents)
 
-    if defaultDurationOrNone is not None and foundNumber:
+    if overrideDuration is not None and foundNumber:
         # we will be manipulating the duration, so we should give this object
         # its own duration object (foundRational implies foundNumber, so this
         # also covers rational durations)

--- a/music21/humdrum/testFiles.py
+++ b/music21/humdrum/testFiles.py
@@ -115,7 +115,7 @@ ojibway = re.sub(r'\s\s\s\s+', '\t',
 '''
                  )
 
-# Tests the two kinds of flavors of JRP
+# Tests the two kinds of flavors of parsing dotted tuplets, regular and JRP
 dottedTuplet = re.sub(r'\s\s\s\s+', '\t',
                       r'''
 **kern

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -18,12 +18,14 @@ for the deep-copy round trip.
 from __future__ import annotations
 
 import re
+import typing as t
 import unittest
 
 from music21 import bar
 from music21 import common
 from music21 import dynamics
 from music21 import expressions
+from music21 import note
 from music21 import roman
 from music21 import stream
 from music21.humdrum import testFiles
@@ -34,7 +36,6 @@ from music21.humdrum.spineParser import (
     SpineEvent,
     flavors,
     hdStringToMeasure,
-    hdStringToNote,
     kernTandemToObject,
 )
 
@@ -146,13 +147,14 @@ class Test(unittest.TestCase):
         (the first note's duration in a chord), sharing the same Duration object;
         a note with its own written duration ignores it.
         '''
-        first = hdStringToNote('8C')
-        inherited = hdStringToNote('E', first.duration)
-        self.assertEqual(inherited.duration.type, 'eighth')
-        self.assertIs(inherited.duration, first.duration)
-
-        ownDuration = hdStringToNote('2G', first.duration)
-        self.assertEqual(ownDuration.duration.type, 'half')
+        ks = KernSpine()
+        ks.setup()
+        c = ks.processChordEvent('8C E 2G')
+        self.assertIs(c.duration, c[0].duration)
+        self.assertEqual(c.notes[0].duration.type, 'eighth')
+        self.assertIs(c[0].duration, c[1].duration)
+        self.assertIsNot(c[0].duration, c[2].duration)
+        self.assertEqual(c.notes[2].duration.type, 'half')
 
     def testPartiallyNotatedChordDurations(self):
         '''
@@ -827,22 +829,25 @@ class Test(unittest.TestCase):
 
     def testFlavors(self):
         prevFlavor = flavors['JRP']
-        flavors['JRP'] = False
-        hdc = HumdrumDataCollection(testFiles.dottedTuplet)
-        hdc.parse()
-        c = hdc.stream
-        flavors['JRP'] = True
-        hdc2 = HumdrumDataCollection(testFiles.dottedTuplet)
-        hdc2.parse()
-        d = hdc2.stream
-        flavors['JRP'] = prevFlavor
-        cn = c.parts[0].measure(1).notes[1]
-        dn = d.parts[0].measure(1).notes[1]
+        try:
+            flavors['JRP'] = False
+            hdc = HumdrumDataCollection(testFiles.dottedTuplet)
+            hdc.parse()
+            c = t.cast(stream.Score, hdc.stream)
+            flavors['JRP'] = True
+            hdc2 = HumdrumDataCollection(testFiles.dottedTuplet)
+            hdc2.parse()
+            d = t.cast(stream.Score, hdc2.stream)
+        finally:
+            flavors['JRP'] = prevFlavor
+        cn = c[note.Note][1]
         self.assertEqual(cn.duration.fullName, 'Eighth Triplet (1/2 QL)')
         self.assertEqual(cn.duration.dots, 0)
         self.assertEqual(repr(cn.duration.tuplets[0].durationNormal),
                          "DurationTuple(type='eighth', dots=1, quarterLength=0.75)")
         self.assertEqual(cn.duration.tuplets[0].durationNormal.dots, 1)
+
+        dn = d[note.Note][1]
         self.assertEqual(dn.duration.fullName, 'Dotted Eighth Triplet (1/2 QL)')
         self.assertEqual(dn.duration.dots, 1)
         self.assertEqual(repr(dn.duration.tuplets[0].durationNormal),

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -119,6 +119,27 @@ class Test(unittest.TestCase):
         self.assertEqual(n.duration.type, 'eighth')
         self.assertTrue(n.duration.slash)
 
+    def testGraceNoteFromProcessNoteEvent(self):
+        ks = KernSpine()
+        ks.setup()
+        # noinspection SpellCheckingInspection
+        a = ks.processNoteEvent('4Cq')
+        self.assertEqual(a.duration.type, 'quarter')
+        self.assertEqual(a.duration.slash, True)
+        # noinspection SpellCheckingInspection
+        a = ks.processNoteEvent('16Cqq')
+        self.assertEqual(a.duration.type, '16th')
+        self.assertEqual(a.duration.slash, False)
+
+    def testChordFromProcessChordEvent(self):
+        ks = KernSpine()
+        ks.setup()
+        c = ks.processChordEvent('8C 8E')
+        self.assertEqual(len(c.notes), 2)
+        self.assertEqual(c.notes[0].duration, c.duration)
+        c = ks.processChordEvent('8C E')
+        self.assertEqual(c.notes[0].duration, c.notes[1].duration)
+
     def testChordNoteInheritsDefaultDuration(self):
         '''
         A note with no written duration takes the given defaultDurationOrNone

--- a/music21/note.py
+++ b/music21/note.py
@@ -969,8 +969,6 @@ class GeneralNote(base.Music21Object):
 
         Appoggiaturas are still a work in progress.
 
-        * Changed in v6: corrected spelling of `appoggiatura` keyword.
-
         >>> ng2 = n.getGrace(appoggiatura=True)
         >>> ng2.duration
         <music21.duration.AppoggiaturaDuration unlinked type:half quarterLength:0.0>
@@ -984,15 +982,17 @@ class GeneralNote(base.Music21Object):
         >>> r.getGrace(inPlace=True)
         >>> r.duration
         <music21.duration.GraceDuration unlinked type:eighth quarterLength:0.0>
+
+        * Changed in v6: corrected spelling of `appoggiatura` keyword.
         '''
-        if inPlace is False:
+        if not inPlace:
             e = copy.deepcopy(self)
         else:
             e = self
 
         e.duration = e.duration.getGraceDuration(appoggiatura=appoggiatura)
 
-        if inPlace is False:
+        if not inPlace:
             return e
 
 


### PR DESCRIPTION
Implement the last improvements from @alexandermorgan 's #1706 PR -- separate out Duration parsing into its own function `hdStringToDuration`.  And added versions of Alex's tests.  Rests now do not create an extra Duration object or have to recompute types.


Also wrote many new Docs.

Separate `extractDuration` function.

Improve typing of `setBeamsForNote`

Fix up old RST typing of `**kern` etc.

Document the strange dotted-tuplet JRP flavor controversy.

Move `parse()` setup routines to their own `setup()` method. (Though I expect reclassing to be dead before v11 is released, so might become moot)

Remove lots of duplicate casts to int, floor, float, etc. from having the code evolve from Python 2.2 up to the present.

Add typing to duration.durationTupleFromTypeDots which helped find a bug in the typing of `Duration.__init__` (dots=None is not allowed)

Giving co-author credit to Alexander Morgan.  Didn't use AI...well, tiny bit, just for sanity checking :-D 
