### PR TITLE
chord: use deque + popleft for geometric-normal-form rotation

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     'tools',
 ]
 
+from collections import deque
 from collections.abc import Iterable, Sequence
 import copy
 import typing as t
@@ -1789,7 +1790,7 @@ class Chord(ChordBase):
         for i in range(1, len(sortedPitchClassList)):
             if sortedPitchClassList[i] != sortedPitchClassList[i - 1]:
                 uniquePitchClassList.append(sortedPitchClassList[i])
-        intervalList = []
+        intervalList: deque[int] = deque()
         for i in range(1, len(uniquePitchClassList)):
             lPC = (uniquePitchClassList[i] - uniquePitchClassList[i - 1]) % 12
             intervalList.append(lPC)
@@ -1797,7 +1798,7 @@ class Chord(ChordBase):
         # make list of rotations
         rotationList = []
         for i in range(0, len(intervalList)):
-            b = intervalList.pop(0)
+            b = intervalList.popleft()
             intervalList.append(b)
             intervalTuple = tuple(intervalList)
             rotationList.append(intervalTuple)


### PR DESCRIPTION
The rotation loop in `geometricNormalForm()` did `intervalList.pop(0)` in a loop `(O(n) per pop -> O(n^2))`; a `deque` with `popleft()` makes each rotation `O(1)`.

 No AI-authored code, except in extracting from meter-speed branch.