### PR TITLE
Fix typo in usingGit developer docs

### DIFF
--- a/documentation/source/developerReference/usingGit.rst
+++ b/documentation/source/developerReference/usingGit.rst
@@ -103,7 +103,7 @@ Making pull requests is easy:
     functionality?
 
     When you've finished writing your description, click on the ``Send pull
-    request`` button. You've sent your pull pull request!
+    request`` button. You've sent your pull request!
 
     ..  image:: images/usingGit/github__pull_requests__3.png
 


### PR DESCRIPTION
Trivial docs fix: "You've sent your pull pull request!" → "You've sent your pull request!" in `documentation/source/developerReference/usingGit.rst`.

## Testing
- RST parses cleanly with docutils (Sphinx `:ref:` role warnings are pre-existing).
- Single-line prose change; no code touched.

## AI disclosure
Prepared with AI assistance (draft authored by an automated contributor; change is a one-word typo fix, fully understood and verified). Per music21's [contributing guidelines](https://github.com/cuthbertLab/music21/blob/master/CONTRIBUTING.md), the change matches project conventions and is a minimal, responsible edit.