### PR TITLE
Honor displayType='always' on first pitch too

### DIFF
--- a/music21/_version.py
+++ b/music21/_version.py
@@ -47,7 +47,7 @@ so change it if a bug or new feature creates a problem with using old pickles.
 '''
 from __future__ import annotations
 
-__version__ = '11.0.0b7'
+__version__ = '11.0.0b8'
 
 def get_version_tuple(vv):
     v = vv.split('.')

--- a/music21/base.py
+++ b/music21/base.py
@@ -26,7 +26,7 @@ available after importing `music21`.
 <class 'music21.base.Music21Object'>
 
 >>> music21.VERSION_STR
-'11.0.0b7'
+'11.0.0b8'
 
 Alternatively, after doing a complete import, these classes are available
 under the module "base":

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4984,20 +4984,7 @@ class Pitch(prebase.ProtoM21Object):
         >>> a4.accidental is None
         True
 
-        `cautionaryAll` and a `displayType` of 'always' or 'even-tied' are honored
-        even when nothing precedes the pitch, and regardless of the key signature:
-
-        >>> fSharp = pitch.Pitch('F#4')
-        >>> fSharp.accidental.displayType = 'always'
-        >>> fSharp.updateAccidentalDisplay(alteredPitches=key.Key('G').alteredPitches)
-        >>> fSharp.accidental.displayStatus
-        True
-
         v8 -- made keyword-only and added `otherSimultaneousPitches`.
-
-        * Changed in v11: `cautionaryAll` and `displayType` of 'always'/'even-tied'
-          are honored for the first pitch of a part (previously an empty `pitchPast`
-          fell through to key-signature logic and could turn the accidental off).
         '''
         # N.B. -- this is a very complex method
         # do not alter it without significant testing.

--- a/music21/pitch.py
+++ b/music21/pitch.py
@@ -4984,7 +4984,20 @@ class Pitch(prebase.ProtoM21Object):
         >>> a4.accidental is None
         True
 
+        `cautionaryAll` and a `displayType` of 'always' or 'even-tied' are honored
+        even when nothing precedes the pitch, and regardless of the key signature:
+
+        >>> fSharp = pitch.Pitch('F#4')
+        >>> fSharp.accidental.displayType = 'always'
+        >>> fSharp.updateAccidentalDisplay(alteredPitches=key.Key('G').alteredPitches)
+        >>> fSharp.accidental.displayStatus
+        True
+
         v8 -- made keyword-only and added `otherSimultaneousPitches`.
+
+        * Changed in v11: `cautionaryAll` and `displayType` of 'always'/'even-tied'
+          are honored for the first pitch of a part (previously an empty `pitchPast`
+          fell through to key-signature logic and could turn the accidental off).
         '''
         # N.B. -- this is a very complex method
         # do not alter it without significant testing.
@@ -5048,6 +5061,17 @@ class Pitch(prebase.ProtoM21Object):
             set_displayStatus(True)
             return
 
+        # here tied and always are treated the same; we assume that
+        # making ties sets the displayStatus, and thus we would not be
+        # overriding that display status here
+        if (cautionaryAll is True
+            or (acc is not None
+                and acc.displayType in ('even-tied', 'always'))):
+            # show all accidentals, no matter what is in the past
+            # or in the key signature
+            set_displayStatus(True)
+            return  # do not search past
+
         # no pitches in the past list
         if not pitchPastAll:
             # if we have no past, we show the accidental if this pitch name
@@ -5088,16 +5112,6 @@ class Pitch(prebase.ProtoM21Object):
                 else:  # names are the same, skip this line of questioning
                     break
         # nope, no conflicting accidentals at this name and octave in the past
-
-        # here tied and always are treated the same; we assume that
-        # making ties sets the displayStatus, and thus we would not be
-        # overriding that display status here
-        if (cautionaryAll is True
-            or (acc is not None
-                and acc.displayType in ('even-tied', 'always'))):
-            # show all accidentals, even if past encountered
-            set_displayStatus(True)
-            return  # do not search past
 
         # store if a match was found and display set from past pitches
         setFromPitchPast = False

--- a/music21/test/test_pitch.py
+++ b/music21/test/test_pitch.py
@@ -396,6 +396,55 @@ class Test(unittest.TestCase):
         n.pitch.updateAccidentalDisplay(overrideStatus=True, alteredPitches=k.alteredPitches)
         self.assertIs(n.pitch.accidental.displayStatus, False)
 
+    def testDisplayTypeAlwaysWithNothingInPast(self):
+        '''
+        `displayType='always'` and `cautionaryAll` win over the key signature
+        even for the first pitch of a part, where nothing precedes it.
+
+        AI-assisted (Claude).
+        '''
+        p = Pitch('An2')
+        p.accidental.displayType = 'always'
+        p.updateAccidentalDisplay()
+        self.assertIs(p.accidental.displayStatus, True)
+
+        # a sharp already implied by the key signature still shows
+        p = Pitch('F#4')
+        p.accidental.displayType = 'always'
+        p.updateAccidentalDisplay(alteredPitches=key.Key('G').alteredPitches)
+        self.assertIs(p.accidental.displayStatus, True)
+
+        # cautionaryAll creates the natural that was not there
+        p = Pitch('B4')
+        p.updateAccidentalDisplay(cautionaryAll=True)
+        self.assertEqual(p.accidental.name, 'natural')
+        self.assertIs(p.accidental.displayStatus, True)
+
+        # 'even-tied' behaves the same as 'always' here
+        p = Pitch('E-3')
+        p.accidental.displayType = 'even-tied'
+        p.updateAccidentalDisplay(alteredPitches=key.Key('E-').alteredPitches)
+        self.assertIs(p.accidental.displayStatus, True)
+
+        # in a stream, every note of the part shows, not just the ones after the first
+        s = converter.parse('tinyNotation: AAn2 Fn')
+        for n in s.recurse().notes:
+            n.pitch.accidental.displayType = 'always'
+        s.makeAccidentals(inPlace=True)
+        self.assertEqual([n.pitch.accidental.displayStatus for n in s.recurse().notes],
+                         [True, True])
+
+        # regression guard: a normal displayType is untouched by the above
+        p = Pitch('F#4')
+        p.updateAccidentalDisplay(alteredPitches=key.Key('G').alteredPitches)
+        self.assertIs(p.accidental.displayStatus, False)
+
+        # regression guard: with a non-empty past, repeated pitches are unchanged
+        past = [Pitch('c#4')]
+        p = Pitch('c#4')
+        p.updateAccidentalDisplay(pitchPast=past)
+        self.assertIs(p.accidental.displayStatus, False)
+
     def testImplicitToExplicitNatural(self):
         p = converter.parse('tinyNotation: 2/4 f4 fn4')
         last_note = p.recurse().notes.last()


### PR DESCRIPTION
First note in piece/part w/ explicit natural set with displayType='always', like tinyNotation Cn was being ignored. Fixed.

updateAccidentalDisplay was short circuiting early if there was no pitchPastAll -- so first note had no way of having its "always" or "even-tied" status read.

See same error in music21j: https://github.com/cuthbertLab/music21j/pull/326

AI-assisted (Claude)