### PR TITLE
Security: Command Injection via subprocess.run in upload.py

### DIFF
--- a/documentation/docbuild/upload.py
+++ b/documentation/docbuild/upload.py
@@ -18,6 +18,7 @@ generally useful beyond to MSAC.
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 
 def getDirBuildHtml():
@@ -29,28 +30,6 @@ def getDirBuildHtml():
     dirBuild = os.path.join(parentDir, 'documentation', 'build')
     dirBuildHtml = os.path.join(dirBuild, 'html')
     return dirBuildHtml
-
-
-# noinspection SpellCheckingInspection
-# def main():
-#     # this needs to be on level higher then the level of the source
-#     remoteHost = 'music21.org'
-#     remoteDir = '/home/bitnami/htdocs/music21docs/'
-#     keyFile = '/Users/cuthbert/Web/trecentoweb_key-us-west-2.pem'
-#     user = 'bitnami'
-#
-#     src = getDirBuildHtml()
-#
-#     # -r flag makes this recursive
-#     # noinspection SpellCheckingInspection
-#     cmdStr = (
-#         f'tar czpf --disable-copyfile --no-xattrs - -C {src} . | '
-#         f'ssh -i "{keyFile}" {user}@{remoteHost} '
-#         f'"tar xzpf - -C {remoteDir}"'
-#     )
-#     print(cmdStr)
-#
-#     os.system(cmdStr)
 
 
 def main():
@@ -78,7 +57,7 @@ def main():
     print('Unzipping on remote server.')
     subprocess.run([
         'ssh', '-i', key, remote,
-        f'unzip -oq {remoteZip} -d {remoteDir} && rm -f {remoteZip}'
+        f'unzip -oq {shlex.quote(remoteZip)} -d {shlex.quote(remoteDir)} && rm -f {shlex.quote(remoteZip)}'
     ], check=True)
 
     # Remove local


### PR DESCRIPTION
## Summary

Security: Command Injection via subprocess.run in upload.py

## Problem

**Severity**: `Medium` | **File**: `documentation/docbuild/upload.py:L47`

The `main()` function in `upload.py` constructs and executes shell commands using `subprocess.run()` with hardcoded paths and parameters. While the current implementation uses list-based arguments (which is safer), the `zipPath`, `key`, `remote`, `remoteZip`, and `remoteDir` variables are hardcoded strings that could potentially be influenced. More critically, the previous implementation (commented out) used `os.system()` with f-string string formatting that directly interpolated user-influenced paths. The current `subprocess.run` calls with `check=True` are safer, but the SSH command still passes a shell string with `f'unzip -oq {remoteZip} -d {remoteDir}'` which is executed via SSH. If any of these variables were to come from external input, it would enable command injection. The hardcoded nature makes this lower risk, but the pattern is dangerous for maintenance.

## Solution

Ensure all paths and parameters passed to subprocess are validated and sanitized. Consider using `shlex.quote()` for any dynamic strings passed to shell commands. Avoid constructing shell command strings with f-strings when possible; use list arguments throughout. Remove the commented-out `os.system()` code to prevent accidental reintroduction.

## Changes

- `documentation/docbuild/upload.py` (modified)