### PR TITLE
Typing tree.spans /  tighten constructors

### DIFF
--- a/music21/tree/spans.py
+++ b/music21/tree/spans.py
@@ -16,16 +16,17 @@ organized by start and stop offsets.
 from __future__ import annotations
 
 import copy
-from math import inf
 import typing as t
 import unittest
 
-from music21.common.types import OffsetQLIn
+from music21.common.types import OffsetQL, OffsetQLIn
 from music21 import environment
 from music21 import exceptions21
 
 if t.TYPE_CHECKING:
     from music21 import base
+    from music21 import note
+    from music21 import pitch
     from music21 import stream
 
 environLocal = environment.Environment('tree.spans')
@@ -75,30 +76,28 @@ class Timespan:
     False
     '''
 
-    def __init__(self, offset=-inf, endTime=inf):
-        if offset is not None:
-            offset = float(offset)
-        self._offset = offset
-        if endTime is not None:
-            endTime = float(endTime)
-        self._endTime = endTime
-        if offset is not None and endTime is not None:
-            if offset > endTime:
-                raise TimespanException(f'offset {offset!r} must be after endTime {endTime!r}')
+    def __init__(self, offset: OffsetQLIn, endTime: OffsetQLIn) -> None:
+        offset = float(offset)
+        self._offset: OffsetQL = offset
+        endTime = float(endTime)
+        self._endTime: OffsetQL = endTime
+        if offset > endTime:
+            raise TimespanException(f'offset {offset!r} must be after endTime {endTime!r}')
 
-    def __eq__(self, expr):
+    def __eq__(self, expr: object) -> bool:
         if type(self) is type(expr):
-            if self.offset == expr.offset:
-                if self.endTime == expr.endTime:
+            other = t.cast('Timespan', expr)
+            if self.offset == other.offset:
+                if self.endTime == other.endTime:
                     return True
         return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         typeName = type(self).__name__
         return f'<{typeName} {self.offset} {self.endTime}>'
 
     @property
-    def offset(self):
+    def offset(self) -> OffsetQL:
         r'''
         The start offset of the Timespan, relative to its
         containing score.
@@ -114,7 +113,7 @@ class Timespan:
         return self._offset
 
     @property
-    def endTime(self):
+    def endTime(self) -> OffsetQL:
         r'''
         The stop offset of the Timespan, relative to its
         containing score.
@@ -129,7 +128,7 @@ class Timespan:
         # this is a property to make it immutable.
         return self._endTime
 
-    def new(self, offset=None, endTime=None):
+    def new(self, *, offset: OffsetQLIn|None = None, endTime: OffsetQLIn|None = None) -> t.Self:
         '''
         return a new object with the given offset and endTime
         '''
@@ -140,7 +139,7 @@ class Timespan:
 
         return type(self)(offset=offset, endTime=endTime)
 
-    def canMerge(self, other):
+    def canMerge(self, other: Timespan) -> tuple[bool, str]:
         '''
         returns a tuple of (True or False) if these timespans can be merged
         with the second element being a message or None.
@@ -168,7 +167,7 @@ class Timespan:
             return (False, message)
         return (True, '')
 
-    def mergeWith(self, other):
+    def mergeWith(self, other: Timespan) -> Timespan:
         r'''
         Merges two consecutive/contiguous timespans, keeping the
         information from the former of the two.
@@ -197,7 +196,7 @@ class Timespan:
             mergedTimespan = other.new(endTime=self.endTime)
         return mergedTimespan
 
-    def splitAt(self, offset):
+    def splitAt(self, offset: OffsetQLIn) -> tuple[t.Self, ...]:
         r'''
         Split Timespan at `offset`.
 
@@ -297,6 +296,8 @@ class ElementTimespan(Timespan):
 
     These are not dynamic, so changing the Score object does not change the
     measureNumber, etc.
+
+    * Changed in v11: order of arguments matches parent class.
     '''
 
     # CLASS VARIABLES #
@@ -322,40 +323,41 @@ class ElementTimespan(Timespan):
 
     def __init__(
         self,
-        element: base.Music21Object|None = None,
+        offset: OffsetQLIn,
+        endTime: OffsetQLIn,
+        element: base.Music21Object,
+        *,
         parentOffset: OffsetQLIn|None = None,
         parentEndTime: OffsetQLIn|None = None,
         parentage: tuple[stream.Stream, ...] = (),
-        offset: OffsetQLIn|None = None,
-        endTime: OffsetQLIn|None = None,
-    ):
+    ) -> None:
         super().__init__(offset=offset, endTime=endTime)
 
-        self.element: base.Music21Object|None = element
-        self.parentage = parentage
+        self.element: base.Music21Object = element
+        self.parentage: tuple[stream.Stream, ...] = parentage
         if parentOffset is not None:
             parentOffset = float(parentOffset)
-        self.parentOffset = parentOffset
+        self.parentOffset: OffsetQL|None = parentOffset
         if parentEndTime is not None:
             parentEndTime = float(parentEndTime)
-        self.parentEndTime = parentEndTime
+        self.parentEndTime: OffsetQL|None = parentEndTime
         if parentOffset is not None and parentEndTime is not None:
             if parentOffset > parentEndTime:
                 raise TimespanException(
                     f'offset {parentOffset!r} must be after parentEndTime {parentEndTime!r}')
 
     # SPECIAL METHODS #
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return self is other
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         typeName = type(self).__name__
         return f'<{typeName} ({self.offset} to {self.endTime}) {self.element!r}>'
 
     # PUBLIC PROPERTIES #
 
     @property
-    def quarterLength(self):
+    def quarterLength(self) -> OffsetQL:
         '''
         The quarterLength of the Timespan, which, due to manipulation, may be different
         from that of the element.
@@ -364,7 +366,7 @@ class ElementTimespan(Timespan):
         >>> n.offset = 1.0
         >>> n.duration.quarterLength = 2.0
 
-        >>> pts = tree.spans.PitchedTimespan(n, offset=n.offset, endTime=3.0)
+        >>> pts = tree.spans.PitchedTimespan(n.offset, 3.0, n)
         >>> pts
         <PitchedTimespan (1.0 to 3.0) <music21.note.Note D->>
         >>> pts.quarterLength
@@ -385,18 +387,19 @@ class ElementTimespan(Timespan):
     # PUBLIC METHODS #
 
     def new(self,
-            element=None,
-            parentOffset=None,
-            parentEndTime=None,
-            offset=None,
-            endTime=None,
-            ):
+            *,
+            offset: OffsetQLIn|None = None,
+            endTime: OffsetQLIn|None = None,
+            element: base.Music21Object|None = None,
+            parentOffset: OffsetQLIn|None = None,
+            parentEndTime: OffsetQLIn|None = None,
+            ) -> t.Self:
         '''
         Create a new object that is identical to the calling object
         but with some parameters overridden.
 
         >>> n = note.Note('C#')
-        >>> pts = tree.spans.PitchedTimespan(n, offset=11.0, endTime=12.0)
+        >>> pts = tree.spans.PitchedTimespan(11.0, 12.0, n)
         >>> pts
         <PitchedTimespan (11.0 to 12.0) <music21.note.Note C#>>
         >>> pts2 = pts.new(endTime=13.0)
@@ -416,18 +419,18 @@ class ElementTimespan(Timespan):
             endTime = self.endTime
 
         return type(self)(
+            offset=offset,
+            endTime=endTime,
             element=element,
             parentOffset=parentOffset,
             parentEndTime=parentEndTime,
             parentage=self.parentage,
-            offset=offset,
-            endTime=endTime,
         )
 
     # PUBLIC PROPERTIES #
 
     @property
-    def measureNumber(self):
+    def measureNumber(self) -> int|None:
         r'''
         The measure number of the measure containing the element.
 
@@ -446,7 +449,10 @@ class ElementTimespan(Timespan):
         #    return x.measureNumber
         # return None
 
-    def getParentageByClass(self, classList):
+    def getParentageByClass(
+        self,
+        classList: type|tuple[type, ...]
+    ) -> stream.Stream|None:
         '''
         returns that is the first parentage that has this classList.
         default stream.Part
@@ -479,7 +485,7 @@ class ElementTimespan(Timespan):
         return None
 
     @property
-    def part(self):
+    def part(self) -> stream.Stream|None:
         '''
         find the object in the parentage that is a Part object:
 
@@ -517,28 +523,37 @@ class ElementTimespan(Timespan):
 
 
 class PitchedTimespan(ElementTimespan):
+    '''
+    A :class:`~music21.tree.spans.ElementTimespan` whose element is a
+    pitched note or chord, exposing its :attr:`pitches`.
+
+    * Changed in v11: order of arguments matches parent class.
+    '''
+    element: note.GeneralNote
+
     def __init__(self,
-                 element=None,
-                 parentOffset=None,
-                 parentEndTime=None,
-                 parentage=None,
-                 offset=None,
-                 endTime=None,
-                 ):
-        super().__init__(element=element,
+                 offset: OffsetQLIn,
+                 endTime: OffsetQLIn,
+                 element: note.GeneralNote,
+                 *,
+                 parentOffset: OffsetQLIn|None = None,
+                 parentEndTime: OffsetQLIn|None = None,
+                 parentage: tuple[stream.Stream, ...] = (),
+                 ) -> None:
+        super().__init__(offset=offset,
+                         endTime=endTime,
+                         element=element,
                          parentOffset=parentOffset,
                          parentEndTime=parentEndTime,
-                         parentage=parentage,
-                         offset=offset,
-                         endTime=endTime)
+                         parentage=parentage)
 
     @property
-    def pitches(self):
+    def pitches(self) -> tuple[pitch.Pitch, ...]:
         r'''
         Gets the pitches of the element wrapped by this PitchedTimespan.
 
         >>> c = chord.Chord('C4 E4 G4')
-        >>> pts = tree.spans.PitchedTimespan(c, offset=0.0, endTime=1.0)
+        >>> pts = tree.spans.PitchedTimespan(0.0, 1.0, c)
         >>> pts.pitches
         (<music21.pitch.Pitch C4>, <music21.pitch.Pitch E4>, <music21.pitch.Pitch G4>)
         >>> pts.pitches == c.pitches
@@ -549,7 +564,7 @@ class PitchedTimespan(ElementTimespan):
         '''
         return self.element.pitches
 
-    def canMerge(self, other):
+    def canMerge(self, other: Timespan) -> tuple[bool, str]:
         '''
         sub-method of base canMerge that checks to see if the pitches are the same.
 
@@ -612,7 +627,7 @@ class PitchedTimespan(ElementTimespan):
         '''
         can, message = super().canMerge(other)
         if can is True:
-            if self.pitches != other.pitches:
+            if self.pitches != t.cast('PitchedTimespan', other).pitches:
                 message = f'Cannot merge {self} with {other}: different pitches'
                 can = False
         return (can, message)


### PR DESCRIPTION
Preparing to use tree.verticality more, we need better typing for tree.spans.TimeSpan and its derived classes, ElementTimespan and PitchedTimespan.

- Timespan offset/endTime are required OffsetQL (no None or -inf/inf defaults).
- ElementTimespan requires an element (base.Music21Object) at construction.
- PitchedTimespan narrows element to note.GeneralNote -- this violates LSP but it's too entrenched to work around.
- parentage defaults to ().

AI-assisted (Claude).