### PR TITLE
Fix invalid MusicXML for an unpitched grace note in a voice

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '11.0.0b6'
+__version__ = '11.0.0b7'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -26,7 +26,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'11.0.0b6'
+'11.0.0b7'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/musicxml/helpers.py
+++ b/music21/musicxml/helpers.py
@@ -151,6 +151,47 @@ def insertBeforeElements(root, insert, tagList=None):
     root.insert(min(insertIndices), insert)
 
 
+def insertAfterElements(root, insert, tagList=None):
+    # noinspection PyShadowingNames
+    '''
+    Insert element `insert` into element `root` directly after the last
+    instance of any child tag given in `tagList`. Insert at the beginning
+    if `tagList` is `None` or no instance is found.
+
+    >>> from xml.etree.ElementTree import fromstring as EL
+    >>> from music21.musicxml.helpers import insertAfterElements, dump
+    >>> root = EL('<note><grace /><voice>1</voice></note>')
+    >>> insert = EL('<unpitched/>')
+
+    >>> insertAfterElements(root, insert, tagList=['grace'])
+    >>> dump(root)
+    <note>
+        <grace />
+        <unpitched />
+        <voice>1</voice>
+    </note>
+
+    Insert at the beginning when nothing in `tagList` matches:
+
+    >>> insert2 = EL('<foo/>')
+    >>> insertAfterElements(root, insert2, tagList=['bar'])
+    >>> dump(root)
+    <note>
+        <foo />
+        <grace />
+        <unpitched />
+        <voice>1</voice>
+    </note>
+    '''
+    insertIndex = 0
+    if tagList:
+        # Iterate children only, not grandchildren
+        for i, child in enumerate(root.findall('*')):
+            if child.tag in tagList:
+                insertIndex = i + 1
+    root.insert(insertIndex, insert)
+
+
 def measureNumberComesBefore(mNum1: str, mNum2: str) -> bool:
     '''
     Determine whether `measureNumber1` strictly precedes

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4645,12 +4645,13 @@ class MeasureExporter(XMLExporterBase):
         _setTagTextFromAttribute(up, mxUnpitched, 'display-step')
         _setTagTextFromAttribute(up, mxUnpitched, 'display-octave')
 
-        # anything that can follow <unpitched> within <note> must be listed
-        # here, since a grace note has no <duration> to insert before (#1732)
-        helpers.insertBeforeElements(
+        # within <note>, only <grace>, <cue>, and <chord> may precede
+        # <unpitched>, so insert after those rather than trying to list
+        # everything that can follow it (#1732)
+        helpers.insertAfterElements(
             mxNote,
             mxUnpitched,
-            tagList=['duration', 'tie', 'instrument', 'footnote', 'level', 'voice', 'type']
+            tagList=['grace', 'cue', 'chord']
         )
 
         return mxNote

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4622,6 +4622,22 @@ class MeasureExporter(XMLExporterBase):
           </unpitched>
           <type>quarter</type>
         </note>
+
+        <unpitched> must come before <voice>, even when there is
+        no <duration>, as on a grace note in a voice:
+
+        >>> MEX.currentVoiceId = 1
+        >>> mxUnpitched = MEX.unpitchedToXml(graceUp)
+        >>> MEX.dump(mxUnpitched)
+        <note>
+          <grace slash="yes" />
+          <unpitched>
+            <display-step>D</display-step>
+            <display-octave>5</display-octave>
+          </unpitched>
+          <voice>1</voice>
+          <type>quarter</type>
+        </note>
         '''
         mxNote = self.noteToXml(up, noteIndexInChord=noteIndexInChord, chordParent=chordParent)
 
@@ -4629,7 +4645,13 @@ class MeasureExporter(XMLExporterBase):
         _setTagTextFromAttribute(up, mxUnpitched, 'display-step')
         _setTagTextFromAttribute(up, mxUnpitched, 'display-octave')
 
-        helpers.insertBeforeElements(mxNote, mxUnpitched, tagList=['duration', 'type'])
+        # anything that can follow <unpitched> within <note> must be listed
+        # here, since a grace note has no <duration> to insert before (#1732)
+        helpers.insertBeforeElements(
+            mxNote,
+            mxUnpitched,
+            tagList=['duration', 'tie', 'instrument', 'footnote', 'level', 'voice', 'type']
+        )
 
         return mxNote
 

--- a/music21/musicxml/test_m21ToXml.py
+++ b/music21/musicxml/test_m21ToXml.py
@@ -229,6 +229,21 @@ class Test(unittest.TestCase):
         xmlOut = self.getXml(m)
         self.assertIn('<voice>hello</voice>', xmlOut)
 
+    def testUnpitchedGraceInVoice(self):
+        '''
+        <unpitched> must precede <voice> even on a grace note, which has
+        no <duration> element to insert before.
+        '''
+        # https://github.com/cuthbertLab/music21/issues/1732
+        grace = note.Unpitched(duration=duration.GraceDuration())
+        v1 = stream.Voice([grace])
+        v2 = stream.Voice([note.Note()])
+        m = stream.Measure([v1, v2])
+
+        tree = self.getET(m)
+        mxNote = tree.find('part/measure/note')
+        self.assertEqual([el.tag for el in mxNote], ['grace', 'unpitched', 'voice', 'type'])
+
     def testVoiceNumberOffsetsThreeStaffsInGroup(self):
         n1_1 = note.Note()
         v1_1 = stream.Voice([n1_1])


### PR DESCRIPTION
Fixes #1732. Following up on the September 2024 comment that you'd be glad to take a fix for this one.

An unpitched grace note in a voice exported `<voice>` ahead of `<unpitched>`, which fails schema validation, since `<unpitched>` has to come right after `<grace>` in the note content model. `unpitchedToXml` retrofits `<unpitched>` into the already-built `<note>` by inserting before the earliest of `<duration>` or `<type>`, but a grace note has no `<duration>`, so anything `noteToXml` had appended in between slipped ahead. The tagList now lists every element that can follow `<unpitched>` within `<note>`, which also fixes the same misplacement for a tied grace note (`<tie>` landed ahead of `<unpitched>` too).

Before, from the issue's repro:

```xml
<note>
  <grace slash="yes" />
  <voice>1</voice>
  <unpitched>
    <display-step>B</display-step>
    <display-octave>4</display-octave>
  </unpitched>
  <type>eighth</type>
</note>
```

After:

```xml
<note>
  <grace slash="yes" />
  <unpitched>
    <display-step>B</display-step>
    <display-octave>4</display-octave>
  </unpitched>
  <voice>1</voice>
  <type>eighth</type>
</note>
```

Added a doctest for the voice case, a regression test in test_m21ToXml.py, and bumped the version to 11.0.0b7 for the writer change. pylint (10.00/10), ruff, mypy, and the musicxml module tests all pass locally.