### PR TITLE
sorting: use modern NamedTuple for SortTuple

### DIFF
--- a/music21/base.py
+++ b/music21/base.py
@@ -1895,7 +1895,7 @@ class Music21Object(prebase.ProtoM21Object):
         (<music21.stream.Score bach>, '9.5 <0.20...>', <RecursionType.ELEMENTS_ONLY>)
 
         Streams have themselves as the first element in their context sites, at position
-        zero and classSortOrder negative infinity.
+        zero and priority negative infinity.
 
         This example shows the context sites for Measure 3 of the
         Alto part. We will get the measure object using direct access to

--- a/music21/sorting.py
+++ b/music21/sorting.py
@@ -1,10 +1,10 @@
 # -----------------------------------------------------------------------------
 # Name:         sorting.py
-# Purpose:      Music21 class for sorting
+# Purpose:      Music21 class for sorting Music21Objects
 #
 # Authors:      Michael Scott Asato Cuthbert
 #
-# Copyright:    Copyright © 2014-2015 Michael Scott Asato Cuthbert
+# Copyright:    Copyright © 2014-2026 Michael Scott Asato Cuthbert
 # License:      BSD, see license.txt
 # -----------------------------------------------------------------------------
 '''
@@ -40,10 +40,6 @@ class SortingException(exceptions21.Music21Exception):
 class SortTuple(t.NamedTuple):
     '''
     Derived class of namedTuple which allows for comparisons with pure ints/fractions.
-
-    * Changed in v11: defined directly as a typed NamedTuple (no separate base class);
-      ``priority`` is now typed ``int | float`` to reflect the ``±inf`` sentinels.
-      (AI-assisted.)
 
     >>> n = note.Note()
     >>> s = stream.Stream()
@@ -97,6 +93,7 @@ class SortTuple(t.NamedTuple):
     >>> st.shortRepr()
     '1.0 <0.20.323>'
 
+    * Changed in v11: priority and classSortOrder can be floats.
     '''
     atEnd: int
     offset: OffsetQL
@@ -187,10 +184,8 @@ class SortTuple(t.NamedTuple):
     def modify(self, **keywords) -> SortTuple:
         '''
         Return a new SortTuple identical to the previous, except with
-        the given keyword modified.  Works only with keywords.
-
-        Identical to ``_replace()`` and ``copy.replace()`` on Py 3.13+;
-        called out to document it.
+        the given keyword modified.  Works only with keywords. (Identical to
+        ``_replace()`` and ``copy.replace()`` on Py 3.13+)
 
         >>> st = sorting.SortTuple(atEnd=0, offset=1.0, priority=0, classSortOrder=20,
         ...           isNotGrace=1, insertIndex=32)
@@ -204,15 +199,14 @@ class SortTuple(t.NamedTuple):
         >>> st3.shortRepr()
         'End <0.20.[Grace].32>'
 
-        The original tuple is never modified (hence tuple):
+        The original tuple is never modified (hence why it's a tuple):
 
         >>> st.offset
         1.0
 
-        Changing offset, but nothing else, helps in creating .flatten() positions.
+        `Stream.flatten()` uses `.modify` to change offsets while keeping other values identical.
 
-        * Changed in v11: delegates to the namedtuple ``_replace``; a bad field
-          name now raises ValueError instead of being silently ignored.
+        * Changed in v11: a bad field name now raises ValueError
         '''
         return self._replace(**keywords)
 
@@ -239,28 +233,31 @@ class SortTuple(t.NamedTuple):
             raise SortingException('Cannot add attributes from a different class')
 
         outList = [max(getattr(self, attr), getattr(other, attr))
-                    if attr in ('atEnd', 'isNotGrace')
-                    else (getattr(self, attr) + getattr(other, attr))
-                    for attr in self._fields]  # _fields are the namedtuple attributes
+                   if attr in ('atEnd', 'isNotGrace')
+                   else (getattr(self, attr) + getattr(other, attr))
+                   for attr in self._fields]  # _fields are the namedtuple attributes
 
         return self.__class__(*outList)
 
     def sub(self, other):
         '''
-        Subtract all attributes from to another.  atEnd and isNotGrace take the min value of either.
+        Subtract all attributes from another SortTuple.
+        `atEnd` and `isNotGrace` take the min value of either.
 
         >>> n = note.Note()
         >>> n.offset = 10
         >>> s = stream.Stream()
         >>> s.offset = 10
-        >>> n.sortTuple()
+        >>> nt = n.sortTuple()
+        >>> nt
         SortTuple(atEnd=0, offset=10.0, priority=0, classSortOrder=20, isNotGrace=1, insertIndex=0)
-        >>> s.sortTuple()
+        >>> st = s.sortTuple()
+        >>> st
         SortTuple(atEnd=0, offset=10.0, priority=0, classSortOrder=-20, isNotGrace=1, insertIndex=0)
-        >>> s.sortTuple().sub(n.sortTuple())
+        >>> st.sub(nt)
         SortTuple(atEnd=0, offset=0.0, priority=0, classSortOrder=-40, isNotGrace=1, insertIndex=0)
 
-        Note that atEnd and isNotGrace are lower bounded at 0.
+        Note that `atEnd` and `isNotGrace` are lower bounded at 0.
         '''
         if not isinstance(other, self.__class__):
             raise SortingException('Cannot add attributes from a different class')

--- a/music21/sorting.py
+++ b/music21/sorting.py
@@ -208,7 +208,7 @@ class SortTuple(t.NamedTuple):
 
         * Changed in v11: a bad field name now raises ValueError
         '''
-        return self._replace(**keywords)
+        return self._replace(**keywords)  # pylint: disable=no-member
 
     def add(self, other):
         '''
@@ -237,7 +237,7 @@ class SortTuple(t.NamedTuple):
         outList = [max(getattr(self, attr), getattr(other, attr))
                    if attr in ('atEnd', 'isNotGrace')
                    else (getattr(self, attr) + getattr(other, attr))
-                   for attr in self._fields]  # _fields are the namedtuple attributes
+                   for attr in self._fields]  # pylint: disable=no-member
 
         return self.__class__(*outList)
 
@@ -267,7 +267,7 @@ class SortTuple(t.NamedTuple):
         outList = [min(getattr(self, attr), getattr(other, attr))
                    if attr in ('atEnd', 'isNotGrace')
                    else (getattr(self, attr) - getattr(other, attr))
-                   for attr in self._fields]  # _fields are the namedtuple attributes
+                   for attr in self._fields]  # pylint: disable=no-member
 
         return self.__class__(*outList)
 

--- a/music21/sorting.py
+++ b/music21/sorting.py
@@ -37,18 +37,13 @@ class SortingException(exceptions21.Music21Exception):
     pass
 
 
-_SortTupleBase = t.NamedTuple('SortTuple', [   # type: ignore[name-match]
-    ('atEnd', int),
-    ('offset', OffsetQL),
-    ('priority', int),
-    ('classSortOrder', int),
-    ('isNotGrace', int),
-    ('insertIndex', int),
-])
-
-class SortTuple(_SortTupleBase):
+class SortTuple(t.NamedTuple):
     '''
     Derived class of namedTuple which allows for comparisons with pure ints/fractions.
+
+    * Changed in v11: defined directly as a typed NamedTuple (no separate base class);
+      ``priority`` is now typed ``int | float`` to reflect the ``±inf`` sentinels.
+      (AI-assisted.)
 
     >>> n = note.Note()
     >>> s = stream.Stream()
@@ -103,13 +98,18 @@ class SortTuple(_SortTupleBase):
     '1.0 <0.20.323>'
 
     '''
-    def __new__(cls, *tupEls, **keywords):
-        # noinspection PyTypeChecker
-        return super(SortTuple, cls).__new__(cls, *tupEls, **keywords)
+    atEnd: int
+    offset: OffsetQL
+    priority: int | float
+    classSortOrder: int | float
+    isNotGrace: int
+    insertIndex: int
 
     def __eq__(self, other):
         if isinstance(other, tuple):
-            return super().__eq__(other)
+            # NB: tuple.__eq__ not super() -- bare super() in a class-syntax NamedTuple
+            # body triggers a __classcell__ RuntimeError at class creation.
+            return tuple.__eq__(self, other)
         try:
             if self.atEnd == 1 and other != INFINITY:
                 return False
@@ -122,7 +122,7 @@ class SortTuple(_SortTupleBase):
 
     def __lt__(self, other):
         if isinstance(other, tuple):
-            return super().__lt__(other)
+            return tuple.__lt__(self, other)
         try:
             if self.atEnd == 1:
                 return False
@@ -133,7 +133,7 @@ class SortTuple(_SortTupleBase):
 
     def __gt__(self, other):
         if isinstance(other, tuple):
-            return super().__gt__(other)
+            return tuple.__gt__(self, other)
         try:
             if self.atEnd == 1 and other != INFINITY:
                 return True
@@ -184,10 +184,13 @@ class SortTuple(_SortTupleBase):
         reprParts.append('>')
         return ''.join(reprParts)
 
-    def modify(self, **keywords):
+    def modify(self, **keywords) -> SortTuple:
         '''
         Return a new SortTuple identical to the previous, except with
         the given keyword modified.  Works only with keywords.
+
+        Identical to ``_replace()`` and ``copy.replace()`` on Py 3.13+;
+        called out to document it.
 
         >>> st = sorting.SortTuple(atEnd=0, offset=1.0, priority=0, classSortOrder=20,
         ...           isNotGrace=1, insertIndex=32)
@@ -207,10 +210,11 @@ class SortTuple(_SortTupleBase):
         1.0
 
         Changing offset, but nothing else, helps in creating .flatten() positions.
+
+        * Changed in v11: delegates to the namedtuple ``_replace``; a bad field
+          name now raises ValueError instead of being silently ignored.
         '''
-        # _fields are the namedtuple attributes
-        outList = [keywords.get(attr, getattr(self, attr)) for attr in self._fields]
-        return self.__class__(*outList)
+        return self._replace(**keywords)
 
     def add(self, other):
         '''

--- a/music21/sorting.py
+++ b/music21/sorting.py
@@ -219,14 +219,16 @@ class SortTuple(t.NamedTuple):
         >>> n.offset = 10
         >>> s = stream.Stream()
         >>> s.offset = 10
-        >>> n.sortTuple()
+        >>> nt = n.sortTuple()
+        >>> nt
         SortTuple(atEnd=0, offset=10.0, priority=0, classSortOrder=20, isNotGrace=1, insertIndex=0)
-        >>> s.sortTuple()
+        >>> st = s.sortTuple()
+        >>> st
         SortTuple(atEnd=0, offset=10.0, priority=0, classSortOrder=-20, isNotGrace=1, insertIndex=0)
-        >>> s.sortTuple().add(n.sortTuple())
+        >>> st.add(nt)
         SortTuple(atEnd=0, offset=20.0, priority=0, classSortOrder=0, isNotGrace=1, insertIndex=0)
 
-        Note that atEnd and isNotGrace are equal to other's value. are upper bounded at 1 and
+        Note that `atEnd` and `isNotGrace` are upper bounded at 1 and
         take the maxValue of either.
         '''
         if not isinstance(other, self.__class__):


### PR DESCRIPTION
Some cleanup for sorting.SortTuple:

typing: note that `inf` and `-inf` are technically floats, so priority has to allow floats if we are going to allow them (which is important).

note that `modify` (from Python 2.5 and earlier) is same as (since Py 2.6/3.0) `_replace()` and (since Py 3.13) `copy.replace()` -- use `_replace()` internally, which also now catches errors on typos.

AI-assisted mostly for confirming that there wouldn't be incompatible repercussions. (Claude)