### PR TITLE
Add .worktreeignore

### DIFF
--- a/.worktreeignore
+++ b/.worktreeignore
@@ -1,0 +1,20 @@
+# .worktreeignore
+#
+# Paths that are git-ignored (see .gitignore) but are expensive to regenerate
+# and worth carrying into / sharing across a fresh worktree, so a new worktree
+# is usable immediately instead of after a full rebuild.
+
+# Python virtual environment (expensive `uv sync`)
+.venv
+
+# Build / packaging artifacts
+dist
+build
+
+# Built documentation (expensive Sphinx build)
+documentation/build
+
+# Tool caches that speed up repeated runs
+.mypy_cache
+.pytest_cache
+.coverage


### PR DESCRIPTION
This file (both Claude and Codex at least support) lists things in .gitignore that should be copied to new worktrees to save time in regenerating.

AI-assisted (Claude)