### PR TITLE
Meter: Speedup with Immutable MeterTerminal and MeterSequence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@
 
 - pytest works but to run the whole suite run music21/test/multiprocessTest.py (or testSingleCoreAll.py 
   if on a single core machine.)
+- It is very unlikely that there were any preexisting failures. If you changed something and
+  now it appears master has also a preexisting failure, you should clear the music21 temp cache.
 - Run `uv run ruff check music21` before making PRs or pushes to open PRs.
 - Run `uv run mypy music21` before making PRs or pushes to open PRs.
 - Never commit `forceSource=True` to a test or doctest (it re-parses from source every

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '11.0.0b6'
+__version__ = '11.0.0b7'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '11.0.0b7'
+__version__ = '11.0.0b8'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '11.0.0b8'
+__version__ = '11.0.0b9'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/analysis/metrical.py
+++ b/music21/analysis/metrical.py
@@ -61,7 +61,7 @@ def labelBeatDepth(streamIn):
 
         # need to make a copy otherwise the .beat/.beatStr values will be messed up (1/4 the normal)
         tsTemp = copy.deepcopy(ts)
-        tsTemp.beatSequence.subdivideNestedHierarchy(depth=3)
+        tsTemp.beatSequence = tsTemp.beatSequence.subdivideNestedHierarchy(depth=3)
 
         for n in m.notesAndRests:
             if hasattr(n, 'tie') and n.tie is not None:

--- a/music21/base.py
+++ b/music21/base.py
@@ -26,7 +26,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'11.0.0b7'
+'11.0.0b8'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/base.py
+++ b/music21/base.py
@@ -26,7 +26,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'11.0.0b8'
+'11.0.0b9'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/base.py
+++ b/music21/base.py
@@ -26,7 +26,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'11.0.0b6'
+'11.0.0b7'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":
@@ -54,7 +54,7 @@ from music21.common.numberTools import opFrac
 from music21.common.types import OffsetQL, OffsetQLIn
 from music21 import defaults
 from music21.derivation import Derivation
-from music21.duration import Duration, DurationException
+from music21.duration import Duration, DurationException, FrozenDuration
 from music21.editorial import Editorial  # import class directly to not conflict with property.
 from music21 import environment
 from music21 import exceptions21
@@ -857,7 +857,15 @@ class Music21Object(prebase.ProtoM21Object):
 
     @quarterLength.setter
     def quarterLength(self, value: OffsetQLIn):
-        self.duration.quarterLength = value
+        try:
+            self.duration.quarterLength = value
+        except TypeError:
+            # self.duration is an immutable FrozenDuration (held shared): replace
+            # it with a mutable copy before changing its length (copy-on-write).
+            if not isinstance(self.duration, FrozenDuration):
+                raise
+            self.duration = self.duration.unfreeze()
+            self.duration.quarterLength = value
 
     @property
     def derivation(self) -> Derivation:
@@ -2795,13 +2803,25 @@ class Music21Object(prebase.ProtoM21Object):
     def duration(self, durationObj: Duration):
         durationObjAlreadyExists = False
         if self._duration is not None:
-            self._duration.client = None
+            try:
+                self._duration.client = None
+            except TypeError:
+                # a FrozenDuration is immutable and has no client to clear
+                if not isinstance(self._duration, FrozenDuration):
+                    raise
             durationObjAlreadyExists = True
 
         try:
             ql = durationObj.quarterLength
             self._duration = durationObj
-            durationObj.client = self
+            try:
+                durationObj.client = self
+            except TypeError:
+                # durationObj is an immutable FrozenDuration (e.g. one from a
+                # TimeSignature): it never changes, so it needs no client
+                # back-reference and can be held shared as-is.
+                if not isinstance(durationObj, FrozenDuration):
+                    raise
             if durationObjAlreadyExists:
                 self.informSites({'changedElement': 'duration', 'quarterLength': ql})
 
@@ -3797,9 +3817,9 @@ class Music21Object(prebase.ProtoM21Object):
             return 'nan'
 
     @property
-    def beatDuration(self) -> Duration:
+    def beatDuration(self) -> FrozenDuration:
         '''
-        Return a :class:`~music21.duration.Duration` of the beat
+        Return a :class:`~music21.duration.FrozenDuration` of the beat
         active for this object as found in the most recently
         positioned Measure.
 
@@ -3815,7 +3835,7 @@ class Music21Object(prebase.ProtoM21Object):
         >>> m.repeatAppend(n, 6)
         >>> n0 = m.notes.first()
         >>> n0.beatDuration
-        <music21.duration.Duration 1.0>
+        <music21.duration.FrozenDuration 1.0>
 
         Notice that the beat duration is the same for all these notes
         and has nothing to do with the duration of the element itself
@@ -3842,16 +3862,17 @@ class Music21Object(prebase.ProtoM21Object):
 
         >>> isolatedNote = note.Note('E4')
         >>> isolatedNote.beatDuration
-        <music21.duration.Duration 0.0>
+        <music21.duration.FrozenDuration 0.0>
 
         * Changed in v6.3: returns a duration.Duration object of length 0 if
           there is no TimeSignature in sites.  Previously raised an exception.
+        * Changed in v11: returns a :class:`~music21.duration.FrozenDuration`.
         '''
         try:
             ts = self._getTimeSignatureForBeat()
             return ts.getBeatDuration(ts.getMeasureOffsetOrMeterModulusOffset(self))
         except Music21ObjectException:
-            return Duration(0)
+            return FrozenDuration(quarterLength=0.0)
 
     @property
     def beatStrength(self) -> float:

--- a/music21/base.py
+++ b/music21/base.py
@@ -3856,6 +3856,17 @@ class Music21Object(prebase.ProtoM21Object):
         >>> isolatedNote.beatDuration
         <music21.duration.FrozenDuration 0.0>
 
+        If you want to modify the frozen beatDuration, call unfreeze on it and
+        assign it to a new variable:
+
+        >>> bd = n0.beatDuration
+        >>> bd
+        <music21.duration.FrozenDuration 1.5>
+        >>> bdThaw = bd.unfreeze()
+        >>> bdThaw.type = 'eighth'
+        >>> bdThaw
+        <music21.duration.Duration 0.75>
+
         * Changed in v6.3: returns a duration.Duration object of length 0 if
           there is no TimeSignature in sites.  Previously raised an exception.
         * Changed in v11: returns a :class:`~music21.duration.FrozenDuration`.

--- a/music21/base.py
+++ b/music21/base.py
@@ -857,15 +857,7 @@ class Music21Object(prebase.ProtoM21Object):
 
     @quarterLength.setter
     def quarterLength(self, value: OffsetQLIn):
-        try:
-            self.duration.quarterLength = value
-        except TypeError:
-            # self.duration is an immutable FrozenDuration (held shared): replace
-            # it with a mutable copy before changing its length (copy-on-write).
-            if not isinstance(self.duration, FrozenDuration):
-                raise
-            self.duration = self.duration.unfreeze()
-            self.duration.quarterLength = value
+        self.duration.quarterLength = value
 
     @property
     def derivation(self) -> Derivation:

--- a/music21/braille/segment.py
+++ b/music21/braille/segment.py
@@ -2365,15 +2365,15 @@ def splitMeasure(music21Measure, beatDivisionOffset=0, useTimeSignature=None):
         except IndexError:
             environRules.warn('Problem in converting a time signature in measure '
                               f'{music21Measure.number}, offset may be wrong')
-    bs = copy.deepcopy(ts.beatSequence)
+    bs = ts.beatSequence
 
     numberOfPartitions = 2
     try:
-        bs.partitionByCount(numberOfPartitions, loadDefault=False)
+        bs = bs.partitionByCount(numberOfPartitions, loadDefault=False)
         (startOffsetZero, endOffsetZero) = bs.getLevelSpan()[0]
     except meter.MeterException:
         numberOfPartitions += 1
-        bs.partitionByCount(numberOfPartitions, loadDefault=False)
+        bs = bs.partitionByCount(numberOfPartitions, loadDefault=False)
         startOffsetZero = bs.getLevelSpan()[0][0]
         endOffsetZero = bs.getLevelSpan()[-2][-1]
     endOffsetZero -= offset

--- a/music21/common/objects.py
+++ b/music21/common/objects.py
@@ -268,9 +268,7 @@ class EqualSlottedObjectMixin(SlottedObjectMixin):
 
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):
-            # Defer to the other operand rather than declaring inequality, so a
-            # subclass with a value-based __eq__ (e.g. duration.FrozenDuration vs
-            # a plain Duration) can still compare equal in either order.
+            # Defer to the other operand rather than declaring inequality
             return NotImplemented
         for thisSlot in self._getSlotsRecursive():
             if thisSlot == 'id':

--- a/music21/common/objects.py
+++ b/music21/common/objects.py
@@ -268,7 +268,10 @@ class EqualSlottedObjectMixin(SlottedObjectMixin):
 
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):
-            return False
+            # Defer to the other operand rather than declaring inequality, so a
+            # subclass with a value-based __eq__ (e.g. duration.FrozenDuration vs
+            # a plain Duration) can still compare equal in either order.
+            return NotImplemented
         for thisSlot in self._getSlotsRecursive():
             if thisSlot == 'id':
                 continue

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -1724,11 +1724,23 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> tupDur1 == tupDur2
         True
 
+        Grace durations are conceptually distinct, so they never equal an ordinary
+        Duration:
+
         >>> graceDur1 = tupDur1.getGraceDuration()
         >>> graceDur1 == tupDur1
         False
+
+        But two grace durations of the same value are equal:
+
         >>> graceDur2 = tupDur2.getGraceDuration()
         >>> graceDur1 == graceDur2
+        True
+
+        A :class:`FrozenDuration` differs from a Duration only in being immutable,
+        so it compares equal to an otherwise-identical Duration:
+
+        >>> duration.Duration(2.0) == duration.FrozenDuration(quarterLength=2.0)
         True
 
         Link status must be the same:
@@ -1736,8 +1748,15 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         >>> tupDur1.linked = False
         >>> tupDur1 == tupDur2
         False
+
+        * Changed in v11: equality is by musical value, not exact class, so a
+          FrozenDuration equals the Duration it represents.
         '''
-        if type(other) is not type(self):
+        if not isinstance(other, Duration):
+            return False
+        # A grace duration is conceptually a different thing from an ordinary
+        # duration, even at the same length; a FrozenDuration is not.
+        if self.isGrace != other.isGrace:
             return False
 
         if self.isComplex != other.isComplex:
@@ -1903,7 +1922,7 @@ class Duration(prebase.ProtoM21Object, SlottedObjectMixin):
         newTuplet.frozen = True
         self.tuplets = self._tuplets + (newTuplet,)
 
-    def augmentOrDiminish(self, amountToScale: OffsetQLIn, retainComponents=False) -> t.Self:
+    def augmentOrDiminish(self, amountToScale: OffsetQLIn, retainComponents=False) -> Duration:
         '''
         Given a number greater than zero, creates a new Duration object
         after
@@ -3088,6 +3107,86 @@ class FrozenDuration(common.objects.FrozenObject, Duration):
         '''
         return self
 
+    def unfreeze(self) -> Duration:
+        '''
+        Return an independent, mutable :class:`Duration` with the same value --
+        faithfully preserving components, tuplets, etc.
+
+        >>> fd = duration.FrozenDuration(type='half', dots=1)
+        >>> d = fd.unfreeze()
+        >>> d
+        <music21.duration.Duration 3.0>
+        >>> type(d) is duration.Duration
+        True
+
+        The copy is mutable and fully independent of the original:
+
+        >>> d.dots = 0
+        >>> d.quarterLength
+        2.0
+        >>> fd.dots
+        1
+
+        Tuplets and unlinked status survive the round trip:
+
+        >>> fd2 = duration.FrozenDuration(2/3)
+        >>> d2 = fd2.unfreeze()
+        >>> d2.tuplets
+        (<music21.duration.Tuplet 3/2/quarter>,)
+        >>> d2.tuplets is fd2.tuplets
+        False
+
+        * New in v11.
+
+        AI-assisted (Claude).
+        '''
+        # Copy the frozen state straight onto a bare mutable Duration.  __new__
+        # skips __init__ (which would just set defaults __setstate__ overwrites);
+        # __setstate__ then restores every slot.  Components/quarterLength/link
+        # status are immutable and shared; only tuplets are mutable, so deep-copy
+        # those (when any) -- meter durations have none, so it is skipped entirely.
+        new = Duration.__new__(Duration)
+        new.__setstate__(self.__getstate__())
+        if self._tuplets:
+            new._tuplets = copy.deepcopy(self._tuplets)
+        new.client = None
+        return new
+
+    def augmentOrDiminish(self, amountToScale: OffsetQLIn, retainComponents=False) -> Duration:
+        '''
+        Like :meth:`Duration.augmentOrDiminish`, but always returns a new, mutable
+        Duration.
+
+        >>> fd = duration.FrozenDuration(quarterLength=1.0)
+        >>> d = fd.augmentOrDiminish(0.5)
+        >>> d
+        <music21.duration.Duration 0.5>
+        >>> type(d) is duration.Duration
+        True
+        '''
+        return self.unfreeze().augmentOrDiminish(
+            amountToScale, retainComponents=retainComponents)
+
+    def splitDotGroups(self, *, inPlace=False) -> Duration:
+        '''
+        Like :meth:`Duration.splitDotGroups`, but `inPlace` must be False since a
+        FrozenDuration cannot be mutated.
+
+        >>> fd = duration.FrozenDuration(quarterLength=1.0)
+        >>> fd.splitDotGroups()
+        <music21.duration.Duration 1.0>
+
+        >>> fd.splitDotGroups(inPlace=True)
+        Traceback (most recent call last):
+        TypeError: This FrozenDuration instance is immutable.
+        '''
+        if inPlace:
+            raise TypeError(f'This {type(self).__name__} instance is immutable.')
+        # unfreeze() already made the copy, so split it in place -- no second copy.
+        thawed = self.unfreeze()
+        thawed.splitDotGroups(inPlace=True)
+        return thawed
+
 class GraceDuration(Duration):
     '''
     A Duration that, no matter how it is created, always has a quarter length
@@ -3652,6 +3751,30 @@ class Test(unittest.TestCase):
     def testCopyAndDeepcopy(self):
         from music21.test.commonTest import testCopyAll
         testCopyAll(self, globals())
+
+    def testFrozenDurationEquality(self):
+        # A FrozenDuration equals the Duration it represents, in either order.
+        d = Duration(2.0)
+        fd = FrozenDuration(quarterLength=2.0)
+        self.assertEqual(d, fd)
+        self.assertEqual(fd, d)
+        self.assertFalse(d != fd)
+        self.assertFalse(fd != d)
+
+        # Equal even from different construction paths (differing internal flags
+        # that a slot-by-slot comparison would trip on).
+        self.assertEqual(Duration(type='half'), fd)
+        self.assertEqual(fd, Duration(type='half'))
+
+        # Same value frozen-vs-frozen is equal; a different value is not.
+        self.assertEqual(FrozenDuration(quarterLength=2.0), fd)
+        self.assertNotEqual(fd, Duration(1.0))
+        self.assertNotEqual(Duration(1.0), fd)
+
+        # A grace duration is conceptually distinct, in either order.
+        grace = d.getGraceDuration()
+        self.assertNotEqual(grace, d)
+        self.assertNotEqual(d, grace)
 
     def testTuple(self):
         # create a tuplet with 5 dotted eighths in the place of 3 double-dotted

--- a/music21/duration.py
+++ b/music21/duration.py
@@ -3107,6 +3107,12 @@ class FrozenDuration(common.objects.FrozenObject, Duration):
         '''
         return self
 
+    def __copy__(self):
+        '''
+        Immutable objects return themselves
+        '''
+        return self
+
     def unfreeze(self) -> Duration:
         '''
         Return an independent, mutable :class:`Duration` with the same value --

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -39,7 +39,7 @@ from music21.meter.core import MeterSequence
 environLocal = environment.Environment('meter')
 
 if t.TYPE_CHECKING:
-    from music21.common.types import OffsetQL
+    from music21.common.types import OffsetQL, OffsetQLIn
     from music21 import stream
 
 # this is just a placeholder so that .beamSequence, etc. do not need to
@@ -791,7 +791,9 @@ class TimeSignature(TimeSignatureBase):
         if beamSequence is not None:
             # could come from self.beamSequence, self.accentSequence,
             #   self.displaySequence, self.accentSequence
-            return beamSequence.duration
+            # unfreeze() so callers get an ordinary, mutable Duration; the meter's
+            # own duration stays a shared, immutable FrozenDuration internally.
+            return beamSequence.duration.unfreeze()
 
         # should never happen.
         return duration.Duration(0)  # pragma: no cover
@@ -901,7 +903,7 @@ class TimeSignature(TimeSignatureBase):
         return self.beatSequence.partitionStr
 
     @property
-    def beatDuration(self) -> duration.Duration:
+    def beatDuration(self) -> duration.FrozenDuration:
         '''
         Return a :class:`~music21.duration.Duration` object equal to the beat unit
         of this Time Signature, if and only if this TimeSignature has a uniform beat unit.
@@ -911,21 +913,21 @@ class TimeSignature(TimeSignatureBase):
 
         >>> ts = meter.TimeSignature('3/4')
         >>> ts.beatDuration
-        <music21.duration.Duration 1.0>
+        <music21.duration.FrozenDuration 1.0>
         >>> ts = meter.TimeSignature('6/8')
         >>> ts.beatDuration
-        <music21.duration.Duration 1.5>
+        <music21.duration.FrozenDuration 1.5>
 
         >>> ts = meter.TimeSignature('7/8')
         >>> ts.beatDuration
-        <music21.duration.Duration 0.5>
+        <music21.duration.FrozenDuration 0.5>
 
         >>> ts = meter.TimeSignature('3/8')
         >>> ts.beatDuration
-        <music21.duration.Duration 1.5>
+        <music21.duration.FrozenDuration 1.5>
         >>> ts.beatCount = 3
         >>> ts.beatDuration
-        <music21.duration.Duration 0.5>
+        <music21.duration.FrozenDuration 0.5>
 
         Cannot do this because of asymmetry
 
@@ -935,6 +937,7 @@ class TimeSignature(TimeSignatureBase):
         music21.exceptions21.TimeSignatureException: non-uniform beat unit: [2.0, 0.75]
 
         * Changed in v7: return NaN rather than raising Exception in property.
+        * Changed in v11: returns a :class:`~music21.duration.FrozenDuration`.
         '''
         post = []
         for ms in self.beatSequence:
@@ -1029,7 +1032,7 @@ class TimeSignature(TimeSignatureBase):
             return 'Other'
 
     @property
-    def beatDivisionDurations(self) -> list[duration.Duration]:
+    def beatDivisionDurations(self) -> list[duration.FrozenDuration]:
         '''
         Return the beat division, or the durations that make up one beat,
         as a list of :class:`~music21.duration.Duration` objects, if and only if
@@ -1037,17 +1040,19 @@ class TimeSignature(TimeSignatureBase):
 
         >>> ts = meter.TimeSignature('3/4')
         >>> ts.beatDivisionDurations
-        [<music21.duration.Duration 0.5>,
-         <music21.duration.Duration 0.5>]
+        [<music21.duration.FrozenDuration 0.5>,
+         <music21.duration.FrozenDuration 0.5>]
 
         >>> ts = meter.TimeSignature('6/8')
         >>> ts.beatDivisionDurations
-        [<music21.duration.Duration 0.5>,
-         <music21.duration.Duration 0.5>,
-         <music21.duration.Duration 0.5>]
+        [<music21.duration.FrozenDuration 0.5>,
+         <music21.duration.FrozenDuration 0.5>,
+         <music21.duration.FrozenDuration 0.5>]
 
         Value returned of non-uniform beat divisions will change at any time
         after v7.1 to avoid raising an exception.
+
+        * Changed in v11: returns :class:`~music21.duration.FrozenDuration` objects.
 
         OMIT_FROM_DOCS
 
@@ -1058,13 +1063,13 @@ class TimeSignature(TimeSignatureBase):
         >>> ts.beatSequence[0]
         <music21.meter.core.MeterTerminal 1/128>
         >>> ts.beatDivisionDurations
-        [<music21.duration.Duration 0.03125>]
+        [<music21.duration.FrozenDuration 0.03125>]
 
         >>> ts = meter.TimeSignature('1/128')
         >>> ts.beatSequence[0]
         <music21.meter.core.MeterTerminal 1/128>
         >>> ts.beatDivisionDurations
-        [<music21.duration.Duration 0.03125>]
+        [<music21.duration.FrozenDuration 0.03125>]
         '''
         post = []
         for mt in self.beatSequence:
@@ -1864,9 +1869,9 @@ class TimeSignature(TimeSignatureBase):
                     return post  # do not add offset for end of bar
                 post.append(o)
 
-    def getBeatDuration(self, qLenPos):
+    def getBeatDuration(self, qLenPos: OffsetQLIn) -> duration.FrozenDuration:
         '''
-        Returns a :class:`~music21.duration.Duration`
+        Returns a :class:`~music21.duration.FrozenDuration`
         object representing the length of the beat
         found at qLenPos.  For most standard
         meters, you can give qLenPos = 0
@@ -1884,15 +1889,15 @@ class TimeSignature(TimeSignatureBase):
 
         >>> ts1 = meter.TimeSignature('3/4')
         >>> ts1.getBeatDuration(0.5)
-        <music21.duration.Duration 1.0>
+        <music21.duration.FrozenDuration 1.0>
         >>> ts1.getBeatDuration(2.5)
-        <music21.duration.Duration 1.0>
+        <music21.duration.FrozenDuration 1.0>
 
         Ex. 2: same for 6/8:
 
         >>> ts2 = meter.TimeSignature('6/8')
         >>> ts2.getBeatDuration(2.5)
-        <music21.duration.Duration 1.5>
+        <music21.duration.FrozenDuration 1.5>
 
         Ex. 3: but for a compound meter of 3/8 + 2/8,
         where you ask for the beat duration
@@ -1900,9 +1905,11 @@ class TimeSignature(TimeSignatureBase):
 
         >>> ts3 = meter.TimeSignature('3/8+2/8')  # will partition as 2 beat
         >>> ts3.getBeatDuration(0.5)
-        <music21.duration.Duration 1.5>
+        <music21.duration.FrozenDuration 1.5>
         >>> ts3.getBeatDuration(1.5)
-        <music21.duration.Duration 1.0>
+        <music21.duration.FrozenDuration 1.0>
+
+        * Changed in v11: returns a :class:`~music21.duration.FrozenDuration`.
         '''
         return self.beatSequence[self.beatSequence.offsetToIndex(qLenPos)].duration
 

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -2128,12 +2128,16 @@ class TimeSignature(TimeSignatureBase):
 
         >>> b = meter.TimeSignature('3/4', 1)
         >>> b.beatSequence = b.beatSequence.setIndex(0, b.beatSequence[0].subdivide(3))
-        >>> b.beatSequence = b.beatSequence.setIndex(
-        ...     0, b.beatSequence[0].setIndex(0, b.beatSequence[0][0].subdivide(2)))
-        >>> b.beatSequence = b.beatSequence.setIndex(
-        ...     0, b.beatSequence[0].setIndex(1, b.beatSequence[0][1].subdivide(2)))
-        >>> b.beatSequence = b.beatSequence.setIndex(
-        ...     0, b.beatSequence[0].setIndex(2, b.beatSequence[0][2].subdivide(2)))
+
+        Subdivide every component of ``beatSequence[0]`` by 2.  Since the sequences
+        are immutable, build up the new inner sequence in a variable and then set it
+        back into ``beatSequence`` once:
+
+        >>> inner = b.beatSequence[0]
+        >>> for i in range(len(inner)):
+        ...     inner = inner.setIndex(i, inner[i].subdivide(2))
+        >>> b.beatSequence = b.beatSequence.setIndex(0, inner)
+
         >>> b.getBeatDepth(0)
         3
         >>> b.getBeatDepth(0.5)

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -40,6 +40,13 @@ from music21.meter.core import (
 
 environLocal = environment.Environment('meter')
 
+# Cache of the fully-configured (display, beam, beat, accent) MeterSequences a
+# TimeSignature.load() produces for a given (value, divisions).  The sequences are
+# immutable and shared, and any later change to a TimeSignature is copy-on-write, so
+# repeated TimeSignatures of the same meter can reuse them and skip the (hashing-heavy)
+# rebuild entirely.
+_defaultSequenceCache: dict[tuple[str, t.Any], tuple[MeterSequence, ...]] = {}
+
 if t.TYPE_CHECKING:
     from music21.common.types import OffsetQL, OffsetQLIn
     from music21 import stream
@@ -602,6 +609,18 @@ class TimeSignature(TimeSignatureBase):
             value = '2/2'
             self.symbol = 'cut'
 
+        cacheKey = (value, divisions)
+        cached = None
+        cacheable = True
+        try:
+            cached = _defaultSequenceCache.get(cacheKey)
+        except TypeError:
+            cacheable = False  # unhashable divisions (e.g. a list): skip the cache
+        if cached is not None:
+            (self.displaySequence, self.beamSequence,
+             self.beatSequence, self.accentSequence) = cached
+            return
+
         self.displaySequence = getMeterSequence(value)
 
         # get simple representation; presently, only slashToTuple
@@ -633,6 +652,11 @@ class TimeSignature(TimeSignatureBase):
                 self._setDefaultAccentWeights(3)  # set partitions based on beat
             except MeterException:
                 environLocal.printDebug(['cannot set default accents for:', self])
+
+        if cacheable:
+            _defaultSequenceCache[cacheKey] = (
+                self.displaySequence, self.beamSequence,
+                self.beatSequence, self.accentSequence)
 
     @property
     def ratioString(self):

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -34,7 +34,9 @@ from music21.exceptions21 import MeterException, TimeSignatureException
 from music21 import style
 
 from music21.meter.tools import slashToTuple, proportionToFraction
-from music21.meter.core import MeterSequence, getMeterTerminal
+from music21.meter.core import (
+    MeterSequence, getMeterSequence, getMeterTerminal, _makeSequence,
+)
 
 environLocal = environment.Environment('meter')
 
@@ -600,7 +602,7 @@ class TimeSignature(TimeSignatureBase):
             value = '2/2'
             self.symbol = 'cut'
 
-        self.displaySequence = MeterSequence(value)
+        self.displaySequence = getMeterSequence(value)
 
         # get simple representation; presently, only slashToTuple
         # supports the fast/slow indication
@@ -613,12 +615,12 @@ class TimeSignature(TimeSignatureBase):
         favorCompound = (division != MeterDivision.SLOW)
 
         # used for beaming
-        self.beamSequence = MeterSequence(value, divisions)
+        self.beamSequence = getMeterSequence(value, divisions)
         # used for getting beat divisions
-        self.beatSequence = MeterSequence(value, divisions)
+        self.beatSequence = getMeterSequence(value, divisions)
 
         # accentSequence is used for setting one level of accents
-        self.accentSequence = MeterSequence(value, divisions)
+        self.accentSequence = getMeterSequence(value, divisions)
 
         if divisions is None:  # set default beam partitions
             # beam is not adjust by tempo indication
@@ -879,12 +881,12 @@ class TimeSignature(TimeSignatureBase):
     @beatCount.setter
     def beatCount(self, value: int):
         try:
-            self.beatSequence.partition(value)
+            self.beatSequence = self.beatSequence.partition(value)
         except MeterException:
             raise TimeSignatureException(f'cannot partition beat with provided value: {value}')
         # create subdivisions using default parameters
         if len(self.beatSequence) > 1:  # if partitioned
-            self.beatSequence.subdividePartitionsEqual()
+            self.beatSequence = self.beatSequence.subdividePartitionsEqual()
 
     @property
     def beatCountName(self) -> str:
@@ -976,7 +978,7 @@ class TimeSignature(TimeSignatureBase):
         * Changed in v7: return 1 instead of a TimeSignatureException.
         '''
         # first, find if there is more than one beat and if all beats are uniformly partitioned
-        post = []
+        post: list[int] = []
         if len(self.beatSequence) == 1:
             return 1
 
@@ -1013,11 +1015,11 @@ class TimeSignature(TimeSignatureBase):
         5/8 + 5/8 with no further subdivisions:
 
         >>> ts = meter.TimeSignature('10/8')
-        >>> ts.beatSequence.partition(2)
+        >>> ts.beatSequence = ts.beatSequence.partition(2)
         >>> ts.beatSequence
         <music21.meter.core.MeterSequence {5/8+5/8}>
         >>> for i, mt in enumerate(ts.beatSequence):
-        ...     ts.beatSequence[i] = mt.subdivideByCount(5)
+        ...     ts.beatSequence = ts.beatSequence.replaceElement(i, mt.subdivideByCount(5))
         >>> ts.beatSequence
         <music21.meter.core.MeterSequence {{1/8+1/8+1/8+1/8+1/8}+{1/8+1/8+1/8+1/8+1/8}}>
         >>> ts.beatDivisionCountName
@@ -1144,7 +1146,11 @@ class TimeSignature(TimeSignatureBase):
     @summedNumerator.setter
     def summedNumerator(self, value: bool):
         if self.displaySequence is not None:
-            self.displaySequence.summedNumerator = value
+            # displaySequence is immutable; swap in a copy with the new flag
+            ds = self.displaySequence
+            self.displaySequence = _makeSequence(
+                ds.numerator, ds.denominator, ds._partition,
+                parenthesis=ds.parenthesis, summedNumerator=value)
 
     # --------------------------------------------------------------------------
     # private methods -- most to be put into the various sequences.
@@ -1170,36 +1176,36 @@ class TimeSignature(TimeSignatureBase):
         if len(self.displaySequence) == 1:
             # create toplevel partitions
             if self.numerator == 2:  # duple meters
-                self.beatSequence.partition(2)
+                self.beatSequence = self.beatSequence.partition(2)
             elif self.numerator == 6 and favorCompound:  # duple meters
-                self.beatSequence.partition(2)
+                self.beatSequence = self.beatSequence.partition(2)
             elif self.numerator == 3 and favorCompound:  # 3/8, 3/16, but not 3/4
-                self.beatSequence.partition(1)
+                self.beatSequence = self.beatSequence.partition(1)
             elif self.numerator == 3:  # triple meters
-                self.beatSequence.partition([1, 1, 1])
+                self.beatSequence = self.beatSequence.partition([1, 1, 1])
             elif self.numerator == 9 and favorCompound:  # triple meters
-                self.beatSequence.partition([3, 3, 3])
+                self.beatSequence = self.beatSequence.partition([3, 3, 3])
             elif self.numerator == 4:  # quadruple meters
-                self.beatSequence.partition(4)
+                self.beatSequence = self.beatSequence.partition(4)
             elif self.numerator == 12 and favorCompound:
-                self.beatSequence.partition(4)
+                self.beatSequence = self.beatSequence.partition(4)
             elif self.numerator >= 15 and self.numerator % 3 == 0 and favorCompound:
                 # quintuple meters and above.
                 num_triples = self.numerator // 3
-                self.beatSequence.partition([3] * num_triples)
+                self.beatSequence = self.beatSequence.partition([3] * num_triples)
             # skip 6 numerators; covered above
             else:  # case of odd meters: 11, 13
-                self.beatSequence.partition(self.numerator)
+                self.beatSequence = self.beatSequence.partition(self.numerator)
 
         # if a complex meter has been given
         else:  # partition by display
             # TODO: remove partitionByMeterSequence usage.
-            self.beatSequence.partition(self.displaySequence)
+            self.beatSequence = self.beatSequence.partition(self.displaySequence)
 
         # create subdivisions, and thus define compound/simple distinction
         if len(self.beatSequence) > 1:  # if partitioned
             try:
-                self.beatSequence.subdividePartitionsEqual()
+                self.beatSequence = self.beatSequence.subdividePartitionsEqual()
             except MeterException:
                 if self.denominator >= 128:
                     pass  # do not raise an exception for unable to subdivide smaller than 128
@@ -1222,24 +1228,26 @@ class TimeSignature(TimeSignatureBase):
 
         # more general, based only on numerator
         elif self.numerator in (2, 3, 4):
-            self.beamSequence.partition(self.numerator)
+            self.beamSequence = self.beamSequence.partition(self.numerator)
             # if denominator is 4, subdivide each partition
             if self.denominator == 4:
                 for i in range(len(self.beamSequence)):  # subdivide  each beat in 2
-                    self.beamSequence[i] = self.beamSequence[i].subdivide(2)
+                    self.beamSequence = self.beamSequence.replaceElement(
+                        i, self.beamSequence[i].subdivide(2))
         elif self.numerator == 5:
             default = [2, 3]
-            self.beamSequence.partition(default)
+            self.beamSequence = self.beamSequence.partition(default)
             # if denominator is 4, subdivide each partition
             if self.denominator == 4:
                 for i in range(len(self.beamSequence)):  # subdivide  each beat in 2
-                    self.beamSequence[i] = self.beamSequence[i].subdivide(default[i])
+                    self.beamSequence = self.beamSequence.replaceElement(
+                        i, self.beamSequence[i].subdivide(default[i]))
 
         elif self.numerator == 7:
-            self.beamSequence.partition(3)  # divide into three groups
+            self.beamSequence = self.beamSequence.partition(3)  # divide into three groups
 
         elif self.numerator in [6, 9, 12, 15, 18, 21]:
-            self.beamSequence.partition([3] * int(self.numerator / 3))
+            self.beamSequence = self.beamSequence.partition([3] * int(self.numerator / 3))
         else:
             pass  # doing nothing will beam all together
         # environLocal.printDebug(f'default beam partitions set to: {self.beamSequence}')
@@ -1286,17 +1294,16 @@ class TimeSignature(TimeSignatureBase):
         #    firstPartitionForm, 'self.beatSequence: ', self.beatSequence, tsStr)
         # using cacheKey speeds up TS creation from 2300 microseconds to 500microseconds
         try:
-            self.accentSequence = copy.deepcopy(
-                _meterSequenceAccentArchetypes[cacheKey]
-            )
+            # archetypes are immutable and shared; no copy needed
+            self.accentSequence = _meterSequenceAccentArchetypes[cacheKey]
             # environLocal.printDebug(['using stored accent archetype:'])
         except KeyError:
             # environLocal.printDebug(['creating a new accent archetype'])
             ms = MeterSequence(tsStr)
             # key operation here
             # div count needs to be the number of top-level beat divisions
-            ms.subdivideNestedHierarchy(depth,
-                                        firstPartitionForm=firstPartitionForm)
+            ms = ms.subdivideNestedHierarchy(depth,
+                                             firstPartitionForm=firstPartitionForm)
 
             # provide a partition for each flattened division
             accentCount = len(ms.flatten())
@@ -1317,16 +1324,17 @@ class TimeSignature(TimeSignatureBase):
                 weightValues[x + 1] = weightValueMin * pow(2, x)
 
             # set weights on accent partitions
-            self.accentSequence.partition([1] * accentCount)
+            self.accentSequence = self.accentSequence.partition([1] * accentCount)
             for i in range(accentCount):
                 # get values from weightValues dictionary; terminals are
                 # immutable, so replace each with a re-weighted cached one
                 mt = self.accentSequence[i]
-                self.accentSequence[i] = getMeterTerminal(
-                    mt.numerator, mt.denominator, weight=weightValues[weightInts[i]])
+                self.accentSequence = self.accentSequence.replaceElement(
+                    i, getMeterTerminal(
+                        mt.numerator, mt.denominator, weight=weightValues[weightInts[i]]))
 
             if cacheKey != _meterSequenceAccentArchetypesNoneCache:
-                _meterSequenceAccentArchetypes[cacheKey] = copy.deepcopy(self.accentSequence)
+                _meterSequenceAccentArchetypes[cacheKey] = self.accentSequence
 
     # --------------------------------------------------------------------------
     # access data for other processing
@@ -1350,8 +1358,8 @@ class TimeSignature(TimeSignatureBase):
         unless we see the context of adjoining durations.
 
         >>> a = meter.TimeSignature('2/4', 2)
-        >>> a.beamSequence[0] = a.beamSequence[0].subdivide(2)
-        >>> a.beamSequence[1] = a.beamSequence[1].subdivide(2)
+        >>> a.beamSequence = a.beamSequence.replaceElement(0, a.beamSequence[0].subdivide(2))
+        >>> a.beamSequence = a.beamSequence.replaceElement(1, a.beamSequence[1].subdivide(2))
         >>> a.beamSequence
         <music21.meter.core.MeterSequence {{1/8+1/8}+{1/8+1/8}}>
         >>> b = [note.Note(type='16th') for _ in range(8)]
@@ -1637,7 +1645,7 @@ class TimeSignature(TimeSignatureBase):
         division.
 
         >>> a = meter.TimeSignature('3/4', 3)
-        >>> a.accentSequence.partition([2, 1])
+        >>> a.accentSequence = a.accentSequence.partition([2, 1])
         >>> a.accentSequence
         <music21.meter.core.MeterSequence {2/4+1/4}>
         >>> a.getAccent(0.0)
@@ -1688,8 +1696,8 @@ class TimeSignature(TimeSignatureBase):
         else:
             weightList = weights
 
-        # terminals are immutable; setLevelWeight replaces them in place
-        self.accentSequence.setLevelWeight(weightList, level)
+        # sequences are immutable; setLevelWeight returns a new one
+        self.accentSequence = self.accentSequence.setLevelWeight(weightList, level)
 
     def averageBeatStrength(self, streamIn, notesOnly=True):
         '''
@@ -1840,7 +1848,7 @@ class TimeSignature(TimeSignatureBase):
         1
         >>> a.getBeat(2.5)
         3
-        >>> a.beatSequence.partition(['3/8', '3/8'])
+        >>> a.beatSequence = a.beatSequence.partition(['3/8', '3/8'])
         >>> a.getBeat(2.5)
         2
         '''
@@ -2021,7 +2029,7 @@ class TimeSignature(TimeSignatureBase):
 
         Works for specifically partitioned meters too:
 
-        >>> a.beatSequence.partition(['3/8', '3/8'])
+        >>> a.beatSequence = a.beatSequence.partition(['3/8', '3/8'])
         >>> a.getBeatProgress(2.5)
         (2, 1.0)
         '''
@@ -2105,10 +2113,13 @@ class TimeSignature(TimeSignatureBase):
         1
 
         >>> b = meter.TimeSignature('3/4', 1)
-        >>> b.beatSequence[0] = b.beatSequence[0].subdivide(3)
-        >>> b.beatSequence[0][0] = b.beatSequence[0][0].subdivide(2)
-        >>> b.beatSequence[0][1] = b.beatSequence[0][1].subdivide(2)
-        >>> b.beatSequence[0][2] = b.beatSequence[0][2].subdivide(2)
+        >>> b.beatSequence = b.beatSequence.replaceElement(0, b.beatSequence[0].subdivide(3))
+        >>> b.beatSequence = b.beatSequence.replaceElement(
+        ...     0, b.beatSequence[0].replaceElement(0, b.beatSequence[0][0].subdivide(2)))
+        >>> b.beatSequence = b.beatSequence.replaceElement(
+        ...     0, b.beatSequence[0].replaceElement(1, b.beatSequence[0][1].subdivide(2)))
+        >>> b.beatSequence = b.beatSequence.replaceElement(
+        ...     0, b.beatSequence[0].replaceElement(2, b.beatSequence[0][2].subdivide(2)))
         >>> b.getBeatDepth(0)
         3
         >>> b.getBeatDepth(0.5)

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -34,7 +34,7 @@ from music21.exceptions21 import MeterException, TimeSignatureException
 from music21 import style
 
 from music21.meter.tools import slashToTuple, proportionToFraction
-from music21.meter.core import MeterSequence
+from music21.meter.core import MeterSequence, getMeterTerminal
 
 environLocal = environment.Environment('meter')
 
@@ -1319,8 +1319,11 @@ class TimeSignature(TimeSignatureBase):
             # set weights on accent partitions
             self.accentSequence.partition([1] * accentCount)
             for i in range(accentCount):
-                # get values from weightValues dictionary
-                self.accentSequence[i].weight = weightValues[weightInts[i]]
+                # get values from weightValues dictionary; terminals are
+                # immutable, so replace each with a re-weighted cached one
+                mt = self.accentSequence[i]
+                self.accentSequence[i] = getMeterTerminal(
+                    mt.numerator, mt.denominator, weight=weightValues[weightInts[i]])
 
             if cacheKey != _meterSequenceAccentArchetypesNoneCache:
                 _meterSequenceAccentArchetypes[cacheKey] = copy.deepcopy(self.accentSequence)
@@ -1685,9 +1688,8 @@ class TimeSignature(TimeSignatureBase):
         else:
             weightList = weights
 
-        msLevel = self.accentSequence.getLevel(level)
-        for i in range(len(msLevel)):
-            msLevel[i].weight = weightList[i % len(weightList)]
+        # terminals are immutable; setLevelWeight replaces them in place
+        self.accentSequence.setLevelWeight(weightList, level)
 
     def averageBeatStrength(self, streamIn, notesOnly=True):
         '''

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -1019,7 +1019,7 @@ class TimeSignature(TimeSignatureBase):
         >>> ts.beatSequence
         <music21.meter.core.MeterSequence {5/8+5/8}>
         >>> for i, mt in enumerate(ts.beatSequence):
-        ...     ts.beatSequence = ts.beatSequence.replaceElement(i, mt.subdivideByCount(5))
+        ...     ts.beatSequence = ts.beatSequence.setIndex(i, mt.subdivideByCount(5))
         >>> ts.beatSequence
         <music21.meter.core.MeterSequence {{1/8+1/8+1/8+1/8+1/8}+{1/8+1/8+1/8+1/8+1/8}}>
         >>> ts.beatDivisionCountName
@@ -1232,7 +1232,7 @@ class TimeSignature(TimeSignatureBase):
             # if denominator is 4, subdivide each partition
             if self.denominator == 4:
                 for i in range(len(self.beamSequence)):  # subdivide  each beat in 2
-                    self.beamSequence = self.beamSequence.replaceElement(
+                    self.beamSequence = self.beamSequence.setIndex(
                         i, self.beamSequence[i].subdivide(2))
         elif self.numerator == 5:
             default = [2, 3]
@@ -1240,7 +1240,7 @@ class TimeSignature(TimeSignatureBase):
             # if denominator is 4, subdivide each partition
             if self.denominator == 4:
                 for i in range(len(self.beamSequence)):  # subdivide  each beat in 2
-                    self.beamSequence = self.beamSequence.replaceElement(
+                    self.beamSequence = self.beamSequence.setIndex(
                         i, self.beamSequence[i].subdivide(default[i]))
 
         elif self.numerator == 7:
@@ -1329,7 +1329,7 @@ class TimeSignature(TimeSignatureBase):
                 # get values from weightValues dictionary; terminals are
                 # immutable, so replace each with a re-weighted cached one
                 mt = self.accentSequence[i]
-                self.accentSequence = self.accentSequence.replaceElement(
+                self.accentSequence = self.accentSequence.setIndex(
                     i, getMeterTerminal(
                         mt.numerator, mt.denominator, weight=weightValues[weightInts[i]]))
 
@@ -1358,8 +1358,8 @@ class TimeSignature(TimeSignatureBase):
         unless we see the context of adjoining durations.
 
         >>> a = meter.TimeSignature('2/4', 2)
-        >>> a.beamSequence = a.beamSequence.replaceElement(0, a.beamSequence[0].subdivide(2))
-        >>> a.beamSequence = a.beamSequence.replaceElement(1, a.beamSequence[1].subdivide(2))
+        >>> a.beamSequence = a.beamSequence.setIndex(0, a.beamSequence[0].subdivide(2))
+        >>> a.beamSequence = a.beamSequence.setIndex(1, a.beamSequence[1].subdivide(2))
         >>> a.beamSequence
         <music21.meter.core.MeterSequence {{1/8+1/8}+{1/8+1/8}}>
         >>> b = [note.Note(type='16th') for _ in range(8)]
@@ -2113,13 +2113,13 @@ class TimeSignature(TimeSignatureBase):
         1
 
         >>> b = meter.TimeSignature('3/4', 1)
-        >>> b.beatSequence = b.beatSequence.replaceElement(0, b.beatSequence[0].subdivide(3))
-        >>> b.beatSequence = b.beatSequence.replaceElement(
-        ...     0, b.beatSequence[0].replaceElement(0, b.beatSequence[0][0].subdivide(2)))
-        >>> b.beatSequence = b.beatSequence.replaceElement(
-        ...     0, b.beatSequence[0].replaceElement(1, b.beatSequence[0][1].subdivide(2)))
-        >>> b.beatSequence = b.beatSequence.replaceElement(
-        ...     0, b.beatSequence[0].replaceElement(2, b.beatSequence[0][2].subdivide(2)))
+        >>> b.beatSequence = b.beatSequence.setIndex(0, b.beatSequence[0].subdivide(3))
+        >>> b.beatSequence = b.beatSequence.setIndex(
+        ...     0, b.beatSequence[0].setIndex(0, b.beatSequence[0][0].subdivide(2)))
+        >>> b.beatSequence = b.beatSequence.setIndex(
+        ...     0, b.beatSequence[0].setIndex(1, b.beatSequence[0][1].subdivide(2)))
+        >>> b.beatSequence = b.beatSequence.setIndex(
+        ...     0, b.beatSequence[0].setIndex(2, b.beatSequence[0][2].subdivide(2)))
         >>> b.getBeatDepth(0)
         3
         >>> b.getBeatDepth(0.5)

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -35,7 +35,7 @@ from music21 import style
 
 from music21.meter.tools import slashToTuple, proportionToFraction
 from music21.meter.core import (
-    MeterSequence, getMeterSequence, getMeterTerminal, _makeSequence,
+    MeterSequence, getMeterSequence, getMeterTerminal, makeSequence,
 )
 
 environLocal = environment.Environment('meter')
@@ -1148,7 +1148,7 @@ class TimeSignature(TimeSignatureBase):
         if self.displaySequence is not None:
             # displaySequence is immutable; swap in a copy with the new flag
             ds = self.displaySequence
-            self.displaySequence = _makeSequence(
+            self.displaySequence = makeSequence(
                 ds.numerator, ds.denominator, ds._partition,
                 parenthesis=ds.parenthesis, summedNumerator=value)
 

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -609,13 +609,16 @@ class TimeSignature(TimeSignatureBase):
             value = '2/2'
             self.symbol = 'cut'
 
-        cacheKey = (value, divisions)
+        # divisions may be list-like -- e.g. ['2/8', '3/8'] (Ariza & Cuthbert 2010) --
+        # so normalize a list to a tuple to make it a usable cache key.
+        keyDivisions = tuple(divisions) if isinstance(divisions, list) else divisions
+        cacheKey = (value, keyDivisions)
         cached = None
         cacheable = True
         try:
             cached = _defaultSequenceCache.get(cacheKey)
         except TypeError:
-            cacheable = False  # unhashable divisions (e.g. a list): skip the cache
+            cacheable = False  # still unhashable (rare): skip the cache
         if cached is not None:
             (self.displaySequence, self.beamSequence,
              self.beatSequence, self.accentSequence) = cached

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -60,11 +60,6 @@ _SENTINEL_METER_SEQUENCE = MeterSequence()
 # also [pow(2,x) for x in range(8)]
 MIN_DENOMINATOR_TYPE = '128th'
 
-# store a module-level dictionary of partitioned meter sequences used
-# for setting default accent weights; store as needed
-_meterSequenceAccentArchetypes: dict[tuple[str, t.Any, int], MeterSequence] = {}
-_meterSequenceAccentArchetypesNoneCache = ('', -1, -1)  # a cache key representing None
-
 def bestTimeSignature(meas: stream.Stream) -> 'music21.meter.TimeSignature':
     # noinspection PyShadowingNames
     '''
@@ -1316,56 +1311,40 @@ class TimeSignature(TimeSignatureBase):
                 firstPartitionForm = len(self.beatSequence)
             else:
                 firstPartitionForm = None
-            cacheKey = (tsStr, firstPartitionForm, depth)
         else:  # derive from meter sequence
             firstPartitionForm = self.beatSequence
-            cacheKey = _meterSequenceAccentArchetypesNoneCache  # cannot cache based on beat form
 
-        # environLocal.printDebug('_setDefaultAccentWeights(): firstPartitionForm set to',
-        #    firstPartitionForm, 'self.beatSequence: ', self.beatSequence, tsStr)
-        # using cacheKey speeds up TS creation from 2300 microseconds to 500microseconds
-        try:
-            # archetypes are immutable and shared; no copy needed
-            self.accentSequence = _meterSequenceAccentArchetypes[cacheKey]
-            # environLocal.printDebug(['using stored accent archetype:'])
-        except KeyError:
-            # environLocal.printDebug(['creating a new accent archetype'])
-            ms = MeterSequence(tsStr)
-            # key operation here
-            # div count needs to be the number of top-level beat divisions
-            ms = ms.subdivideNestedHierarchy(depth,
-                                             firstPartitionForm=firstPartitionForm)
+        ms = MeterSequence(tsStr)
+        # key operation here
+        # div count needs to be the number of top-level beat divisions
+        ms = ms.subdivideNestedHierarchy(depth, firstPartitionForm=firstPartitionForm)
 
-            # provide a partition for each flattened division
-            accentCount = len(ms.flatten())
-            # environLocal.printDebug(['got accentCount', accentCount, 'ms: ', ms])
-            divStep = self.barDuration.quarterLength / accentCount
-            weightInts = [0] * accentCount  # weights as integer/depth counts
-            for i in range(accentCount):
-                ql = opFrac(i * divStep)
-                weightInts[i] = ms.offsetToDepth(ql, align='quantize', index=i)
+        # provide a partition for each flattened division
+        accentCount = len(ms.flatten())
+        divStep = self.barDuration.quarterLength / accentCount
+        weightInts = [0] * accentCount  # weights as integer/depth counts
+        for i in range(accentCount):
+            ql = opFrac(i * divStep)
+            weightInts[i] = ms.offsetToDepth(ql, align='quantize', index=i)
 
-            maxInt = max(weightInts)
-            weightValues = {}  # reference dictionary
-            # minimum value, something like 1/16, to be multiplied by powers of 2
-            weightValueMin = 1 / pow(2, maxInt - 1)
-            for x in range(maxInt):
-                # multiply base value (0.125) by 1, 2, 4
-                # there is never a 0 integer weight, so add 1 to dictionary
-                weightValues[x + 1] = weightValueMin * pow(2, x)
+        maxInt = max(weightInts)
+        weightValues = {}  # reference dictionary
+        # minimum value, something like 1/16, to be multiplied by powers of 2
+        weightValueMin = 1 / pow(2, maxInt - 1)
+        for x in range(maxInt):
+            # multiply base value (0.125) by 1, 2, 4
+            # there is never a 0 integer weight, so add 1 to dictionary
+            weightValues[x + 1] = weightValueMin * pow(2, x)
 
-            # set weights on accent partitions
-            self.accentSequence = self.accentSequence.partition([1] * accentCount)
-            for i in range(accentCount):
-                # get values from weightValues dictionary; terminals are
-                # immutable, so replace each with a re-weighted cached one
-                mt = self.accentSequence[i]
-                self.accentSequence = self.accentSequence.setIndex(
-                    i, getMeterTerminal(
-                        mt.numerator, mt.denominator, weight=weightValues[weightInts[i]]))
-
-            if cacheKey != _meterSequenceAccentArchetypesNoneCache:
-                _meterSequenceAccentArchetypes[cacheKey] = self.accentSequence
+        # set weights on accent partitions
+        self.accentSequence = self.accentSequence.partition([1] * accentCount)
+        for i in range(accentCount):
+            # get values from weightValues dictionary; terminals are
+            # immutable, so replace each with a re-weighted cached one
+            mt = self.accentSequence[i]
+            self.accentSequence = self.accentSequence.setIndex(
+                i, getMeterTerminal(
+                    mt.numerator, mt.denominator, weight=weightValues[weightInts[i]]))
 
     # --------------------------------------------------------------------------
     # access data for other processing

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -812,6 +812,10 @@ class TimeSignature(TimeSignatureBase):
 
         >>> meter.TimeSignature().barDuration
         <music21.duration.Duration 4.0>
+
+        Note: this currently returns an ordinary (mutable) Duration, but it is
+        expected to return an immutable :class:`~music21.duration.FrozenDuration`
+        in v12 -- do not rely on being able to modify it in place.
         '''
         if self._overriddenBarDuration:
             return self._overriddenBarDuration

--- a/music21/meter/base.py
+++ b/music21/meter/base.py
@@ -40,12 +40,16 @@ from music21.meter.core import (
 
 environLocal = environment.Environment('meter')
 
-# Cache of the fully-configured (display, beam, beat, accent) MeterSequences a
-# TimeSignature.load() produces for a given (value, divisions).  The sequences are
+# Cache of the fully-configured MeterSequences a TimeSignature.load() produces for a
+# given (value, divisions).  Each value is a 4-tuple in the fixed order
+# (displaySequence, beamSequence, beatSequence, accentSequence).  The sequences are
 # immutable and shared, and any later change to a TimeSignature is copy-on-write, so
 # repeated TimeSignatures of the same meter can reuse them and skip the (hashing-heavy)
 # rebuild entirely.
-_defaultSequenceCache: dict[tuple[str, t.Any], tuple[MeterSequence, ...]] = {}
+_defaultSequenceCache: dict[
+    tuple[str, t.Any],
+    tuple[MeterSequence, MeterSequence, MeterSequence, MeterSequence],
+] = {}
 
 if t.TYPE_CHECKING:
     from music21.common.types import OffsetQL, OffsetQLIn

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -222,30 +222,9 @@ class MeterCore:
         ms = _buildSequence(self)  # do not need to autoWeight here
         return ms.partitionByList(numeratorList)  # this will split weight
 
-    def subdivideByOther(self, other: MeterSequence) -> MeterSequence:
-        '''
-        Return a MeterSequence based on another MeterSequence
-
-        >>> a = meter.MeterSequence('1/4+1/4+1/4')
-        >>> a
-        <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
-        >>> b = meter.MeterSequence('3/8+3/8')
-        >>> a.subdivideByOther(b)
-        <music21.meter.core.MeterSequence {{3/8+3/8}}>
-
-        >>> terminal = meter.MeterTerminal('1/4')
-        >>> divider = meter.MeterSequence('1/8+1/8')
-        >>> terminal.subdivideByOther(divider)
-        <music21.meter.core.MeterSequence {{1/8+1/8}}>
-        '''
-        if other.duration.quarterLength != self.duration.quarterLength:
-            raise MeterException(f'cannot subdivide by other: {other}')
-        # elevate to meter sequence
-        return _buildSequence(other)  # do not need to autoWeight here
-
     def subdivide(
         self,
-        value: Sequence[int | str] | MeterSequence | int
+        value: Sequence[int | str] | int
     ) -> MeterSequence:
         '''
         Subdivision takes a MeterTerminal and, making it into a collection of MeterTerminals,
@@ -258,8 +237,6 @@ class MeterCore:
         '''
         if common.isListLike(value):
             return self.subdivideByList(value)
-        elif isinstance(value, MeterSequence):
-            return self.subdivideByOther(value)
         elif common.isNum(value):
             return self.subdivideByCount(value)
         else:
@@ -548,9 +525,10 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
 
     * Changed in v11: MeterSequence is immutable, hashable, deep-copies to
       itself, and its formerly in-place operations return a new sequence.
-      Removed `load()` (set values when creating the sequence), the `weight`
-      setter (use `withWeight()`), and item assignment `ms[i] = x` (use
-      `setIndex()`).
+      Removed `load()` (set values when creating the sequence),
+      `subdivideByOther()` (it only wrapped its argument in a new sequence),
+      the `weight` setter (use `withWeight()`), and item assignment
+      `ms[i] = x` (use `setIndex()`).
 
     AI-assisted (Claude).
     '''
@@ -665,9 +643,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         if extra:
             raise ValueError(
                 f'MeterSequence.modify() does not accept {sorted(extra)}; allowed '
-                'keywords are partition, parenthesis, summedNumerator.  numerator, '
-                'denominator, and weight follow from the partition -- change them via '
-                'partition(), subdividePartitionsEqual(), setIndex(), etc.')
+                'keywords are partition, parenthesis, summedNumerator.')
         partition = tuple(keywords.get('partition', self._partition))
         numerator, denominator = _ratioFromPartition(partition)
         return makeSequence(

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -393,8 +393,19 @@ class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> a.modify(numerator=3) is c
         True
 
+        Any keyword other than numerator/denominator/weight raises a ValueError:
+
+        >>> a.modify(parenthesis=True)
+        Traceback (most recent call last):
+        ValueError: MeterTerminal.modify() does not accept ['parenthesis']...
+
         AI-assisted (Claude).
         '''
+        extra = set(keywords) - {'numerator', 'denominator', 'weight'}
+        if extra:
+            raise ValueError(
+                f'MeterTerminal.modify() does not accept {sorted(extra)}; allowed '
+                'keywords are numerator, denominator, weight.')
         return getMeterTerminal(
             numerator=keywords.get('numerator', self._numerator),
             denominator=keywords.get('denominator', self._denominator),
@@ -613,15 +624,16 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
     def modify(self, **keywords) -> MeterSequence:
         '''
         Return a (cached) MeterSequence identical to this one except for the
-        given ``numerator``, ``denominator``,
-        ``partition``, ``parenthesis`` and/or ``summedNumerator``
-        keyword(s).
+        given ``partition``, ``parenthesis`` and/or ``summedNumerator`` keyword(s).
 
         The original is unchanged, since a MeterSequence is immutable.
 
-        Analogous to :func:`copy.replace` (Python 3.13+); for changing the
-        partition structure itself prefer the functional :meth:`partition`,
-        :meth:`subdividePartitionsEqual`, and :meth:`setIndex`.
+        Analogous to :func:`copy.replace` (Python 3.13+).  Unlike
+        :meth:`MeterTerminal.modify`, the numerator, denominator, and weight cannot
+        be changed here -- they follow from the partition -- so change the structure
+        with :meth:`partition`, :meth:`subdividePartitionsEqual`, :meth:`setIndex`,
+        etc.  Any keyword other than partition/parenthesis/summedNumerator raises a
+        ValueError.
 
         >>> ms = meter.MeterSequence('4/4', 4)
         >>> ms
@@ -638,36 +650,26 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> ms.parenthesis
         False
 
-        Changing the numerator or denominator rebuilds the sequence with that many
-        equal parts:
+        Trying to change the numerator, denominator, or weight raises a ValueError:
 
-        >>> ms3 = ms.modify(numerator=3)
-        >>> ms3
-        <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
-
-        Any other keyword, including weight, is ignored.
-
-        >>> ms.weight
-        1.0
-        >>> ms.modify(weight=1.5).weight
-        1.0
-
-        For other changes to the MeterSequence, see methods
-        :meth:`subdivide`, :meth:`partition`, etc.
+        >>> ms.modify(numerator=3)
+        Traceback (most recent call last):
+        ValueError: MeterSequence.modify() does not accept ['numerator']...
+        >>> ms.modify(weight=1.5)
+        Traceback (most recent call last):
+        ValueError: MeterSequence.modify() does not accept ['weight']...
 
         AI-assisted (Claude).
         '''
-        if 'partition' in keywords:
-            partition = tuple(keywords['partition'])
-            numerator, denominator = _ratioFromPartition(partition)
-        elif 'numerator' in keywords or 'denominator' in keywords:
-            numerator = keywords.get('numerator', self._numerator)
-            denominator = keywords.get('denominator', self._denominator)
-            # rebuild the new ratio as `numerator` equal parts (each 1/denominator)
-            partition = getMeterSequence(f'{numerator}/{denominator}', numerator)._partition
-        else:
-            partition = self._partition
-            numerator, denominator = self._numerator, self._denominator
+        extra = set(keywords) - {'partition', 'parenthesis', 'summedNumerator'}
+        if extra:
+            raise ValueError(
+                f'MeterSequence.modify() does not accept {sorted(extra)}; allowed '
+                'keywords are partition, parenthesis, summedNumerator.  numerator, '
+                'denominator, and weight follow from the partition -- change them via '
+                'partition(), subdividePartitionsEqual(), setIndex(), etc.')
+        partition = tuple(keywords.get('partition', self._partition))
+        numerator, denominator = _ratioFromPartition(partition)
         return makeSequence(
             numerator, denominator, partition,
             parenthesis=keywords.get('parenthesis', self.parenthesis),

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -359,6 +359,50 @@ class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
     def __str__(self):
         return str(int(self.numerator)) + '/' + str(int(self.denominator))
 
+    def modify(self, **keywords) -> MeterTerminal:
+        '''
+        Return a (cached) MeterTerminal identical to this one except for the
+        given ``numerator``, ``denominator`` and/or ``weight`` keyword(s); the
+        other values carry over.  The original is unchanged, since a
+        MeterTerminal is immutable.
+
+        This is how to "change" an immutable terminal -- analogous to
+        :func:`copy.replace` (Python 3.13+) or ``namedtuple._replace``.
+
+        >>> a = meter.MeterTerminal('2/4', weight=0.5)
+        >>> b = a.modify(weight=0.25)
+        >>> b
+        <music21.meter.core.MeterTerminal 2/4>
+        >>> b.weight
+        0.25
+
+        The original is unchanged, and the un-named values carry over (here the
+        weight stays 0.5):
+
+        >>> a.weight
+        0.5
+        >>> c = a.modify(numerator=3)
+        >>> c
+        <music21.meter.core.MeterTerminal 3/4>
+        >>> c.weight
+        0.5
+
+        modify goes through the cache, so identical results share one object:
+
+        >>> a.modify(numerator=3) is c
+        True
+
+        AI-assisted (Claude).
+        '''
+        return getMeterTerminal(
+            numerator=keywords.get('numerator', self._numerator),
+            denominator=keywords.get('denominator', self._denominator),
+            weight=keywords.get('weight', self._weight),
+        )
+
+    # copy.replace() support (Python 3.13+)
+    __replace__ = modify
+
     # -------------------------------------------------------------------------
     # properties
 
@@ -371,10 +415,9 @@ class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> a.weight
         0.5
 
-        To get a MeterTerminal with a different weight, specify the existing
-        numerator and denominator and the new weight:
+        To get a MeterTerminal with a different weight, use :meth:`modify`:
 
-        >>> meter.core.getMeterTerminal(a.numerator, a.denominator, weight=0.25)
+        >>> a.modify(weight=0.25)
         <music21.meter.core.MeterTerminal 2/4>
 
         * Changed in v11: weight is immutable and must be a float (not int).
@@ -390,10 +433,9 @@ class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> a.numerator
         2
 
-        To get a MeterTerminal with a different numerator, specify the new
-        numerator and the existing denominator and weight:
+        To get a MeterTerminal with a different numerator, use :meth:`modify`:
 
-        >>> meter.core.getMeterTerminal(3, a.denominator, weight=a.weight)
+        >>> a.modify(numerator=3)
         <music21.meter.core.MeterTerminal 3/4>
 
         * Changed in v11: numerator is immutable.
@@ -409,10 +451,9 @@ class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> a.denominator
         4
 
-        To get a MeterTerminal with a different denominator, specify the
-        existing numerator, the new denominator, and the existing weight:
+        To get a MeterTerminal with a different denominator, use :meth:`modify`:
 
-        >>> meter.core.getMeterTerminal(a.numerator, 8, weight=a.weight)
+        >>> a.modify(denominator=8)
         <music21.meter.core.MeterTerminal 2/8>
 
         * Changed in v11: denominator is immutable.
@@ -529,7 +570,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         numerator, denominator, partitionList, summedNumerator = _loadData(value)
         parenthesis = False
         if partitionRequest is not None:
-            built = _makeSequence(
+            built = makeSequence(
                 numerator, denominator, tuple(partitionList),
                 summedNumerator=summedNumerator
             ).partition(partitionRequest)
@@ -564,6 +605,39 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         A MeterSequence is immutable, so a shallow copy is also just itself.
         '''
         return self
+
+    def modify(self, **keywords) -> MeterSequence:
+        '''
+        Return a (cached) MeterSequence identical to this one except for the
+        given ``partition``, ``parenthesis`` and/or ``summedNumerator``
+        keyword(s); the numerator and denominator follow from the partition.
+        The original is unchanged, since a MeterSequence is immutable.
+
+        Analogous to :func:`copy.replace` (Python 3.13+); for changing the
+        partition structure itself prefer the functional :meth:`partition`,
+        :meth:`subdividePartitionsEqual`, and :meth:`replaceElement`.
+
+        >>> ms = meter.MeterSequence('4/4', 4)
+        >>> ms.parenthesis
+        False
+        >>> ms2 = ms.modify(parenthesis=True)
+        >>> ms2.parenthesis
+        True
+        >>> ms.parenthesis
+        False
+
+        AI-assisted (Claude).
+        '''
+        partition = tuple(keywords.get('partition', self._partition))
+        numerator, denominator = _ratioFromPartition(partition)
+        return makeSequence(
+            numerator, denominator, partition,
+            parenthesis=keywords.get('parenthesis', self.parenthesis),
+            summedNumerator=keywords.get('summedNumerator', self.summedNumerator),
+        )
+
+    # copy.replace() support (Python 3.13+)
+    __replace__ = modify
 
     def __getitem__(self, key: int) -> MeterNode:
         '''
@@ -677,7 +751,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
 
         AI-assisted (Claude).
         '''
-        return _makeSequence(
+        return makeSequence(
             self._numerator, self._denominator, tuple(partition),
             parenthesis=self.parenthesis, summedNumerator=self.summedNumerator)
 
@@ -1973,7 +2047,7 @@ _meterSequenceCache: dict[
 ] = {}
 
 
-def _makeSequence(
+def makeSequence(
     numerator: int,
     denominator: int,
     partition: tuple,
@@ -2022,7 +2096,7 @@ def getMeterSequence(
     AI-assisted (Claude).
     '''
     built = MeterSequence(value, partitionRequest)
-    return _makeSequence(
+    return makeSequence(
         built._numerator, built._denominator, built._partition,
         parenthesis=built.parenthesis, summedNumerator=built.summedNumerator)
 
@@ -2144,7 +2218,7 @@ def _buildSequence(
     '''
     numerator, denominator, partition, summedNumerator = _loadData(
         value, autoWeight=autoWeight, targetWeight=targetWeight)
-    ms = _makeSequence(numerator, denominator, tuple(partition),
+    ms = makeSequence(numerator, denominator, tuple(partition),
                        summedNumerator=summedNumerator)
     if partitionRequest is not None:
         ms = ms.partition(partitionRequest)

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -78,10 +78,11 @@ class MeterTerminal(prebase.ProtoM21Object, FrozenObject):
     )
 
     # INITIALIZER #
-    def __init__(self, slashNotation: str|None = None, weight: int|float = 1, *,
+    def __init__(self, slashNotation: str|None = None, weight: float = 1.0, *,
                  numerator: int = 0, denominator: int = 1):
-        # because of how they are copied, MeterTerminals must not have any
-        # initialization parameters without defaults
+        # MeterSequence (a subclass) builds an empty instance via
+        # super().__init__() -- in its __init__ and __deepcopy__ -- so every
+        # parameter here must keep a default.
         if slashNotation is not None:
             # raise MeterException early if there is a problem.
             values = tools.slashToTuple(slashNotation)
@@ -89,7 +90,7 @@ class MeterTerminal(prebase.ProtoM21Object, FrozenObject):
             denominator = values.denominator
         self._numerator: int = numerator
         self._denominator: int = denominator
-        self._weight: int|float = weight
+        self._weight: float = weight
 
     # SPECIAL METHODS #
 
@@ -102,6 +103,12 @@ class MeterTerminal(prebase.ProtoM21Object, FrozenObject):
         A MeterTerminal is immutable and shared, so deep-copying it simply
         returns the same object (a large performance win, since MeterTerminals
         are copied constantly as part of Streams and TimeSignatures).
+        '''
+        return self
+
+    def __copy__(self):
+        '''
+        A MeterTerminal is immutable, so a shallow copy is also just itself.
         '''
         return self
 
@@ -268,42 +275,56 @@ class MeterTerminal(prebase.ProtoM21Object, FrozenObject):
     # properties
 
     @property
-    def weight(self) -> float|int:
+    def weight(self) -> float:
         '''
-        Return the weight of a MeterTerminal (read-only; a MeterTerminal is
-        immutable).
+        Return the weight of a MeterTerminal.
 
         >>> a = meter.MeterTerminal('2/4', 0.5)
         >>> a.weight
         0.5
+
+        To get one with a different weight, make a new terminal:
+
+        >>> meter.core.getMeterTerminal(a.numerator, a.denominator, weight=0.25)
+        <music21.meter.core.MeterTerminal 2/4>
+
+        * Changed in v11: weight is immutable and must be a float (not int).
         '''
         return self._weight
 
     @property
     def numerator(self) -> int:
         '''
-        Return the numerator of the MeterTerminal (read-only; a MeterTerminal
-        is immutable).
+        Return the numerator of the MeterTerminal.
 
         >>> a = meter.MeterTerminal('2/4')
         >>> a.numerator
         2
-        >>> a.duration.quarterLength
-        2.0
+
+        To get one with a different numerator, make a new terminal:
+
+        >>> meter.core.getMeterTerminal(3, a.denominator)
+        <music21.meter.core.MeterTerminal 3/4>
+
+        * Changed in v11: numerator is immutable.
         '''
         return self._numerator
 
     @property
     def denominator(self) -> int:
         '''
-        Return the denominator of the meter terminal (read-only; a
-        MeterTerminal is immutable).
+        Return the denominator of the MeterTerminal.
 
         >>> a = meter.MeterTerminal('2/4')
         >>> a.denominator
         4
-        >>> a.duration.quarterLength
-        2.0
+
+        To get one with a different denominator, make a new terminal:
+
+        >>> meter.core.getMeterTerminal(a.numerator, 8)
+        <music21.meter.core.MeterTerminal 2/8>
+
+        * Changed in v11: denominator is immutable.
         '''
         return self._denominator
 
@@ -369,11 +390,11 @@ class MeterTerminal(prebase.ProtoM21Object, FrozenObject):
 
 # -----------------------------------------------------------------------------
 
-_meterTerminalCache: dict[tuple[int, int, type, float|int], MeterTerminal] = {}
+_meterTerminalCache: dict[tuple[int, int, float], MeterTerminal] = {}
 
 
 def getMeterTerminal(numerator: int, denominator: int,
-                     weight: float|int = 1) -> MeterTerminal:
+                     weight: float = 1.0) -> MeterTerminal:
     '''
     Return a shared, cached, immutable :class:`MeterTerminal` for these values.
 
@@ -392,9 +413,7 @@ def getMeterTerminal(numerator: int, denominator: int,
 
     AI-assisted (Claude).
     '''
-    # the weight's type is part of the key: an int 1 and a float 1.0 compare
-    # equal but must stay distinct terminals so the exact weight is preserved.
-    key = (numerator, denominator, type(weight), weight)
+    key = (numerator, denominator, weight)
     cached = _meterTerminalCache.get(key)
     if cached is None:
         cached = MeterTerminal(numerator=numerator, denominator=denominator, weight=weight)
@@ -492,6 +511,13 @@ class MeterSequence(MeterTerminal):
         new.parenthesis = self.parenthesis
 
         return new
+
+    def __copy__(self):
+        '''
+        A MeterSequence is mutable (unlike its MeterTerminal base), so a copy
+        must be an independent object, not the shared self.
+        '''
+        return self.__deepcopy__()
 
     def __getitem__(self, key: int) -> MeterTerminal:
         '''
@@ -1227,7 +1253,7 @@ class MeterSequence(MeterTerminal):
                                 | MeterSequence
                                 | None) = None,
              autoWeight: bool = False,
-             targetWeight: int|float|None = None):
+             targetWeight: float|None = None):
         '''
         This method is called when a MeterSequence is created, or if a MeterSequence is re-set.
 
@@ -1330,7 +1356,7 @@ class MeterSequence(MeterTerminal):
     # do not permit setting of numerator/denominator
 
     @property
-    def weight(self) -> int | float:
+    def weight(self) -> float:
         '''
         Get the weight for the MeterSequence, or set the weight and thereby change the weights
         for each object in this MeterSequence.
@@ -1384,7 +1410,7 @@ class MeterSequence(MeterTerminal):
         return summation
 
     @weight.setter
-    def weight(self, value: int | float) -> None:
+    def weight(self, value: float) -> None:
         # environLocal.printDebug(['calling setWeight with value', value])
         if not common.isNum(value):
             raise MeterException('weight values must be numbers')
@@ -1807,29 +1833,29 @@ class MeterSequence(MeterTerminal):
         single level of the MeterSequence.
 
         >>> a = meter.MeterSequence('4/4', 4)
-        >>> a.setLevelWeight([1, 2, 3, 4])
+        >>> a.setLevelWeight([1.0, 2.0, 3.0, 4.0])
         >>> a.getLevelWeight()
-        [1, 2, 3, 4]
+        [1.0, 2.0, 3.0, 4.0]
 
         >>> b = meter.MeterSequence('4/4', 4)
-        >>> b.setLevelWeight([2, 3])
+        >>> b.setLevelWeight([2.0, 3.0])
         >>> b.getLevelWeight(0)
-        [2, 3, 2, 3]
+        [2.0, 3.0, 2.0, 3.0]
 
         >>> b[1] = b[1].subdivide(2)
         >>> b[3] = b[3].subdivide(2)
         >>> b.getLevelWeight(0)
-        [2, 3.0, 2, 3.0]
+        [2.0, 3.0, 2.0, 3.0]
 
         >>> b[3][0] = b[3][0].subdivide(2)
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.getLevelWeight(0)
-        [2, 3.0, 2, 3.0]
+        [2.0, 3.0, 2.0, 3.0]
         >>> b.getLevelWeight(1)
-        [2, 1.5, 1.5, 2, 1.5, 1.5]
+        [2.0, 1.5, 1.5, 2.0, 1.5, 1.5]
         >>> b.getLevelWeight(2)
-        [2, 1.5, 1.5, 2, 0.75, 0.75, 1.5]
+        [2.0, 1.5, 1.5, 2.0, 0.75, 0.75, 1.5]
 
         * Changed in v11: terminals are immutable, so each affected terminal is
           replaced in place by a cached one carrying the new weight.

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -325,6 +325,10 @@ class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
             values = tools.slashToTuple(slashNotation)
             numerator = values.numerator
             denominator = values.denominator
+        # Set the slots on the known-safe init path with object.__setattr__ to
+        # bypass FrozenObject's expensive per-set inspection (which walks the
+        # stack to find where in a sequence we are); afterwards the object is
+        # fully immutable.
         object.__setattr__(self, '_numerator', numerator)
         object.__setattr__(self, '_denominator', denominator)
         object.__setattr__(self, '_weight', weight)
@@ -367,7 +371,8 @@ class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> a.weight
         0.5
 
-        To get one with a different weight, make a new terminal:
+        To get a MeterTerminal with a different weight, specify the existing
+        numerator and denominator and the new weight:
 
         >>> meter.core.getMeterTerminal(a.numerator, a.denominator, weight=0.25)
         <music21.meter.core.MeterTerminal 2/4>
@@ -385,9 +390,10 @@ class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> a.numerator
         2
 
-        To get one with a different numerator, make a new terminal:
+        To get a MeterTerminal with a different numerator, specify the new
+        numerator and the existing denominator and weight:
 
-        >>> meter.core.getMeterTerminal(3, a.denominator)
+        >>> meter.core.getMeterTerminal(3, a.denominator, weight=a.weight)
         <music21.meter.core.MeterTerminal 3/4>
 
         * Changed in v11: numerator is immutable.
@@ -403,9 +409,10 @@ class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> a.denominator
         4
 
-        To get one with a different denominator, make a new terminal:
+        To get a MeterTerminal with a different denominator, specify the
+        existing numerator, the new denominator, and the existing weight:
 
-        >>> meter.core.getMeterTerminal(a.numerator, 8)
+        >>> meter.core.getMeterTerminal(a.numerator, 8, weight=a.weight)
         <music21.meter.core.MeterTerminal 2/8>
 
         * Changed in v11: denominator is immutable.
@@ -458,7 +465,7 @@ def getMeterTerminal(numerator: int, denominator: int,
 
 class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
     '''
-    A MeterSequence is an immutable, hashable list of MeterTerminals, or
+    A MeterSequence is an immutable, hashable sequence of MeterTerminals, or
     other MeterSequences.
 
     >>> ms = meter.MeterSequence('4/4', 4)
@@ -617,6 +624,8 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> a.replaceElement(3, a[0][0])
         Traceback (most recent call last):
         music21.exceptions21.MeterException: cannot insert {1/16+1/16} into space of 1/4
+
+        * New in v11: functional replacement for ``ms[index] = value`` assignment.
 
         AI-assisted (Claude).
         '''
@@ -1255,10 +1264,21 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
             summation += obj.weight  # may be a MeterTerminal or MeterSequence
         return summation
 
-    def _withWeight(self, targetWeight: float) -> MeterSequence:
+    def withWeight(self, targetWeight: float) -> MeterSequence:
         '''
         Return a new MeterSequence whose children are re-weighted so that they
         sum (proportionally) to ``targetWeight``.
+
+        This is the immutable replacement for the pre-v11 ``ms.weight = x``
+        setter: rather than re-weighting the children in place, request a new
+        sequence.
+
+        >>> ms = meter.MeterSequence('4/4', 4)
+        >>> ms2 = ms.withWeight(1.0)
+        >>> [mt.weight for mt in ms2]
+        [0.25, 0.25, 0.25, 0.25]
+
+        * New in v11: replaces the ``weight`` setter.
 
         AI-assisted (Claude).
         '''
@@ -2047,7 +2067,7 @@ def _applyWeight(partition, numerator: int, denominator: int, targetWeight: floa
         partRatio = mt.numerator / mt.denominator
         newWeight = targetWeight * (partRatio / totalRatio)
         if isinstance(mt, MeterSequence):
-            out.append(mt._withWeight(newWeight))
+            out.append(mt.withWeight(newWeight))
         else:
             out.append(getMeterTerminal(mt.numerator, mt.denominator, weight=newWeight))
     return out
@@ -2089,7 +2109,7 @@ def _loadData(
     elif isinstance(value, MeterCore):  # a MeterTerminal or MeterSequence
         if targetWeight is not None:
             if isinstance(value, MeterSequence):
-                value = value._withWeight(targetWeight)
+                value = value.withWeight(targetWeight)
             else:
                 # a terminal is immutable: swap in a re-weighted cached one
                 value = getMeterTerminal(value.numerator, value.denominator,

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -300,7 +300,8 @@ class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
     True
 
     * Changed in v11: MeterTerminal is immutable, deep-copies to itself, and
-      compares by value.
+      compares by value.  Removed the numerator/denominator/weight/duration
+      setters (set values when creating the terminal, or use `modify()`).
 
     AI-assisted (Claude).
     '''
@@ -516,7 +517,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
     Like :class:`~music21.meter.core.MeterTerminal`, a MeterSequence is an
     immutable value object.  Its structure cannot be changed after creation;
     the "mutating" methods (:meth:`partition`, :meth:`subdividePartitionsEqual`,
-    :meth:`setLevelWeight`, :meth:`replaceElement`, ...) instead RETURN a new
+    :meth:`setLevelWeight`, :meth:`setIndex`, ...) instead RETURN a new
     MeterSequence and leave ``self`` unchanged:
 
     >>> ms2 = ms.partition(2)
@@ -536,6 +537,9 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
 
     * Changed in v11: MeterSequence is immutable, hashable, deep-copies to
       itself, and its formerly in-place operations return a new sequence.
+      Removed `load()` (set values when creating the sequence), the `weight`
+      setter (use `withWeight()`), and item assignment `ms[i] = x` (use
+      `setIndex()`).
 
     AI-assisted (Claude).
     '''
@@ -615,7 +619,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
 
         Analogous to :func:`copy.replace` (Python 3.13+); for changing the
         partition structure itself prefer the functional :meth:`partition`,
-        :meth:`subdividePartitionsEqual`, and :meth:`replaceElement`.
+        :meth:`subdividePartitionsEqual`, and :meth:`setIndex`.
 
         >>> ms = meter.MeterSequence('4/4', 4)
         >>> ms.parenthesis
@@ -675,7 +679,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         '''
         return len(self._partition)
 
-    def replaceElement(self, index: int, value: MeterNode) -> MeterSequence:
+    def setIndex(self, index: int, value: MeterNode) -> MeterSequence:
         '''
         Return a new MeterSequence with the element at `index` replaced by
         `value` (which must occupy the same ratio of time as the element it
@@ -687,15 +691,15 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         <music21.meter.core.MeterSequence {1/4+1/4+1/4+1/4}>
         >>> a[0]
         <music21.meter.core.MeterTerminal 1/4>
-        >>> a = a.replaceElement(0, a[0].subdivide(2))
+        >>> a = a.setIndex(0, a[0].subdivide(2))
         >>> a
         <music21.meter.core.MeterSequence {{1/8+1/8}+1/4+1/4+1/4}>
-        >>> a = a.replaceElement(0, a[0].replaceElement(0, a[0][0].subdivide(2)))
+        >>> a = a.setIndex(0, a[0].setIndex(0, a[0][0].subdivide(2)))
         >>> a
         <music21.meter.core.MeterSequence {{{1/16+1/16}+1/8}+1/4+1/4+1/4}>
         >>> a[3]
         <music21.meter.core.MeterTerminal 1/4>
-        >>> a.replaceElement(3, a[0][0])
+        >>> a.setIndex(3, a[0][0])
         Traceback (most recent call last):
         music21.exceptions21.MeterException: cannot insert {1/16+1/16} into space of 1/4
 
@@ -1094,10 +1098,10 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
 
         To subdivide a nested component, replace it functionally:
 
-        >>> ms = ms.replaceElement(0, ms[0].subdividePartitionsEqual(2))
+        >>> ms = ms.setIndex(0, ms[0].subdividePartitionsEqual(2))
         >>> ms
         <music21.meter.core.MeterSequence {{{1/16+1/16}+{1/16+1/16}}+{1/8+1/8}}>
-        >>> ms = ms.replaceElement(1, ms[1].subdividePartitionsEqual(2))
+        >>> ms = ms.setIndex(1, ms[1].subdividePartitionsEqual(2))
         >>> ms
         <music21.meter.core.MeterSequence {{{1/16+1/16}+{1/16+1/16}}+{{1/16+1/16}+{1/16+1/16}}}>
 
@@ -1379,7 +1383,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> len(b)
         3
 
-        >>> a = a.replaceElement(1, a[1].subdivide(4))
+        >>> a = a.setIndex(1, a[1].subdivide(4))
         >>> len(a)
         3
         >>> a
@@ -1396,7 +1400,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
          <music21.meter.core.MeterTerminal 1/16>,
          <music21.meter.core.MeterTerminal 1/4>]
 
-        >>> a = a.replaceElement(1, a[1].replaceElement(2, a[1][2].subdivide(4)))
+        >>> a = a.setIndex(1, a[1].setIndex(2, a[1][2].subdivide(4)))
         >>> a
         <music21.meter.core.MeterSequence {1/4+{1/16+1/16+{1/64+1/64+1/64+1/64}+1/16}+1/4}>
         >>> b = a._getFlatList()
@@ -1430,7 +1434,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         Now take a MeterSequence and subdivide the second beat into 4 parts:
 
         >>> ms = meter.MeterSequence('3/4', 3)
-        >>> ms = ms.replaceElement(1, ms[1].subdivide(4))
+        >>> ms = ms.setIndex(1, ms[1].subdivide(4))
         >>> ms
         <music21.meter.core.MeterSequence {1/4+{1/16+1/16+1/16+1/16}+1/4}>
         >>> b = ms.flatten()
@@ -1439,7 +1443,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> b
         <music21.meter.core.MeterSequence {1/4+1/16+1/16+1/16+1/16+1/4}>
 
-        >>> ms = ms.replaceElement(1, ms[1].replaceElement(2, ms[1][2].subdivide(4)))
+        >>> ms = ms.setIndex(1, ms[1].setIndex(2, ms[1][2].subdivide(4)))
         >>> ms
         <music21.meter.core.MeterSequence {1/4+{1/16+1/16+{1/64+1/64+1/64+1/64}+1/16}+1/4}>
         >>> b = ms.flatten()
@@ -1492,8 +1496,8 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> ms = ms.partition(4)
         >>> ms.isUniformPartition()
         True
-        >>> ms = ms.replaceElement(0, ms[0].subdivideByCount(2))
-        >>> ms = ms.replaceElement(1, ms[1].subdivideByCount(4))
+        >>> ms = ms.setIndex(0, ms[0].subdivideByCount(2))
+        >>> ms = ms.setIndex(1, ms[1].subdivideByCount(4))
         >>> ms.isUniformPartition()
         True
         >>> ms.isUniformPartition(depth=1)
@@ -1538,9 +1542,9 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         1 quarter, 2 eighth, 1 quarter, ((2-sixteenths) + 1 eighth).
 
         >>> b = meter.MeterSequence('4/4', 4)
-        >>> b = b.replaceElement(1, b[1].subdivide(2))
-        >>> b = b.replaceElement(3, b[3].subdivide(2))
-        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
+        >>> b = b.setIndex(1, b[1].subdivide(2))
+        >>> b = b.setIndex(3, b[3].subdivide(2))
+        >>> b = b.setIndex(3, b[3].setIndex(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
 
@@ -1643,9 +1647,9 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         level. A sort of flatness with variable depth.
 
         >>> b = meter.MeterSequence('4/4', 4)
-        >>> b = b.replaceElement(1, b[1].subdivide(2))
-        >>> b = b.replaceElement(3, b[3].subdivide(2))
-        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
+        >>> b = b.setIndex(1, b[1].subdivide(2))
+        >>> b = b.setIndex(3, b[3].subdivide(2))
+        >>> b = b.setIndex(3, b[3].setIndex(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.getLevel(0)
@@ -1662,9 +1666,9 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         For a given level, return the time span of each terminal or sequence
 
         >>> b = meter.MeterSequence('4/4', 4)
-        >>> b = b.replaceElement(1, b[1].subdivide(2))
-        >>> b = b.replaceElement(3, b[3].subdivide(2))
-        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
+        >>> b = b.setIndex(1, b[1].subdivide(2))
+        >>> b = b.setIndex(3, b[3].subdivide(2))
+        >>> b = b.setIndex(3, b[3].setIndex(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.getLevelSpan(0)
@@ -1698,12 +1702,12 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> b.getLevelWeight(0)
         [0.25, 0.25, 0.25, 0.25]
 
-        >>> b = b.replaceElement(1, b[1].subdivide(2))
-        >>> b = b.replaceElement(3, b[3].subdivide(2))
+        >>> b = b.setIndex(1, b[1].subdivide(2))
+        >>> b = b.setIndex(3, b[3].subdivide(2))
         >>> b.getLevelWeight(0)
         [0.25, 0.25, 0.25, 0.25]
 
-        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
+        >>> b = b.setIndex(3, b[3].setIndex(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.getLevelWeight(0)
@@ -1733,12 +1737,12 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> b.getLevelWeight(0)
         [2.0, 3.0, 2.0, 3.0]
 
-        >>> b = b.replaceElement(1, b[1].subdivide(2))
-        >>> b = b.replaceElement(3, b[3].subdivide(2))
+        >>> b = b.setIndex(1, b[1].subdivide(2))
+        >>> b = b.setIndex(3, b[3].subdivide(2))
         >>> b.getLevelWeight(0)
         [2.0, 3.0, 2.0, 3.0]
 
-        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
+        >>> b = b.setIndex(3, b[3].setIndex(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.getLevelWeight(0)
@@ -1853,7 +1857,7 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         The len of the returned list also provides the depth at the specified qLen.
 
         >>> a = meter.MeterSequence('3/4', 3)
-        >>> a = a.replaceElement(1, a[1].subdivide(4))
+        >>> a = a.setIndex(1, a[1].subdivide(4))
         >>> a
         <music21.meter.core.MeterSequence {1/4+{1/16+1/16+1/16+1/16}+1/4}>
         >>> len(a)
@@ -1986,9 +1990,9 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         start, quantize, or end.
 
         >>> b = meter.MeterSequence('4/4', 4)
-        >>> b = b.replaceElement(1, b[1].subdivide(2))
-        >>> b = b.replaceElement(3, b[3].subdivide(2))
-        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
+        >>> b = b.setIndex(1, b[1].subdivide(2))
+        >>> b = b.setIndex(3, b[3].subdivide(2))
+        >>> b = b.setIndex(3, b[3].setIndex(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.offsetToDepth(0)
@@ -2246,10 +2250,10 @@ def _replaceAtPath(root: MeterSequence, path: tuple[int, ...], newNode) -> Meter
     '''
     idx = path[0]
     if len(path) == 1:
-        return root.replaceElement(idx, newNode)
+        return root.setIndex(idx, newNode)
     child = t.cast('MeterSequence', root[idx])
     newChild = _replaceAtPath(child, path[1:], newNode)
-    return root.replaceElement(idx, newChild)
+    return root.setIndex(idx, newChild)
 
 
 def _subdivideNestedByPaths(

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -16,13 +16,14 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import copy
+from functools import lru_cache
 import typing as t
 
 from music21 import common
 from music21.common.numberTools import opFrac
 from music21.common.objects import SlottedObjectMixin
 from music21.common.types import OffsetQLIn
-from music21.duration import Duration, DurationException
+from music21.duration import Duration, FrozenDuration
 from music21 import environment
 from music21.exceptions21 import MeterException
 from music21.meter import tools
@@ -329,43 +330,64 @@ class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
         self._denominator = value
         self._ratioChanged()
 
+    @staticmethod
+    @lru_cache(1024)
+    def _durationFromNumeratorDenominator(
+        numerator: int,
+        denominator: int,
+    ) -> FrozenDuration:
+        '''
+        Return the (immutable) duration equal in length to a numerator/denominator
+        ratio.
+
+        Cached, since a small set of ratios (1/4, 1/8, 3/8, ...) recurs constantly.
+
+        >>> meter.core.MeterTerminal._durationFromNumeratorDenominator(3, 8)
+        <music21.duration.FrozenDuration 1.5>
+
+        AI-assisted (Claude).
+        '''
+        # NOTE: this is a performance critical method.
+        return FrozenDuration(quarterLength=(4.0 * numerator) / denominator)
+
     def _ratioChanged(self):
         '''
-        If ratio has been changed, call this to update duration
+        If the ratio has changed, call this to refresh the cached duration.
         '''
-        # NOTE: this is a performance critical method and should only be
-        # called when necessary
-        self._duration = Duration()
-        try:
-            self._duration.quarterLength = (
-                (4.0 * self.numerator) / self.denominator
-            )
-        except DurationException:
-            environLocal.printDebug(
-                ['DurationException encountered',
-                 'numerator/denominator',
-                 self.numerator,
-                 self.denominator
-                 ]
-            )
+        self._duration = self._durationFromNumeratorDenominator(
+            self.numerator, self.denominator
+        )
 
 
     @property
     def duration(self):
         '''
-        duration gets or sets a duration value that
-        is equal in length of the terminal.
+        Returns a :class:`~music21.duration.FrozenDuration` equal in length to this
+        terminal (or sequence).  It is shared and cached, and therefore immutable:
 
-        >>> a = meter.MeterTerminal()
-        >>> a.numerator = 3
-        >>> a.denominator = 8
-        >>> d = a.duration
-        >>> d.type
+        >>> a = meter.MeterTerminal('3/8')
+        >>> a.duration
+        <music21.duration.FrozenDuration 1.5>
+        >>> a.duration.type
         'quarter'
-        >>> d.dots
+        >>> a.duration.dots
         1
-        >>> d.quarterLength
-        1.5
+
+        Trying to change it raises an exception:
+
+        >>> a.duration.quarterLength = 5.0
+        Traceback (most recent call last):
+        TypeError: This FrozenDuration instance is immutable.
+
+        If you need a changeable duration, unfreeze it first:
+
+        >>> changeable = a.duration.unfreeze()
+        >>> changeable.quarterLength = 5.0
+        >>> changeable
+        <music21.duration.Duration 5.0>
+
+        * Changed in v11: returns a shared, immutable
+          :class:`~music21.duration.FrozenDuration` (was a mutable Duration).
         '''
         if self._overriddenDuration:
             return self._overriddenDuration

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -21,9 +21,9 @@ import typing as t
 
 from music21 import common
 from music21.common.numberTools import opFrac
-from music21.common.objects import SlottedObjectMixin
+from music21.common.objects import FrozenObject
 from music21.common.types import OffsetQLIn
-from music21.duration import Duration, FrozenDuration
+from music21.duration import FrozenDuration
 from music21 import environment
 from music21.exceptions21 import MeterException
 from music21.meter import tools
@@ -33,7 +33,7 @@ environLocal = environment.Environment('meter.core')
 
 # -----------------------------------------------------------------------------
 
-class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
+class MeterTerminal(prebase.ProtoM21Object, FrozenObject):
     '''
     A MeterTerminal is a nestable primitive of rhythmic division.
 
@@ -46,62 +46,64 @@ class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
     >>> a = meter.MeterTerminal('5/2')
     >>> a.duration.quarterLength
     10.0
+
+    A MeterTerminal is an immutable value object defined solely by its
+    numerator, denominator, and weight.  Its attributes cannot be changed
+    after creation; instead make a new one (see :func:`getMeterTerminal`):
+
+    >>> a.numerator = 6
+    Traceback (most recent call last):
+    TypeError: This MeterTerminal instance is immutable.
+
+    Because it is immutable, deep-copying a MeterTerminal returns the same
+    shared object, and equality is by value:
+
+    >>> import copy
+    >>> copy.deepcopy(a) is a
+    True
+    >>> meter.MeterTerminal('2/4') == meter.MeterTerminal('2/4')
+    True
+
+    * Changed in v11: MeterTerminal is immutable, deep-copies to itself, and
+      compares by value.
+
+    AI-assisted (Claude).
     '''
     # CLASS VARIABLES #
 
     __slots__ = (
         '_denominator',
-        '_duration',
         '_numerator',
-        '_overriddenDuration',
         '_weight',
     )
 
     # INITIALIZER #
-    def __init__(self, slashNotation: str|None = None, weight: int|float = 1):
+    def __init__(self, slashNotation: str|None = None, weight: int|float = 1, *,
+                 numerator: int = 0, denominator: int = 1):
         # because of how they are copied, MeterTerminals must not have any
         # initialization parameters without defaults
-        self._duration: Duration|None = None
-        self._numerator: int = 0
-        self._denominator: int = 1
-        self._weight: int|float = 1  # do not use setter here -- bad override in MeterSequence
-        self._overriddenDuration: Duration|None = None
-
         if slashNotation is not None:
-            # assign directly to values, not properties, to avoid
-            # calling _ratioChanged more than necessary
-            values = tools.slashToTuple(slashNotation)  # raise MeterException early if problem.
-            self._numerator = values.numerator
-            self._denominator = values.denominator
-
-        self._ratioChanged()  # sets self._duration
-
-        # this will set the underlying weight attribute directly for data checking
-        # explicitly calling base class method to avoid problems
-        # in the derived class MeterSequence
-        self._weight = weight
+            # raise MeterException early if there is a problem.
+            values = tools.slashToTuple(slashNotation)
+            numerator = values.numerator
+            denominator = values.denominator
+        self._numerator: int = numerator
+        self._denominator: int = denominator
+        self._weight: int|float = weight
 
     # SPECIAL METHODS #
 
     def __deepcopy__(self, memo=None):
         '''
-        Helper method to for the deepcopy function in copy.py.
+        Helper method for the deepcopy function in copy.py.
 
         Do not call this directly.
 
-        Defining a custom __deepcopy__ here is a performance boost,
-        particularly in not copying _duration, directly assigning _weight, and
-        other benefits.
+        A MeterTerminal is immutable and shared, so deep-copying it simply
+        returns the same object (a large performance win, since MeterTerminals
+        are copied constantly as part of Streams and TimeSignatures).
         '''
-        # call class to get a new, empty instance
-        new = self.__class__()
-        # for name in dir(self):
-        new._numerator = self._numerator
-        new._denominator = self._denominator
-        new._ratioChanged()  # faster than copying dur
-        # new._duration = copy.deepcopy(self._duration, memo)
-        new._weight = self._weight  # these are numbers
-        return new
+        return self
 
     def _reprInternal(self):
         return str(self)
@@ -268,67 +270,42 @@ class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
     @property
     def weight(self) -> float|int:
         '''
-        Return or set the weight of a MeterTerminal
+        Return the weight of a MeterTerminal (read-only; a MeterTerminal is
+        immutable).
 
-        >>> a = meter.MeterTerminal('2/4')
-        >>> a.weight = 0.5
+        >>> a = meter.MeterTerminal('2/4', 0.5)
         >>> a.weight
         0.5
         '''
         return self._weight
 
-    @weight.setter
-    def weight(self, value: float|int):
-        self._weight = value
-
     @property
     def numerator(self) -> int:
         '''
-        Return or set the numerator of the MeterTerminal
+        Return the numerator of the MeterTerminal (read-only; a MeterTerminal
+        is immutable).
 
         >>> a = meter.MeterTerminal('2/4')
         >>> a.numerator
         2
         >>> a.duration.quarterLength
         2.0
-        >>> a.numerator = 11
-        >>> a.duration.quarterLength
-        11.0
         '''
         return self._numerator
-
-    @numerator.setter
-    def numerator(self, value: int):
-        self._numerator = value
-        self._ratioChanged()
 
     @property
     def denominator(self) -> int:
         '''
-        Get or set the denominator of the meter terminal
+        Return the denominator of the meter terminal (read-only; a
+        MeterTerminal is immutable).
 
         >>> a = meter.MeterTerminal('2/4')
         >>> a.denominator
         4
         >>> a.duration.quarterLength
         2.0
-        >>> a.denominator = 8
-        >>> a.duration.quarterLength
-        1.0
-
-        >>> a.denominator = 7
-        Traceback (most recent call last):
-        music21.exceptions21.MeterException: bad denominator value: 7
         '''
         return self._denominator
-
-    @denominator.setter
-    def denominator(self, value: int):
-        # use duration.typeFromNumDict?
-        if value not in tools.validDenominatorsSet:
-            raise MeterException(f'bad denominator value: {value}')
-        self._denominator = value
-        self._ratioChanged()
 
     @staticmethod
     @lru_cache(1024)
@@ -349,15 +326,6 @@ class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
         '''
         # NOTE: this is a performance critical method.
         return FrozenDuration(quarterLength=(4.0 * numerator) / denominator)
-
-    def _ratioChanged(self):
-        '''
-        If the ratio has changed, call this to refresh the cached duration.
-        '''
-        self._duration = self._durationFromNumeratorDenominator(
-            self.numerator, self.denominator
-        )
-
 
     @property
     def duration(self):
@@ -389,14 +357,7 @@ class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
         * Changed in v11: returns a shared, immutable
           :class:`~music21.duration.FrozenDuration` (was a mutable Duration).
         '''
-        if self._overriddenDuration:
-            return self._overriddenDuration
-        else:
-            return self._duration
-
-    @duration.setter
-    def duration(self, value: Duration):
-        self._overriddenDuration = value
+        return self._durationFromNumeratorDenominator(self.numerator, self.denominator)
 
     @property
     def depth(self):
@@ -404,6 +365,41 @@ class MeterTerminal(prebase.ProtoM21Object, SlottedObjectMixin):
         Return how many levels deep this part is -- the depth of a terminal is always 1
         '''
         return 1
+
+
+# -----------------------------------------------------------------------------
+
+_meterTerminalCache: dict[tuple[int, int, type, float|int], MeterTerminal] = {}
+
+
+def getMeterTerminal(numerator: int, denominator: int,
+                     weight: float|int = 1) -> MeterTerminal:
+    '''
+    Return a shared, cached, immutable :class:`MeterTerminal` for these values.
+
+    Because MeterTerminals are immutable, identical `(numerator, denominator,
+    weight)` triples can all share one object.  This is how a "changed" terminal
+    is produced: instead of mutating an existing terminal, request the cached
+    terminal for the new values.
+
+    >>> mt = meter.core.getMeterTerminal(1, 4)
+    >>> mt
+    <music21.meter.core.MeterTerminal 1/4>
+    >>> meter.core.getMeterTerminal(1, 4) is mt
+    True
+    >>> meter.core.getMeterTerminal(1, 4, weight=0.5) is mt
+    False
+
+    AI-assisted (Claude).
+    '''
+    # the weight's type is part of the key: an int 1 and a float 1.0 compare
+    # equal but must stay distinct terminals so the exact weight is preserved.
+    key = (numerator, denominator, type(weight), weight)
+    cached = _meterTerminalCache.get(key)
+    if cached is None:
+        cached = MeterTerminal(numerator=numerator, denominator=denominator, weight=weight)
+        _meterTerminalCache[key] = cached
+    return cached
 
 
 # -----------------------------------------------------------------------------
@@ -422,6 +418,21 @@ class MeterSequence(MeterTerminal):
         'parenthesis',
         'summedNumerator',
     )
+
+    # A MeterSequence is mutable, unlike its MeterTerminal base class.  Setting
+    # `frozen = False` tells FrozenObject to allow attribute assignment; bypassing
+    # FrozenObject's __setattr__/__delattr__ entirely also avoids their per-set
+    # overhead on this performance-critical (frequently rebuilt) object.
+    frozen = False
+    __setattr__ = object.__setattr__  # type: ignore[assignment]
+    __delattr__ = object.__delattr__  # type: ignore[assignment]
+
+    # A MeterSequence holds mutable, unhashable slots (a list and a dict), so it
+    # cannot use FrozenObject's value-based comparison/hashing.  Restore identity
+    # semantics.
+    __eq__ = object.__eq__
+    __ne__ = object.__ne__
+    __hash__ = object.__hash__
 
     # INITIALIZER #
 
@@ -477,10 +488,6 @@ class MeterSequence(MeterTerminal):
         new._denominator = self._denominator
         # noinspection PyArgumentList
         new._partition = copy.deepcopy(self._partition, memo)
-        new._ratioChanged()  # faster than copying dur
-        # new._duration = copy.deepcopy(self._duration, memo)
-
-        new._overriddenDuration = self._overriddenDuration
         new.summedNumerator = self.summedNumerator
         new.parenthesis = self.parenthesis
 
@@ -603,15 +610,10 @@ class MeterSequence(MeterTerminal):
 
         if isinstance(value, MeterTerminal):  # may be a MeterSequence
             mt = value
-        else:  # assume it is a string
-            mt = MeterTerminal(value)
+        else:  # assume it is a string; share the cached immutable terminal
+            values = tools.slashToTuple(value)
+            mt = getMeterTerminal(values.numerator, values.denominator)
 
-        # if isinstance(value, str):
-        #     mt = MeterTerminal(value)
-        # elif isinstance(value, MeterTerminal):  # may be a MeterSequence
-        #     mt = value
-        # else:
-        #     raise MeterException(f'cannot add {value} to this sequence')
         self._partition.append(mt)
         # clear cache
         self._levelListCache = {}
@@ -1271,8 +1273,7 @@ class MeterSequence(MeterTerminal):
         if isinstance(value, str):
             ratioList, self.summedNumerator = tools.slashMixedToFraction(value)
             for n, d in ratioList:
-                slashNotation = f'{n}/{d}'
-                self._addTerminal(MeterTerminal(slashNotation))
+                self._addTerminal(getMeterTerminal(n, d))
             self._updateRatio()
             if targetWeight is not None:
                 self.weight = targetWeight
@@ -1281,7 +1282,12 @@ class MeterSequence(MeterTerminal):
             # if we have a single MeterTerminal and autoWeight is active
             # set this terminal to the old weight
             if targetWeight is not None:
-                value.weight = targetWeight
+                if isinstance(value, MeterSequence):
+                    value.weight = targetWeight
+                else:
+                    # a terminal is immutable: swap in a re-weighted cached one
+                    value = getMeterTerminal(value.numerator, value.denominator,
+                                             weight=targetWeight)
             self._addTerminal(value)
             self._updateRatio()
             # do not need to set weight, as based on terminal
@@ -1318,8 +1324,6 @@ class MeterSequence(MeterTerminal):
         # can only set to private attributes
         # self._numerator, self._denominator = None, 1
         self._numerator, self._denominator = tools.fractionSum(fTuple)
-        # must call ratio changed directly as not using properties
-        self._ratioChanged()
 
     # --------------------------------------------------------------------------
     # properties
@@ -1360,18 +1364,15 @@ class MeterSequence(MeterTerminal):
         >>> accentSequence.weight
         0.75
 
-        Changing the weight of the child sequence will affect the parent, since this is
-        not cached, but recomputed on each call.
-
-        >>> downbeat.weight = 0.375
-        >>> accentSequence.weight
-        0.625
-
-        Changing the weight on the parent sequence will reset weights on the children
+        A MeterSequence's weight is not cached; it is recomputed from its parts
+        on each call.  Setting the weight on the parent sequence resets the
+        weights on its children so that they sum to the requested value:
 
         >>> accentSequence.weight = 1.0
-        >>> (downbeat.weight, upbeat.weight)
+        >>> (accentSequence[0].weight, accentSequence[1].weight)
         (0.5, 0.5)
+        >>> accentSequence.weight
+        1.0
 
         Assume this MeterSequence is a whole, not a part of some larger MeterSequence.
         Thus, we cannot use numerator/denominator relationship
@@ -1397,13 +1398,16 @@ class MeterSequence(MeterTerminal):
                 f'or this denominator {self._denominator} {type(self._denominator)}'
             ) from te
 
-        for mt in self._partition:
-            # for mt in self:
-            partRatio = mt._numerator / mt._denominator
-            mt.weight = value * (partRatio / totalRatio)
-            # mt.weight = (partRatio/totalRatio) #* totalRatio
-            # environLocal.printDebug(['setting weight based on part, total, weight',
-            #    partRatio, totalRatio, mt.weight])
+        for i, mt in enumerate(self._partition):
+            partRatio = mt.numerator / mt.denominator
+            newWeight = value * (partRatio / totalRatio)
+            if isinstance(mt, MeterSequence):
+                # a nested MeterSequence is still mutable: recurse
+                mt.weight = newWeight
+            else:
+                # a terminal is immutable: swap in a re-weighted cached one
+                self._partition[i] = getMeterTerminal(
+                    mt.numerator, mt.denominator, weight=newWeight)
 
     def _getFlatList(self):
         '''
@@ -1701,11 +1705,12 @@ class MeterSequence(MeterTerminal):
                         levelCount - 1, flat)
                 else:  # level count is at zero
                     if flat:  # make sequence into a terminal
-                        mt = MeterTerminal(
-                            f'{partition_i.numerator}/{partition_i.denominator}'
+                        # weight matches that of the sequence it flattens
+                        mt = getMeterTerminal(
+                            partition_i.numerator,
+                            partition_i.denominator,
+                            weight=partition_i.weight,
                         )
-                        # set weight to that of the sequence
-                        mt.weight = partition_i.weight
                         mtList.append(mt)
                     else:  # it is not a terminal, it is a meter sequence
                         mtList.append(partition_i)
@@ -1825,11 +1830,39 @@ class MeterSequence(MeterTerminal):
         [2, 1.5, 1.5, 2, 1.5, 1.5]
         >>> b.getLevelWeight(2)
         [2, 1.5, 1.5, 2, 0.75, 0.75, 1.5]
+
+        * Changed in v11: terminals are immutable, so each affected terminal is
+          replaced in place by a cached one carrying the new weight.
         '''
-        levelObjs = self.getLevelList(level)
-        for i in range(len(levelObjs)):
-            mt = levelObjs[i]
-            mt.weight = weightList[i % len(weightList)]
+        self._applyLevelWeights(weightList, level)
+
+    def _applyLevelWeights(self, weightList, level, startIndex=0):
+        '''
+        Recursively re-weight the leaf terminals reached at `level`, mirroring
+        the flattening order of :meth:`getLevelList` (flat=True) so that the same
+        terminals are affected and the same running index into `weightList` is
+        used.  Since terminals are immutable, each is replaced in its parent
+        partition by a cached, re-weighted one.  Returns the next running index.
+
+        AI-assisted (Claude).
+        '''
+        idx = startIndex
+        for i, partition_i in enumerate(self._partition):
+            if not isinstance(partition_i, MeterSequence):
+                newWeight = weightList[idx % len(weightList)]
+                self._partition[i] = getMeterTerminal(
+                    partition_i.numerator, partition_i.denominator, weight=newWeight)
+                idx += 1
+            elif level > 0:
+                idx = partition_i._applyLevelWeights(weightList, level - 1, idx)
+            else:
+                # getLevelList(flat=True) flattens this sequence to a single
+                # synthetic terminal that has no persistent home; only the index
+                # advances (matching the historical behavior).
+                idx += 1
+        # clear cache
+        self._levelListCache = {}
+        return idx
 
     # --------------------------------------------------------------------------
     # given a quarter note position, return the active index

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -15,7 +15,6 @@ This module defines two component objects for defining nested metrical structure
 from __future__ import annotations
 
 from collections.abc import Sequence
-import copy
 from functools import lru_cache
 import typing as t
 
@@ -31,9 +30,245 @@ from music21 import prebase
 
 environLocal = environment.Environment('meter.core')
 
+# a MeterTerminal or a MeterSequence, the two kinds of things that can appear
+# inside a MeterSequence's partition.  (PEP 695 type aliases are evaluated
+# lazily, so the forward references resolve fine.)
+type MeterNode = MeterTerminal | MeterSequence
+
+
+# -----------------------------------------------------------------------------
+class MeterCore:
+    '''
+    A mixin holding the read-only behavior shared by both
+    :class:`~music21.meter.core.MeterTerminal` and
+    :class:`~music21.meter.core.MeterSequence`.
+
+    Each subclass supplies ``numerator``, ``denominator``, and ``weight``
+    properties; MeterCore provides the derived, immutable behaviors: the
+    duration, ratio comparison, and the various ``subdivide`` methods (which
+    build and return a new :class:`~music21.meter.core.MeterSequence`).
+
+    AI-assisted (Claude).
+    '''
+    __slots__ = ()
+
+    # these are supplied by the concrete classes as read-only properties;
+    # declared here (as stubs) for the type checker and to document the contract.
+    @property
+    def numerator(self) -> int:
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    def denominator(self) -> int:
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    def weight(self) -> float:
+        raise NotImplementedError  # pragma: no cover
+
+    @staticmethod
+    @lru_cache(1024)
+    def _durationFromNumeratorDenominator(
+        numerator: int,
+        denominator: int,
+    ) -> FrozenDuration:
+        '''
+        Return the (immutable) duration equal in length to a numerator/denominator
+        ratio.
+
+        Cached, since a small set of ratios (1/4, 1/8, 3/8, ...) recurs constantly.
+
+        >>> meter.core.MeterTerminal._durationFromNumeratorDenominator(3, 8)
+        <music21.duration.FrozenDuration 1.5>
+
+        AI-assisted (Claude).
+        '''
+        # NOTE: this is a performance critical method.
+        return FrozenDuration(quarterLength=(4.0 * numerator) / denominator)
+
+    @property
+    def duration(self) -> FrozenDuration:
+        '''
+        Returns a :class:`~music21.duration.FrozenDuration` equal in length to this
+        terminal (or sequence).  It is shared and cached, and therefore immutable:
+
+        >>> a = meter.MeterTerminal('3/8')
+        >>> a.duration
+        <music21.duration.FrozenDuration 1.5>
+        >>> a.duration.type
+        'quarter'
+        >>> a.duration.dots
+        1
+
+        Trying to change it raises an exception:
+
+        >>> a.duration.quarterLength = 5.0
+        Traceback (most recent call last):
+        TypeError: This FrozenDuration instance is immutable.
+
+        If you need a changeable duration, unfreeze it first:
+
+        >>> changeable = a.duration.unfreeze()
+        >>> changeable.quarterLength = 5.0
+        >>> changeable
+        <music21.duration.Duration 5.0>
+
+        * Changed in v11: returns a shared, immutable
+          :class:`~music21.duration.FrozenDuration` (was a mutable Duration).
+        '''
+        return self._durationFromNumeratorDenominator(self.numerator, self.denominator)
+
+    def _reprInternal(self):
+        return str(self)
+
+    def ratioEqual(self, other) -> bool:
+        '''
+        Compare the numerator and denominator of another object.
+        Note that these have to be exact matches; 3/4 is not the same as 6/8
+
+        >>> a = meter.MeterTerminal('3/4')
+        >>> b = meter.MeterTerminal('6/4')
+        >>> c = meter.MeterTerminal('2/4')
+        >>> d = meter.MeterTerminal('3/4')
+        >>> a.ratioEqual(b)
+        False
+        >>> a.ratioEqual(c)
+        False
+        >>> a.ratioEqual(d)
+        True
+        '''
+        if other is None:
+            return False
+        if (other.numerator == self.numerator
+                and other.denominator == self.denominator):
+            return True
+        else:
+            return False
+
+    # -------------------------------------------------------------------------
+
+    def subdivideByCount(self, countRequest=None) -> MeterSequence:
+        '''
+        returns a MeterSequence made up of taking this MeterTerminal and
+        subdividing it into the given number of parts.  Each of those parts
+        is a MeterTerminal
+
+        >>> a = meter.MeterTerminal('3/4')
+        >>> b = a.subdivideByCount(3)
+        >>> b
+        <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
+        >>> len(b)
+        3
+        >>> b[0]
+        <music21.meter.core.MeterTerminal 1/4>
+
+        What happens if we do this?
+
+        >>> a = meter.MeterTerminal('5/8')
+        >>> b = a.subdivideByCount(2)
+        >>> b
+        <music21.meter.core.MeterSequence {2/8+3/8}>
+        >>> len(b)
+        2
+        >>> b[0]
+        <music21.meter.core.MeterTerminal 2/8>
+        >>> b[1]
+        <music21.meter.core.MeterTerminal 3/8>
+
+        But what if you want to divide into 3/8+2/8 or something else?
+        for that, see the :meth:`~music21.meter.MeterSequence.partition` method
+        of :class:`~music21.meter.MeterSequence`.
+        '''
+        # cannot set the weight of this MeterSequence w/o having offsets
+        # pass this object as an argument; when subdividing, use autoWeight
+        return _buildSequence(self, countRequest, autoWeight=True, targetWeight=self.weight)
+
+    def subdivideByList(self, numeratorList) -> MeterSequence:
+        '''
+        Return a MeterSequence dividing this
+        MeterTerminal according to the numeratorList
+
+        >>> a = meter.MeterTerminal('3/4')
+        >>> b = a.subdivideByList([1, 1, 1])
+        >>> b
+        <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
+        >>> len(b)
+        3
+        >>> b[0]
+        <music21.meter.core.MeterTerminal 1/4>
+
+        Unequal subdivisions work:
+
+        >>> c = a.subdivideByList([1, 2])
+        >>> c
+        <music21.meter.core.MeterSequence {1/4+2/4}>
+        >>> len(c)
+        2
+        >>> (c[0], c[1])
+        (<music21.meter.core.MeterTerminal 1/4>, <music21.meter.core.MeterTerminal 2/4>)
+
+        So does subdividing by strings
+
+        >>> c = a.subdivideByList(['2/4', '1/4'])
+        >>> len(c)
+        2
+        >>> (c[0], c[1])
+        (<music21.meter.core.MeterTerminal 2/4>, <music21.meter.core.MeterTerminal 1/4>)
+
+        See :meth:`~music21.meter.MeterSequence.partitionByList` method
+        of :class:`~music21.meter.MeterSequence` for more details.
+        '''
+        # elevate to meter sequence, then partition
+        ms = _buildSequence(self)  # do not need to autoWeight here
+        return ms.partitionByList(numeratorList)  # this will split weight
+
+    def subdivideByOther(self, other: MeterSequence) -> MeterSequence:
+        '''
+        Return a MeterSequence based on another MeterSequence
+
+        >>> a = meter.MeterSequence('1/4+1/4+1/4')
+        >>> a
+        <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
+        >>> b = meter.MeterSequence('3/8+3/8')
+        >>> a.subdivideByOther(b)
+        <music21.meter.core.MeterSequence {{3/8+3/8}}>
+
+        >>> terminal = meter.MeterTerminal('1/4')
+        >>> divider = meter.MeterSequence('1/8+1/8')
+        >>> terminal.subdivideByOther(divider)
+        <music21.meter.core.MeterSequence {{1/8+1/8}}>
+        '''
+        if other.duration.quarterLength != self.duration.quarterLength:
+            raise MeterException(f'cannot subdivide by other: {other}')
+        # elevate to meter sequence
+        return _buildSequence(other)  # do not need to autoWeight here
+
+    def subdivide(
+        self,
+        value: Sequence[int | str] | MeterSequence | int
+    ) -> MeterSequence:
+        '''
+        Subdivision takes a MeterTerminal and, making it into a collection of MeterTerminals,
+        Returns a MeterSequence.
+
+        This is different from partitioning a MeterSequence. `subdivide` does not happen
+        in place and instead returns a new object.
+
+        If an integer is provided, assume it is a partition count.
+        '''
+        if common.isListLike(value):
+            return self.subdivideByList(value)
+        elif isinstance(value, MeterSequence):
+            return self.subdivideByOther(value)
+        elif common.isNum(value):
+            return self.subdivideByCount(value)
+        else:
+            raise MeterException(f'cannot process partition argument {value}')
+
+
 # -----------------------------------------------------------------------------
 
-class MeterTerminal(prebase.ProtoM21Object, FrozenObject):
+class MeterTerminal(prebase.ProtoM21Object, MeterCore, FrozenObject):
     '''
     A MeterTerminal is a nestable primitive of rhythmic division.
 
@@ -77,20 +312,22 @@ class MeterTerminal(prebase.ProtoM21Object, FrozenObject):
         '_weight',
     )
 
+    # slot type declarations (for the type checker); set via object.__setattr__
+    _numerator: int
+    _denominator: int
+    _weight: float
+
     # INITIALIZER #
     def __init__(self, slashNotation: str|None = None, weight: float = 1.0, *,
                  numerator: int = 0, denominator: int = 1):
-        # MeterSequence (a subclass) builds an empty instance via
-        # super().__init__() -- in its __init__ and __deepcopy__ -- so every
-        # parameter here must keep a default.
         if slashNotation is not None:
             # raise MeterException early if there is a problem.
             values = tools.slashToTuple(slashNotation)
             numerator = values.numerator
             denominator = values.denominator
-        self._numerator: int = numerator
-        self._denominator: int = denominator
-        self._weight: float = weight
+        object.__setattr__(self, '_numerator', numerator)
+        object.__setattr__(self, '_denominator', denominator)
+        object.__setattr__(self, '_weight', weight)
 
     # SPECIAL METHODS #
 
@@ -117,159 +354,6 @@ class MeterTerminal(prebase.ProtoM21Object, FrozenObject):
 
     def __str__(self):
         return str(int(self.numerator)) + '/' + str(int(self.denominator))
-
-    def ratioEqual(self, other):
-        '''
-        Compare the numerator and denominator of another object.
-        Note that these have to be exact matches; 3/4 is not the same as 6/8
-
-        >>> a = meter.MeterTerminal('3/4')
-        >>> b = meter.MeterTerminal('6/4')
-        >>> c = meter.MeterTerminal('2/4')
-        >>> d = meter.MeterTerminal('3/4')
-        >>> a.ratioEqual(b)
-        False
-        >>> a.ratioEqual(c)
-        False
-        >>> a.ratioEqual(d)
-        True
-        '''
-        if other is None:
-            return False
-        if (other.numerator == self.numerator
-                and other.denominator == self.denominator):
-            return True
-        else:
-            return False
-
-    # -------------------------------------------------------------------------
-
-    def subdivideByCount(self, countRequest=None):
-        '''
-        returns a MeterSequence made up of taking this MeterTerminal and
-        subdividing it into the given number of parts.  Each of those parts
-        is a MeterTerminal
-
-        >>> a = meter.MeterTerminal('3/4')
-        >>> b = a.subdivideByCount(3)
-        >>> b
-        <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
-        >>> len(b)
-        3
-        >>> b[0]
-        <music21.meter.core.MeterTerminal 1/4>
-
-        What happens if we do this?
-
-        >>> a = meter.MeterTerminal('5/8')
-        >>> b = a.subdivideByCount(2)
-        >>> b
-        <music21.meter.core.MeterSequence {2/8+3/8}>
-        >>> len(b)
-        2
-        >>> b[0]
-        <music21.meter.core.MeterTerminal 2/8>
-        >>> b[1]
-        <music21.meter.core.MeterTerminal 3/8>
-
-        But what if you want to divide into 3/8+2/8 or something else?
-        for that, see the :meth:`~music21.meter.MeterSequence.load` method
-        of :class:`~music21.meter.MeterSequence`.
-        '''
-        # elevate to meter sequence
-        ms = MeterSequence()
-        # cannot set the weight of this MeterSequence w/o having offsets
-        # pass this MeterTerminal as an argument
-        # when subdividing, use autoWeight
-        ms.load(self, countRequest, autoWeight=True, targetWeight=self.weight)
-        return ms
-
-    def subdivideByList(self, numeratorList):
-        '''
-        Return a MeterSequence dividing this
-        MeterTerminal according to the numeratorList
-
-        >>> a = meter.MeterTerminal('3/4')
-        >>> b = a.subdivideByList([1, 1, 1])
-        >>> b
-        <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
-        >>> len(b)
-        3
-        >>> b[0]
-        <music21.meter.core.MeterTerminal 1/4>
-
-        Unequal subdivisions work:
-
-        >>> c = a.subdivideByList([1, 2])
-        >>> c
-        <music21.meter.core.MeterSequence {1/4+2/4}>
-        >>> len(c)
-        2
-        >>> (c[0], c[1])
-        (<music21.meter.core.MeterTerminal 1/4>, <music21.meter.core.MeterTerminal 2/4>)
-
-        So does subdividing by strings
-
-        >>> c = a.subdivideByList(['2/4', '1/4'])
-        >>> len(c)
-        2
-        >>> (c[0], c[1])
-        (<music21.meter.core.MeterTerminal 2/4>, <music21.meter.core.MeterTerminal 1/4>)
-
-        See :meth:`~music21.meter.MeterSequence.partitionByList` method
-        of :class:`~music21.meter.MeterSequence` for more details.
-        '''
-        # elevate to meter sequence
-        ms = MeterSequence()
-        ms.load(self)  # do not need to autoWeight here
-        ms.partitionByList(numeratorList)  # this will split weight
-        return ms
-
-    def subdivideByOther(self, other: 'music21.meter.MeterSequence'):
-        '''
-        Return a MeterSequence based on another MeterSequence
-
-        >>> a = meter.MeterSequence('1/4+1/4+1/4')
-        >>> a
-        <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
-        >>> b = meter.MeterSequence('3/8+3/8')
-        >>> a.subdivideByOther(b)
-        <music21.meter.core.MeterSequence {{3/8+3/8}}>
-
-        >>> terminal = meter.MeterTerminal('1/4')
-        >>> divider = meter.MeterSequence('1/8+1/8')
-        >>> terminal.subdivideByOther(divider)
-        <music21.meter.core.MeterSequence {{1/8+1/8}}>
-        '''
-        # elevate to meter sequence
-        ms = MeterSequence()
-        if other.duration.quarterLength != self.duration.quarterLength:
-            raise MeterException(f'cannot subdivide by other: {other}')
-        ms.load(other)  # do not need to autoWeight here
-        # ms.partitionByOtherMeterSequence(other)  # this will split weight
-        return ms
-
-    def subdivide(
-        self,
-        value: Sequence[int | str] | MeterSequence | int
-    ):
-        '''
-        Subdivision takes a MeterTerminal and, making it into a collection of MeterTerminals,
-        Returns a MeterSequence.
-
-        This is different from partitioning a MeterSequence. `subdivide` does not happen
-        in place and instead returns a new object.
-
-        If an integer is provided, assume it is a partition count.
-        '''
-        if common.isListLike(value):
-            return self.subdivideByList(value)
-        elif isinstance(value, MeterSequence):
-            return self.subdivideByOther(value)
-        elif common.isNum(value):
-            return self.subdivideByCount(value)
-        else:
-            raise MeterException(f'cannot process partition argument {value}')
 
     # -------------------------------------------------------------------------
     # properties
@@ -328,58 +412,6 @@ class MeterTerminal(prebase.ProtoM21Object, FrozenObject):
         '''
         return self._denominator
 
-    @staticmethod
-    @lru_cache(1024)
-    def _durationFromNumeratorDenominator(
-        numerator: int,
-        denominator: int,
-    ) -> FrozenDuration:
-        '''
-        Return the (immutable) duration equal in length to a numerator/denominator
-        ratio.
-
-        Cached, since a small set of ratios (1/4, 1/8, 3/8, ...) recurs constantly.
-
-        >>> meter.core.MeterTerminal._durationFromNumeratorDenominator(3, 8)
-        <music21.duration.FrozenDuration 1.5>
-
-        AI-assisted (Claude).
-        '''
-        # NOTE: this is a performance critical method.
-        return FrozenDuration(quarterLength=(4.0 * numerator) / denominator)
-
-    @property
-    def duration(self):
-        '''
-        Returns a :class:`~music21.duration.FrozenDuration` equal in length to this
-        terminal (or sequence).  It is shared and cached, and therefore immutable:
-
-        >>> a = meter.MeterTerminal('3/8')
-        >>> a.duration
-        <music21.duration.FrozenDuration 1.5>
-        >>> a.duration.type
-        'quarter'
-        >>> a.duration.dots
-        1
-
-        Trying to change it raises an exception:
-
-        >>> a.duration.quarterLength = 5.0
-        Traceback (most recent call last):
-        TypeError: This FrozenDuration instance is immutable.
-
-        If you need a changeable duration, unfreeze it first:
-
-        >>> changeable = a.duration.unfreeze()
-        >>> changeable.quarterLength = 5.0
-        >>> changeable
-        <music21.duration.Duration 5.0>
-
-        * Changed in v11: returns a shared, immutable
-          :class:`~music21.duration.FrozenDuration` (was a mutable Duration).
-        '''
-        return self._durationFromNumeratorDenominator(self.numerator, self.denominator)
-
     @property
     def depth(self):
         '''
@@ -424,34 +456,58 @@ def getMeterTerminal(numerator: int, denominator: int,
 # -----------------------------------------------------------------------------
 
 
-class MeterSequence(MeterTerminal):
+class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
     '''
-    A meter sequence is a list of MeterTerminals, or other MeterSequences
+    A MeterSequence is an immutable, hashable list of MeterTerminals, or
+    other MeterSequences.
+
+    >>> ms = meter.MeterSequence('4/4', 4)
+    >>> ms
+    <music21.meter.core.MeterSequence {1/4+1/4+1/4+1/4}>
+
+    Like :class:`~music21.meter.core.MeterTerminal`, a MeterSequence is an
+    immutable value object.  Its structure cannot be changed after creation;
+    the "mutating" methods (:meth:`partition`, :meth:`subdividePartitionsEqual`,
+    :meth:`setLevelWeight`, :meth:`replaceElement`, ...) instead RETURN a new
+    MeterSequence and leave ``self`` unchanged:
+
+    >>> ms2 = ms.partition(2)
+    >>> ms2
+    <music21.meter.core.MeterSequence {1/2+1/2}>
+    >>> ms
+    <music21.meter.core.MeterSequence {1/4+1/4+1/4+1/4}>
+
+    Because it is immutable, deep-copying a MeterSequence returns the same
+    shared object, and equality is by value:
+
+    >>> import copy
+    >>> copy.deepcopy(ms) is ms
+    True
+    >>> meter.MeterSequence('4/4', 4) == meter.MeterSequence('4/4', 4)
+    True
+
+    * Changed in v11: MeterSequence is immutable, hashable, deep-copies to
+      itself, and its formerly in-place operations return a new sequence.
+
+    AI-assisted (Claude).
     '''
 
     # CLASS VARIABLES #
 
     __slots__ = (
-        '_levelListCache',
+        '_denominator',
+        '_numerator',
         '_partition',
         'parenthesis',
         'summedNumerator',
     )
 
-    # A MeterSequence is mutable, unlike its MeterTerminal base class.  Setting
-    # `frozen = False` tells FrozenObject to allow attribute assignment; bypassing
-    # FrozenObject's __setattr__/__delattr__ entirely also avoids their per-set
-    # overhead on this performance-critical (frequently rebuilt) object.
-    frozen = False
-    __setattr__ = object.__setattr__  # type: ignore[assignment]
-    __delattr__ = object.__delattr__  # type: ignore[assignment]
-
-    # A MeterSequence holds mutable, unhashable slots (a list and a dict), so it
-    # cannot use FrozenObject's value-based comparison/hashing.  Restore identity
-    # semantics.
-    __eq__ = object.__eq__
-    __ne__ = object.__ne__
-    __hash__ = object.__hash__
+    # slot type declarations (for the type checker); set via object.__setattr__
+    _numerator: int
+    _denominator: int
+    _partition: tuple[MeterNode, ...]
+    parenthesis: bool
+    summedNumerator: bool
 
     # INITIALIZER #
 
@@ -460,66 +516,49 @@ class MeterSequence(MeterTerminal):
         value: str | MeterTerminal | Sequence[MeterTerminal] | Sequence[str] | None = None,
         partitionRequest: t.Any|None = None,
     ):
-        super().__init__()
+        # Build the data on the known-safe init path using object.__setattr__ to
+        # bypass FrozenObject's expensive per-set inspection; after __init__ the
+        # object is fully immutable.
+        numerator, denominator, partitionList, summedNumerator = _loadData(value)
+        parenthesis = False
+        if partitionRequest is not None:
+            built = _makeSequence(
+                numerator, denominator, tuple(partitionList),
+                summedNumerator=summedNumerator
+            ).partition(partitionRequest)
+            numerator = built._numerator
+            denominator = built._denominator
+            partitionList = list(built._partition)
+            summedNumerator = built.summedNumerator
+            parenthesis = built.parenthesis
 
-        self._numerator: int = 1  # rationalized
-        self._denominator: int = 0  # lowest common multiple
-        self._partition: list[MeterTerminal|MeterSequence] = []
-        self._levelListCache: dict[tuple[int, bool], list[MeterTerminal]] = {}
-
-        # this attribute is only used in MeterTerminals, and note
-        # in MeterSequences; a MeterSequence's weight is based solely
-        # on the sum of its component parts.
-        # del self._weight -- no -- screws up pickling -- cannot del a slotted object
-
-        # Bool stores whether this meter was provided as a summed numerator
-        self.summedNumerator: bool = False
-
-        # An optional parameter used only in meter display sequences.
-        # Needed in cases where a meter component is parenthetical
-        self.parenthesis: bool = False
-
-        if value is not None:
-            self.load(value, partitionRequest)
+        object.__setattr__(self, '_numerator', numerator)
+        object.__setattr__(self, '_denominator', denominator)
+        object.__setattr__(self, '_partition', tuple(partitionList))
+        object.__setattr__(self, 'summedNumerator', summedNumerator)
+        object.__setattr__(self, 'parenthesis', parenthesis)
 
     # SPECIAL METHODS #
 
     def __deepcopy__(self, memo=None):
         '''
-        Helper method to copy.py's deepcopy function. Call it from there.
-
-        Defining a custom __deepcopy__ here is a performance boost,
-        particularly in not copying _duration and other benefits.
-
-        Notably, self._levelListCache is not copied,
-        which may not be needed in the copy and may be large.
+        A MeterSequence is immutable and shared, so deep-copying it simply
+        returns the same object.
 
         >>> from copy import deepcopy
         >>> ms1 = meter.MeterSequence('4/4+3/8')
-        >>> ms2 = deepcopy(ms1)
-        >>> ms2
-        <music21.meter.core.MeterSequence {4/4+3/8}>
+        >>> deepcopy(ms1) is ms1
+        True
         '''
-        # call class to get a new, empty instance
-        new = self.__class__()
-        # for name in dir(self):
-        new._numerator = self._numerator
-        new._denominator = self._denominator
-        # noinspection PyArgumentList
-        new._partition = copy.deepcopy(self._partition, memo)
-        new.summedNumerator = self.summedNumerator
-        new.parenthesis = self.parenthesis
-
-        return new
+        return self
 
     def __copy__(self):
         '''
-        A MeterSequence is mutable (unlike its MeterTerminal base), so a copy
-        must be an independent object, not the shared self.
+        A MeterSequence is immutable, so a shallow copy is also just itself.
         '''
-        return self.__deepcopy__()
+        return self
 
-    def __getitem__(self, key: int) -> MeterTerminal:
+    def __getitem__(self, key: int) -> MeterNode:
         '''
         Get an MeterTerminal (or MeterSequence) from _partition
 
@@ -555,42 +594,47 @@ class MeterSequence(MeterTerminal):
         '''
         return len(self._partition)
 
-    def __setitem__(self, key: int, value: MeterTerminal):
+    def replaceElement(self, index: int, value: MeterNode) -> MeterSequence:
         '''
-        Insert items at index positions.
+        Return a new MeterSequence with the element at `index` replaced by
+        `value` (which must occupy the same ratio of time as the element it
+        replaces).  This is the immutable replacement for the old
+        ``ms[index] = value`` item assignment.
 
         >>> a = meter.MeterSequence('4/4', 4)
         >>> a
         <music21.meter.core.MeterSequence {1/4+1/4+1/4+1/4}>
         >>> a[0]
         <music21.meter.core.MeterTerminal 1/4>
-        >>> a[0] = a[0].subdivide(2)
+        >>> a = a.replaceElement(0, a[0].subdivide(2))
         >>> a
         <music21.meter.core.MeterSequence {{1/8+1/8}+1/4+1/4+1/4}>
-        >>> a[0][0] = a[0][0].subdivide(2)
+        >>> a = a.replaceElement(0, a[0].replaceElement(0, a[0][0].subdivide(2)))
         >>> a
         <music21.meter.core.MeterSequence {{{1/16+1/16}+1/8}+1/4+1/4+1/4}>
         >>> a[3]
         <music21.meter.core.MeterTerminal 1/4>
-        >>> a[3] = a[0][0]
+        >>> a.replaceElement(3, a[0][0])
         Traceback (most recent call last):
-        ...
         music21.exceptions21.MeterException: cannot insert {1/16+1/16} into space of 1/4
+
+        AI-assisted (Claude).
         '''
         # comparison of numerator and denominator
-        if not isinstance(value, MeterTerminal):
+        if not isinstance(value, MeterCore):
             raise MeterException('values in MeterSequences must be MeterTerminals or '
                                  f'MeterSequences, not {value}')
-        if value.ratioEqual(self[key]):
-            self._partition[key] = value
-        else:
-            raise MeterException(f'cannot insert {value} into space of {self[key]}')
-
-        # clear cache
-        self._levelListCache = {}
+        if not value.ratioEqual(self[index]):
+            raise MeterException(f'cannot insert {value} into space of {self[index]}')
+        newPartition = list(self._partition)
+        newPartition[index] = value
+        return self._rebuild(newPartition)
 
     def __str__(self):
         return '{' + self.partitionDisplay + '}'
+
+    def _reprInternal(self):
+        return str(self)
 
     @property
     def partitionDisplay(self):
@@ -617,32 +661,16 @@ class MeterSequence(MeterTerminal):
 
     # -------------------------------------------------------------------------
 
-    def _clearPartition(self) -> None:
+    def _rebuild(self, partition: list) -> MeterSequence:
         '''
-        This will not sync with .numerator and .denominator if called alone
+        Return a cached MeterSequence with the same numerator, denominator,
+        parenthesis, and summedNumerator as ``self`` but a new partition.
+
+        AI-assisted (Claude).
         '''
-        self._partition = []
-        # clear cache
-        self._levelListCache = {}
-
-    def _addTerminal(self, value: MeterTerminal|str) -> None:
-        '''
-        Add an object to the partition list. This does not update numerator and denominator.
-
-        ???: (targetWeight is the expected total Weight for this MeterSequence. This
-        would be self.weight, but often partitions are cleared before _addTerminal is called.)
-        '''
-        # NOTE: this is a performance critical method
-
-        if isinstance(value, MeterTerminal):  # may be a MeterSequence
-            mt = value
-        else:  # assume it is a string; share the cached immutable terminal
-            values = tools.slashToTuple(value)
-            mt = getMeterTerminal(values.numerator, values.denominator)
-
-        self._partition.append(mt)
-        # clear cache
-        self._levelListCache = {}
+        return _makeSequence(
+            self._numerator, self._denominator, tuple(partition),
+            parenthesis=self.parenthesis, summedNumerator=self.summedNumerator)
 
     def getPartitionOptions(self) -> tools.MeterOptions:
         '''
@@ -682,24 +710,23 @@ class MeterSequence(MeterTerminal):
 
     # -------------------------------------------------------------------------
 
-    def partitionByCount(self, countRequest: int, loadDefault: bool = True) -> None:
+    def partitionByCount(self, countRequest: int, loadDefault: bool = True) -> MeterSequence:
         '''
-        Divide the current MeterSequence into the requested number of parts.
+        Return a new MeterSequence dividing this one into the requested number
+        of parts.
 
         If it is not possible to divide it into the requested number, and
-        loadDefault is `True`, then give the default partition:
-
-        This will destroy any established structure in the stored partition.
+        loadDefault is `True`, then give the default partition.
 
         >>> a = meter.MeterSequence('4/4')
         >>> a
         <music21.meter.core.MeterSequence {4/4}>
-        >>> a.partitionByCount(2)
+        >>> a = a.partitionByCount(2)
         >>> a
         <music21.meter.core.MeterSequence {1/2+1/2}>
         >>> str(a)
         '{1/2+1/2}'
-        >>> a.partitionByCount(4)
+        >>> a = a.partitionByCount(4)
         >>> a
         <music21.meter.core.MeterSequence {1/4+1/4+1/4+1/4}>
         >>> str(a)
@@ -709,13 +736,13 @@ class MeterSequence(MeterTerminal):
         meter is irregular:
 
         >>> b = meter.MeterSequence('5/8')
-        >>> b.partitionByCount(2)
+        >>> b = b.partitionByCount(2)
         >>> b
          <music21.meter.core.MeterSequence {2/8+3/8}>
 
         This relies on a pre-defined exemption for partitioning 5 by 3:
 
-        >>> b.partitionByCount(3)
+        >>> b = b.partitionByCount(3)
         >>> str(b)
         '{2/8+2/8+1/8}'
 
@@ -723,7 +750,7 @@ class MeterSequence(MeterTerminal):
         there is no known way to do this:
 
         >>> a = meter.MeterSequence('5/8')
-        >>> a.partitionByCount(11)
+        >>> a = a.partitionByCount(11)
         >>> str(a)
         '{2/8+3/8}'
 
@@ -733,6 +760,7 @@ class MeterSequence(MeterTerminal):
         Traceback (most recent call last):
         music21.exceptions21.MeterException: Cannot set partition by 11 (5/8)
 
+        * Changed in v11: returns a new MeterSequence rather than mutating in place.
         '''
         opts = self.getPartitionOptions()
         optMatch = None
@@ -753,40 +781,38 @@ class MeterSequence(MeterTerminal):
                 )
 
         targetWeight = self.weight
-        # environLocal.printDebug(['partitionByCount, targetWeight', targetWeight])
-        self._clearPartition()  # weight will now be zero
-        for mStr in optMatch:
-            self._addTerminal(mStr)
-        self.weight = targetWeight
+        partition = [_coerceTerminal(mStr) for mStr in optMatch]
+        partition = _applyWeight(partition, self.numerator, self.denominator, targetWeight)
+        return self._rebuild(partition)
 
-        # clear cache
-        self._levelListCache = {}
-
-    def partitionByList(self, numeratorList: Sequence[int] | Sequence[str]) -> None:
+    def partitionByList(
+        self,
+        numeratorList: Sequence[int] | Sequence[str]
+    ) -> MeterSequence:
         '''
-        Given a numerator list, partition MeterSequence into a new list
-        of MeterTerminals
+        Given a numerator list, return a new MeterSequence partitioned into a
+        list of MeterTerminals.
 
         >>> a = meter.MeterSequence('4/4')
-        >>> a.partitionByList([1, 1, 1, 1])
+        >>> a = a.partitionByList([1, 1, 1, 1])
         >>> str(a)
         '{1/4+1/4+1/4+1/4}'
 
         This divides it into two equal parts:
 
-        >>> a.partitionByList([1, 1])
+        >>> a = a.partitionByList([1, 1])
         >>> str(a)
         '{1/2+1/2}'
 
         And now into one big part:
 
-        >>> a.partitionByList([1])
+        >>> a = a.partitionByList([1])
         >>> str(a)
         '{1/1}'
 
         Here we divide 4/4 very unconventionally:
 
-        >>> a.partitionByList(['3/4', '1/8', '1/8'])
+        >>> a = a.partitionByList(['3/4', '1/8', '1/8'])
         >>> a
         <music21.meter.core.MeterSequence {3/4+1/8+1/8}>
 
@@ -795,25 +821,26 @@ class MeterSequence(MeterTerminal):
         >>> a.partitionByList(['3/4', '1/8', '5/8'])
         Traceback (most recent call last):
         music21.exceptions21.MeterException: Cannot set partition by ['3/4', '1/8', '5/8']
+
+        * Changed in v11: returns a new MeterSequence rather than mutating in place.
         '''
-        optMatch: MeterSequence | None | tuple[str, ...] = None
+        optMatch: Sequence[MeterNode] | tuple[str, ...] | None = None
 
         # assume a list of terminal definitions
         if isinstance(numeratorList[0], str):
-            # TODO: working with private methods of a created MeterSequence
-            test = MeterSequence()
-            for mtStr in numeratorList:
-                test._addTerminal(t.cast(str, mtStr))
-            test._updateRatio()
+            testPartition = [_coerceTerminal(t.cast(str, mtStr)) for mtStr in numeratorList]
+            testNum, testDen = _ratioFromPartition(testPartition)
+            testDur = MeterCore._durationFromNumeratorDenominator(
+                testNum, testDen).quarterLength
             # if durations are equal, this can be used as a partition
-            if self.duration.quarterLength == test.duration.quarterLength:
-                optMatch = test
+            if self.duration.quarterLength == testDur:
+                optMatch = testPartition
             else:
                 raise MeterException(f'Cannot set partition by {numeratorList}')
 
-        elif sum(t.cast(list[int], numeratorList)) in [self.numerator * x for x in range(1, 9)]:
+        elif sum(t.cast('list[int]', numeratorList)) in [self.numerator * x for x in range(1, 9)]:
             for i in range(1, 9):
-                if sum(t.cast(list[int], numeratorList)) == self.numerator * i:
+                if sum(t.cast('list[int]', numeratorList)) == self.numerator * i:
                     optMatchInner: list[str] = []
                     for n in numeratorList:
                         optMatchInner.append(f'{n}/{self.denominator * i}')
@@ -835,19 +862,15 @@ class MeterSequence(MeterTerminal):
                 f'Cannot set partition by {numeratorList} ({self.numerator}/{self.denominator})'
             )
 
-        # Since we have a numerator/denominator match, set this MeterSequence
+        # Since we have a numerator/denominator match, build the new sequence
         targetWeight = self.weight
-        self._clearPartition()  # clears self.weight
-        for mStr in optMatch:
-            self._addTerminal(mStr)
-        self.weight = targetWeight
+        partition = [_coerceTerminal(mStr) for mStr in optMatch]
+        partition = _applyWeight(partition, self.numerator, self.denominator, targetWeight)
+        return self._rebuild(partition)
 
-        # clear cache
-        self._levelListCache = {}
-
-    def partitionByOtherMeterSequence(self, other: MeterSequence) -> None:
+    def partitionByOtherMeterSequence(self, other: MeterSequence) -> MeterSequence:
         '''
-        Set partition to that found in another
+        Return a new MeterSequence with the partition found in another
         MeterSequence.
 
         >>> a = meter.MeterSequence('4/4', 4)
@@ -855,33 +878,31 @@ class MeterSequence(MeterTerminal):
         '{1/4+1/4+1/4+1/4}'
 
         >>> b = meter.MeterSequence('4/4', 2)
-        >>> a.partitionByOtherMeterSequence(b)
+        >>> a = a.partitionByOtherMeterSequence(b)
         >>> len(a)
         2
         >>> str(a)
         '{1/2+1/2}'
+
+        * Changed in v11: returns a new MeterSequence rather than mutating in place.
         '''
         if (self.numerator == other.numerator
                 and self.denominator == other.denominator):
             targetWeight = self.weight
-            self._clearPartition()
-            for mt in other:
-                self._addTerminal(copy.deepcopy(mt))
-            self.weight = targetWeight
+            # other's members are immutable, so they can be shared directly
+            partition = list(other._partition)
+            partition = _applyWeight(partition, self.numerator, self.denominator, targetWeight)
+            return self._rebuild(partition)
         else:
             raise MeterException('Cannot set partition for unequal MeterSequences')
-
-        # clear cache
-        self._levelListCache = {}
 
     def partition(
         self,
         value: int | Sequence[str] | Sequence[MeterTerminal] | Sequence[int] | MeterSequence,
         loadDefault=False
-    ) -> None:
+    ) -> MeterSequence:
         '''
-        Partitioning creates and sets a number of MeterTerminals
-        that make up this MeterSequence.
+        Return a new MeterSequence partitioned according to `value`.
 
         A simple way to partition based on argument time. Single integers
         are treated as beat counts; lists are treated as numerator lists;
@@ -898,13 +919,13 @@ class MeterSequence(MeterTerminal):
         1
         >>> str(b)
         '{13/8}'
-        >>> b.partition(13)
+        >>> b = b.partition(13)
         >>> len(b)
         13
         >>> str(b)
         '{1/8+1/8+1/8+...+1/8}'
 
-        >>> a.partition(b)
+        >>> a = a.partition(b)
         >>> len(a)
         13
         >>> str(a)
@@ -918,7 +939,7 @@ class MeterSequence(MeterTerminal):
         music21.exceptions21.MeterException: Cannot set partition by 2 (3/128)
 
         >>> c = meter.MeterSequence('3/128')
-        >>> c.partition(2, loadDefault=True)
+        >>> c = c.partition(2, loadDefault=True)
         >>> len(c)
         3
         >>> str(c)
@@ -926,20 +947,21 @@ class MeterSequence(MeterTerminal):
 
         * Changed in v9.3: if given a list it must either be all numbers, all strings,
           or all MeterTerminals, not a mix (which was undocumented and buggy)
+        * Changed in v11: returns a new MeterSequence rather than mutating in place.
         '''
         if common.isListLike(value):
-            self.partitionByList(value)
+            return self.partitionByList(value)
         elif isinstance(value, MeterSequence):
-            self.partitionByOtherMeterSequence(value)
+            return self.partitionByOtherMeterSequence(value)
         elif isinstance(value, int):
-            self.partitionByCount(value, loadDefault=loadDefault)
+            return self.partitionByCount(value, loadDefault=loadDefault)
         else:
             raise MeterException(f'cannot process partition argument {value}')
 
-    def subdividePartitionsEqual(self, divisions: int|None = None) -> None:
+    def subdividePartitionsEqual(self, divisions: int|None = None) -> MeterSequence:
         '''
-        Subdivide all partitions by equally-spaced divisions,
-        given a divisions value. Manipulates this MeterSequence in place.
+        Return a new MeterSequence with all partitions subdivided by
+        equally-spaced divisions, given a divisions value.
 
         Divisions value may optionally be a MeterSequence,
         from which a top-level partitioning structure is derived.
@@ -960,7 +982,7 @@ class MeterSequence(MeterTerminal):
         Divide the Sequence into two parts, so now there are two
         MeterTerminals of 1/4 each:
 
-        >>> ms.partition(2)
+        >>> ms = ms.partition(2)
         >>> ms
         <music21.meter.core.MeterSequence {1/4+1/4}>
         >>> len(ms)
@@ -973,7 +995,7 @@ class MeterSequence(MeterTerminal):
         But what happens if we want to divide each of those into 1/8+1/8 are replace
         them by MeterSequences?  subdividePartitionsEqual is what is needed.
 
-        >>> ms.subdividePartitionsEqual(2)
+        >>> ms = ms.subdividePartitionsEqual(2)
         >>> ms
         <music21.meter.core.MeterSequence {{1/8+1/8}+{1/8+1/8}}>
 
@@ -987,20 +1009,19 @@ class MeterSequence(MeterTerminal):
         >>> ms[1]
         <music21.meter.core.MeterSequence {1/8+1/8}>
 
-        There is not a way (the authors know of) to get to the next level.
-        You would just need to do them individually.
+        To subdivide a nested component, replace it functionally:
 
-        >>> ms[0].subdividePartitionsEqual(2)
+        >>> ms = ms.replaceElement(0, ms[0].subdividePartitionsEqual(2))
         >>> ms
         <music21.meter.core.MeterSequence {{{1/16+1/16}+{1/16+1/16}}+{1/8+1/8}}>
-        >>> ms[1].subdividePartitionsEqual(2)
+        >>> ms = ms.replaceElement(1, ms[1].subdividePartitionsEqual(2))
         >>> ms
         <music21.meter.core.MeterSequence {{{1/16+1/16}+{1/16+1/16}}+{{1/16+1/16}+{1/16+1/16}}}>
 
         If None is given as a parameter, then it will try to find something logical.
 
         >>> ms = meter.MeterSequence('2/4+3/4')
-        >>> ms.subdividePartitionsEqual(None)
+        >>> ms = ms.subdividePartitionsEqual(None)
         >>> ms
         <music21.meter.core.MeterSequence {{1/4+1/4}+{1/4+1/4+1/4}}>
 
@@ -1013,11 +1034,13 @@ class MeterSequence(MeterTerminal):
         Traceback (most recent call last):
         music21.exceptions21.MeterException: Cannot set partition by 5 (3/8)
 
+        * Changed in v11: returns a new MeterSequence rather than mutating in place.
         '''
-        divisionsLocal: int = 1
+        newPartition: list[MeterNode] = []
         for i in range(len(self)):
+            el = self[i]
             if divisions is None:  # get dynamically
-                partitionNumerator: int = self[i].numerator
+                partitionNumerator: int = el.numerator
                 if partitionNumerator in (1, 2, 4, 8, 16, 32, 64):
                     divisionsLocal = 2
                 elif partitionNumerator == 3:
@@ -1029,108 +1052,49 @@ class MeterSequence(MeterTerminal):
                     divisionsLocal = partitionNumerator
             else:
                 divisionsLocal = divisions
-            # environLocal.printDebug(['got divisions:', divisionsLocal,
-            #   'for numerator', self[i].numerator, 'denominator', self[i].denominator])
-            self[i] = self[i].subdivide(divisionsLocal)
+            newPartition.append(el.subdivide(divisionsLocal))
 
-        # clear cache
-        self._levelListCache = {}
-
-    def _subdivideNested(self, processObjList, divisions):
-        # noinspection PyShadowingNames
-        '''
-        Recursive nested call routine. Returns a list of the MeterSequences at the newly created
-        level.
-
-        >>> ms = meter.MeterSequence('2/4')
-        >>> ms.partition(2)
-        >>> ms
-        <music21.meter.core.MeterSequence {1/4+1/4}>
-        >>> ms[0]
-        <music21.meter.core.MeterTerminal 1/4>
-
-        >>> post = ms._subdivideNested([ms], 2)
-        >>> ms
-        <music21.meter.core.MeterSequence {{1/8+1/8}+{1/8+1/8}}>
-        >>> ms[0]
-        <music21.meter.core.MeterSequence {1/8+1/8}>
-        >>> post
-        [<music21.meter.core.MeterSequence {1/8+1/8}>, <music21.meter.core.MeterSequence {1/8+1/8}>]
-        >>> ms[0] is post[0]
-        True
-
-        >>> post2 = ms._subdivideNested(post, 2)  # pass post here
-        >>> ms
-        <music21.meter.core.MeterSequence {{{1/16+1/16}+{1/16+1/16}}+{{1/16+1/16}+{1/16+1/16}}}>
-        >>> post2
-        [<music21.meter.core.MeterSequence {1/16+1/16}>,
-         <music21.meter.core.MeterSequence {1/16+1/16}>,
-         <music21.meter.core.MeterSequence {1/16+1/16}>,
-         <music21.meter.core.MeterSequence {1/16+1/16}>]
-
-        Notice that since we gave a list of lists, post2 is now one level down
-
-        >>> post2[0] is ms[0]
-        False
-        >>> post2[0] is ms[0][0]
-        True
-
-        '''
-        for obj in processObjList:
-            obj.subdividePartitionsEqual(divisions)
-        # gather references for recursive processing
-        post = []
-        for obj in processObjList:
-            for sub in obj:
-                post.append(sub)
-        # clear cache
-        self._levelListCache = {}
-        return post
+        return self._rebuild(newPartition)
 
     def subdivideNestedHierarchy(self, depth, firstPartitionForm=None,
-                                 normalizeDenominators=True):
+                                 normalizeDenominators=True) -> MeterSequence:
         '''
-        Create nested structure down to a specified depth;
-        the first division is set to one; the second division
-        may be by 2 or 3; remaining divisions are always by 2.
-
-        This a destructive procedure that will remove
-        any existing partition structures.
+        Return a new MeterSequence with a nested structure down to a specified
+        depth; the first division is set to one; the second division may be by
+        2 or 3; remaining divisions are always by 2.
 
         `normalizeDenominators`, if True, will reduce all denominators to the same minimum level.
 
         >>> ms = meter.MeterSequence('4/4')
         >>> ms.subdivideNestedHierarchy(1)
-        >>> ms
         <music21.meter.core.MeterSequence {{1/2+1/2}}>
         >>> ms.subdivideNestedHierarchy(2)
-        >>> ms
         <music21.meter.core.MeterSequence {{{1/4+1/4}+{1/4+1/4}}}>
         >>> ms.subdivideNestedHierarchy(3)
-        >>> ms
         <music21.meter.core.MeterSequence {{{{1/8+1/8}+{1/8+1/8}}+{{1/8+1/8}+{1/8+1/8}}}}>
 
         I think you get the picture!
 
-        The effects above are not cumulative.  Users can skip directly to
-        whatever level of hierarchy they want.
+        The effects above are not cumulative -- each call starts from ``ms`` --
+        so users can skip directly to whatever level of hierarchy they want.
 
         >>> ms2 = meter.MeterSequence('4/4')
         >>> ms2.subdivideNestedHierarchy(3)
-        >>> ms2
         <music21.meter.core.MeterSequence {{{{1/8+1/8}+{1/8+1/8}}+{{1/8+1/8}+{1/8+1/8}}}}>
+
+        * Changed in v11: returns a new MeterSequence rather than mutating in place.
+
+        AI-assisted (Claude).
         '''
         # as a hierarchical representation, zeroth subdivision must be 1
-        self.partition(1)
+        ms = self.partition(1)
         depthCount = 0
 
         # initial divisions are often based on numerator or are provided
         # by looking at the number of top-level beat partitions
         # thus, 6/8 will have 2, 18/4 should have 5
         if isinstance(firstPartitionForm, MeterSequence):
-            # change self in place, as we cannot re-assign to self:
-            #     self = self.subdivideByOther(firstPartitionForm.getLevel(0))
-            self.load(firstPartitionForm.getLevel(0))
+            ms = _buildSequence(firstPartitionForm.getLevel(0))
             depthCount += 1
         else:  # can be just a number
             if firstPartitionForm is None:
@@ -1140,57 +1104,47 @@ class MeterSequence(MeterTerminal):
                 divFirst = 2
             elif firstPartitionForm in [3]:
                 divFirst = 3
-    #             elif firstPartitionForm in [6, 9, 12, 15, 18]:
-    #                 divFirst = firstPartitionForm / 3
             # otherwise, set the first div to the number of beats; in 18/4
             # this should be 6
             else:  # set to numerator
                 divFirst = firstPartitionForm
 
             # use partitions equal, divide by number
-            self.subdividePartitionsEqual(divFirst)
-            # self[h] = self[h].subdivide(divFirst)
+            ms = ms.subdividePartitionsEqual(divFirst)
             depthCount += 1
 
-#         environLocal.printDebug(['subdivideNestedHierarchy(): firstPartitionForm:',
-#   firstPartitionForm, ': self: ', self])
-
-        # all other partitions are recursive; start first with list
-        post = [self[0]]
+        # all other partitions are recursive; start first with list of paths
+        post: list[tuple[int, ...]] = [(0,)]
         while depthCount < depth:
             # setting divisions to None will get either 2/3 for all components
-            post = self._subdivideNested(post, divisions=None)
+            ms, post = _subdivideNestedByPaths(ms, post, None)
             depthCount += 1
             # need to detect cases of unequal denominators
             if not normalizeDenominators:
                 continue
             while True:
                 d = []
-                for ref in post:
-                    if ref.denominator not in d:
-                        d.append(ref.denominator)
+                for p in post:
+                    den = _getAtPath(ms, p).denominator
+                    if den not in d:
+                        d.append(den)
                 # if we have more than one denominator; we need to normalize
-                # environLocal.printDebug(['subdivideNestedHierarchy():', 'd',  d,
-                #   'post', post, 'depthCount', depthCount])
                 if len(d) > 1:
-                    postNew = []
-                    for i in range(len(post)):
+                    postNew: list[tuple[int, ...]] = []
+                    minD = min(d)
+                    for p in post:
                         # if this is a lower denominator (1/4 not 1/8),
                         # process again
-                        if post[i].denominator == min(d):
-                            postNew += self._subdivideNested([post[i]],
-                                                             divisions=None)
+                        if _getAtPath(ms, p).denominator == minD:
+                            ms, childPaths = _subdivideNestedByPaths(ms, [p], None)
+                            postNew += childPaths
                         else:  # keep original if no problem
-                            postNew.append(post[i])
+                            postNew.append(p)
                     post = postNew  # reassigning to original
                 else:
                     break
 
-        # clear cache; done in self._subdivideNested and possibly not
-        # needed here
-        self._levelListCache = {}
-
-        # environLocal.printDebug(['subdivideNestedHierarchy(): post nested processing:',  self])
+        return ms
 
     # --------------------------------------------------------------------------
     @property
@@ -1242,144 +1196,47 @@ class MeterSequence(MeterTerminal):
             return str(count) + '-uple'
 
     # --------------------------------------------------------------------------
-    # loading is always destructive
-
-    def load(self,
-             value: str | MeterTerminal | Sequence[MeterTerminal] | Sequence[str],
-             partitionRequest: (int
-                                | Sequence[str]
-                                | Sequence[MeterTerminal]
-                                | Sequence[int]
-                                | MeterSequence
-                                | None) = None,
-             autoWeight: bool = False,
-             targetWeight: float|None = None):
-        '''
-        This method is called when a MeterSequence is created, or if a MeterSequence is re-set.
-
-        User can enter a list of values or an abbreviated slash notation.
-
-        autoWeight, if True, will attempt to set weights.
-        targetWeight, if given, will be used instead of self.weight
-
-        loading is a destructive operation.
-
-        >>> a = meter.MeterSequence()
-        >>> a.load('4/4', 4)
-        >>> a
-        <music21.meter.core.MeterSequence {1/4+1/4+1/4+1/4}>
-        >>> str(a)
-        '{1/4+1/4+1/4+1/4}'
-
-        >>> a.load('4/4', 2)  # request 2 beats
-        >>> a
-        <music21.meter.core.MeterSequence {1/2+1/2}>
-        >>> str(a)
-        '{1/2+1/2}'
-
-        >>> a.load('5/8', 2)  # request 2 beats
-        >>> str(a)
-        '{2/8+3/8}'
-
-        >>> a.load('5/8+4/4')
-        >>> str(a)
-        '{5/8+4/4}'
-        '''
-        # NOTE: this is a performance critical method
-        if autoWeight:
-            if targetWeight is None:
-                # get from current MeterSequence
-                targetWeight = self.weight  # store old
-        else:  # None will not set any value
-            targetWeight = None
-
-        # environLocal.printDebug(['calling load in MeterSequence, got targetWeight', targetWeight])
-        self._clearPartition()
-
-        if isinstance(value, str):
-            ratioList, self.summedNumerator = tools.slashMixedToFraction(value)
-            for n, d in ratioList:
-                self._addTerminal(getMeterTerminal(n, d))
-            self._updateRatio()
-            if targetWeight is not None:
-                self.weight = targetWeight
-
-        elif isinstance(value, MeterTerminal):
-            # if we have a single MeterTerminal and autoWeight is active
-            # set this terminal to the old weight
-            if targetWeight is not None:
-                if isinstance(value, MeterSequence):
-                    value.weight = targetWeight
-                else:
-                    # a terminal is immutable: swap in a re-weighted cached one
-                    value = getMeterTerminal(value.numerator, value.denominator,
-                                             weight=targetWeight)
-            self._addTerminal(value)
-            self._updateRatio()
-            # do not need to set weight, as based on terminal
-            # environLocal.printDebug([
-            #    'created MeterSequence from MeterTerminal; old weight, new weight',
-            #    value.weight, self.weight])
-
-        elif common.isIterable(value):  # a list of Terminals or Sequence es
-            for obj in value:
-                # environLocal.printDebug(f'creating MeterSequence with {obj}')
-                self._addTerminal(obj)
-            self._updateRatio()
-            if targetWeight is not None:
-                self.weight = targetWeight
-        else:
-            raise MeterException(f'cannot create a MeterSequence with a {value!r}')
-
-        if partitionRequest is not None:
-            self.partition(partitionRequest)
-
-        # clear cache
-        self._levelListCache = {}
-
-    def _updateRatio(self):
-        '''
-        Look at _partition to determine the total
-        numerator and denominator values for this sequence
-
-        This should only be called internally, as MeterSequences
-        are supposed to be immutable (mostly)
-        '''
-        fTuple = tuple((mt.numerator, mt.denominator) for mt in self._partition)
-        # clear first to avoid partial updating
-        # can only set to private attributes
-        # self._numerator, self._denominator = None, 1
-        self._numerator, self._denominator = tools.fractionSum(fTuple)
-
-    # --------------------------------------------------------------------------
     # properties
     # do not permit setting of numerator/denominator
 
     @property
+    def numerator(self) -> int:
+        '''
+        Return the numerator of the MeterSequence (the rationalized total).
+
+        >>> meter.MeterSequence('3/4+3/8').numerator
+        9
+        '''
+        return self._numerator
+
+    @property
+    def denominator(self) -> int:
+        '''
+        Return the denominator of the MeterSequence (the lowest common multiple).
+
+        >>> meter.MeterSequence('3/4+3/8').denominator
+        8
+        '''
+        return self._denominator
+
+    @property
     def weight(self) -> float:
         '''
-        Get the weight for the MeterSequence, or set the weight and thereby change the weights
-        for each object in this MeterSequence.
+        Return the weight for the MeterSequence: the sum of the weights of each
+        object in this MeterSequence.
 
         By default, all the partitions of a MeterSequence's weights sum to 1.0
 
         >>> a = meter.MeterSequence('3/4')
         >>> a.weight
         1.0
-        >>> a.partition(3)
+        >>> a = a.partition(3)
         >>> a
         <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
         >>> a.weight
         1.0
         >>> a[0].weight
         0.3333...
-
-        But this MeterSequence might be embedded in another one, so perhaps
-        its weight should be 0.5?
-
-        >>> a.weight = 0.5
-        >>> a[0].weight
-        0.16666...
 
         When creating a new MeterSequence from MeterTerminals, the sequence has
         the weight of the sum of those creating it.
@@ -1390,50 +1247,24 @@ class MeterSequence(MeterTerminal):
         >>> accentSequence.weight
         0.75
 
-        A MeterSequence's weight is not cached; it is recomputed from its parts
-        on each call.  Setting the weight on the parent sequence resets the
-        weights on its children so that they sum to the requested value:
-
-        >>> accentSequence.weight = 1.0
-        >>> (accentSequence[0].weight, accentSequence[1].weight)
-        (0.5, 0.5)
-        >>> accentSequence.weight
-        1.0
-
-        Assume this MeterSequence is a whole, not a part of some larger MeterSequence.
-        Thus, we cannot use numerator/denominator relationship
-        as a scalar.
+        A MeterSequence's weight is not stored; it is recomputed from its parts
+        on each call.
         '''
         summation = 0.0
         for obj in self._partition:
             summation += obj.weight  # may be a MeterTerminal or MeterSequence
         return summation
 
-    @weight.setter
-    def weight(self, value: float) -> None:
-        # environLocal.printDebug(['calling setWeight with value', value])
-        if not common.isNum(value):
-            raise MeterException('weight values must be numbers')
+    def _withWeight(self, targetWeight: float) -> MeterSequence:
+        '''
+        Return a new MeterSequence whose children are re-weighted so that they
+        sum (proportionally) to ``targetWeight``.
 
-        try:
-            totalRatio = self._numerator / self._denominator
-        except TypeError as te:
-            raise MeterException(
-                'Something wrong with the type of '
-                f'this numerator {self._numerator} {type(self._numerator)} '
-                f'or this denominator {self._denominator} {type(self._denominator)}'
-            ) from te
-
-        for i, mt in enumerate(self._partition):
-            partRatio = mt.numerator / mt.denominator
-            newWeight = value * (partRatio / totalRatio)
-            if isinstance(mt, MeterSequence):
-                # a nested MeterSequence is still mutable: recurse
-                mt.weight = newWeight
-            else:
-                # a terminal is immutable: swap in a re-weighted cached one
-                self._partition[i] = getMeterTerminal(
-                    mt.numerator, mt.denominator, weight=newWeight)
+        AI-assisted (Claude).
+        '''
+        partition = _applyWeight(
+            self._partition, self._numerator, self._denominator, targetWeight)
+        return self._rebuild(partition)
 
     def _getFlatList(self):
         '''
@@ -1445,7 +1276,7 @@ class MeterSequence(MeterTerminal):
         to concatenate them.
 
         >>> a = meter.MeterSequence('3/4')
-        >>> a.partition(3)
+        >>> a = a.partition(3)
         >>> b = a._getFlatList()
         >>> b
         [<music21.meter.core.MeterTerminal 1/4>,
@@ -1454,7 +1285,7 @@ class MeterSequence(MeterTerminal):
         >>> len(b)
         3
 
-        >>> a[1] = a[1].subdivide(4)
+        >>> a = a.replaceElement(1, a[1].subdivide(4))
         >>> len(a)
         3
         >>> a
@@ -1471,7 +1302,7 @@ class MeterSequence(MeterTerminal):
          <music21.meter.core.MeterTerminal 1/16>,
          <music21.meter.core.MeterTerminal 1/4>]
 
-        >>> a[1][2] = a[1][2].subdivide(4)
+        >>> a = a.replaceElement(1, a[1].replaceElement(2, a[1][2].subdivide(4)))
         >>> a
         <music21.meter.core.MeterSequence {1/4+{1/16+1/16+{1/64+1/64+1/64+1/64}+1/16}+1/4}>
         >>> b = a._getFlatList()
@@ -1479,7 +1310,7 @@ class MeterSequence(MeterTerminal):
         9
         '''
         # Is this the same as getLevelList(0)?
-        mtList = []
+        mtList: list[MeterNode] = []
         for obj in self._partition:  # or for obj in self
             if not isinstance(obj, MeterSequence):
                 mtList.append(obj)
@@ -1501,12 +1332,11 @@ class MeterSequence(MeterTerminal):
         <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
         >>> len(b)
         3
-        >>> b is ms
-        False
 
-        Now take the original MeterSequence and subdivide the second beat into 4 parts:
+        Now take a MeterSequence and subdivide the second beat into 4 parts:
 
-        >>> ms[1] = ms[1].subdivide(4)
+        >>> ms = meter.MeterSequence('3/4', 3)
+        >>> ms = ms.replaceElement(1, ms[1].subdivide(4))
         >>> ms
         <music21.meter.core.MeterSequence {1/4+{1/16+1/16+1/16+1/16}+1/4}>
         >>> b = ms.flatten()
@@ -1515,7 +1345,7 @@ class MeterSequence(MeterTerminal):
         >>> b
         <music21.meter.core.MeterSequence {1/4+1/16+1/16+1/16+1/16+1/4}>
 
-        >>> ms[1][2] = ms[1][2].subdivide(4)
+        >>> ms = ms.replaceElement(1, ms[1].replaceElement(2, ms[1][2].subdivide(4)))
         >>> ms
         <music21.meter.core.MeterSequence {1/4+{1/16+1/16+{1/64+1/64+1/64+1/64}+1/16}+1/4}>
         >>> b = ms.flatten()
@@ -1524,9 +1354,7 @@ class MeterSequence(MeterTerminal):
         >>> b
         <music21.meter.core.MeterSequence {1/4+1/16+1/16+1/64+1/64+1/64+1/64+1/16+1/4}>
         '''
-        post = MeterSequence()
-        post.load(self._getFlatList())
-        return post
+        return MeterSequence(self._getFlatList())
 
     @property
     def flatWeight(self):
@@ -1542,7 +1370,6 @@ class MeterSequence(MeterTerminal):
     def depth(self):
         '''
         Return how many unique levels deep this part is
-        This should be optimized to store values unless the structure has changed.
         '''
         depth = 0  # start with 0, will count this level
 
@@ -1568,11 +1395,11 @@ class MeterSequence(MeterTerminal):
         >>> ms = meter.MeterSequence('4/4')
         >>> ms.isUniformPartition()
         True
-        >>> ms.partition(4)
+        >>> ms = ms.partition(4)
         >>> ms.isUniformPartition()
         True
-        >>> ms[0] = ms[0].subdivideByCount(2)
-        >>> ms[1] = ms[1].subdivideByCount(4)
+        >>> ms = ms.replaceElement(0, ms[0].subdivideByCount(2))
+        >>> ms = ms.replaceElement(1, ms[1].subdivideByCount(4))
         >>> ms.isUniformPartition()
         True
         >>> ms.isUniformPartition(depth=1)
@@ -1585,7 +1412,7 @@ class MeterSequence(MeterTerminal):
         >>> ms = meter.MeterSequence('5/8', 5)
         >>> ms.isUniformPartition()
         True
-        >>> ms.partition(2)
+        >>> ms = ms.partition(2)
         >>> ms.isUniformPartition()
         False
 
@@ -1606,7 +1433,7 @@ class MeterSequence(MeterTerminal):
     # --------------------------------------------------------------------------
     # alternative representations
 
-    def getLevelList(self, levelCount: int, flat: bool = True) -> list[MeterTerminal]:
+    def getLevelList(self, levelCount: int, flat: bool = True) -> list[MeterNode]:
         '''
         Recursive utility function that gets everything at a certain level.
 
@@ -1617,9 +1444,9 @@ class MeterSequence(MeterTerminal):
         1 quarter, 2 eighth, 1 quarter, ((2-sixteenths) + 1 eighth).
 
         >>> b = meter.MeterSequence('4/4', 4)
-        >>> b[1] = b[1].subdivide(2)
-        >>> b[3] = b[3].subdivide(2)
-        >>> b[3][0] = b[3][0].subdivide(2)
+        >>> b = b.replaceElement(1, b[1].subdivide(2))
+        >>> b = b.replaceElement(3, b[3].subdivide(2))
+        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
 
@@ -1679,70 +1506,40 @@ class MeterSequence(MeterTerminal):
 
         OMIT_FROM_DOCS
 
-        Test that cache is used and does not get manipulated
+        A fresh list is returned each call, so a caller may mutate it safely:
 
         >>> b = meter.MeterSequence('3/4', 3)
-        >>> (0, True) in b._levelListCache
-        False
         >>> o = b.getLevelList(0)
-
-        Mess with the list:
-
         >>> o.append(meter.core.MeterTerminal('1/8'))
-        >>> o
-        [<music21.meter.core.MeterTerminal 1/4>,
-         <music21.meter.core.MeterTerminal 1/4>,
-         <music21.meter.core.MeterTerminal 1/4>,
-         <music21.meter.core.MeterTerminal 1/8>]
-
-        Cache is populated:
-
-        >>> (0, True) in b._levelListCache
-        True
-
-        But a new list is created.
-
+        >>> len(o)
+        4
         >>> b.getLevelList(0)
         [<music21.meter.core.MeterTerminal 1/4>,
          <music21.meter.core.MeterTerminal 1/4>,
          <music21.meter.core.MeterTerminal 1/4>]
-
         >>> b.getLevelList(0)[0] is o[0]
         True
         '''
-        cacheKey = (levelCount, flat)
-        try:  # check in cache
-            return list(tuple(self._levelListCache[cacheKey]))
-        except KeyError:
-            pass
-
-        mtList: list[MeterTerminal] = []
-        for i in range(len(self._partition)):
-            # environLocal.printDebug(['getLevelList weight', i, self[i].weight])
-            partition_i: MeterTerminal|MeterSequence = self._partition[i]
+        mtList: list[MeterNode] = []
+        for partition_i in self._partition:
             if not isinstance(partition_i, MeterSequence):
-                mt = self[i]  # a MeterTerminal
-                mtList.append(mt)
+                mtList.append(partition_i)  # a MeterTerminal
             else:  # it is a MeterSequence
                 if levelCount > 0:  # retain this sequence but get lower level
                     # reduce level by 1 when recursing; do not
                     # change levelCount here
-                    mtList += partition_i.getLevelList(
-                        levelCount - 1, flat)
+                    mtList += partition_i.getLevelList(levelCount - 1, flat)
                 else:  # level count is at zero
                     if flat:  # make sequence into a terminal
                         # weight matches that of the sequence it flattens
-                        mt = getMeterTerminal(
+                        mtList.append(getMeterTerminal(
                             partition_i.numerator,
                             partition_i.denominator,
                             weight=partition_i.weight,
-                        )
-                        mtList.append(mt)
+                        ))
                     else:  # it is not a terminal, it is a meter sequence
                         mtList.append(partition_i)
 
-        # store in cache but let this be manipulated
-        self._levelListCache[cacheKey] = list(tuple(mtList))
         return mtList
 
     def getLevel(self, level=0, flat=True):
@@ -1752,9 +1549,9 @@ class MeterSequence(MeterTerminal):
         level. A sort of flatness with variable depth.
 
         >>> b = meter.MeterSequence('4/4', 4)
-        >>> b[1] = b[1].subdivide(2)
-        >>> b[3] = b[3].subdivide(2)
-        >>> b[3][0] = b[3][0].subdivide(2)
+        >>> b = b.replaceElement(1, b[1].subdivide(2))
+        >>> b = b.replaceElement(3, b[3].subdivide(2))
+        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.getLevel(0)
@@ -1771,9 +1568,9 @@ class MeterSequence(MeterTerminal):
         For a given level, return the time span of each terminal or sequence
 
         >>> b = meter.MeterSequence('4/4', 4)
-        >>> b[1] = b[1].subdivide(2)
-        >>> b[3] = b[3].subdivide(2)
-        >>> b[3][0] = b[3][0].subdivide(2)
+        >>> b = b.replaceElement(1, b[1].subdivide(2))
+        >>> b = b.replaceElement(3, b[3].subdivide(2))
+        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.getLevelSpan(0)
@@ -1807,12 +1604,12 @@ class MeterSequence(MeterTerminal):
         >>> b.getLevelWeight(0)
         [0.25, 0.25, 0.25, 0.25]
 
-        >>> b[1] = b[1].subdivide(2)
-        >>> b[3] = b[3].subdivide(2)
+        >>> b = b.replaceElement(1, b[1].subdivide(2))
+        >>> b = b.replaceElement(3, b[3].subdivide(2))
         >>> b.getLevelWeight(0)
         [0.25, 0.25, 0.25, 0.25]
 
-        >>> b[3][0] = b[3][0].subdivide(2)
+        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.getLevelWeight(0)
@@ -1827,27 +1624,27 @@ class MeterSequence(MeterTerminal):
             post.append(mt.weight)
         return post
 
-    def setLevelWeight(self, weightList, level=0):
+    def setLevelWeight(self, weightList, level=0) -> MeterSequence:
         '''
         The `weightList` is an array of weights to be applied to a
-        single level of the MeterSequence.
+        single level of the MeterSequence.  Returns a new MeterSequence.
 
         >>> a = meter.MeterSequence('4/4', 4)
-        >>> a.setLevelWeight([1.0, 2.0, 3.0, 4.0])
+        >>> a = a.setLevelWeight([1.0, 2.0, 3.0, 4.0])
         >>> a.getLevelWeight()
         [1.0, 2.0, 3.0, 4.0]
 
         >>> b = meter.MeterSequence('4/4', 4)
-        >>> b.setLevelWeight([2.0, 3.0])
+        >>> b = b.setLevelWeight([2.0, 3.0])
         >>> b.getLevelWeight(0)
         [2.0, 3.0, 2.0, 3.0]
 
-        >>> b[1] = b[1].subdivide(2)
-        >>> b[3] = b[3].subdivide(2)
+        >>> b = b.replaceElement(1, b[1].subdivide(2))
+        >>> b = b.replaceElement(3, b[3].subdivide(2))
         >>> b.getLevelWeight(0)
         [2.0, 3.0, 2.0, 3.0]
 
-        >>> b[3][0] = b[3][0].subdivide(2)
+        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.getLevelWeight(0)
@@ -1857,38 +1654,37 @@ class MeterSequence(MeterTerminal):
         >>> b.getLevelWeight(2)
         [2.0, 1.5, 1.5, 2.0, 0.75, 0.75, 1.5]
 
-        * Changed in v11: terminals are immutable, so each affected terminal is
-          replaced in place by a cached one carrying the new weight.
+        * Changed in v11: returns a new MeterSequence rather than mutating in place.
         '''
-        self._applyLevelWeights(weightList, level)
+        new, unused_idx = self._withLevelWeights(weightList, level, 0)
+        return new
 
-    def _applyLevelWeights(self, weightList, level, startIndex=0):
+    def _withLevelWeights(self, weightList, level, startIndex=0) -> tuple[MeterSequence, int]:
         '''
         Recursively re-weight the leaf terminals reached at `level`, mirroring
         the flattening order of :meth:`getLevelList` (flat=True) so that the same
         terminals are affected and the same running index into `weightList` is
-        used.  Since terminals are immutable, each is replaced in its parent
-        partition by a cached, re-weighted one.  Returns the next running index.
+        used.  Returns the new MeterSequence and the next running index.
 
         AI-assisted (Claude).
         '''
         idx = startIndex
+        newPartition = list(self._partition)
         for i, partition_i in enumerate(self._partition):
             if not isinstance(partition_i, MeterSequence):
                 newWeight = weightList[idx % len(weightList)]
-                self._partition[i] = getMeterTerminal(
+                newPartition[i] = getMeterTerminal(
                     partition_i.numerator, partition_i.denominator, weight=newWeight)
                 idx += 1
             elif level > 0:
-                idx = partition_i._applyLevelWeights(weightList, level - 1, idx)
+                child, idx = partition_i._withLevelWeights(weightList, level - 1, idx)
+                newPartition[i] = child
             else:
                 # getLevelList(flat=True) flattens this sequence to a single
                 # synthetic terminal that has no persistent home; only the index
                 # advances (matching the historical behavior).
                 idx += 1
-        # clear cache
-        self._levelListCache = {}
-        return idx
+        return self._rebuild(newPartition), idx
 
     # --------------------------------------------------------------------------
     # given a quarter note position, return the active index
@@ -1903,13 +1699,13 @@ class MeterSequence(MeterTerminal):
         0
         >>> a.offsetToIndex(3.5)
         0
-        >>> a.partition(4)
+        >>> a = a.partition(4)
         >>> a.offsetToIndex(0.5)
         0
         >>> a.offsetToIndex(3.5)
         3
 
-        >>> a.partition([1, 2, 1])
+        >>> a = a.partition([1, 2, 1])
         >>> len(a)
         3
         >>> a.offsetToIndex(2.9)
@@ -1963,7 +1759,7 @@ class MeterSequence(MeterTerminal):
         The len of the returned list also provides the depth at the specified qLen.
 
         >>> a = meter.MeterSequence('3/4', 3)
-        >>> a[1] = a[1].subdivide(4)
+        >>> a = a.replaceElement(1, a[1].subdivide(4))
         >>> a
         <music21.meter.core.MeterSequence {1/4+{1/16+1/16+1/16+1/16}+1/4}>
         >>> len(a)
@@ -2096,9 +1892,9 @@ class MeterSequence(MeterTerminal):
         start, quantize, or end.
 
         >>> b = meter.MeterSequence('4/4', 4)
-        >>> b[1] = b[1].subdivide(2)
-        >>> b[3] = b[3].subdivide(2)
-        >>> b[3][0] = b[3][0].subdivide(2)
+        >>> b = b.replaceElement(1, b[1].subdivide(2))
+        >>> b = b.replaceElement(3, b[3].subdivide(2))
+        >>> b = b.replaceElement(3, b[3].replaceElement(0, b[3][0].subdivide(2)))
         >>> b
         <music21.meter.core.MeterSequence {1/4+{1/8+1/8}+1/4+{{1/16+1/16}+1/8}}>
         >>> b.offsetToDepth(0)
@@ -2147,6 +1943,241 @@ class MeterSequence(MeterTerminal):
                     score += 1
 
         return score
+
+
+# -----------------------------------------------------------------------------
+# module-level building helpers for the immutable MeterSequence
+
+_meterSequenceCache: dict[
+    tuple[int, int, tuple, bool, bool], MeterSequence
+] = {}
+
+
+def _makeSequence(
+    numerator: int,
+    denominator: int,
+    partition: tuple,
+    *,
+    parenthesis: bool = False,
+    summedNumerator: bool = False,
+) -> MeterSequence:
+    '''
+    Return a shared, cached, immutable MeterSequence for these values,
+    building it directly (bypassing __init__) when it is not already cached.
+
+    AI-assisted (Claude).
+    '''
+    key = (numerator, denominator, partition, parenthesis, summedNumerator)
+    cached = _meterSequenceCache.get(key)
+    if cached is not None:
+        return cached
+    ms = MeterSequence.__new__(MeterSequence)
+    object.__setattr__(ms, '_numerator', numerator)
+    object.__setattr__(ms, '_denominator', denominator)
+    object.__setattr__(ms, '_partition', partition)
+    object.__setattr__(ms, 'parenthesis', parenthesis)
+    object.__setattr__(ms, 'summedNumerator', summedNumerator)
+    _meterSequenceCache[key] = ms
+    return ms
+
+
+def getMeterSequence(
+    value: str | MeterTerminal | Sequence[MeterTerminal] | Sequence[str] | None = None,
+    partitionRequest: t.Any | None = None,
+) -> MeterSequence:
+    '''
+    Return a shared, cached, immutable :class:`MeterSequence` built from the
+    same inputs as the :class:`MeterSequence` constructor.
+
+    Because MeterSequences are immutable, identical inputs all share one
+    object -- so, e.g., every default ``4/4`` TimeSignature reuses the same
+    beam/beat/accent/display sequences.
+
+    >>> ms = meter.core.getMeterSequence('4/4', 4)
+    >>> ms
+    <music21.meter.core.MeterSequence {1/4+1/4+1/4+1/4}>
+    >>> meter.core.getMeterSequence('4/4', 4) is ms
+    True
+
+    AI-assisted (Claude).
+    '''
+    built = MeterSequence(value, partitionRequest)
+    return _makeSequence(
+        built._numerator, built._denominator, built._partition,
+        parenthesis=built.parenthesis, summedNumerator=built.summedNumerator)
+
+
+def _coerceTerminal(value: MeterTerminal | MeterSequence | str) -> MeterNode:
+    '''
+    Return a MeterTerminal/MeterSequence for the given value: if it is already a
+    MeterCore, return it as-is (they are immutable and shareable); if it is a
+    string, return the cached terminal for that slash notation.
+
+    AI-assisted (Claude).
+    '''
+    # NOTE: this is a performance critical helper
+    if isinstance(value, MeterCore):  # MeterTerminal or MeterSequence
+        return value
+    # assume it is a string; share the cached immutable terminal
+    values = tools.slashToTuple(value)
+    return getMeterTerminal(values.numerator, values.denominator)
+
+
+def _ratioFromPartition(partition) -> tuple[int, int]:
+    '''
+    Return the (numerator, denominator) sum (not reduced) for a partition of
+    MeterTerminals/MeterSequences.
+
+    AI-assisted (Claude).
+    '''
+    return tools.fractionSum(tuple((mt.numerator, mt.denominator) for mt in partition))
+
+
+def _applyWeight(partition, numerator: int, denominator: int, targetWeight: float) -> list:
+    '''
+    Return a new partition list whose members are re-weighted so that they
+    sum (proportionally by ratio) to ``targetWeight``.  Terminals are replaced
+    by cached re-weighted ones; nested sequences are re-weighted recursively.
+
+    AI-assisted (Claude).
+    '''
+    totalRatio = numerator / denominator
+    out: list[MeterNode] = []
+    for mt in partition:
+        partRatio = mt.numerator / mt.denominator
+        newWeight = targetWeight * (partRatio / totalRatio)
+        if isinstance(mt, MeterSequence):
+            out.append(mt._withWeight(newWeight))
+        else:
+            out.append(getMeterTerminal(mt.numerator, mt.denominator, weight=newWeight))
+    return out
+
+
+def _loadData(
+    value: str | MeterTerminal | Sequence[MeterTerminal] | Sequence[str] | None = None,
+    *,
+    autoWeight: bool = False,
+    targetWeight: float | None = None,
+) -> tuple[int, int, list, bool]:
+    '''
+    Build the raw data for a MeterSequence from a value: return
+    ``(numerator, denominator, partitionList, summedNumerator)``.
+
+    `autoWeight`/`targetWeight` mirror the old ``MeterSequence.load``: when
+    ``targetWeight`` is provided the members are re-weighted to sum to it.
+
+    AI-assisted (Claude).
+    '''
+    # NOTE: this is a performance critical helper
+    if not autoWeight:
+        targetWeight = None
+
+    if value is None:
+        return 1, 0, [], False
+
+    summedNumerator = False
+    partition: list[MeterNode] = []
+
+    if isinstance(value, str):
+        ratioList, summedNumerator = tools.slashMixedToFraction(value)
+        for n, d in ratioList:
+            partition.append(getMeterTerminal(n, d))
+        numerator, denominator = _ratioFromPartition(partition)
+        if targetWeight is not None:
+            partition = _applyWeight(partition, numerator, denominator, targetWeight)
+
+    elif isinstance(value, MeterCore):  # a MeterTerminal or MeterSequence
+        if targetWeight is not None:
+            if isinstance(value, MeterSequence):
+                value = value._withWeight(targetWeight)
+            else:
+                # a terminal is immutable: swap in a re-weighted cached one
+                value = getMeterTerminal(value.numerator, value.denominator,
+                                         weight=targetWeight)
+        partition.append(value)
+        numerator, denominator = _ratioFromPartition(partition)
+
+    elif common.isIterable(value):  # a list of Terminals or Sequences
+        for obj in value:
+            partition.append(_coerceTerminal(obj))
+        numerator, denominator = _ratioFromPartition(partition)
+        if targetWeight is not None:
+            partition = _applyWeight(partition, numerator, denominator, targetWeight)
+    else:
+        raise MeterException(f'cannot create a MeterSequence with a {value!r}')
+
+    return numerator, denominator, partition, summedNumerator
+
+
+def _buildSequence(
+    value=None,
+    partitionRequest=None,
+    *,
+    autoWeight: bool = False,
+    targetWeight: float | None = None,
+) -> MeterSequence:
+    '''
+    Build a cached, immutable MeterSequence from a value (and optional
+    partitionRequest), applying weights as the old ``load`` did.
+
+    AI-assisted (Claude).
+    '''
+    numerator, denominator, partition, summedNumerator = _loadData(
+        value, autoWeight=autoWeight, targetWeight=targetWeight)
+    ms = _makeSequence(numerator, denominator, tuple(partition),
+                       summedNumerator=summedNumerator)
+    if partitionRequest is not None:
+        ms = ms.partition(partitionRequest)
+    return ms
+
+
+def _getAtPath(root: MeterSequence, path: tuple[int, ...]) -> MeterNode:
+    '''
+    Return the node reached by following `path` (a tuple of indices) from `root`.
+
+    AI-assisted (Claude).
+    '''
+    node: MeterNode = root
+    for i in path:
+        node = t.cast('MeterSequence', node)[i]
+    return node
+
+
+def _replaceAtPath(root: MeterSequence, path: tuple[int, ...], newNode) -> MeterSequence:
+    '''
+    Return a new root MeterSequence with the node at `path` replaced by
+    `newNode`, rebuilding each ancestor functionally.
+
+    AI-assisted (Claude).
+    '''
+    idx = path[0]
+    if len(path) == 1:
+        return root.replaceElement(idx, newNode)
+    child = t.cast('MeterSequence', root[idx])
+    newChild = _replaceAtPath(child, path[1:], newNode)
+    return root.replaceElement(idx, newChild)
+
+
+def _subdivideNestedByPaths(
+    root: MeterSequence,
+    paths: list[tuple[int, ...]],
+    divisions,
+) -> tuple[MeterSequence, list[tuple[int, ...]]]:
+    '''
+    Subdivide (equally) each node reached by a path in `paths`, rebuilding the
+    root functionally, and return the new root plus the list of paths to the
+    newly created child nodes.
+
+    AI-assisted (Claude).
+    '''
+    newPaths: list[tuple[int, ...]] = []
+    for p in paths:
+        node = t.cast('MeterSequence', _getAtPath(root, p))
+        newNode = node.subdividePartitionsEqual(divisions)
+        root = _replaceAtPath(root, p, newNode)
+        for j in range(len(newNode)):
+            newPaths.append(p + (j,))
+    return root, newPaths
 
 
 if __name__ == '__main__':

--- a/music21/meter/core.py
+++ b/music21/meter/core.py
@@ -613,8 +613,10 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
     def modify(self, **keywords) -> MeterSequence:
         '''
         Return a (cached) MeterSequence identical to this one except for the
-        given ``partition``, ``parenthesis`` and/or ``summedNumerator``
-        keyword(s); the numerator and denominator follow from the partition.
+        given ``numerator``, ``denominator``,
+        ``partition``, ``parenthesis`` and/or ``summedNumerator``
+        keyword(s).
+
         The original is unchanged, since a MeterSequence is immutable.
 
         Analogous to :func:`copy.replace` (Python 3.13+); for changing the
@@ -622,6 +624,12 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         :meth:`subdividePartitionsEqual`, and :meth:`setIndex`.
 
         >>> ms = meter.MeterSequence('4/4', 4)
+        >>> ms
+        <music21.meter.core.MeterSequence {1/4+1/4+1/4+1/4}>
+
+        Modify so that there's a parenthesis around the whole sequence. The original
+        is unchanged.
+
         >>> ms.parenthesis
         False
         >>> ms2 = ms.modify(parenthesis=True)
@@ -630,10 +638,36 @@ class MeterSequence(prebase.ProtoM21Object, MeterCore, FrozenObject):
         >>> ms.parenthesis
         False
 
+        Changing the numerator or denominator rebuilds the sequence with that many
+        equal parts:
+
+        >>> ms3 = ms.modify(numerator=3)
+        >>> ms3
+        <music21.meter.core.MeterSequence {1/4+1/4+1/4}>
+
+        Any other keyword, including weight, is ignored.
+
+        >>> ms.weight
+        1.0
+        >>> ms.modify(weight=1.5).weight
+        1.0
+
+        For other changes to the MeterSequence, see methods
+        :meth:`subdivide`, :meth:`partition`, etc.
+
         AI-assisted (Claude).
         '''
-        partition = tuple(keywords.get('partition', self._partition))
-        numerator, denominator = _ratioFromPartition(partition)
+        if 'partition' in keywords:
+            partition = tuple(keywords['partition'])
+            numerator, denominator = _ratioFromPartition(partition)
+        elif 'numerator' in keywords or 'denominator' in keywords:
+            numerator = keywords.get('numerator', self._numerator)
+            denominator = keywords.get('denominator', self._denominator)
+            # rebuild the new ratio as `numerator` equal parts (each 1/denominator)
+            partition = getMeterSequence(f'{numerator}/{denominator}', numerator)._partition
+        else:
+            partition = self._partition
+            numerator, denominator = self._numerator, self._denominator
         return makeSequence(
             numerator, denominator, partition,
             parenthesis=keywords.get('parenthesis', self.parenthesis),

--- a/music21/meter/tests.py
+++ b/music21/meter/tests.py
@@ -76,23 +76,21 @@ class TestExternal(unittest.TestCase):
 
 class Test(unittest.TestCase):
     def testMeterSubdivision(self):
-        a = MeterSequence()
-        a.load('4/4', 4)
+        a = MeterSequence('4/4', 4)
         self.assertEqual(str(a), '{1/4+1/4+1/4+1/4}')
 
-        a[0] = a[0].subdivide(2)
+        a = a.replaceElement(0, a[0].subdivide(2))
         self.assertEqual(str(a), '{{1/8+1/8}+1/4+1/4+1/4}')
 
-        a[3] = a[3].subdivide(4)
+        a = a.replaceElement(3, a[3].subdivide(4))
         self.assertEqual(str(a), '{{1/8+1/8}+1/4+1/4+{1/16+1/16+1/16+1/16}}')
 
     def testMeterSequenceDeepcopy(self):
-        a = MeterSequence()
-        a.load('4/4', 4)
+        a = MeterSequence('4/4', 4)
         b = copy.deepcopy(a)
-        self.assertIsNot(a, b)
-        # TODO: equity of meter sequences not yet defined.
-        # self.assertEqual(a, b)
+        # a MeterSequence is immutable, so deepcopy returns the same object
+        self.assertIs(a, b)
+        self.assertEqual(a, b)
 
     def testTimeSignatureDeepcopy(self):
         c = TimeSignature('4/4')
@@ -188,13 +186,18 @@ class Test(unittest.TestCase):
 
     def testOffsetToDepth(self):
         # get a maximally divided 4/4 to the level of 1/8
+        def recSub(node, remaining):
+            # functionally subdivide node by 2 for `remaining` levels
+            if remaining == 0:
+                return node
+            sub = node.subdivide(2)
+            for idx in range(len(sub)):
+                sub = sub.replaceElement(idx, recSub(sub[idx], remaining - 1))
+            return sub
+
         a = MeterSequence('4/4')
         for h in range(len(a)):
-            a[h] = a[h].subdivide(2)
-            for i in range(len(a[h])):
-                a[h][i] = a[h][i].subdivide(2)
-                for j in range(len(a[h][i])):
-                    a[h][i][j] = a[h][i][j].subdivide(2)
+            a = a.replaceElement(h, recSub(a[h], 3))
 
         # matching with starts result in a Lerdahl-Jackendoff style depth
         match = [4, 1, 2, 1, 3, 1, 2, 1]
@@ -314,36 +317,28 @@ class Test(unittest.TestCase):
                                  beatDur[i])
 
     def testSubdividePartitionsEqual(self):
-        ms = MeterSequence('2/4')
-        ms.subdividePartitionsEqual(None)
+        ms = MeterSequence('2/4').subdividePartitionsEqual(None)
         self.assertEqual(str(ms), '{{1/4+1/4}}')
 
-        ms = MeterSequence('3/4')
-        ms.subdividePartitionsEqual(None)
+        ms = MeterSequence('3/4').subdividePartitionsEqual(None)
         self.assertEqual(str(ms), '{{1/4+1/4+1/4}}')
 
-        ms = MeterSequence('6/8')
-        ms.subdividePartitionsEqual(None)
+        ms = MeterSequence('6/8').subdividePartitionsEqual(None)
         self.assertEqual(str(ms), '{{3/8+3/8}}')
 
-        ms = MeterSequence('6/16')
-        ms.subdividePartitionsEqual(None)
+        ms = MeterSequence('6/16').subdividePartitionsEqual(None)
         self.assertEqual(str(ms), '{{3/16+3/16}}')
 
-        ms = MeterSequence('3/8+3/8')
-        ms.subdividePartitionsEqual(None)
+        ms = MeterSequence('3/8+3/8').subdividePartitionsEqual(None)
         self.assertEqual(str(ms), '{{1/8+1/8+1/8}+{1/8+1/8+1/8}}')
 
-        ms = MeterSequence('2/8+3/8')
-        ms.subdividePartitionsEqual(None)
+        ms = MeterSequence('2/8+3/8').subdividePartitionsEqual(None)
         self.assertEqual(str(ms), '{{1/8+1/8}+{1/8+1/8+1/8}}')
 
-        ms = MeterSequence('5/8')
-        ms.subdividePartitionsEqual(None)
+        ms = MeterSequence('5/8').subdividePartitionsEqual(None)
         self.assertEqual(str(ms), '{{1/8+1/8+1/8+1/8+1/8}}')
 
-        ms = MeterSequence('3/8+3/4')
-        ms.subdividePartitionsEqual(None)  # can partition by another
+        ms = MeterSequence('3/8+3/4').subdividePartitionsEqual(None)  # can partition by another
         self.assertEqual(str(ms), '{{1/8+1/8+1/8}+{1/4+1/4+1/4}}')
 
     def testSetDefaultAccentWeights(self):
@@ -441,7 +436,7 @@ class Test(unittest.TestCase):
         from music21 import meter
         # create a meter with 6 beats but beams in 2 groups
         ts = meter.TimeSignature('6/8')
-        ts.beatSequence.partition(6)
+        ts.beatSequence = ts.beatSequence.partition(6)
         self.assertEqual(str(ts.beatSequence), '{1/8+1/8+1/8+1/8+1/8+1/8}')
         self.assertEqual(str(ts.beamSequence), '{3/8+3/8}')
 

--- a/music21/meter/tests.py
+++ b/music21/meter/tests.py
@@ -19,7 +19,9 @@ from music21 import duration
 from music21 import note
 from music21 import stream
 from music21.meter.base import TimeSignature
-from music21.meter.core import MeterSequence, MeterTerminal
+from music21.meter.core import (
+    MeterSequence, MeterTerminal, getMeterSequence, getMeterTerminal,
+)
 
 class TestExternal(unittest.TestCase):
     show = True
@@ -79,10 +81,10 @@ class Test(unittest.TestCase):
         a = MeterSequence('4/4', 4)
         self.assertEqual(str(a), '{1/4+1/4+1/4+1/4}')
 
-        a = a.replaceElement(0, a[0].subdivide(2))
+        a = a.setIndex(0, a[0].subdivide(2))
         self.assertEqual(str(a), '{{1/8+1/8}+1/4+1/4+1/4}')
 
-        a = a.replaceElement(3, a[3].subdivide(4))
+        a = a.setIndex(3, a[3].subdivide(4))
         self.assertEqual(str(a), '{{1/8+1/8}+1/4+1/4+{1/16+1/16+1/16+1/16}}')
 
     def testMeterSequenceDeepcopy(self):
@@ -101,6 +103,53 @@ class Test(unittest.TestCase):
         e = TimeSignature('slow 6/8')
         f = TimeSignature('fast 6/8')
         self.assertNotEqual(e, f)
+
+    def testMeterTerminalCache(self):
+        # identical (numerator, denominator, weight) -> one shared object
+        a = getMeterTerminal(1, 4)
+        self.assertIs(a, getMeterTerminal(1, 4))
+        self.assertIs(a, getMeterTerminal(numerator=1, denominator=4, weight=1.0))
+        # a different weight is a different terminal
+        self.assertIsNot(a, getMeterTerminal(1, 4, weight=0.5))
+        # value equality regardless of how they were built
+        self.assertEqual(MeterTerminal('1/4'), getMeterTerminal(1, 4))
+
+    def testMeterTerminalModify(self):
+        a = getMeterTerminal(2, 4, weight=0.5)
+        # modify changes only the named slot(s); the rest carry over
+        b = a.modify(weight=0.25)
+        self.assertEqual((b.numerator, b.denominator, b.weight), (2, 4, 0.25))
+        c = a.modify(numerator=3)
+        self.assertEqual((c.numerator, c.denominator, c.weight), (3, 4, 0.5))
+        # the original is unchanged (immutable) and setting a slot raises
+        self.assertEqual(a.weight, 0.5)
+        with self.assertRaises(TypeError):
+            a.weight = 0.25
+        # modify is wired through the cache, and __replace__ is an alias
+        self.assertIs(a.modify(weight=0.25), b)
+        self.assertIs(a.__replace__(numerator=3), c)
+
+    def testMeterSequenceCache(self):
+        # identical value -> one shared MeterSequence
+        self.assertIs(getMeterSequence('4/4', 4), getMeterSequence('4/4', 4))
+        # every default 4/4 TimeSignature shares its owned sequences
+        a = TimeSignature('4/4')
+        b = TimeSignature('4/4')
+        for seqName in ('beamSequence', 'beatSequence',
+                        'accentSequence', 'displaySequence'):
+            self.assertIs(getattr(a, seqName), getattr(b, seqName), seqName)
+
+    def testMeterSequenceModify(self):
+        a = MeterSequence('4/4', 4)
+        self.assertFalse(a.parenthesis)
+        b = a.modify(parenthesis=True)
+        self.assertTrue(b.parenthesis)
+        self.assertFalse(a.parenthesis)  # original unchanged
+        # a mutating attempt on the immutable sequence raises
+        with self.assertRaises(TypeError):
+            a.parenthesis = True
+        # modify is cache-wired: same result from two independent sequences
+        self.assertIs(b, MeterSequence('4/4', 4).modify(parenthesis=True))
 
     def testGetBeams(self):
         ts = TimeSignature('6/8')
@@ -192,12 +241,12 @@ class Test(unittest.TestCase):
                 return node
             sub = node.subdivide(2)
             for idx in range(len(sub)):
-                sub = sub.replaceElement(idx, recSub(sub[idx], remaining - 1))
+                sub = sub.setIndex(idx, recSub(sub[idx], remaining - 1))
             return sub
 
         a = MeterSequence('4/4')
         for h in range(len(a)):
-            a = a.replaceElement(h, recSub(a[h], 3))
+            a = a.setIndex(h, recSub(a[h], 3))
 
         # matching with starts result in a Lerdahl-Jackendoff style depth
         match = [4, 1, 2, 1, 3, 1, 2, 1]

--- a/music21/meter/tests.py
+++ b/music21/meter/tests.py
@@ -105,12 +105,18 @@ class Test(unittest.TestCase):
         self.assertNotEqual(e, f)
 
     def testMeterTerminalCache(self):
-        # identical (numerator, denominator, weight) -> one shared object
+        # this is an internal test, so it inspects the private cache directly
+        from music21.meter.core import _meterTerminalCache
+        # getMeterTerminal populates the cache under its (numerator, denominator,
+        # weight) key, and a repeat request is the very object stored there
         a = getMeterTerminal(1, 4)
+        self.assertIs(_meterTerminalCache[(1, 4, 1.0)], a)
         self.assertIs(a, getMeterTerminal(1, 4))
         self.assertIs(a, getMeterTerminal(numerator=1, denominator=4, weight=1.0))
-        # a different weight is a different terminal
-        self.assertIsNot(a, getMeterTerminal(1, 4, weight=0.5))
+        # a different weight is a different terminal, stored under its own key
+        b = getMeterTerminal(1, 4, weight=0.5)
+        self.assertIsNot(a, b)
+        self.assertIs(_meterTerminalCache[(1, 4, 0.5)], b)
         # value equality regardless of how they were built
         self.assertEqual(MeterTerminal('1/4'), getMeterTerminal(1, 4))
 
@@ -130,10 +136,22 @@ class Test(unittest.TestCase):
         self.assertIs(a.__replace__(numerator=3), c)
 
     def testMeterSequenceCache(self):
-        # identical value -> one shared MeterSequence
-        self.assertIs(getMeterSequence('4/4', 4), getMeterSequence('4/4', 4))
-        # every default 4/4 TimeSignature shares its owned sequences
+        # this is an internal test, so it inspects the private caches directly
+        from music21.meter.core import _meterSequenceCache
+        from music21.meter.base import _defaultSequenceCache
+        # getMeterSequence stores the built sequence in the sequence cache, and a
+        # repeat request is the very object stored there
+        ms = getMeterSequence('4/4', 4)
+        self.assertIs(getMeterSequence('4/4', 4), ms)
+        self.assertTrue(any(cached is ms for cached in _meterSequenceCache.values()))
+        # TimeSignature.load stores its configured (display, beam, beat, accent)
+        # sequences under (value, divisions); a repeat 4/4 reuses exactly those
         a = TimeSignature('4/4')
+        display, beam, beat, accent = _defaultSequenceCache[('4/4', None)]
+        self.assertIs(a.displaySequence, display)
+        self.assertIs(a.beamSequence, beam)
+        self.assertIs(a.beatSequence, beat)
+        self.assertIs(a.accentSequence, accent)
         b = TimeSignature('4/4')
         for seqName in ('beamSequence', 'beatSequence',
                         'accentSequence', 'displaySequence'):

--- a/music21/meter/tests.py
+++ b/music21/meter/tests.py
@@ -134,6 +134,9 @@ class Test(unittest.TestCase):
         # modify is wired through the cache, and __replace__ is an alias
         self.assertIs(a.modify(weight=0.25), b)
         self.assertIs(a.__replace__(numerator=3), c)
+        # an unhandled keyword raises rather than being silently ignored
+        with self.assertRaises(ValueError):
+            a.modify(parenthesis=True)
 
     def testMeterSequenceCache(self):
         # this is an internal test, so it inspects the private caches directly
@@ -168,6 +171,11 @@ class Test(unittest.TestCase):
             a.parenthesis = True
         # modify is cache-wired: same result from two independent sequences
         self.assertIs(b, MeterSequence('4/4', 4).modify(parenthesis=True))
+        # numerator/denominator/weight are not modifiable here (they follow from
+        # the partition); an unhandled keyword raises
+        for kw in ({'numerator': 3}, {'denominator': 8}, {'weight': 1.5}):
+            with self.assertRaises(ValueError):
+                a.modify(**kw)
 
     def testGetBeams(self):
         ts = TimeSignature('6/8')

--- a/music21/test/test_base.py
+++ b/music21/test/test_base.py
@@ -20,6 +20,7 @@ from music21 import clef
 from music21.common.enums import ElementSearch, OffsetSpecial
 from music21 import converter
 from music21 import corpus
+from music21 import duration
 from music21 import dynamics
 from music21 import editorial
 from music21 import exceptions21
@@ -78,6 +79,27 @@ class Test(unittest.TestCase):
         n.groups[0] = 'bassoon'
         self.assertFalse('flute' in n.groups)
         self.assertTrue('flute' in b.groups)
+
+    def testAssignFrozenDurationKeepsClientUnset(self):
+        '''
+        A FrozenDuration (e.g. a MeterSequence's duration) may be assigned as an
+        element's .duration; it is held shared -- not thawed -- and its client is
+        left unset, since a frozen duration never changes.  Changing the element's
+        length then does copy-on-write, leaving the shared frozen duration intact.
+        '''
+        frozen = meter.MeterSequence('4/4').duration
+        self.assertIsInstance(frozen, duration.FrozenDuration)
+
+        n = note.Note()
+        n.duration = frozen
+        self.assertIs(n.duration, frozen)
+        self.assertIsNone(frozen.client)
+
+        # copy-on-write: setting the length swaps in a mutable copy
+        n.quarterLength = 3.0
+        self.assertEqual(n.quarterLength, 3.0)
+        self.assertNotIsInstance(n.duration, duration.FrozenDuration)
+        self.assertEqual(frozen.quarterLength, 4.0)  # original untouched
 
     def testOffsets(self):
         a = ElementWrapper(note.Note('A#'))

--- a/music21/test/test_base.py
+++ b/music21/test/test_base.py
@@ -80,12 +80,13 @@ class Test(unittest.TestCase):
         self.assertFalse('flute' in n.groups)
         self.assertTrue('flute' in b.groups)
 
-    def testAssignFrozenDurationKeepsClientUnset(self):
+    def testAssignFrozenDurationStaysFrozen(self):
         '''
         A FrozenDuration (e.g. a MeterSequence's duration) may be assigned as an
         element's .duration; it is held shared -- not thawed -- and its client is
-        left unset, since a frozen duration never changes.  Changing the element's
-        length then does copy-on-write, leaving the shared frozen duration intact.
+        left unset, since a frozen duration never changes.  It stays frozen: trying
+        to change the element's length raises, and it is up to the caller to
+        unfreeze first if they want a mutable duration.
         '''
         frozen = meter.MeterSequence('4/4').duration
         self.assertIsInstance(frozen, duration.FrozenDuration)
@@ -95,11 +96,11 @@ class Test(unittest.TestCase):
         self.assertIs(n.duration, frozen)
         self.assertIsNone(frozen.client)
 
-        # copy-on-write: setting the length swaps in a mutable copy
-        n.quarterLength = 3.0
-        self.assertEqual(n.quarterLength, 3.0)
-        self.assertNotIsInstance(n.duration, duration.FrozenDuration)
-        self.assertEqual(frozen.quarterLength, 4.0)  # original untouched
+        # the duration stays frozen: n.quarterLength = x (i.e.
+        # n.duration.quarterLength = x) raises rather than silently copying.
+        with self.assertRaises(TypeError):
+            n.quarterLength = 3.0
+        self.assertEqual(frozen.quarterLength, 4.0)  # untouched
 
     def testOffsets(self):
         a = ElementWrapper(note.Note('A#'))


### PR DESCRIPTION
_Draft: Until I can get through some of the deeper AI muck here -- mostly in docs -- the bones are very good._

# TimeSignatures get Faster

Headline: TimeSignature objects change very little for standard users except their creation is sped up **100x** after the first time signature of that type has happened.  Time signature creation moves from 52µs to .54µs (540ns!).  

Deepcopying TimeSignatures also got 10x faster, from 32µs to 3.3µs!

This moves one of the slowest parts of music21 to one of the fastest. It used to be that each TS took the time of 25 notes.

# What changed probably doesn't affect you.

Only very powerful but less-often used features for changing the agogic accents, default beaming, and display of compound time signatures are significantly changed.

## MeterTerminals and MeterSequences become immutable

TimeSignatures are made up of 4 MeterSequences (ways of organizing the meter, like into 4 beats in 4/4 = 1/4+1/4+1/4+1/4).  Each of those is made up of other MeterSequences (for compound meter or complex organization) or eventually MeterTerminals (like 1/4).

These sequences are now immutable.  So you can't divide (2/4+2/4) into (1/4+1/4+1/4+1/4) with partition(2) anymore.  What you can do is from (2/4+2/4)  use partition(2) to create a new MeterSequence as (1/4+1/4+1/4+1/4) and assign that where you want it.  A small drawback for people working with MeterSequences that allows each time signature's default MeterSequences to be cached and reused.

to retrieve a MeterTerminal or Sequence from the cache use `meter.core.getMeterTerminal` or `getMeterTerminal`

## TimeSignature and Music21Object beatDuration becomes a FrozenDuration

`Music21Object.beatDuration` becomes a FrozenDuration that cannot be manipulated.  This allows it to share a duration with a MeterSequence and with all MeterSequences of the same meter (e.g. '4/4').  Call `unfreeze()` on it to get an unfrozen version().

Same with `beatDivisionDurations`

I purposely did not make `TimeSignature.barDuration` a FrozenDuration in this PR since both inside and outside music21 it is known to be manipulated.  This is expected to become a FrozenDuration in v12 or after.

## Consequences

* `ms = MeterSequence(); ms.load('4/4')`  fails.  Just do `ms = MeterSequence('4/4')`
* `ms[0] = ms[0].subdivide(2)` cannot modify in place: `ms = a.setIndex(0, a[0].subdivide(2))` (might change)
* `mt = MeterTerminal('3/4'); mt.numerator = 2` becomes `mt = MeterTerminal('3/4'); mt = mt.modify(numerator=2)`
* `ts = meter.TimeSignature('6/8'); ts.beatSequence.partition(6);` second statement becomes `ts.beatSequence = ts.beatSequence.partition(6)`

## Design and Future

Programmers who have worked with immutable Javascript web frameworks like React or Lit will understand this paradigm; it is however a little foreign to Python.  There are no plans to make the whole music21 toolkit immutable by design -- the speedups are not worth the backwards incompatibilities.  However, certain classes such as Microtones and Tuplets might migrate this way into the future (Tuplets attached to Durations are already immutable/frozen)

## Misc

* `EqualSlottedObjectMixin` objects now return NotImplemented rather than False for comparison with unequal types.
* Because the ImmutableObjects cache speeds things up so much, we've removed `_meterSequenceAccentArchetypes` Cache, which only was now going to come into play the second and subsequent time you created a 4/4 meter with a different accent pattern than default.  It was the original cache taking construction from 2300 µs → 500 µs (each!), but I wanted to simplify where I could since I was adding complexity elsewhere.

Started from an abandoned branch (meter-speed) from 2022; AI-assistance (Claude) helped me get the refactor over the edge.  