### PR TITLE
Support sus4 chords in root-finding algorithm

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -1668,7 +1668,7 @@ class Chord(ChordBase):
         Generally use root() instead, since if a chord doesn't know its root,
         root() will run ._findRoot() automatically.
         '''
-        def rootnessFunction(rootThirdList):
+        def rootnessFunction(rootThirdList, is_sus4_chord=False):
             '''
             Returns a value for how likely this pitch is to be a root given the
             number of thirds and fifths above it.
@@ -1687,6 +1687,14 @@ class Chord(ChordBase):
             for root_index, val in enumerate(rootThirdList):
                 if val is True:
                     score += 1 / (root_index + 6)
+            # sus4 bonus: for sus4 chords (no note has both a 3rd and 5th above it),
+            # reward a note that has a 4th (index 4) and 5th (index 1) above it.
+            # orderedChordSteps = (3, 5, 7, 2, 4, 6) so index 0=3rd, 1=5th, 4=4th
+            if is_sus4_chord:
+                has_fifth = rootThirdList[1] if len(rootThirdList) > 1 else False
+                has_fourth = rootThirdList[4] if len(rootThirdList) > 4 else False
+                if has_fourth and has_fifth:
+                    score += 1 / 6  # same weight as having a third
             return score
 
         # FIND ROOT FAST -- for cases where one note has perfectly stacked
@@ -1735,6 +1743,12 @@ class Chord(ChordBase):
         rootnessFunctionScores = []
         orderedChordSteps = (3, 5, 7, 2, 4, 6)
 
+        # Detect sus4 chords: no note has both a 3rd (step+2) and 5th (step+4) above it
+        is_sus4_chord = not any(
+            (sn + 2) % 7 in stepNumsToPitches and (sn + 4) % 7 in stepNumsToPitches
+            for sn in stepNums
+        )
+
         for p in nonDuplicatingPitches:
             currentListOfThirds = []
             this_step_num = pitch.STEP_TO_DNN_OFFSET[p.step]
@@ -1744,7 +1758,7 @@ class Chord(ChordBase):
                 else:
                     currentListOfThirds.append(False)
 
-            rootnessScore = rootnessFunction(currentListOfThirds)
+            rootnessScore = rootnessFunction(currentListOfThirds, is_sus4_chord=is_sus4_chord)
             rootnessFunctionScores.append(rootnessScore)
 
         mostRootyIndex = rootnessFunctionScores.index(max(rootnessFunctionScores))

--- a/music21/test/test_chord.py
+++ b/music21/test/test_chord.py
@@ -362,6 +362,31 @@ class Test(unittest.TestCase):
         self.assertEqual(unscrambledChord3.pitches[3].name, 'F')
         self.assertEqual(unscrambledChord3.pitches[4].name, 'A-')
 
+    def testSus4RootFinding(self):
+        # Regression test for https://github.com/cuthbertLab/music21/issues/1650
+        # sus4 chords should correctly identify their root
+
+        # Basic sus4 seventh chord from the issue report
+        sus4_seventh = chord.Chord('F B- C E-')
+        self.assertEqual(sus4_seventh.root().name, 'F')
+
+        # Simple sus4 triad
+        sus4_triad = chord.Chord('C F G')
+        self.assertEqual(sus4_triad.root().name, 'C')
+
+        # sus4 in different inversion (F in bass)
+        sus4_inv = chord.Chord('C F G B-')
+        self.assertEqual(sus4_inv.root().name, 'C')
+
+        # Regular chords should still work correctly
+        self.assertEqual(chord.Chord('C E G').root().name, 'C')
+        self.assertEqual(chord.Chord('C E- G').root().name, 'C')
+        self.assertEqual(chord.Chord('C E G B-').root().name, 'C')
+
+        # C11 chord (has both 3rd and 11th) should still return C, not F
+        c11 = chord.Chord('C E G B- D F')
+        self.assertEqual(c11.root().name, 'C')
+
     def testEnharmonicSimplification(self):
         eFlat = note.Note(63)
         self.assertEqual(eFlat.pitch.name, 'E-')


### PR DESCRIPTION
Fixes #1650.

**Note: This contribution was developed with AI assistance (Claude/Anthropic), as declared per the contributing guidelines.**

**Problem**

chord.Chord('F B- C E-').root() incorrectly returned C instead of F. The _findRoot method's rootnessFunction only scored notes based on thirds, fifths, sevenths, etc. above them, but gave no credit for a fourth, so sus4 chord roots were never correctly identified.

**Solution**

Added sus4 chord detection to _findRoot. Before scoring, we check whether any note in the chord has both a third and fifth above it. If none do (indicating a sus4 chord), we apply a bonus to notes that have both a fourth and fifth above them, giving sus4 roots the same base score as notes with a third above them in regular chords.

This avoids incorrectly boosting notes in chords that happen to have an eleventh (like C11 = C E G B- D F), where C has both a third and fifth above it, so the sus4 path is not triggered.

**Tests**

Added testSus4RootFinding in test/test_chord.py covering:

Basic sus4 seventh chord from the issue (F B- C E- → F)
Simple sus4 triad (C F G → C)
sus4 with seventh (C F G B- → C)
Regression: regular major, minor, dominant seventh still correct
Regression: C11 chord still returns C, not F

All 27 tests pass.