### PR TITLE
Humdrum: Retire defaultlist, GlobalComment bugs, GlobalRef m21obj?

### DIFF
--- a/music21/common/objects.py
+++ b/music21/common/objects.py
@@ -27,6 +27,8 @@ import time
 import typing as t
 import weakref
 
+from music21.common.decorators import deprecated
+
 
 class RelativeCounter(collections.Counter):
     '''
@@ -102,7 +104,13 @@ class defaultlist(list):
     >>> a = common.defaultlist(lambda:True)
     >>> a[5]
     True
+
+    * Deprecated in v11: use a plain list or a dict instead.  This was a
+      transitional helper from when music21 was ported from Perl, where you
+      could read or assign past the end of a list and get default values.
+      Work within normal Python types instead.
     '''
+    @deprecated('v11', 'v12', 'use a plain list or a dict instead')
     def __init__(self, fx: Callable[[], t.Any]) -> None:
         super().__init__()
         self._fx = fx

--- a/music21/humdrum/__init__.py
+++ b/music21/humdrum/__init__.py
@@ -19,8 +19,8 @@ Humdrum programs and their closest music21 equivalents:
 ============  =================================================  =========================================================================================================================================================================
 Humdrum       music21                                            notes
 ============  =================================================  =========================================================================================================================================================================
-assemble_     Not needed                                         Use python commands to unite objects and `s.insert(0, p)` to put a part at the beginning of a multipart score.
-census_       Not needed                                         Use python to create census equivalents.
+assemble_     Not needed                                         Use Python commands to unite objects and `s.insert(0, p)` to put a part at the beginning of a multipart score.
+census_       Not needed                                         Use Python to create census equivalents.
 cents_        `interval.ChromaticInterval.cents`
 cleave_       Not needed                                         kern specific, not needed
 context_      Not needed                                         Use object.next and object.prev to get some context for many objects and :meth:`~music21.base.Music21Object.getContextByClass` to find the most recent object of a given type
@@ -30,7 +30,7 @@ degree_       see above for "`deg`"
 diss_         Spectral analysis.  Out of scope for m21.          Would be "analysis.kkdiss" for Kameoka and Kuriyagawa.
 ditto_        see Notes                                          :meth:`~music21.stream.Stream.chordify` and the offsetTree objects accomplish similar things. Use `copy.copy(object)` or `copy.deepcopy(object)` to get another copy of an object.
 encode_       `midi.(severaltools)`                              Multifunction Humdrum program.  See the midi directory for some replacements.  Or for simple conversion, `converter.parse` and `show('midi')` do this automatically.
-extract_      Not needed                                         Use python commands to extract objects with certain properties.
+extract_      Not needed                                         Use Python commands to extract objects with certain properties.
 fields_       Not needed
 fin2hum_      `music21.converter.parse` (filename)               Enigma Transport Format did not take off and is rarely used. Software to convert Enigma to MusicXML is available from Recordare.
 freq_         see :meth:`~music21.pitch.Pitch.frequency`
@@ -39,7 +39,7 @@ hum2fin_      `.write('musicxml')`                               Writes to Music
 humdrum_      Not needed                                         The `spineParser` will report errors when parsing.
 humsed_       Not needed
 humver_       Not needed
-infot_        Not needed                                         Use general purpose python information theory models.
+infot_        Not needed                                         Use general purpose Python information theory models.
 iv_           :meth:`~music21.chord.Chord.intervalVector`
 kern_         None                                               Output to Humdrum is not currently supported
 key_          :meth:`~music21.stream.Stream.analyze` ('key')

--- a/music21/humdrum/__init__.py
+++ b/music21/humdrum/__init__.py
@@ -20,57 +20,57 @@ Humdrum programs and their closest music21 equivalents:
 Humdrum       music21                                            notes
 ============  =================================================  =========================================================================================================================================================================
 assemble_     Not needed                                         Use python commands to unite objects and `s.insert(0, p)` to put a part at the beginning of a multipart score.
-census_       Not needed                                         Use python to create census equivalents
+census_       Not needed                                         Use python to create census equivalents.
 cents_        `interval.ChromaticInterval.cents`
 cleave_       Not needed                                         kern specific, not needed
 context_      Not needed                                         Use object.next and object.prev to get some context for many objects and :meth:`~music21.base.Music21Object.getContextByClass` to find the most recent object of a given type
 correl_       Not needed                                         Use numpy.corrcoef() or other, more sophisticated code
-deg_          Several tools, see Notes                           Closest is :meth:`~music21.scale.Scale.getScaleDegreeAndAccidentalFromPitch`. See also `stream.Stream.analyze('key')`
+deg_          Several tools, see Notes                           Closest is :meth:`~music21.scale.Scale.getScaleDegreeAndAccidentalFromPitch`. See also `stream.Stream.analyze('key')`.
 degree_       see above for "`deg`"
-diss_         Spectral analysis.  Out of scope for m21           Would be "analysis.kkdiss" for Kameoka and Kuriyagawa.
-ditto_        see Notes                                          :meth:`~music21.stream.Stream.chordify` and the offsetTree objects accomplish similar things. Use `copy.copy(object)` or `copy.deepcopy(object)` to get another copy of an object
-encode_       `midi.(severaltools)`                              Multifunction Humdrum program.  See the midi directory for some replacements.  Or for simple conversion, `converter.parse` and `show('midi')` do this automatically
-extract_      Not needed                                         Use python commands to extract objects with certain properties
+diss_         Spectral analysis.  Out of scope for m21.          Would be "analysis.kkdiss" for Kameoka and Kuriyagawa.
+ditto_        see Notes                                          :meth:`~music21.stream.Stream.chordify` and the offsetTree objects accomplish similar things. Use `copy.copy(object)` or `copy.deepcopy(object)` to get another copy of an object.
+encode_       `midi.(severaltools)`                              Multifunction Humdrum program.  See the midi directory for some replacements.  Or for simple conversion, `converter.parse` and `show('midi')` do this automatically.
+extract_      Not needed                                         Use python commands to extract objects with certain properties.
 fields_       Not needed
-fin2hum_      `music21.converter.parse` (filename)               Enigma Transport Format did not take off and is rarely used. Software to convert Enigma to MusicXML is available from recordare
+fin2hum_      `music21.converter.parse` (filename)               Enigma Transport Format did not take off and is rarely used. Software to convert Enigma to MusicXML is available from Recordare.
 freq_         see :meth:`~music21.pitch.Pitch.frequency`
 hint_         see Notes                                          :meth:`~music21.stream.Stream.attachIntervalsBetweenStreams` See music21-tools trecento.capua demo to show how it can be done.
-hum2fin_      `.write('musicxml')`                               Writes to musicXML.  A music21 to Enigma converter will not be written (obsolete format)
+hum2fin_      `.write('musicxml')`                               Writes to MusicXML.  A music21 to Enigma converter will not be written (obsolete format).
 humdrum_      Not needed                                         The `spineParser` will report errors when parsing.
 humsed_       Not needed
 humver_       Not needed
-infot_        Not needed                                         Use general purpose python information theory models
+infot_        Not needed                                         Use general purpose python information theory models.
 iv_           :meth:`~music21.chord.Chord.intervalVector`
 kern_         None                                               Output to Humdrum is not currently supported
 key_          :meth:`~music21.stream.Stream.analyze` ('key')
-melac_        see Notes                                          :meth:`~music21.analysis.metrical.thomassenMelodicAccent`.  incorporates Humdrum additions for giving accent of the first and last notes.
-metpos_       `1 / obj.beatStrength()`                           the beatStrength of an object is essentially something similar but inverted.  beatStrength handles irregular meters.
+melac_        see Notes                                          :meth:`~music21.analysis.metrical.thomassenMelodicAccent`.  Incorporates Humdrum additions for giving accent of the first and last notes.
+metpos_       `1 / obj.beatStrength()`                           The beatStrength of an object is essentially something similar but inverted.  beatStrength handles irregular meters.
 midi_         `.show('midi')`
 midireset_    None                                               Not needed for now because we do not write directly to MIDI.  A midi.allOff() will be needed for direct midi access.
 mint_         `interval.Interval(note1, note2)`                  Or :meth:`~music21.stream.Stream.melodicIntervals`
 nf_           :meth:`~music21.chord.Chord.normalOrder`           Also :meth:`~music21.chord.Chord.primeForm`, :meth:`~music21.chord.Chord.intervalVector`, :meth:`~music21.chord.Chord.forteClass`, :meth:`~music21.chord.Chord.getZRelation` etc.
 num_          Not needed                                         try: `for i in range(len(s.recurse().getElementsByClass(X)))` etc.
-patt_         `search.*`                                         see also, for instance, trecento.find_trecento_fragments for an example of a pattern searching module
-pattern_      `search.*`                                         see patt above
+patt_         `search.*`                                         See also, for instance, trecento.find_trecento_fragments for an example of a pattern searching module.
+pattern_      `search.*`                                         See patt above.
 pc_           :meth:`~music21.pitch.Pitch.pitchClass`
 pcset_        see `Pitch.*` and `Chord.*`                        Pitch.pitchClass and pitchClassString, Chord.normalOrder, .primeForm, .intervalVector, etc.
 perform_      `.show('midi')`
 pf_           :meth:`~music21.chord.Chord.primeForm`             Also :meth:`~music21.chord.Chord.normalOrder` etc.
 pitch_        :meth:`~music21.pitch.Pitch.nameWithOctave`
-proof_        Not needed                                         See `humdrum` command above; However, something like this could be useful for each encoding format.
+proof_        Not needed                                         See `humdrum` command above; however, something like this could be useful for each encoding format.
 recode_       `"if"`
-record_       via music21j                                       Not yet determined if it is a good idea to record directly to music21 within music21 -- our MIDI to music21 converter should suffice.  But note that audioSearch.recording gives recording transcription abilities
+record_       via music21j                                       Not yet determined if it is a good idea to record directly to music21 within music21 -- our MIDI to music21 converter should suffice.  But note that audioSearch.recording gives recording transcription abilities.
 regexp_       Not needed                                         Use `re` module in Python core, not music21
 reihe_        :class:`~music21.serial.TwelveToneRow`
 rend_         Not needed                                         Object properties perform the same function.
 rid_          Not needed                                         Use :meth:`~music21.stream.Stream.getElementsByClass` or :meth:`~music21.stream.Stream.getElementsNotOfClass` instead
-scramble_     Not needed                                         Use random module in Python core, not music21.  However, see composition tools for some sophisticated scrambling methods
+scramble_     Not needed                                         Use random module in Python core, not music21.  However, see composition tools for some sophisticated scrambling methods.
 semits_       see Notes                                          :meth:`~music21.pitch.Pitch.ps`, :meth:`~music21.pitch.Pitch.p.midiNote` or :meth:`~music21.interval.Interval.chromatic`.  See also :class:`music21.pitch.Accidental`, esp. the `.alter` property.
 simil_        Many implementations
 smf_          `.write('midi')`                                   See midi above
-solfa_        :meth:`~music21.scale.ConcreteScale.solfeg`        Use variant='humdrum' to get exact Humdrum solfeg syllables
+solfa_        :meth:`~music21.scale.ConcreteScale.solfeg`        Use variant='humdrum' to get exact Humdrum solfeg syllables.
 solfg_        :meth:`~music21.pitch.Pitch.french`                Also .dutch, .italian, .spanish
-strophe_      :meth:`~music21.text.assembleLyrics`               You probably won't need this though
+strophe_      :meth:`~music21.text.assembleLyrics`               You probably won't need this though.
 synco_        To-Do                                              Will be "analysis.leeLHiggins" but not yet written -- low priority
 tacet_        Not needed                                         see `midireset` above; -i will not be supported
 timebase_     Not needed                                         stream.getElementsByOffset() will cover most uses

--- a/music21/humdrum/harmParser.py
+++ b/music21/humdrum/harmParser.py
@@ -27,24 +27,24 @@ def convertHarmToRoman(harmStr: str) -> str|None:
     This is necessary because the two notations are not
     identical. For example, a "V7b" in `**harm` turns into "V65".
 
-    Instantiate a HarmParser to process `**harm` strings
+    Instantiate a HarmParser to process `**harm` strings.
 
     >>> convertHarmToRoman = humdrum.harmParser.convertHarmToRoman
 
-    Convert a few `**harm` strings to music21.roman.RomanNumeral figures
+    Convert a few `**harm` strings to music21.roman.RomanNumeral figures.
 
     >>> diatonicTriads = ['I', 'Vc', 'Ib', 'iib', 'V', 'viiob', 'vib']
     >>> [convertHarmToRoman(x) for x in diatonicTriads]
     ['I', 'V64', 'I6', 'ii6', 'V', 'viio6', 'vi6']
 
-    A few seventh-chord inversions
+    A few seventh-chord inversions.
     >>> diatonicSevenths = ['V7', 'viio7c', 'V7d', 'viio7b', 'V7c']
     >>> [convertHarmToRoman(x) for x in diatonicSevenths]
     ['V7', 'viio43', 'V2', 'viio65', 'V43']
 
     Inversion-wise, augmented sixth chords are a bit tricky.
     German and French are treated as seventh-chords (4 notes).
-    Italians are treated as triads.
+    Italian sixths are treated as triads.
 
     >>> italianSixths = ['Lt', 'Ltb', 'Ltc']
     >>> [convertHarmToRoman(x) for x in italianSixths]
@@ -86,7 +86,7 @@ def convertHarmToRoman(harmStr: str) -> str|None:
     isSeventh = False
     if harm['intervals'] and '7' in harm['intervals']:
         isSeventh = True
-    # Numeric inversions (although it is more the 'figured bass')
+    # Numeric inversions (although it is more like the 'figured bass')
     if harm['inversion']:
         inversionNumber = ['a', 'b', 'c', 'd'].index(harm['inversion'])
     else:
@@ -117,7 +117,7 @@ def convertHarmToRoman(harmStr: str) -> str|None:
 
 class HarmDefs:
     '''
-    Regular expression definitions for the HarmParser class
+    Regular expression definitions for the HarmParser class.
     '''
 
     # Detect lowered or raised root (-|lowered, #|raised)
@@ -197,7 +197,7 @@ class HarmDefs:
 
 class HarmParser:
     '''
-    Parses an expression in `**harm` syntax
+    Parses an expression in `**harm` syntax.
     '''
 
     defs = HarmDefs()

--- a/music21/humdrum/harmParser.py
+++ b/music21/humdrum/harmParser.py
@@ -37,7 +37,8 @@ def convertHarmToRoman(harmStr: str) -> str|None:
     >>> [convertHarmToRoman(x) for x in diatonicTriads]
     ['I', 'V64', 'I6', 'ii6', 'V', 'viio6', 'vi6']
 
-    A few seventh-chord inversions.
+    A few seventh-chord inversions:
+
     >>> diatonicSevenths = ['V7', 'viio7c', 'V7d', 'viio7b', 'V7c']
     >>> [convertHarmToRoman(x) for x in diatonicSevenths]
     ['V7', 'viio43', 'V2', 'viio65', 'V43']

--- a/music21/humdrum/questions.py
+++ b/music21/humdrum/questions.py
@@ -78,7 +78,7 @@ class Test(unittest.TestCase):
     #     # for part in partStream.partData:
     #     # a part stream could have an iterator that partitions itself
     #     # into measure-length part streams
-    #     for measure in partStream.getElementsByClass(stream.Measure)():  # () ?
+    #     for measure in partStream.getElementsByClass(stream.Measure):
     #         # measure is a partStream isolated for just the desired measure
     #         # assuming only one meter per measure
     #         meterObj = measure['meter']
@@ -120,7 +120,7 @@ class Test(unittest.TestCase):
     #         # this could be contained w/n a part stream
     #         pageStream = partStream['pages']
     #         # assuming we have classes for things on pages, such as
-    #         # titles and other tex annotations
+    #         # titles and other text annotations
     #         # here, we get these only from the first page
     #         titleCandidates += pageStream[0].getElementsByClass(TextAnnotation)
     #         # an additional slot might be used to store metadata, also
@@ -145,7 +145,7 @@ class Test(unittest.TestCase):
     #     partStream = converter.parse('dichterliebe1.xml')
     #
     #     # we might look at arpeggios as a type of extractable phrase,
-    #     # looking fo open spacings, even rhythms, and chordal forms
+    #     # looking for open spacings, even rhythms, and chordal forms
     #     phraseStream = analysis.phraseExtract(partStream, ['arpeggio'])
     #     newStream = Stream()
     #     newStream.append(partStream.notationStream)
@@ -230,7 +230,7 @@ class Test(unittest.TestCase):
 
     # def xtest010(self):
     #     '''
-    #     Assemble individual parts into a full scores.
+    #     Assemble individual parts into a full scores. [sic]
     #     '''
     #     partStream = PartStream()
     #     for part in PartsList:
@@ -502,7 +502,7 @@ class Test(unittest.TestCase):
 #     8.    Are dynamic swells (crescendo-diminuendos) more
 #                common than dips (diminuendos-crescendos)?
 #     9.    Are lower pitches likely to be shorter and higher pitches likely to be longer?
-#     10.    Assemble individual parts into a full scores.
+#     10.    Assemble individual parts into a full scores. [sic]
 #     11.    Assemble syllables into words for some vocal text.
 #     12.    Calculate all the permuted harmonic intervals in a chord.
 #     13.    Calculate changes of listeners' heart-rate from physiological data.
@@ -548,7 +548,7 @@ class Test(unittest.TestCase):
 #     46.    Count the number of notes in measures 8 to 16.
 #     47.    Count the number of notes in the exposition.
 #     48.    Count the number of phrases in a score.
-#     49.    Count the number of phrases in each work containing `Liebe' in the title.
+#     49.    Count the number of phrases in each work containing 'Liebe' in the title.
 #     50.    Count the number of phrases in the development.
 #     51.    Count the number of phrases that begin on the subdominant pitch.
 #     52.    Count the number of phrases that end on the subdominant pitch.
@@ -617,7 +617,7 @@ class Test(unittest.TestCase):
 #                tends to be shorter than the final phrase.
 #     99.    Determine whether the subdominant pitch is used
 #                less often in pop melodies than in French chanson.
-#     100.    Determine whether the words `high,' `hoch,' or `haut'
+#     100.    Determine whether the words 'high,' 'hoch,' or 'haut'
 #                tend to coincide with higher pitches in a vocal work.
 #     101.    Determine whether there are any notes in the bassoon part.
 #     102.    Determine whether tonic pitches tend to be followed
@@ -637,7 +637,7 @@ class Test(unittest.TestCase):
 #     113.    Estimate the degree of emotionality for some vocal text.
 #     114.    Estimate the sensory dissonance evoked by some frequency spectrum.
 #     115.    Expand all the verses for a strophic song.
-#     116.    Expand repeats to a `through-composed' version of the score.
+#     116.    Expand repeats to a 'through-composed' version of the score.
 #     117.    Extract anacrusis material and the final measure from two scores.
 #     118.    Extract and transpose the trumpet part to concert pitch.
 #     119.    Extract any transposing instruments.
@@ -678,7 +678,7 @@ class Test(unittest.TestCase):
 #     154.    Find all 18th century works that include French horns and oboes.
 #     155.    Find all Corelli works that contain a change of meter.
 #     156.    Find all heterophonic works.
-#     157.    Find all jazz works designated `bebop' in style.
+#     157.    Find all jazz works designated 'bebop' in style.
 #     158.    Find all Rondo movements.
 #     159.    Find all scores composed by Cesar Franck.
 #     160.    Find all scores containing one or more brass instruments.
@@ -717,7 +717,7 @@ class Test(unittest.TestCase):
 #     189.    Identify all scores containing a tuba but not a trumpet.
 #     190.    Identify all works not in the keys of C major, G major, B-flat major or D minor.
 #     191.    Identify all works that are in compound meters, but not quadruple compound.
-#     192.    Identify all works that end with a `tierce de picardie'.
+#     192.    Identify all works that end with a 'tierce de picardie'.
 #     193.    Identify alliterations in a vocal text.
 #     194.    Identify any augmented sixth chords.
 #     195.    Identify any augmented sixth intervals in Bach's two-part inventions.
@@ -740,16 +740,16 @@ class Test(unittest.TestCase):
 #     210.    Identify any subdominant chords between measures 80 and 86.
 #     211.    Identify any tritone intervals that are not spelled
 #                as augmented fourths or diminished fifths.
-#     212.    Identify any works that are classified as `Ballads'.
+#     212.    Identify any works that are classified as 'Ballads'.
 #     213.    Identify any works that are in irregular meters.
 #     214.    Identify any works that are in simple triple meters.
 #     215.    Identify any works that are not composed by [Robert] Schumann.
 #     216.    Identify any works that bear a dedication.
 #     217.    Identify any works that contain passages in 9/8 meter.
 #     218.    Identify any works that contain passages in either 3/8 or 9/8 meter.
-#     219.    Identify any works that contain the word `Amour' in the title.
-#     220.    Identify any works that contain the words `Drei' and `Koenige'.
-#     221.    Identify any works that contain the words `Liebe' and `Tod' in the title.
+#     219.    Identify any works that contain the word 'Amour' in the title.
+#     220.    Identify any works that contain the words 'Drei' and 'Koenige'.
+#     221.    Identify any works that contain the words 'Liebe' and 'Tod' in the title.
 #     222.    Identify any works that don't contain any double barlines.
 #     223.    Identify any works whose instrumentation includes a cornet but not a trumpet.
 #     224.    Identify any works whose instrumentation includes a trumpet and a cornet.
@@ -763,7 +763,7 @@ class Test(unittest.TestCase):
 #     232.    Identify how often a high subdominant note in a long-short-long rhythm is
 #                followed by a low submediant in a long-long-short context.
 #     233.    Identify how often the flute is resting when the trumpet is active.
-#     234.    Identify how the melodic intervals in measures 8 to 32.
+#     234.    Identify how the melodic intervals in measures 8 to 32. [sic]
 #     235.    Identify melodic intervals (avoiding intervals spanning rests).
 #     236.    Identify overlapped parts.
 #     237.    Identify parts that are out of range.
@@ -772,7 +772,7 @@ class Test(unittest.TestCase):
 #     240.    Identify possible recapitulation passages.
 #     241.    Identify possible sonata-allegro movements.
 #     242.    Identify progressions that are similar to II-IV-V-I.
-#     243.    Identify similes using `like' or `as' in some vocal text.
+#     243.    Identify similes using 'like' or 'as' in some vocal text.
 #     244.    Identify the available versions of a score.
 #     245.    Identify the average overall dynamic level for a work.
 #     246.    Identify the crossing of parts.
@@ -786,7 +786,7 @@ class Test(unittest.TestCase):
 #     254.    Identify the most common harmonic interval arrangement in some score.
 #     255.    Identify the most common harmonic progression apart from the V-I progression.
 #     256.    Identify the most common sequence of five melodic intervals.
-#     257.    Identify the most common word following `gloria' in Gregorian chants.
+#     257.    Identify the most common word following 'gloria' in Gregorian chants.
 #     258.    Identify the number of notes per syllable for some score.
 #     259.    Identify the number of notes per word for some score.
 #     260.    Identify the number of syllables per phrase for some work.
@@ -804,9 +804,9 @@ class Test(unittest.TestCase):
 #     270.    Identify unison doublings.
 #     271.    Identify what harmonic intervals precede the interval of an octave.
 #     272.    Identify what scale degree most commonly precedes the dominant pitch.
-#     273.    Identify whether a score contains an `Andante' section.
+#     273.    Identify whether a score contains an 'Andante' section.
 #     274.    Identify whether a score contains any double sharps.
-#     275.    Identify whether any score contains an `Andante' section.
+#     275.    Identify whether any score contains an 'Andante' section.
 #     276.    Identify whether drinking songs are more apt to be in triple meter.
 #     277.    Identify whether dynamics are gradual or terraced.
 #     278.    Identify whether large leaps involving
@@ -815,7 +815,7 @@ class Test(unittest.TestCase):
 #     280.    Identify whether the subdominant occurs more frequently in one repertory than another.
 #     281.    Identify whether there are any tritone melodic intervals in the vocal parts.
 #     282.    Identify whether titles containing the
-#                word `death' or more likely to be in minor keys.
+#                word 'death' or more likely to be in minor keys. [sic]
 #     283.    Identify whether two songs have identical lyrics.
 #     284.    Identify whether two works are identical apart from transposition.
 #     285.    Identify whether two works have identical harmonies.
@@ -839,7 +839,7 @@ class Test(unittest.TestCase):
 #     303.    Locate any doubled seventh scale degrees.
 #     304.    Locate any parallel fifths between the bass and alto voices.
 #     305.    Locate instances of the pitch sequence D-S-C-H in Shostakovich's music.
-#     306.    Locate occurrences of the word `Liebe' in some lyrics.
+#     306.    Locate occurrences of the word 'Liebe' in some lyrics.
 #     307.    Locate submediant pitches that are approached by
 #                an ascending major third followed by a descending major second.
 #     308.    Locate the most emotionally charged words in some vocal text.
@@ -850,7 +850,7 @@ class Test(unittest.TestCase):
 #     313.    Play a melody but eliminate all tonic pitches.
 #     314.    Play a melody but replace all tonic pitches by rests.
 #     315.    Play just the rhythm of a work.
-#     316.    Play some MIDI data from the `second theme'.
+#     316.    Play some MIDI data from the 'second theme'.
 #     317.    Play some MIDI data.
 #     318.    Play the clarinet part for the 4th and 8th phrases.
 #     319.    Play the first and last measures from the Coda section at half tempo.
@@ -859,7 +859,7 @@ class Test(unittest.TestCase):
 #     322.    Play the MIDI data from the next G#.
 #     323.    Play the MIDI data from the next pause.
 #     324.    Play the thema and first variation at the same time.
-#     325.    Play the `Trio' section.
+#     325.    Play the 'Trio' section.
 #     326.    Print a transposed version of the accompaniment parts.
 #     327.    Rearrange a score so the measures are in reverse order.
 #     328.    Renumber all measures in a score.
@@ -887,7 +887,6 @@ class Test(unittest.TestCase):
 #     349.    Transpose from one key to another.
 #     350.    Transpose to Dorian mode.
 #     351.    Transpose up a minor third.
-#
 
 
 # ------------------------------------------------------------------------------

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -662,7 +662,9 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                     continue
                 # a spine-path token at this position always has a spine
                 # assigned from the first pass above.
-                assert currentSpine is not None
+                if currentSpine is None:  # pragma: no cover
+                    raise ValueError(
+                        f'spine-path token at line {lineNumber} has no active spine')
                 if thisEvent.contents == '*-':  # terminate spine
                     currentSpine.endingPoint = lineNumber
                 elif thisEvent.contents == '*^':  # split spine assume they are voices

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -765,8 +765,8 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
         for i, event in enumerate(eventList):
             if isinstance(event, GlobalReferenceLine):
-                # references become metadata, not Stream objects, but are still
-                # counted so neighbouring comments keep the same priority.
+                # References become metadata, not Stream objects, but are still
+                # counted so neighboring comments keep the same priority.
                 numberOfGlobalEventsInARow += 1
                 references.append(GlobalReference(event.code, event.value))
             elif isinstance(event, GlobalCommentLine):
@@ -928,7 +928,7 @@ class GlobalReferenceLine(HumdrumLine):
     # noinspection SpellCheckingInspection
     r'''
     A GlobalReferenceLine is a type of HumdrumLine that contains
-    information/metadata about the Humdrum document.
+    a Reference Record or information/metadata about the Humdrum document.
 
     In Humdrum it is represented by three exclamation points
     followed by non-whitespace followed by a colon.  Examples::
@@ -963,8 +963,8 @@ class GlobalReferenceLine(HumdrumLine):
 
     TODO: add parsing of three-digit Kern comment codes into fuller metadata
     TODO: parse ``@``/``@@`` language tags here (e.g. ``!!!OPT@@RUS:``, ``!!!OPT@FRE:``)
-    and propagate language/isPrimary so that GlobalReference.updateMetadata
-    can attach ``metadata.Text(value, language=...)`` instead of bare strings.
+      and propagate language/isPrimary so that GlobalReference.updateMetadata
+      can attach ``metadata.Text(value, language=...)`` instead of bare strings.
     '''
     def __init__(self, lineNumber: int = 0, contents: str = '!!! NUL: None') -> None:
         self.lineNumber = lineNumber
@@ -2972,10 +2972,16 @@ class GlobalComment(base.Music21Object):
 class GlobalReference(prebase.ProtoM21Object):
     # noinspection SpellCheckingInspection
     '''
-    Represents a reference record in the score (Humdrum's term).  Unlike a
-    GlobalComment, a GlobalReference is never placed in the stream -- it is
-    converted to metadata -- so it is a plain ProtoM21Object, not a
-    Music21Object.  See Humdrum User's Guide Chapter 2.
+    An item of metadata or "library-type information' called a "Reference Record"
+    in Humdrum.  The music21 term `GlobalReference` uses Global in the sense that
+    it applies to all spines, but also to the score as a whole.
+
+    All GlobalReferences are stored in SpineParser's .globalReferences array
+    during parsing and then stored in the Score's metadata at the end of parsing.
+    The position of a GlobalReference in the Humdrum file does not affect
+    where it is placed in the score's metadata (though later ones will overwrite
+    earlier ones). Humdrum tradition is to place most important reference records
+    at the top of the file and less important ones at the end.
 
     >>> sc = humdrum.spineParser.GlobalReference('!!!REF:this is a global reference')
     >>> sc
@@ -3012,6 +3018,9 @@ class GlobalReference(prebase.ProtoM21Object):
     'FRE'
     >>> sc.isPrimary
     False
+
+    Changed in v11: GlobalReferences are no longer Music21Object subclasses, since they
+        should not be placed in locations in a Stream.
     '''
     def __init__(
         self,
@@ -3145,9 +3154,9 @@ class GlobalReference(prebase.ProtoM21Object):
 
     def updateMetadata(self, md: metadata.Metadata) -> None:
         '''
-        update a metadata object according to information in this GlobalReference
+        Update a metadata object according to information in this GlobalReference.
 
-        See Humdrum guide Appendix I for information
+        See Humdrum guide Appendix I for information.
         '''
         c = self.code
         v = self.value

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -16,7 +16,7 @@ simply want to call:
 >>> #_DOCS_SHOW myFile.show()
 
 The methods in here are documented for developers wishing to expand
-music21's ability to parse humdrum.
+music21's ability to parse Humdrum.
 
 SpineParsing consists of several steps.
 
@@ -27,7 +27,7 @@ SpineParsing consists of several steps.
     Protospines that separate become new Protospines with their parentSpine indicated.  Protospines
     that merge again are then followed by the same Protospine as before.  This will cause problems
     if a voice re-merges with another staff, but in practice I have not
-    seen a .krn file that does this and
+    seen a .krn file that does this, and it
     should be avoided in any case.
 * HumdrumSpines are reclassed according to their exclusive definition.
     :samp:`**kern` becomes KernSpines, etc.
@@ -154,7 +154,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         (Craig Stuart Sapp confirmed this to me.)
 
         The Aarden/Miller Palestrina dataset uses ``\*-`` followed by ``**kern``
-        at the changes of sections thus some parsing of multiple exclusive
+        at the changes of sections, so some parsing of multiple exclusive
         interpretations in a protospine may be necessary.  But none change definition.
 
     (2) Split spines are assumed to be voices in a single spine staff.
@@ -415,7 +415,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         >>> print(eList[0].value)
         Beethoven, Ludwig van
 
-        Print line number 4 (which is eList[3] in zero indexed)
+        Print line number 4 (which is eList[3] zero-indexed)
 
         >>> print(eList[3].spineData)
         ['C4', 'pp']
@@ -691,7 +691,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                     newSpineList.append(newSpine2)
                 elif thisEvent.contents == '*v':
                     # merge spine -- n.b. we allow non-adjacent
-                    # lines to be merged. this is incorrect
+                    # lines to be merged. This is incorrect
                     # per Humdrum syntax, but is easily done.
                     if not mergerActive:
                         # assume that previous spine continues
@@ -722,7 +722,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                         exchangeAwaitingSpine = currentSpine
                     else:
                         # if second exchange is not found, then both
-                        # lines disappear and exception is raised
+                        # lines disappear and exception is raised.
                         # n.b. we allow more than one PAIR of exchanges
                         # in a line so long as the first
                         # is totally finished by the time the second happens
@@ -748,7 +748,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
         Run after `self.spineCollection.createMusic21Streams()`.
         Is run automatically by `self.parse()`.
-        uses `self.spineCollection.getOffsetsAndPrioritiesByLineNumber()`
+        Uses `self.spineCollection.getOffsetsAndPrioritiesByLineNumber()`.
         '''
         spineCollection = self.spineCollection
         if spineCollection is None:
@@ -879,7 +879,7 @@ class HumdrumLine(prebase.ProtoM21Object):
     HumdrumLine is a dummy class for subclassing
     :class:`~music21.humdrum.spineParser.SpineLine`,
     :class:`~music21.humdrum.spineParser.GlobalCommentLine`, and
-    :class:`~music21.humdrum.spineParser.GlobalReferenceLine` classes
+    :class:`~music21.humdrum.spineParser.GlobalReferenceLine` classes,
     all of which represent one horizontal line of
     text in a :class:`~music21.humdrum.spineParser.HumdrumDataCollection`
     that is aware of its
@@ -1084,7 +1084,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
     been simplified.
 
     A subclass of HumdrumSpine should be defined for each ``**type``. Those
-    subclasses cannot redefine `__init__()`
+    subclasses cannot redefine `__init__()`.
 
     A HumdrumSpine is a collection of events arranged vertically that have a
     connection to each other.
@@ -1176,7 +1176,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
 
     def append(self, event: SpineEvent) -> None:
         '''
-        add an item to this Spine
+        Add an item to this Spine.
         '''
         self.eventList.append(event)
 
@@ -1201,7 +1201,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
 
     def _getSpineType(self) -> str:
         '''
-        searches the current and parent spineType for a search
+        Searches the current and parent spineType.
         '''
         if self._spineType:
             return self._spineType
@@ -1228,7 +1228,7 @@ class HumdrumSpine(prebase.ProtoM21Object):
         measures.  Works with pickup measures, etc. Does not
         automatically create ties, etc.
 
-        Why not just use Stream.makeMeasures()? because
+        Why not just use Stream.makeMeasures()? Because
         Humdrum measures contain extra information about barlines
         etc. and pickups are explicitly defined.
 
@@ -1437,7 +1437,7 @@ class KernSpine(HumdrumSpine):
 
     def processNoteEvent(self, eventC: str) -> note.GeneralNote:
         '''
-        similar to hdStringToNote, this method processes a string representing a single
+        Similar to hdStringToNote, this method processes a string representing a single
         note, but stores information about current beam and tuplet state.
         '''
         eventNote = hdStringToNote(eventC)
@@ -1497,7 +1497,7 @@ class KernSpine(HumdrumSpine):
 
     def setBeamsForNote(self, n: note.GeneralNote) -> None:
         '''
-        sets the beams for a Note (or Chord) given self.currentBeamNumbers
+        Sets the beams for a Note (or Chord) given self.currentBeamNumbers
         and updates self.currentBeamNumbers based on stop beams.
 
         Safe enough to use on elements such as rests that don't have beam info.
@@ -1518,7 +1518,7 @@ class KernSpine(HumdrumSpine):
                         self.currentBeamNumbers += 1
 
     def setTupletTypeForNote(self, n: note.GeneralNote) -> None:
-        # nested tuplets not supported by humdrum.
+        # nested tuplets not supported by Humdrum.
         nDur = n.duration
         nTuplets = n.duration.tuplets
 
@@ -1603,7 +1603,7 @@ class HarmSpine(HumdrumSpine):
 
     The harm roman numeral annotations are parsed using
     a superset of the original ``**harm`` Humdrum representation, written
-    for python and extending the syntax based on other projects like the
+    for Python and extending the syntax based on other projects like the
     RomanText and the MuseScore roman numeral notations.
     '''
     def parse(self) -> None:
@@ -1706,8 +1706,8 @@ class SpineEvent(prebase.ProtoM21Object):
 
     def toNote(self, convertString: str|None = None) -> note.GeneralNote:
         r'''
-        parse the object as a ``**kern`` note and return a
-        :class:`~music21.note.Note` object (or Rest, or Chord)
+        Parse the object as a ``**kern`` note and return a
+        :class:`~music21.note.Note` object (or Rest, or Chord).
 
         >>> se = humdrum.spineParser.SpineEvent('DD#4')
         >>> n = se.toNote()
@@ -1756,7 +1756,7 @@ class SpineCollection(prebase.ProtoM21Object):
 
     def addSpine(self, streamClass: type[stream.Stream] = stream.Part) -> HumdrumSpine:
         '''
-        creates a new spine in the collection and returns it.
+        Creates a new spine in the collection and returns it.
 
         By default, the underlying music21 class of the spine is
         :class:`~music21.stream.Part`.  This can be overridden
@@ -1790,15 +1790,15 @@ class SpineCollection(prebase.ProtoM21Object):
     def appendSpine(self, spine: HumdrumSpine) -> None:
         '''
         appendSpine(spine) -- appends an already existing HumdrumSpine
-        to the SpineCollection.  Returns void
+        to the SpineCollection.  Returns void.
         '''
         self.spines.append(spine)
 
     def getSpineById(self, spineId: int) -> HumdrumSpine:
         '''
-        returns the HumdrumSpine with the given id.
+        Returns the HumdrumSpine with the given id.
 
-        raises a HumdrumException if the spine with a given id is not found
+        Raises a HumdrumException if the spine with a given id is not found.
         '''
         for thisSpine in self.spines:
             if thisSpine.id == spineId:
@@ -1823,7 +1823,7 @@ class SpineCollection(prebase.ProtoM21Object):
         >>> hsc.spines
         [<music21.humdrum.spineParser.HumdrumSpine: 1>]
 
-        raises a HumdrumException if the spine with a given id is not found
+        Raises a HumdrumException if the spine with a given id is not found.
         '''
         for s in self.spines:
             if s.id == spineId:
@@ -1911,7 +1911,7 @@ class SpineCollection(prebase.ProtoM21Object):
             if not thisSpine.childSpines:
                 continue
 
-            # only spines with children spines and parent spines continue
+            # only spines with child spines and parent spines continue
             newStream = thisSpine.stream.__class__()
             insertPoints = sorted(thisSpine.childSpineInsertPoints)
             lastLineNumber = -1
@@ -1932,8 +1932,8 @@ class SpineCollection(prebase.ProtoM21Object):
             thisSpine.stream = newStream
 
             # some spines were not inserted because the
-            # insertion point was at the end of the parent spine
-            # happens in some musedata conversions, such as beethoven 5, movement 1.
+            # insertion point was at the end of the parent spine.
+            # Happens in some musedata conversions, such as Beethoven 5, movement 1.
             for i in insertPoints:
                 self.performSpineInsertion(thisSpine, newStream, i)
             # for removeMe in removeSpines:
@@ -1970,8 +1970,8 @@ class SpineCollection(prebase.ProtoM21Object):
     def reclassSpines(self) -> None:
         r'''
         Changes the classes of HumdrumSpines to more specific types
-        (KernSpine, DynamicSpine)
-        according to their spineType (e.g., ``**kern``, ``**dynam``)
+        (KernSpine, DynamSpine)
+        according to their spineType (e.g., ``**kern``, ``**dynam``).
         '''
         for thisSpine in self.spines:
             if thisSpine.spineType == 'kern':
@@ -2007,10 +2007,10 @@ class SpineCollection(prebase.ProtoM21Object):
 
     def moveObjectsToMeasures(self) -> None:
         '''
-        run moveElementsIntoMeasures for each HumdrumSpine
+        Run moveElementsIntoMeasures for each HumdrumSpine
         that is not a sub-spine.
 
-        Also fixes up the tuplets using duration.TupletFixer
+        Also fixes up the tuplets using duration.TupletFixer.
         '''
         tf = duration.TupletFixer()
 
@@ -2029,7 +2029,7 @@ class SpineCollection(prebase.ProtoM21Object):
 
     def attachNonKernEvents(self) -> None:
         '''
-        move :samp:`**dynam` and :samp:`**lyrics/**text` information to the appropriate staff.
+        Move :samp:`**dynam` and :samp:`**lyrics/**text` information to the appropriate staff.
 
         Assumes that :samp:`*staff` is consistent through the spine.
 
@@ -2124,9 +2124,9 @@ class SpineCollection(prebase.ProtoM21Object):
 
     def makeVoices(self) -> None:
         '''
-        make voices for each kernSpine -- why not just run
-        stream.makeVoices() ? because we have more information
-        here that lets us make voices more intelligently
+        Make voices for each kernSpine -- why not just run
+        stream.makeVoices() ? Because we have more information
+        here that lets us make voices more intelligently.
 
         Should be done after measures have been made.
         '''
@@ -2177,7 +2177,7 @@ class SpineCollection(prebase.ProtoM21Object):
 
     def parseMusic21(self) -> None:
         '''
-        runs spine.parse() for each Spine,
+        Runs spine.parse() for each Spine,
         thus populating the spine.stream for each Spine.
         '''
         for thisSpine in self.spines:
@@ -2235,7 +2235,7 @@ class EventCollection(prebase.ProtoM21Object):
     >>> ec2.spinePathData
     False
 
-    In the future, EventCollection may enforce that all events have the same lineNumber
+    In the future, EventCollection may enforce that all events have the same lineNumber.
 
     * New in v10: lineNumber.
     '''
@@ -2405,9 +2405,9 @@ def hdStringToDuration(contents: str) -> duration.Duration:
     >>> d.tuplets[0].totalTupletLength()
     3.5
 
-    The latter definition (a double-dotted quarter-note triplet) though used in
+    The latter definition (a double-dotted quarter-note triplet), though used in
     https://kern.humdrum.org/cgi-bin/ksdata?l=musedata/mozart/quartet&file=k421-01.krn&f=kern
-    and the Josquin Research Project (JRP) is incorrect, seeing as it
+    and the Josquin Research Project (JRP), is incorrect, seeing as it
     contradicts the specification in
     https://www.humdrum.org/Humdrum/representations/kern.html#N-Tuplets
     (_"92.." is the correct ``**kern`` encoding for a note whose duration is
@@ -2420,7 +2420,7 @@ def hdStringToDuration(contents: str) -> duration.Duration:
 
     If you want the JRP definition, where dots apply to the note, not tuplet,
     set humdrum.spineParser.flavors['JRP'] = True before calling converter.parse()
-    or anything other parsing routine like hdStringToDuration:
+    or any other parsing routine like hdStringToDuration:
 
     >>> humdrum.spineParser.flavors['JRP'] = True
     >>> d = humdrum.spineParser.hdStringToDuration('6..fff')
@@ -2543,7 +2543,7 @@ def hdStringToNote(
     overrideDuration: duration.Duration|None = None,
 ) -> note.GeneralNote:
     '''
-    returns a :class:`~music21.note.Note` (or Rest or Unpitched, etc.)
+    Returns a :class:`~music21.note.Note` (or Rest or Unpitched, etc.)
     matching the current SpineEvent.
 
     Does not check to see that it is sane or part of a :samp:`**kern` spine, etc.
@@ -2730,7 +2730,7 @@ def hdStringToMeasure(
     previousMeasure: stream.Measure|None = None,
 ) -> stream.Measure:
     '''
-    kern uses an equals sign followed by processing instructions to
+    Kern uses an equals sign followed by processing instructions to
     create new measures.
 
     * Changed in v10: repeat dots are encoded as :class:`~music21.bar.Repeat`
@@ -2802,7 +2802,7 @@ def hdStringToMeasure(
 
 def kernTandemToObject(tandem: str) -> base.Music21Object|None:
     '''
-    Kern uses symbols such as :samp:`*M5/4` and :samp:`*clefG2`, etc., to control processing
+    Kern uses symbols such as :samp:`*M5/4` and :samp:`*clefG2`, etc., to control processing.
 
     This method converts them to music21 objects.
 
@@ -2972,7 +2972,7 @@ class GlobalComment(base.Music21Object):
 class GlobalReference(prebase.ProtoM21Object):
     # noinspection SpellCheckingInspection
     '''
-    An item of metadata or "library-type information' called a "Reference Record"
+    An item of metadata or "library-type information" called a "Reference Record"
     in Humdrum.  The music21 term `GlobalReference` uses Global in the sense that
     it applies to all spines, but also to the score as a whole.
 

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -166,6 +166,8 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         self.protoSpines: list[ProtoSpine] = []
         self.eventCollections: list[EventCollection] = []
         self.spineCollection: SpineCollection|None = None
+        # populated by insertGlobalEvents(), consumed by parseMetadata()
+        self.globalReferences: list[GlobalReference] = []
 
         if isinstance(dataStream, str):
             dataStream = dataStream.splitlines()
@@ -739,8 +741,10 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
     def insertGlobalEvents(self) -> None:
         '''
-        Insert the Global Events (GlobalReferenceLines and GlobalCommentLines) into an appropriate
-        place in the outer Stream.
+        Insert GlobalComments (from GlobalCommentLines) into the outer Stream,
+        and collect GlobalReferences (from GlobalReferenceLines) into
+        `self.globalReferences`.  References become metadata in
+        :meth:`parseMetadata`, not Stream objects, so they are not inserted here.
 
         Run after `self.spineCollection.createMusic21Streams()`.
         Is run automatically by `self.parse()`.
@@ -755,11 +759,17 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         eventList = self.eventList
         maxEventList = len(eventList)
         numberOfGlobalEventsInARow = 0
-        insertList: list[tuple[OffsetQL, GlobalReference|GlobalComment]] = []
-        appendList: list[GlobalReference|GlobalComment] = []
+        insertList: list[tuple[OffsetQL, GlobalComment]] = []
+        appendList: list[GlobalComment] = []
+        references: list[GlobalReference] = []
 
         for i, event in enumerate(eventList):
-            if isinstance(event, (GlobalReferenceLine, GlobalCommentLine)):
+            if isinstance(event, GlobalReferenceLine):
+                # references become metadata, not Stream objects, but are still
+                # counted so neighbouring comments keep the same priority.
+                numberOfGlobalEventsInARow += 1
+                references.append(GlobalReference(event.code, event.value))
+            elif isinstance(event, GlobalCommentLine):
                 numberOfGlobalEventsInARow += 1
                 insertOffset: OffsetQL|None = None
                 insertPriority = 0
@@ -771,31 +781,25 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                                           - 40
                                           + numberOfGlobalEventsInARow)
                         break
-                el: GlobalReference|GlobalComment
-                if isinstance(event, GlobalReferenceLine):
-                    # TODO: Fix GlobalReference (added in 2012; as of 2016 not sure what to fix)
-                    #    might add language?
-                    el = GlobalReference(event.code, event.value)
-                else:
-                    el = GlobalComment(event.value)
-                el.priority = insertPriority
+                comment = GlobalComment(event.value)
+                comment.priority = insertPriority
                 if insertOffset is None:
-                    appendList.append(el)
+                    appendList.append(comment)
                 else:
-                    insertTuple = (insertOffset, el)
-                    insertList.append(insertTuple)
-                # self.stream.insert(insertOffset, el)
+                    insertList.append((insertOffset, comment))
             else:
                 numberOfGlobalEventsInARow = 0
 
-        for offset, el in insertList:
-            self.stream.coreInsert(offset, el)
+        self.globalReferences = references
+
+        for offset, comment in insertList:
+            self.stream.coreInsert(offset, comment)
 
         if insertList:
             self.stream.coreElementsChanged()
 
-        for el in appendList:
-            self.stream.coreAppend(el)
+        for comment in appendList:
+            self.stream.coreAppend(comment)
 
         if appendList:
             self.stream.coreElementsChanged()
@@ -828,20 +832,15 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
     def parseMetadata(self, s: stream.Stream|None = None) -> None:
         '''
-        Create a metadata object for the file.
+        Create a metadata object for the file from the GlobalReferences
+        collected by :meth:`insertGlobalEvents`.
         '''
         if s is None:
             s = self.stream
         md = metadata.Metadata()
         s.metadata = md
-        grToRemove: list[GlobalReference] = []
-
-        for gr in s[GlobalReference]:
+        for gr in self.globalReferences:
             gr.updateMetadata(md)
-            grToRemove.append(gr)
-
-        if grToRemove:
-            s.remove(grToRemove, recurse=True)
 
 
 class HumdrumFile(HumdrumDataCollection):
@@ -2970,11 +2969,13 @@ class GlobalComment(base.Music21Object):
         return repr(self.comment)
 
 
-class GlobalReference(base.Music21Object):
+class GlobalReference(prebase.ProtoM21Object):
     # noinspection SpellCheckingInspection
     '''
-    A Music21Object that represents a reference in the score, called a "reference record"
-    in Humdrum.  See Humdrum User's Guide Chapter 2.
+    Represents a reference record in the score (Humdrum's term).  Unlike a
+    GlobalComment, a GlobalReference is never placed in the stream -- it is
+    converted to metadata -- so it is a plain ProtoM21Object, not a
+    Music21Object.  See Humdrum User's Guide Chapter 2.
 
     >>> sc = humdrum.spineParser.GlobalReference('!!!REF:this is a global reference')
     >>> sc
@@ -3016,9 +3017,7 @@ class GlobalReference(base.Music21Object):
         self,
         codeOrAll: str = '',
         valueOrNone: str|None = None,
-        **keywords,
     ) -> None:
-        super().__init__(**keywords)
         codeOrAll = re.sub(r'^!!!+', '', codeOrAll)
         codeOrAll = codeOrAll.strip()
         if valueOrNone is None and ':' in codeOrAll:

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -73,7 +73,6 @@ from music21 import base
 from music21 import beam  # cast only, can use 'beam' if it ever becomes circular.
 from music21 import chord
 from music21 import clef
-from music21 import common
 from music21 import dynamics
 from music21 import duration
 from music21 import environment
@@ -607,13 +606,17 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
         # currentSpineList is a list of currently active
         # spines ordered from left to right.
-        currentSpineList = common.defaultlist(lambda: None)
+        currentSpineList: list[HumdrumSpine|None] = []
         spineCollection = SpineCollection()
 
         # go through the event collections line by line
         for i in range(len(eventCollections)):
             thisEventCollection = eventCollections[i]
             lineNumber = thisEventCollection.lineNumber
+            # ensure a slot for every spine position; positions never assigned
+            # (or dropped by a previous merge) read back as None.
+            if len(currentSpineList) < maxSpines:
+                currentSpineList += [None] * (maxSpines - len(currentSpineList))
             for j in range(maxSpines):
                 thisEvent = protoSpines[j].eventList[i]
 
@@ -641,12 +644,12 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
             # thus, this is illegal.  The C#4 will be ignored:
             # *x     *x     C#4
 
-            newSpineList = common.defaultlist(lambda: None)
+            newSpineList: list[HumdrumSpine|None] = []
 
             # These are either False OR the spine being merged/exchanged.
             # TODO: separate the two concepts.
-            mergerActive = False
-            exchangeActive = False
+            mergerActive: bool|HumdrumSpine = False
+            exchangeActive: HumdrumSpine|None = None
             for j in range(maxSpines):
                 thisEvent = protoSpines[j].eventList[i]
                 currentSpine = currentSpineList[j]
@@ -657,6 +660,9 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                     continue
                 elif thisEvent is None:
                     continue
+                # a spine-path token at this position always has a spine
+                # assigned from the first pass above.
+                assert currentSpine is not None
                 if thisEvent.contents == '*-':  # terminate spine
                     currentSpine.endingPoint = lineNumber
                 elif thisEvent.contents == '*^':  # split spine assume they are voices
@@ -704,7 +710,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                         mergerActive = False
 
                 elif thisEvent.contents == '*x':  # exchange spine
-                    if exchangeActive is False:
+                    if exchangeActive is None:
                         exchangeActive = currentSpine
                     else:
                         # if second exchange is not found, then both
@@ -714,11 +720,11 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                         # is totally finished by the time the second happens
                         newSpineList.append(currentSpine)
                         newSpineList.append(exchangeActive)
-                        exchangeActive = False
+                        exchangeActive = None
                 else:  # null processing code '*'
                     newSpineList.append(currentSpine)
 
-            if exchangeActive is not False:
+            if exchangeActive is not None:
                 raise HumdrumException('ProtoSpine found with unpaired exchange instruction '
                                        f'at line {lineNumber} [{thisEventCollection.events}]')
             currentSpineList = newSpineList
@@ -2229,8 +2235,8 @@ class EventCollection(prebase.ProtoM21Object):
     * New in v10: lineNumber.
     '''
     def __init__(self, maxSpines: int = 0, lineNumber: int = 0) -> None:
-        self.events: common.defaultlist = common.defaultlist(lambda: None)
-        self.lastEvents: common.defaultlist = common.defaultlist(lambda: None)
+        self.events: list[SpineEvent|None] = [None] * maxSpines
+        self.lastEvents: dict[int, SpineEvent] = {}
         self.maxSpines: int = maxSpines
         self.lineNumber: int = lineNumber
         self.spinePathData: bool = False
@@ -2248,7 +2254,10 @@ class EventCollection(prebase.ProtoM21Object):
 
     def addGlobalEvent(self, globalEvent: HumdrumLine) -> None:
         for i in range(self.maxSpines):
-            self.events[i] = globalEvent
+            # global lines fill every cell, but the caller immediately overwrites
+            # each cell with a placeholder SpineEvent, so a HumdrumLine never
+            # survives in self.events (which is therefore typed SpineEvent|None).
+            self.events[i] = globalEvent  # type: ignore[call-overload]
 
     def getSpineEvent(self, spineNum: int) -> SpineEvent|None:
         return self.events[spineNum]
@@ -2257,10 +2266,10 @@ class EventCollection(prebase.ProtoM21Object):
         # returns the lastEvent if set (
         # should only happen if currentEvent is '.')
         # or the current event
-        if self.lastEvents[spineNum] is not None:
-            return self.lastEvents[spineNum]
-        else:
-            return self.events[spineNum]
+        lastEvent = self.lastEvents.get(spineNum)
+        if lastEvent is not None:
+            return lastEvent
+        return self.events[spineNum]
 
     def getAllOccurring(self) -> list[SpineEvent|None]:
         retEvents: list[SpineEvent|None] = []

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -548,10 +548,8 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
             # placeholder cell: either a SpineLine with no data this far over,
             # or a global line (GlobalComment, GlobalReference, or BlankLine).
-            if not isinstance(currentLine, SpineLine) and j == 0:
-                # not SpineLine = GlobalComment, GlobalReference, or BlankLine.
-                # global events register once, against the first column
-                thisEventCollection.addGlobalEvent(currentLine)
+            # Global lines are inserted separately by insertGlobalEvents() reading
+            # self.eventList, so nothing is recorded against this EventCollection.
             placeholder = SpineEvent('', currentLine.lineNumber)
             placeholder.protoSpineId = j
             thisEventCollection.addSpineEvent(j, placeholder)
@@ -2253,13 +2251,6 @@ class EventCollection(prebase.ProtoM21Object):
     def addLastSpineEvent(self, spineNum: int, spineEvent: SpineEvent) -> None:
         # should only add if current 'event' is '.' or a comment
         self.lastEvents[spineNum] = spineEvent
-
-    def addGlobalEvent(self, globalEvent: HumdrumLine) -> None:
-        for i in range(self.maxSpines):
-            # global lines fill every cell, but the caller immediately overwrites
-            # each cell with a placeholder SpineEvent, so a HumdrumLine never
-            # survives in self.events (which is therefore typed SpineEvent|None).
-            self.events[i] = globalEvent  # type: ignore[call-overload]
 
     def getSpineEvent(self, spineNum: int) -> SpineEvent|None:
         return self.events[spineNum]

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -647,10 +647,11 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
             # A merge or exchange spine-path op spans two cells on this line.
             # mergerActive flags an open merge; mergerParentSpine is the first
             # spine's parent to merge back into (None if it had none).
-            # exchangeActive is the first spine of an open exchange.
             mergerActive = False
             mergerParentSpine: HumdrumSpine|None = None
-            exchangeActive: HumdrumSpine|None = None
+            # the HumdrumSpine awaiting another one to exchange with.
+            # Or None if no exchange is active.
+            exchangeAwaitingSpine: HumdrumSpine|None = None
             for j in range(maxSpines):
                 thisEvent = protoSpines[j].eventList[i]
                 currentSpine = currentSpineList[j]
@@ -712,8 +713,8 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                         mergerParentSpine = None
 
                 elif thisEvent.contents == '*x':  # exchange spine
-                    if exchangeActive is None:
-                        exchangeActive = currentSpine
+                    if exchangeAwaitingSpine is None:
+                        exchangeAwaitingSpine = currentSpine
                     else:
                         # if second exchange is not found, then both
                         # lines disappear and exception is raised
@@ -721,12 +722,12 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                         # in a line so long as the first
                         # is totally finished by the time the second happens
                         newSpineList.append(currentSpine)
-                        newSpineList.append(exchangeActive)
-                        exchangeActive = None
+                        newSpineList.append(exchangeAwaitingSpine)
+                        exchangeAwaitingSpine = None
                 else:  # null processing code '*'
                     newSpineList.append(currentSpine)
 
-            if exchangeActive is not None:
+            if exchangeAwaitingSpine is not None:
                 raise HumdrumException('ProtoSpine found with unpaired exchange instruction '
                                        f'at line {lineNumber} [{thisEventCollection.events}]')
             currentSpineList = newSpineList

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -217,12 +217,15 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         self.spineCollection = self.createHumdrumSpines()
         spineCollection = t.cast(SpineCollection, self.spineCollection)
         spineCollection.createMusic21Streams()
-        self.insertGlobalEvents()
         for thisSpine in spineCollection:
             thisSpine.stream.id = 'spine_' + str(thisSpine.id)
         for thisSpine in spineCollection:
             if thisSpine.parentSpine is None and thisSpine.spineType == 'kern':
                 score.insert(thisSpine.stream)
+        # insert global events after the parts are in the score, so that
+        # trailing comments (appended at highestTime) land at the end of the
+        # music rather than at 0.0 in an empty score.
+        self.insertGlobalEvents()
 
         self.parseMetadata()
         return score

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -27,8 +27,7 @@ SpineParsing consists of several steps.
     Protospines that separate become new Protospines with their parentSpine indicated.  Protospines
     that merge again are then followed by the same Protospine as before.  This will cause problems
     if a voice re-merges with another staff, but in practice I have not
-    seen a .krn file that does this, and it
-    should be avoided in any case.
+    seen a .krn file that does this, and it should be avoided in any case.
 * HumdrumSpines are reclassed according to their exclusive definition.
     :samp:`**kern` becomes KernSpines, etc.
 * All reclassed HumdrumSpines are filled with music21 objects in their .stream property.
@@ -415,7 +414,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
         >>> print(eList[0].value)
         Beethoven, Ludwig van
 
-        Print line number 4 (which is eList[3] zero-indexed)
+        Print line number 4 (which is eList[3] in Python's zero-indexed format)
 
         >>> print(eList[3].spineData)
         ['C4', 'pp']

--- a/music21/humdrum/spineParser.py
+++ b/music21/humdrum/spineParser.py
@@ -644,9 +644,12 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
 
             newSpineList: list[HumdrumSpine|None] = []
 
-            # These are either False OR the spine being merged/exchanged.
-            # TODO: separate the two concepts.
-            mergerActive: bool|HumdrumSpine = False
+            # A merge or exchange spine-path op spans two cells on this line.
+            # mergerActive flags an open merge; mergerParentSpine is the first
+            # spine's parent to merge back into (None if it had none).
+            # exchangeActive is the first spine of an open exchange.
+            mergerActive = False
+            mergerParentSpine: HumdrumSpine|None = None
             exchangeActive: HumdrumSpine|None = None
             for j in range(maxSpines):
                 thisEvent = protoSpines[j].eventList[i]
@@ -684,12 +687,10 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                     # merge spine -- n.b. we allow non-adjacent
                     # lines to be merged. this is incorrect
                     # per Humdrum syntax, but is easily done.
-                    if mergerActive is False:
+                    if not mergerActive:
                         # assume that previous spine continues
-                        if currentSpine.parentSpine is not None:
-                            mergerActive = currentSpine.parentSpine
-                        else:
-                            mergerActive = True
+                        mergerActive = True
+                        mergerParentSpine = currentSpine.parentSpine
                         currentSpine.endingPoint = lineNumber
                     else:
                         # if second merger code is not found then
@@ -698,9 +699,9 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                         # merge back to parent if possible:
                         if currentSpine.parentSpine is not None:
                             newSpineList.append(currentSpine.parentSpine)
-                        # or merge back to other spine's parent:
-                        elif mergerActive is not True:  # other spine parent set
-                            newSpineList.append(mergerActive)
+                        # or merge back to the first spine's parent:
+                        elif mergerParentSpine is not None:
+                            newSpineList.append(mergerParentSpine)
                         # or make a new spine:
                         else:
                             s = spineCollection.addSpine(streamClass=stream.Part)
@@ -708,6 +709,7 @@ class HumdrumDataCollection(prebase.ProtoM21Object):
                             newSpineList.append(s)
 
                         mergerActive = False
+                        mergerParentSpine = None
 
                 elif thisEvent.contents == '*x':  # exchange spine
                     if exchangeActive is None:

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -846,8 +846,14 @@ class Test(unittest.TestCase):
         hdc.parse()
         s = hdc.stream
 
-        comments = [gc.comment for gc in s.recurse().getElementsByClass(GlobalComment)]
-        self.assertEqual(comments, ['a global comment here', 'comment at the end'])
+        # the leading comment lands at 0.0; the trailing one at the end of the
+        # music (the two quarter notes total 2.0), not back at 0.0.
+        flat = s.flatten()
+        commentInfo = [(gc.comment, gc.offset)
+                       for gc in flat.getElementsByClass(GlobalComment)]
+        self.assertEqual(
+            commentInfo,
+            [('a global comment here', 0.0), ('comment at the end', 2.0)])
 
         self.assertIsNotNone(s.metadata)
         self.assertEqual(str(s.metadata.composer), 'Test Composer')

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -30,6 +30,7 @@ from music21 import roman
 from music21 import stream
 from music21.humdrum import testFiles
 from music21.humdrum.spineParser import (
+    GlobalComment,
     HumdrumDataCollection,
     KernSpine,
     SpineComment,
@@ -826,6 +827,34 @@ class Test(unittest.TestCase):
         md = c.metadata
         self.assertIsNotNone(md.composer)
         self.assertIn('Palestrina', md.composer)
+
+    def testGlobalEventsReachStream(self):
+        # !!! references become metadata; !! comments become GlobalComment
+        # objects in the stream; a blank line is ignored without error.
+        src = '\n'.join([
+            '!!!COM: Test Composer',
+            '!!!OTL: Test Title',
+            '!! a global comment here',
+            '',  # blank line in the middle
+            '**kern',
+            '4c',
+            '4d',
+            '*-',
+            '!! comment at the end',
+        ])
+        hdc = HumdrumDataCollection(src)
+        hdc.parse()
+        s = hdc.stream
+
+        comments = [gc.comment for gc in s.recurse().getElementsByClass(GlobalComment)]
+        self.assertEqual(comments, ['a global comment here', 'comment at the end'])
+
+        self.assertIsNotNone(s.metadata)
+        self.assertEqual(str(s.metadata.composer), 'Test Composer')
+        self.assertEqual(str(s.metadata.title), 'Test Title')
+
+        # the blank line did not derail parsing
+        self.assertEqual(len(s.recurse().notes), 2)
 
     def testFlavors(self):
         prevFlavor = flavors['JRP']

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -858,8 +858,9 @@ class Test(unittest.TestCase):
             commentInfo,
             [('a global comment here', 0.0), ('comment at the end', 2.0)])
 
-        # references go to metadata and are removed from the stream entirely.
-        self.assertFalse(list(s.recurse().getElementsByClass(GlobalReference)))
+        # references become metadata only (GlobalReference is not a stream
+        # object), so none of them appear among the stream's elements.
+        self.assertFalse([el for el in s.recurse() if isinstance(el, GlobalReference)])
         self.assertIsNotNone(s.metadata)
         self.assertEqual(str(s.metadata.composer), 'Test Composer')
         self.assertEqual(str(s.metadata.title), 'Test Title')

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -96,7 +96,7 @@ class Test(unittest.TestCase):
 
     def testGraceNoteKeepsWrittenDuration(self):
         '''
-        A single `q` is a slashed grace note that keeps its written duration
+        A single `q` is a slashed grace note that keeps its written duration.
         '''
         n = SpineEvent('16ccq').toNote()
         self.assertTrue(n.duration.isGrace)
@@ -242,7 +242,7 @@ class Test(unittest.TestCase):
 
     def x_testFakePiece(self):
         '''
-        test loading a fake piece with spine paths, lyrics, dynamics, etc.
+        Test loading a fake piece with spine paths, lyrics, dynamics, etc.
         '''
         hdc = HumdrumDataCollection(testFiles.fakeTest)
         hdc.parse()

--- a/music21/humdrum/tests.py
+++ b/music21/humdrum/tests.py
@@ -31,6 +31,7 @@ from music21 import stream
 from music21.humdrum import testFiles
 from music21.humdrum.spineParser import (
     GlobalComment,
+    GlobalReference,
     HumdrumDataCollection,
     KernSpine,
     SpineComment,
@@ -829,8 +830,9 @@ class Test(unittest.TestCase):
         self.assertIn('Palestrina', md.composer)
 
     def testGlobalEventsReachStream(self):
-        # !!! references become metadata; !! comments become GlobalComment
-        # objects in the stream; a blank line is ignored without error.
+        # !! comments become GlobalComment objects in the stream; !!! references
+        # become metadata (known codes proper, unknown ones custom) and do not
+        # stay in the stream; a blank line is ignored without error.
         src = '\n'.join([
             '!!!COM: Test Composer',
             '!!!OTL: Test Title',
@@ -841,6 +843,7 @@ class Test(unittest.TestCase):
             '4d',
             '*-',
             '!! comment at the end',
+            '!!!XYZ: trailing free-form ref',
         ])
         hdc = HumdrumDataCollection(src)
         hdc.parse()
@@ -855,9 +858,13 @@ class Test(unittest.TestCase):
             commentInfo,
             [('a global comment here', 0.0), ('comment at the end', 2.0)])
 
+        # references go to metadata and are removed from the stream entirely.
+        self.assertFalse(list(s.recurse().getElementsByClass(GlobalReference)))
         self.assertIsNotNone(s.metadata)
         self.assertEqual(str(s.metadata.composer), 'Test Composer')
         self.assertEqual(str(s.metadata.title), 'Test Title')
+        # an unknown code (even trailing) is kept as custom metadata, not lost.
+        self.assertEqual(str(s.metadata.getCustom('XYZ')[0]), 'trailing free-form ref')
 
         # the blank line did not derail parsing
         self.assertEqual(len(s.recurse().notes), 2)


### PR DESCRIPTION
`common.defaultlist` was a hack I made in the first couple of weeks of making music21 in Python.  I had been working in Perl, where `@a = [];  $a[20] = 4;` was totally acceptable to set `$a[0]` to `$a[19]` to None-type (`undef`) and used this constantly.  So I put in defaultlist (originally PerlArray -- there was a PerlHash to go along with it).  By the time I finished writing Humdrum parsing, I was ready to use actual Python lists.  Nearly 20 years later, it's time for defaultlist to go.

Surprisingly the two main places where defaultlist was used are best represented in opposite ways:  self.events (spine events per line) are always filled, so setting to `[None] * maxSpines` was simple.  `lastEvents,` however, was sparse, so best represented by a dict.

GlobalComments were not be properly placed at the right point in the Stream.  Fixed.

addGlobalEvent turned out to do nothing -- it would be immediately written over!  :-)  insertGlobalEvents was the actually functioning routine.

GlobalReference were made to be Music21Objects just so they could ride along with the Stream until the end and be removed.  Now they are just ProtoM21Objects and they are all documented as affecting the whole Score.

AI-Assisted (Claude) -- PR written entirely by Myke.