### PR TITLE
figuredBass: replace 'RT'/'_' sentinels with same-typed sentinel values

### DIFF
--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -20,14 +20,13 @@ from music21 import voiceLeading
 from music21.common.numberTools import opFrac
 from music21.common.types import OffsetQL
 from music21.figuredBass import possibility
+from music21.figuredBass.possibility import Possibility
 from music21.exceptions21 import Music21Exception
 
 if t.TYPE_CHECKING:
     from collections.abc import Callable
 
-# Voice-leading here works on possibility.Possibility tuples (one Pitch per part).
-# A part that is silent (a rest, or any non-Note) is represented by a Pitch whose ps
-# is possibility.POSSIBILITY_REST_PS; the checks skip those placeholder pitches.
+# Voice-leading here works on Possibility tuples (one Pitch per part).
 # (offset, endTime) delimiting a voice-leading moment.
 type OffsetEndTime = tuple[OffsetQL, OffsetQL]
 # (partNumberA, partNumberB) one-indexed voice pair forming a violation.
@@ -237,7 +236,7 @@ def correlateHarmonies(
 
 def checkSinglePossibilities(
     music21Stream: stream.Score,
-    functionToApply: Callable[[possibility.Possibility], list[PartPair]],
+    functionToApply: Callable[[Possibility], list[PartPair]],
     color: str | None = '#FF0000',
     debug: bool = False
 ) -> None:
@@ -304,7 +303,7 @@ def checkSinglePossibilities(
 def checkConsecutivePossibilities(
     music21Stream: stream.Score,
     functionToApply: Callable[
-        [possibility.Possibility, possibility.Possibility], list[PartPair]
+        [Possibility, Possibility], list[PartPair]
     ],
     color: str | None = '#FF0000',
     debug: bool = False
@@ -389,7 +388,7 @@ def checkConsecutivePossibilities(
 # represent two voices which form a voice crossing.
 
 
-def voiceCrossing(possibA: possibility.Possibility) -> list[PartPair]:
+def voiceCrossing(possibA: Possibility) -> list[PartPair]:
     '''
     Returns a list of (partNumberA, partNumberB) pairs, each representing
     two voices which form a voice crossing. The parts from the lowest part to
@@ -433,7 +432,7 @@ def voiceCrossing(possibA: possibility.Possibility) -> list[PartPair]:
 
 
 def parallelFifths(
-    possibA: possibility.Possibility, possibB: possibility.Possibility
+    possibA: Possibility, possibB: Possibility
 ) -> list[PartPair]:
     '''
     Returns a list of (partNumberA, partNumberB) pairs, each representing
@@ -477,7 +476,7 @@ def parallelFifths(
     []
     '''
     partViolations: list[PartPair] = []
-    pairsList = list(zip(possibA, possibB, strict=True))
+    pairsList = possibility.partPairs(possibA, possibB)
 
     for pair1Index in range(len(pairsList)):
         (higherPitchA, higherPitchB) = pairsList[pair1Index]
@@ -506,7 +505,7 @@ def parallelFifths(
 
 
 def hiddenFifths(
-    possibA: possibility.Possibility, possibB: possibility.Possibility
+    possibA: Possibility, possibB: Possibility
 ) -> list[PartPair]:
     '''
     Returns a list with a (highestPart, lowestPart) pair which represents
@@ -558,7 +557,7 @@ def hiddenFifths(
     * Changed in v11: renamed from hiddenFifth (singular) to match parallelFifths.
     '''
     partViolations: list[PartPair] = []
-    pairsList = list(zip(possibA, possibB, strict=True))
+    pairsList = possibility.partPairs(possibA, possibB)
     (highestPitchA, highestPitchB) = pairsList[0]
     (lowestPitchA, lowestPitchB) = pairsList[-1]
     if any(_isRest(p) for p in (
@@ -581,7 +580,7 @@ def hiddenFifths(
 
 
 def parallelOctaves(
-    possibA: possibility.Possibility, possibB: possibility.Possibility
+    possibA: Possibility, possibB: Possibility
 ) -> list[PartPair]:
     '''
     Returns a list of (partNumberA, partNumberB) pairs, each representing
@@ -626,7 +625,7 @@ def parallelOctaves(
     []
     '''
     partViolations: list[PartPair] = []
-    pairsList = list(zip(possibA, possibB, strict=True))
+    pairsList = possibility.partPairs(possibA, possibB)
 
     for pair1Index in range(len(pairsList)):
         (higherPitchA, higherPitchB) = pairsList[pair1Index]
@@ -655,7 +654,7 @@ def parallelOctaves(
 
 
 def hiddenOctaves(
-    possibA: possibility.Possibility, possibB: possibility.Possibility
+    possibA: Possibility, possibB: Possibility
 ) -> list[PartPair]:
     '''
     Returns a list with a (highestPart, lowestPart) pair which represents
@@ -697,7 +696,7 @@ def hiddenOctaves(
     * Changed in v11: renamed from hiddenOctave (singular) to match parallelOctaves.
     '''
     partViolations: list[PartPair] = []
-    pairsList = list(zip(possibA, possibB, strict=True))
+    pairsList = possibility.partPairs(possibA, possibB)
     (highestPitchA, highestPitchB) = pairsList[0]
     (lowestPitchA, lowestPitchB) = pairsList[-1]
     if any(_isRest(p) for p in (
@@ -725,10 +724,7 @@ def hiddenOctaves(
 def generalNoteToPitch(music21GeneralNote: note.GeneralNote) -> pitch.Pitch:
     '''
     Takes a :class:`~music21.note.GeneralNote`. If it is a :class:`~music21.note.Note`,
-    returns its pitch. Otherwise (a rest, a chord, or anything that is not a single
-    Note) returns a placeholder :class:`~music21.pitch.Pitch` whose ps is
-    :obj:`~music21.figuredBass.possibility.POSSIBILITY_REST_PS`; the voice-leading
-    checks skip such placeholders.
+    returns its pitch.
 
     >>> n1 = note.Note('G5')
     >>> c1 = chord.Chord(['C3', 'E3', 'G3'])

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -302,9 +302,7 @@ def checkSinglePossibilities(
 
 def checkConsecutivePossibilities(
     music21Stream: stream.Score,
-    functionToApply: Callable[
-        [Possibility, Possibility], list[PartPair]
-    ],
+    functionToApply: Callable[[Possibility, Possibility], list[PartPair]],
     color: str | None = '#FF0000',
     debug: bool = False
 ) -> None:
@@ -431,9 +429,7 @@ def voiceCrossing(possibA: Possibility) -> list[PartPair]:
 # computed by one module is valid for the other.  See possibility.py for the definitions.
 
 
-def parallelFifths(
-    possibA: Possibility, possibB: Possibility
-) -> list[PartPair]:
+def parallelFifths(possibA: Possibility, possibB: Possibility) -> list[PartPair]:
     '''
     Returns a list of (partNumberA, partNumberB) pairs, each representing
     two voices which form parallel fifths.
@@ -504,9 +500,7 @@ def parallelFifths(
     return partViolations
 
 
-def hiddenFifths(
-    possibA: Possibility, possibB: Possibility
-) -> list[PartPair]:
+def hiddenFifths(possibA: Possibility, possibB: Possibility) -> list[PartPair]:
     '''
     Returns a list with a (highestPart, lowestPart) pair which represents
     a hidden fifth between shared outer parts of possibA and possibB. The
@@ -579,9 +573,7 @@ def hiddenFifths(
     return partViolations
 
 
-def parallelOctaves(
-    possibA: Possibility, possibB: Possibility
-) -> list[PartPair]:
+def parallelOctaves(possibA: Possibility, possibB: Possibility) -> list[PartPair]:
     '''
     Returns a list of (partNumberA, partNumberB) pairs, each representing
     two voices which form parallel octaves.
@@ -653,9 +645,7 @@ def parallelOctaves(
     return partViolations
 
 
-def hiddenOctaves(
-    possibA: Possibility, possibB: Possibility
-) -> list[PartPair]:
+def hiddenOctaves(possibA: Possibility, possibB: Possibility) -> list[PartPair]:
     '''
     Returns a list with a (highestPart, lowestPart) pair which represents
     a hidden octave between shared outer parts of possibA and possibB. The

--- a/music21/figuredBass/checker.py
+++ b/music21/figuredBass/checker.py
@@ -25,15 +25,23 @@ from music21.exceptions21 import Music21Exception
 if t.TYPE_CHECKING:
     from collections.abc import Callable
 
-# A vertical sonority observed from a score for voice-leading checking: one
-# element per part, each a Pitch or the rest placeholder 'RT' returned by
-# generalNoteToPitch.  Distinct from possibility.Possibility, which is pitch-only
-# and represents a candidate realization rather than an observed sonority.
-type PossibilityWithRests = tuple[pitch.Pitch | t.Literal['RT'], ...]
+# Voice-leading here works on possibility.Possibility tuples (one Pitch per part).
+# A part that is silent (a rest, or any non-Note) is represented by a Pitch whose ps
+# is possibility.POSSIBILITY_REST_PS; the checks skip those placeholder pitches.
 # (offset, endTime) delimiting a voice-leading moment.
 type OffsetEndTime = tuple[OffsetQL, OffsetQL]
 # (partNumberA, partNumberB) one-indexed voice pair forming a violation.
 type PartPair = tuple[int, int]
+
+
+def _isRest(p: pitch.Pitch) -> bool:
+    '''
+    True if p is the rest placeholder returned by :func:`generalNoteToPitch`
+    (a :class:`~music21.pitch.Pitch` whose ps is
+    :obj:`~music21.figuredBass.possibility.POSSIBILITY_REST_PS`) rather than a
+    sounding pitch. Voice-leading checks skip these.
+    '''
+    return p.ps == possibility.POSSIBILITY_REST_PS
 
 
 # ------------------------------------------------------------------------------
@@ -229,7 +237,7 @@ def correlateHarmonies(
 
 def checkSinglePossibilities(
     music21Stream: stream.Score,
-    functionToApply: Callable[[PossibilityWithRests], list[PartPair]],
+    functionToApply: Callable[[possibility.Possibility], list[PartPair]],
     color: str | None = '#FF0000',
     debug: bool = False
 ) -> None:
@@ -295,7 +303,9 @@ def checkSinglePossibilities(
 
 def checkConsecutivePossibilities(
     music21Stream: stream.Score,
-    functionToApply: Callable[[PossibilityWithRests, PossibilityWithRests], list[PartPair]],
+    functionToApply: Callable[
+        [possibility.Possibility, possibility.Possibility], list[PartPair]
+    ],
     color: str | None = '#FF0000',
     debug: bool = False
 ) -> None:
@@ -379,7 +389,7 @@ def checkConsecutivePossibilities(
 # represent two voices which form a voice crossing.
 
 
-def voiceCrossing(possibA: PossibilityWithRests) -> list[PartPair]:
+def voiceCrossing(possibA: possibility.Possibility) -> list[PartPair]:
     '''
     Returns a list of (partNumberA, partNumberB) pairs, each representing
     two voices which form a voice crossing. The parts from the lowest part to
@@ -403,11 +413,11 @@ def voiceCrossing(possibA: PossibilityWithRests) -> list[PartPair]:
     partViolations: list[PartPair] = []
     for part1Index in range(len(possibA)):
         higherPitch = possibA[part1Index]
-        if not isinstance(higherPitch, pitch.Pitch):
+        if _isRest(higherPitch):
             continue
         for part2Index in range(part1Index + 1, len(possibA)):
             lowerPitch = possibA[part2Index]
-            if not isinstance(lowerPitch, pitch.Pitch):
+            if _isRest(lowerPitch):
                 continue
             if higherPitch < lowerPitch:
                 partViolations.append((part1Index + 1, part2Index + 1))
@@ -422,7 +432,9 @@ def voiceCrossing(possibA: PossibilityWithRests) -> list[PartPair]:
 # computed by one module is valid for the other.  See possibility.py for the definitions.
 
 
-def parallelFifths(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -> list[PartPair]:
+def parallelFifths(
+    possibA: possibility.Possibility, possibB: possibility.Possibility
+) -> list[PartPair]:
     '''
     Returns a list of (partNumberA, partNumberB) pairs, each representing
     two voices which form parallel fifths.
@@ -469,15 +481,11 @@ def parallelFifths(possibA: PossibilityWithRests, possibB: PossibilityWithRests)
 
     for pair1Index in range(len(pairsList)):
         (higherPitchA, higherPitchB) = pairsList[pair1Index]
-        if not isinstance(higherPitchA, pitch.Pitch):
-            continue
-        if not isinstance(higherPitchB, pitch.Pitch):
+        if _isRest(higherPitchA) or _isRest(higherPitchB):
             continue
         for pair2Index in range(pair1Index + 1, len(pairsList)):
             (lowerPitchA, lowerPitchB) = pairsList[pair2Index]
-            if not isinstance(lowerPitchA, pitch.Pitch):
-                continue
-            if not isinstance(lowerPitchB, pitch.Pitch):
+            if _isRest(lowerPitchA) or _isRest(lowerPitchB):
                 continue
             if not abs(higherPitchA.ps - lowerPitchA.ps) % 12 == 7:
                 continue
@@ -497,7 +505,9 @@ def parallelFifths(possibA: PossibilityWithRests, possibB: PossibilityWithRests)
     return partViolations
 
 
-def hiddenFifths(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -> list[PartPair]:
+def hiddenFifths(
+    possibA: possibility.Possibility, possibB: possibility.Possibility
+) -> list[PartPair]:
     '''
     Returns a list with a (highestPart, lowestPart) pair which represents
     a hidden fifth between shared outer parts of possibA and possibB. The
@@ -551,13 +561,8 @@ def hiddenFifths(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -
     pairsList = list(zip(possibA, possibB, strict=True))
     (highestPitchA, highestPitchB) = pairsList[0]
     (lowestPitchA, lowestPitchB) = pairsList[-1]
-    if not isinstance(highestPitchA, pitch.Pitch):
-        return partViolations
-    if not isinstance(highestPitchB, pitch.Pitch):
-        return partViolations
-    if not isinstance(lowestPitchA, pitch.Pitch):
-        return partViolations
-    if not isinstance(lowestPitchB, pitch.Pitch):
+    if any(_isRest(p) for p in (
+            highestPitchA, highestPitchB, lowestPitchA, lowestPitchB)):
         return partViolations
 
     if abs(highestPitchB.ps - lowestPitchB.ps) % 12 == 7:
@@ -575,7 +580,9 @@ def hiddenFifths(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -
     return partViolations
 
 
-def parallelOctaves(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -> list[PartPair]:
+def parallelOctaves(
+    possibA: possibility.Possibility, possibB: possibility.Possibility
+) -> list[PartPair]:
     '''
     Returns a list of (partNumberA, partNumberB) pairs, each representing
     two voices which form parallel octaves.
@@ -623,15 +630,11 @@ def parallelOctaves(possibA: PossibilityWithRests, possibB: PossibilityWithRests
 
     for pair1Index in range(len(pairsList)):
         (higherPitchA, higherPitchB) = pairsList[pair1Index]
-        if not isinstance(higherPitchA, pitch.Pitch):
-            continue
-        if not isinstance(higherPitchB, pitch.Pitch):
+        if _isRest(higherPitchA) or _isRest(higherPitchB):
             continue
         for pair2Index in range(pair1Index + 1, len(pairsList)):
             (lowerPitchA, lowerPitchB) = pairsList[pair2Index]
-            if not isinstance(lowerPitchA, pitch.Pitch):
-                continue
-            if not isinstance(lowerPitchB, pitch.Pitch):
+            if _isRest(lowerPitchA) or _isRest(lowerPitchB):
                 continue
             if not abs(higherPitchA.ps - lowerPitchA.ps) % 12 == 0:
                 continue
@@ -651,7 +654,9 @@ def parallelOctaves(possibA: PossibilityWithRests, possibB: PossibilityWithRests
     return partViolations
 
 
-def hiddenOctaves(possibA: PossibilityWithRests, possibB: PossibilityWithRests) -> list[PartPair]:
+def hiddenOctaves(
+    possibA: possibility.Possibility, possibB: possibility.Possibility
+) -> list[PartPair]:
     '''
     Returns a list with a (highestPart, lowestPart) pair which represents
     a hidden octave between shared outer parts of possibA and possibB. The
@@ -695,13 +700,8 @@ def hiddenOctaves(possibA: PossibilityWithRests, possibB: PossibilityWithRests) 
     pairsList = list(zip(possibA, possibB, strict=True))
     (highestPitchA, highestPitchB) = pairsList[0]
     (lowestPitchA, lowestPitchB) = pairsList[-1]
-    if not isinstance(highestPitchA, pitch.Pitch):
-        return partViolations
-    if not isinstance(highestPitchB, pitch.Pitch):
-        return partViolations
-    if not isinstance(lowestPitchA, pitch.Pitch):
-        return partViolations
-    if not isinstance(lowestPitchB, pitch.Pitch):
+    if any(_isRest(p) for p in (
+            highestPitchA, highestPitchB, lowestPitchA, lowestPitchB)):
         return partViolations
 
     if abs(highestPitchB.ps - lowestPitchB.ps) % 12 == 0:
@@ -722,23 +722,33 @@ def hiddenOctaves(possibA: PossibilityWithRests, possibB: PossibilityWithRests) 
 # Helper Methods
 
 
-def generalNoteToPitch(music21GeneralNote: note.GeneralNote) -> pitch.Pitch | t.Literal['RT']:
+def generalNoteToPitch(music21GeneralNote: note.GeneralNote) -> pitch.Pitch:
     '''
     Takes a :class:`~music21.note.GeneralNote`. If it is a :class:`~music21.note.Note`,
-    returns its pitch. Otherwise, returns the string "RT", a rest placeholder.
+    returns its pitch. Otherwise (a rest, a chord, or anything that is not a single
+    Note) returns a placeholder :class:`~music21.pitch.Pitch` whose ps is
+    :obj:`~music21.figuredBass.possibility.POSSIBILITY_REST_PS`; the voice-leading
+    checks skip such placeholders.
 
     >>> n1 = note.Note('G5')
     >>> c1 = chord.Chord(['C3', 'E3', 'G3'])
 
     >>> figuredBass.checker.generalNoteToPitch(n1)
     <music21.pitch.Pitch G5>
-    >>> figuredBass.checker.generalNoteToPitch(c1)
-    'RT'
+
+    A chord (or rest) becomes the rest placeholder:
+
+    >>> restPlaceholder = figuredBass.checker.generalNoteToPitch(c1)
+    >>> restPlaceholder.ps == figuredBass.possibility.POSSIBILITY_REST_PS
+    True
+    >>> restPlaceholder.ps
+    0.0
     '''
     if isinstance(music21GeneralNote, note.Note):
         return music21GeneralNote.pitch
-    else:
-        return 'RT'
+    restPlaceholder = pitch.Pitch()
+    restPlaceholder.ps = possibility.POSSIBILITY_REST_PS
+    return restPlaceholder
 
 
 _DOC_ORDER = [extractHarmonies, getVoiceLeadingMoments,

--- a/music21/figuredBass/notation.py
+++ b/music21/figuredBass/notation.py
@@ -10,12 +10,18 @@ from __future__ import annotations
 
 import copy
 import re
-import typing as t
 import unittest
 
 from music21 import exceptions21
 from music21 import pitch
 from music21 import prebase
+
+EXTENDER_SENTINEL: int = -1
+'''
+Sentinel value used in a :class:`~music21.figuredBass.notation.Notation`'s
+``numbers`` and ``origNumbers`` for an extender ("``_``") figure that carries no
+number of its own.
+'''
 
 shorthandNotation: dict[tuple[int|None, ...], tuple[int, ...]] = {
                      (None,): (5, 3),
@@ -210,12 +216,12 @@ class Notation(prebase.ProtoM21Object):
         # Parse notation string
         self.notationColumn: str = notationColumn or ''
         self.figureStrings: list[str] = []
-        # numbers are usually ints, but an extender-only figure stores the
-        # underscore string '_' as its "number" (see _parseNotationColumn), and a
-        # figure with a modifier but no number stores None until longhand expansion.
-        self.origNumbers: tuple[int|str|None, ...] = ()
+        # numbers are usually ints, but an extender-only figure stores
+        # EXTENDER_SENTINEL (see _parseNotationColumn), and a figure with a modifier
+        # but no number stores None until longhand expansion.
+        self.origNumbers: tuple[int|None, ...] = ()
         self.origModStrings: tuple[str|None, ...] = ()
-        self.numbers: tuple[int|str|None, ...] = ()
+        self.numbers: tuple[int|None, ...] = ()
         self.modifierStrings: tuple[str|None, ...] = ()
         self.extenders: list[bool] = []
         self.hasExtenders: bool = False
@@ -287,7 +293,7 @@ class Notation(prebase.ProtoM21Object):
         figures = re.split(delimiter, self.notationColumn)
         patternA1 = '([0-9_]*)'
         patternA2 = '([^0-9_]*)'
-        numbers: list[int|str|None] = []
+        numbers: list[int|None] = []
         modifierStrings: list[str|None] = []
         figureStrings: list[str] = []
 
@@ -303,14 +309,14 @@ class Notation(prebase.ProtoM21Object):
             if not (len(m1) <= 1 or len(m2) <= 1):
                 raise NotationException('Invalid Notation: ' + figure)
 
-            number: int|str|None = None
+            number: int|None = None
             modifierString: str|None = None
             extender = False
             if m1:
                 # if no number is there and only an extender is found.
                 if '_' in m1:
                     self.hasExtenders = True
-                    number = '_'
+                    number = EXTENDER_SENTINEL
                     extender = True
                 else:
                     # is an extender part of the number string?
@@ -354,13 +360,12 @@ class Notation(prebase.ProtoM21Object):
         ('-', '-')
         '''
         oldNumbers = self.numbers
-        newNumbers: tuple[int|str|None, ...] = oldNumbers
+        newNumbers: tuple[int|None, ...] = oldNumbers
         oldModifierStrings = self.modifierStrings
         newModifierStrings: tuple[str|None, ...] = oldModifierStrings
 
         try:
-            shorthandKey = t.cast('tuple[int|None, ...]', oldNumbers)
-            newNumbers = shorthandNotation[shorthandKey]
+            newNumbers = shorthandNotation[oldNumbers]
             modStrings: list[str|None] = []
 
             expandedOldNumbers = tuple(
@@ -504,12 +509,12 @@ class Figure(prebase.ProtoM21Object):
 
     def __init__(
         self,
-        number: int|str|None = 1,
+        number: int|None = 1,
         modifierString: str|None = '',
         *,
         extender: bool = False
     ) -> None:
-        self.number: int|str|None = number
+        self.number: int|None = number
         self.modifierString: str|None = modifierString
         self.modifier: Modifier = Modifier(modifierString)
         # look for extender's underscore
@@ -541,7 +546,7 @@ class Figure(prebase.ProtoM21Object):
             num = 'pure-extender'
             ext = ''
         else:
-            num = str(self.number)
+            num = '_' if self.number == EXTENDER_SENTINEL else str(self.number)
             ext = '(extender)' if self.hasExtender else ''
         mod = repr(self.modifier).replace('music21.figuredBass.notation.', '')
         return f'{num}{ext} {mod}'
@@ -779,7 +784,31 @@ _DOC_ORDER = [Notation, Figure, Modifier]
 
 
 class Test(unittest.TestCase):
-    pass
+    def testExtenderOnlyFigureUsesSentinel(self):
+        # A bare underscore is an extender that carries no number of its own,
+        # so its number is EXTENDER_SENTINEL in both origNumbers and numbers.
+        n = Notation('_')
+        self.assertTrue(n.hasExtenders)
+        self.assertEqual(n.extenders, [True])
+        self.assertEqual(n.origNumbers, (EXTENDER_SENTINEL,))
+        self.assertEqual(n.numbers, (EXTENDER_SENTINEL,))
+
+    def testNumberWithExtenderKeepsItsNumber(self):
+        # A number directly followed by '_' keeps the number and flags the extender;
+        # the sentinel is only for extenders with no number.
+        n = Notation('7_')
+        self.assertTrue(n.hasExtenders)
+        self.assertEqual(n.extenders, [True])
+        self.assertEqual(n.origNumbers, (7,))
+        self.assertEqual(n.numbers, (7, 5, 3))
+        self.assertNotIn(EXTENDER_SENTINEL, n.numbers)
+
+    def testExtenderSentinelRendersAsUnderscore(self):
+        # The sentinel is shown as '_' in repr, never as its raw -1 value.
+        f = Figure(EXTENDER_SENTINEL, extender=True)
+        self.assertEqual(f.number, EXTENDER_SENTINEL)
+        self.assertIn('_(extender)', repr(f))
+        self.assertNotIn('-1', repr(f))
 
 
 if __name__ == '__main__':

--- a/music21/figuredBass/notation.py
+++ b/music21/figuredBass/notation.py
@@ -216,8 +216,8 @@ class Notation(prebase.ProtoM21Object):
         # Parse notation string
         self.notationColumn: str = notationColumn or ''
         self.figureStrings: list[str] = []
-        # numbers are usually ints, but an extender-only figure stores
-        # EXTENDER_SENTINEL (see _parseNotationColumn), and a figure with a modifier
+        # numbers are usually strings cast as int()s, but an extender-only figure stores
+        # the int EXTENDER_SENTINEL (see _parseNotationColumn), and a figure with a modifier
         # but no number stores None until longhand expansion.
         self.origNumbers: tuple[int|None, ...] = ()
         self.origModStrings: tuple[str|None, ...] = ()

--- a/music21/figuredBass/possibility.py
+++ b/music21/figuredBass/possibility.py
@@ -73,6 +73,12 @@ from music21 import voiceLeading
 # part to the lowest part (the last element is the bass).
 type Possibility = tuple[pitch.Pitch, ...]
 
+POSSIBILITY_REST_PS: float = 0.0
+'''
+Sentinel :attr:`~music21.pitch.Pitch.ps` value marking a rest (or any non-Note)
+in an observed sonority.
+'''
+
 
 # SINGLE POSSIBILITY RULE-CHECKING METHODS
 # ----------------------------------------


### PR DESCRIPTION
Both checker and notation used a value of a different type to flag an unusual case. Replace them with documented sentinels of the type that is expected in all other cases:

- Possibilities are Tuples of Pitches.  Late in the game, rests appeared.  They were represented by 'RT' - now they are represented by Pitches with ps = 0.0 (POSSIBILITY_REST_PS = 0.0)
- Numbers in FB are 1, 2, 3, ... etc.  ... or extenders which were represented by the string '_'.  Now they are represented by EXTENDER_SENTINEL = -1 (notation.py) so that numbers are always numbers.

AI-assisted (Claude)