### PR TITLE
Capitalize python docstrings

### DIFF
--- a/music21/common/classTools.py
+++ b/music21/common/classTools.py
@@ -136,7 +136,7 @@ def isIterable(usrData: t.Any) -> t.TypeGuard[Iterable]:
     >>> common.isIterable(stream.Stream())
     True
 
-    Ranges are not iterators by python 3, but return True
+    Ranges are not iterators by Python 3, but return True
 
     >>> common.isIterable(range(20))
     True

--- a/music21/common/numberTools.py
+++ b/music21/common/numberTools.py
@@ -447,7 +447,7 @@ def roundToHalfInteger(num: float|int) -> float|int:
     >>> common.roundToHalfInteger(0.75)
     1
 
-    unlike python round function, does the same for 1.25 and 1.75
+    unlike Python round function, does the same for 1.25 and 1.75
 
     >>> common.roundToHalfInteger(1.25)
     1.5

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -129,7 +129,7 @@ class SubConverter:
         equipped to show in this format.
 
         Default True. Might be False if, say
-        a Lilypond converter is used and Lilypond
+        a LilyPond converter is used and LilyPond
         is not installed.
         '''
         return True
@@ -399,9 +399,9 @@ class ConverterIPython(SubConverter):
 
 class ConverterLilypond(SubConverter):
     '''
-    Convert to Lilypond and from there usually to png, pdf, or svg.
+    Convert to LilyPond and from there usually to png, pdf, or svg.
 
-    Note: that the proper format for displaying Lilypond in Jupyter
+    Note: that the proper format for displaying LilyPond in Jupyter
     notebook in v9 is ipython.lily.png and not lily.ipython.png
     '''
     registerFormats = ('lilypond', 'lily')

--- a/music21/editorial.py
+++ b/music21/editorial.py
@@ -68,7 +68,7 @@ class Editorial(prebase.ProtoM21Object, dict):
     >>> n = note.Note('F')
     >>> n.editorial.ficta = fictaSharp
     >>> assert(n.editorial.ficta.alter == 1.0) #_DOCS_HIDE
-    >>> #_DOCS_SHOW n.show('lily.png')  # only Lilypond currently supports musica ficta
+    >>> #_DOCS_SHOW n.show('lily.png')  # only LilyPond currently supports musica ficta
 
     .. image:: images/noteEditorialFictaSharp.*
         :width: 103

--- a/music21/environment.py
+++ b/music21/environment.py
@@ -528,7 +528,7 @@ class _EnvironmentCore:
         the directory from tempfile.gettempdir(). The location of this directory
         depends on OS.
 
-        Note the temporary directory may be different in each python session.
+        Note the temporary directory may be different in each Python session.
         '''
         if self._checkAccessibility(self.defaultRootTempDir):
             return self.defaultRootTempDir

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -36,7 +36,7 @@ Pickle is a Python-specific
 idea for storing objects.  The `pickle` module stores objects as a text file
 that can't be easily read by non-Python applications; it also isn't guaranteed
 to work across Python versions or even computers.  However, it works well, is
-fast, and is a standard part of python.
+fast, and is a standard part of Python.
 
 JSON was originally created to pass
 JavaScript objects from a web server to a web browser, but its utility
@@ -50,7 +50,7 @@ uses explicit lists of attributes that need to be stored and just saves those. T
 homemade set of methods that are specifically tailored for music21; but it misses some things that
 may be important to you.  The second approach uses the freely distributable
 `jsonpickle` module. This approach probably stores more data than
-a person not using music21 or python is likely to want, but can be used to get back an entire
+a person not using music21 or Python is likely to want, but can be used to get back an entire
 music21 Stream with no conversion.
 
 Both JSON and Pickle files can be huge, but `freezeThaw` can compress them with

--- a/music21/lily/lilyObjects.py
+++ b/music21/lily/lilyObjects.py
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Name:         lily/objects.py
-# Purpose:      python objects representing lilypond
+# Purpose:      Python objects representing Lilypond
 #
 # Authors:      Michael Scott Asato Cuthbert
 #               Jeremy Teitelbaum (Lilypond 2.24 adaptations)

--- a/music21/lily/lilyObjects.py
+++ b/music21/lily/lilyObjects.py
@@ -1,19 +1,19 @@
 # ------------------------------------------------------------------------------
 # Name:         lily/objects.py
-# Purpose:      Python objects representing Lilypond
+# Purpose:      Python objects representing LilyPond
 #
 # Authors:      Michael Scott Asato Cuthbert
-#               Jeremy Teitelbaum (Lilypond 2.24 adaptations)
+#               Jeremy Teitelbaum (LilyPond 2.24 adaptations)
 #
 # Copyright:    Copyright © 2007-2025 Michael Scott Asato Cuthbert
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
-music21 translates to Lilypond format and if Lilypond is installed on the
+music21 translates to LilyPond format and if LilyPond is installed on the
 local computer, can automatically generate .pdf, .png, and .svg versions
-of musical files using Lilypond.
+of musical files using LilyPond.
 
-The Grammar for Lilypond comes from
+The Grammar for LilyPond comes from
 http://lilypond.org/doc/v2.14/Documentation/notation/lilypond-grammar
 '''
 from __future__ import annotations
@@ -370,7 +370,7 @@ class LyLilypondHeader(LyObject):
 
 class LyEmbeddedScm(LyObject):
     r'''
-    represents Scheme embedded in Lilypond code.
+    represents Scheme embedded in LilyPond code.
 
     Can be either an SCM_TOKEN (Scheme Token) or SCM_IDENTIFIER String stored in self.content
 

--- a/music21/lily/translate.py
+++ b/music21/lily/translate.py
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Name:         lily/translate.py
-# Purpose:      music21 classes for translating to Lilypond
+# Purpose:      music21 classes for translating to LilyPond
 #
 # Authors:      Michael Scott Asato Cuthbert
 #
@@ -8,9 +8,9 @@
 # License:      BSD, see license.txt
 # ------------------------------------------------------------------------------
 '''
-music21 translates to Lilypond format and if Lilypond is installed on the
+music21 translates to LilyPond format and if LilyPond is installed on the
 local computer, can automatically generate .pdf, .png, and .svg versions
-of musical files using Lilypond.
+of musical files using LilyPond.
 '''
 from __future__ import annotations
 
@@ -210,7 +210,7 @@ class LilypondConverter:
                 versionPieces = versionString.split('.')
         except OSError as exc:  # pragma: no cover
             raise LilyTranslateException(
-                'Cannot find a copy of Lilypond installed on your system. '
+                'Cannot find a copy of LilyPond installed on your system. '
                 + 'Please be sure it is installed. And that your '
                 + "environment.UserSettings()['lilypondPath'] is set to find it.") from exc
 
@@ -247,7 +247,7 @@ class LilypondConverter:
         except IndexError:  # pragma: no cover
             self.context = self.topLevelObject
 
-    # ----------- Set a complete Lilypond Tree from a music21 object ----------#
+    # ----------- Set a complete LilyPond Tree from a music21 object ----------#
 
     def textFromMusic21Object(self, m21ObjectIn):
         r'''
@@ -279,7 +279,7 @@ class LilypondConverter:
 
     def loadFromMusic21Object(self, m21ObjectIn):
         r'''
-        Create a Lilypond object hierarchy in self.topLevelObject from an
+        Create a LilyPond object hierarchy in self.topLevelObject from an
         arbitrary music21 object.
 
         TODO: make lilypond automatically run makeNotation.makeTupletBrackets(s)
@@ -2410,7 +2410,7 @@ class LilypondConverter:
                        backend=None, fileName=None, skipWriting=False):
         r'''
         creates a .ly file from self.topLevelObject via .writeLyFile
-        then runs the file through Lilypond.
+        then runs the file through LilyPond.
 
         Returns the full path of the file produced by lilypond including the format extension.
 

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -272,7 +272,7 @@ class TimeSignature(TimeSignatureBase):
     that they apply to.  Alternatively you can put the time signature at the
     front of a `Part` or at the beginning of a `Score`, and they will work
     within music21, but they won't necessarily display properly in MusicXML,
-    Lilypond, etc.  So best is to create structures where the TimeSignature
+    LilyPond, etc.  So best is to create structures where the TimeSignature
     goes in the first Measure of the score, as below:
 
     >>> s = stream.Score()

--- a/music21/musicxml/lilypondTestSuite/__init__.py
+++ b/music21/musicxml/lilypondTestSuite/__init__.py
@@ -1,12 +1,12 @@
 '''
-The Lilypond MusicXML Test Suite comes from
+The LilyPond MusicXML Test Suite comes from
 https://github.com/cuthbertLab/musicxmlTestSuite
 and is a fork of
 http://lilypond.org/doc/v2.18/input/regression/musicxml/collated-files
 
 The test suite is licensed under the MIT license
 (https://opensource.org/license/mit/)
-and copyrighted by the Lilypond project.
+and copyrighted by the LilyPond project.
 '''
 import unittest
 

--- a/music21/musicxml/xmlToM21.py
+++ b/music21/musicxml/xmlToM21.py
@@ -842,7 +842,7 @@ class MusicXMLImporter(XMLParserBase):
             partId = p.get('id')
             if partId is None:  # pragma: no cover
                 partId = list(self.mxScorePartDict.keys())[0]
-                # Lilypond Test Suite allows for parsing w/o a part ID for one part
+                # LilyPond Test Suite allows for parsing w/o a part ID for one part
             try:
                 mxScorePart = self.mxScorePartDict[partId]
             except KeyError:  # pragma: no cover

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -1163,7 +1163,7 @@ class Accidental(prebase.ProtoM21Object, style.StyleMixin):
 
     def set(self, name: str|int|float, *, allowNonStandardValue: bool = False) -> None:
         '''
-        Change the type of the Accidental.  Strings, numbers, and Lilypond (German-like)
+        Change the type of the Accidental.  Strings, numbers, and LilyPond (German-like)
         abbreviations are all accepted.  All other values will change
         after setting.
 

--- a/music21/stream/core.py
+++ b/music21/stream/core.py
@@ -345,7 +345,7 @@ class StreamCore(Music21Object):
         This is not the same as getElementById, which refers to the id
         attribute which may be manually set and not unique.
 
-        However, some implementations of python will reuse object locations, sometimes
+        However, some implementations of Python will reuse object locations, sometimes
         quickly, so don't keep these around.
 
         Used by spanner and variant.

--- a/music21/style.py
+++ b/music21/style.py
@@ -67,7 +67,7 @@ class Style(ProtoM21Object):
         'hideObjectOnPrint': '''
             If set to `True`, the Music21Object will not print upon output
             (only used in MusicXML output at this point and
-            in Lilypond output for notes, chords, and rests).
+            in LilyPond output for notes, chords, and rests).
             ''',
         'units': '''
             What distances are measured in.  The default "tenths" is a concept

--- a/music21/test/testRunner.py
+++ b/music21/test/testRunner.py
@@ -154,7 +154,7 @@ def mainTest(*testClasses, **keywords):
         if __name__ == '__main__':
             music21.mainTest(Test)
 
-    This module tries to fix up some differences between python2 and python3 so
+    This module tries to fix up some differences between Python 2 and Python 3 so
     that the same doctests can work.  These differences can now be removed, but
     I cannot remember what they are!
     '''

--- a/music21/tinyNotation.py
+++ b/music21/tinyNotation.py
@@ -9,7 +9,7 @@
 # -------------------------------------------------------------------------------
 '''
 tinyNotation is a simple way of specifying single line melodies
-that uses a notation somewhat similar to Lilypond but with WAY fewer
+that uses a notation somewhat similar to LilyPond but with WAY fewer
 options.  It was originally developed to notate trecento (medieval Italian)
 music, but it is pretty useful for a lot of short examples, so we have
 made it a generally supported music21 format.


### PR DESCRIPTION
Also change Lilypond/lilypond to `LilyPond` except in places where it would be backwards incompatible.

AI-assisted (Claude).