### PR TITLE
Avoid flipping displayStatus None -> True on explicit naturals

### DIFF
--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -5145,6 +5145,7 @@ class Pitch(prebase.ProtoM21Object):
             # and it is not a natural, it should always be set to display
             if (pPastInMeasure is False
                     and acc is not None
+                    and acc.name != 'natural'
                     and not self._nameInKeySignature(alteredPitches)):
                 acc.displayStatus = True
                 return  # do not search past

--- a/music21/test/test_pitch.py
+++ b/music21/test/test_pitch.py
@@ -407,6 +407,18 @@ class Test(unittest.TestCase):
         p.makeAccidentals(inPlace=True)
         self.assertIs(last_note.pitch.accidental.displayStatus, False)
 
+    def testExplicitNaturalDisplayStatusNone(self):
+        p = converter.parse('tinyNotation: d1 d1')
+        first_note = p.recurse().notes.first()
+        last_note = p.recurse().notes.last()
+        first_note.pitch.accidental = pitch.Accidental('natural')
+        last_note.pitch.accidental = pitch.Accidental('natural')
+        self.assertIsNone(first_note.pitch.accidental.displayStatus)
+        self.assertIsNone(last_note.pitch.accidental.displayStatus)
+        p.makeAccidentals(inPlace=True)
+        self.assertIs(first_note.pitch.accidental.displayStatus, False)
+        self.assertIs(last_note.pitch.accidental.displayStatus, False)
+
     def testIfAbsolutelyNecessary(self):
         '''
         Beginning of test cases for if-absolutely-necessary.


### PR DESCRIPTION
From the bottom of the bug report in https://github.com/cuthbertLab/music21j/issues/315#issue-4804500040, I noticed that for a stream like `d1 d1`, when applying a `Natural` accidental to both notes with a displayStatus of None, only subsequent ones had an explicit `displayStatus = True`.