### PR TITLE
Fix malformed ratio in sparschuh-stanhope.scl

### DIFF
--- a/music21/scale/scala/scl/sparschuh-stanhope.scl
+++ b/music21/scale/scala/scl/sparschuh-stanhope.scl
@@ -9,7 +9,7 @@ Sparschuh's (2010) septenarian variant of Stanhopes (1806) idea
 4/3       ! F
 620/441   ! F# (45/32) * (3968/3969 ~-0.436...Cents flattend )
 3/2       ! G
-697//441  ! G# (128/81) * (6273/6272  ~+0.276...Cents sharper )
+697/441   ! G# (128/81) * (6273/6272  ~+0.276...Cents sharper )
 82/49     ! A (5/3) * (246/245 ~+7.052...Cents sharper )
 16/9      ! Bb
 15/8      ! B


### PR DESCRIPTION
Degree 8 is written `697//441`, with a doubled slash. No Scala parser can read it: the file is unparseable from that line on.

This changes one character and preserves the column alignment of the surrounding degrees. No other file in the archive contains a doubled slash.


Claude adds:
Note that music21 still cannot parse this file after the fix, for an unrelated reason: ScalaData.parse only skips lines that *start* with `!` and does not strip trailing inline `!` comments.

I'm not sure about that, haven't tested but might be interesting to reviewers/maintainers