### PR TITLE
Simplify boolean comparisons

### DIFF
--- a/documentation/docbuild/documenters.py
+++ b/documentation/docbuild/documenters.py
@@ -1564,13 +1564,13 @@ class CorpusDocumenter(Documenter):
         # worksAreVirtual = corpusWork.virtual
         # if worksAreVirtual:
         #     workTitle += ' (*virtual*)'
-        if isSingleWork is False:
+        if not isSingleWork:
             result.append(workTitle)
             result.append('')
         procedure = self.getRstWorkFileDictFormat
         # if worksAreVirtual:
         #     procedure = self.getRstVirtualWorkFileDictFormat
-        if isSingleWork is False:
+        if not isSingleWork:
             for corpusFile in corpusWork.files:
                 result.extend(['- ' + procedure(corpusFile), ''])
         else:

--- a/documentation/source/usersGuide/usersGuide_20_examples2.ipynb
+++ b/documentation/source/usersGuide/usersGuide_20_examples2.ipynb
@@ -703,7 +703,7 @@
     "    if analyzedKey.mode != 'minor':\n",
     "        return False\n",
     "    lastChord = getLastChord(score)\n",
-    "    if lastChord.isMinorTriad() is False:\n",
+    "    if not lastChord.isMinorTriad():\n",
     "        return False\n",
     "    if lastChord.root().name != analyzedKey.tonic.name:\n",
     "        return False\n",

--- a/music21/alpha/analysis/fixer.py
+++ b/music21/alpha/analysis/fixer.py
@@ -57,7 +57,7 @@ class DeleteFixer(OMRMidiFixer):
     def fix(self):
         super().fix()
         for (midiRef, omrRef, op) in self.changes:
-            if self.checkIfNoteInstance(midiRef, omrRef) is False:
+            if not self.checkIfNoteInstance(midiRef, omrRef):
                 continue
             # if they are the same, don't bother to try changing it
             # 3 is the number of noChange Ops
@@ -140,7 +140,7 @@ class EnharmonicFixer(OMRMidiFixer):
     >>> fixer3.fix()
     >>> omrNote3.pitch.accidental
 
-    TEST 4 (case 2-1) e.g MIDI = g#, ground truth = a-, OMR = an
+    TEST 4 (case 2-1) e.g. MIDI = g#, ground truth = a-, OMR = an
 
     >>> midiNote4 = note.Note('G#4')
     >>> omrNote4 = note.Note('An4')
@@ -156,7 +156,7 @@ class EnharmonicFixer(OMRMidiFixer):
     >>> omrNote4.pitch.accidental
     <music21.pitch.Accidental flat>
 
-    TEST 5 (case 2-2) e.g midi = g-, gt = f#, omr = fn
+    TEST 5 (case 2-2) e.g. midi = g-, gt = f#, omr = fn
 
     >>> midiNote5 = note.Note('G-4')
     >>> omrNote5 = note.Note('Fn4')
@@ -237,7 +237,7 @@ class EnharmonicFixer(OMRMidiFixer):
         for (midiRef, omrRef, op) in self.changes:
             omrRef.style.color = 'black'
             # if they're not notes, don't bother with rest
-            if self.checkIfNoteInstance(midiRef, omrRef) is False:
+            if not self.checkIfNoteInstance(midiRef, omrRef):
                 continue
             # if they are the same, don't bother to try changing it
             # 3 is the number of noChange Ops
@@ -253,7 +253,7 @@ class EnharmonicFixer(OMRMidiFixer):
                     omrRef.pitch.accidental = None
                 else:
                     # case 2-1: midi note is sharp, omr note is one step higher and natural,
-                    # should be a flat instead. e.g midi = g#, gt = a-, omr = an
+                    # should be a flat instead. e.g. midi = g#, gt = a-, omr = an
                     # omr note has higher ps than midi-- on a higher
                     # line or space than midi note
                     if omrRef.pitch > midiRef.pitch:
@@ -261,7 +261,7 @@ class EnharmonicFixer(OMRMidiFixer):
                                                   ).isEnharmonic(midiRef.pitch):
                             omrRef.pitch.accidental = pitch.Accidental('flat')
                     # case 2-2: midi note is flat, omr note is one step lower and natural,
-                    # should be a flat instead. e.g midi = g-, gt = f#, omr = fn
+                    # should be a flat instead. e.g. midi = g-, gt = f#, omr = fn
                     # omr note has lower ps than midi-- on a higher line
                     # or space than midi note
                     elif omrRef.pitch < midiRef.pitch:
@@ -399,7 +399,7 @@ class OrnamentFixer(OMRMidiFixer):
         * show: True when note should be colored blue
 
         Returns True if added successfully, or False if there was already an
-        ornament on the note and it wasn't added.
+        ornament on the note, and it wasn't added.
         '''
         if not any(isinstance(e, expressions.Ornament) for e in selectedNote.expressions):
             selectedNote.expressions.append(ornament)

--- a/music21/analysis/enharmonics.py
+++ b/music21/analysis/enharmonics.py
@@ -99,7 +99,7 @@ class EnharmonicSimplifier:
         Returns a score according to the number of sharps and flats in a possible spelling.
         The score is the sum of the flats and sharps + 1, multiplied by the alterationPenalty.
         '''
-        if self.ruleObject.alterationPenalty is False:
+        if not self.ruleObject.alterationPenalty:
             return 1
 
         joinedPossibility = ''.join([p.name for p in possibility])
@@ -114,7 +114,7 @@ class EnharmonicSimplifier:
         the score is given by the number of the lesser used accidental (sharps or flats)
         multiplied by the mixSharpsFlatsPenalty.
         '''
-        if self.ruleObject.mixSharpsFlatsPenalty is False:
+        if not self.ruleObject.mixSharpsFlatsPenalty:
             return 1
 
         joinedPossibility = ''.join([p.name for p in possibility])
@@ -128,7 +128,7 @@ class EnharmonicSimplifier:
         Returns a score based on the number of augmented and diminished intervals between
         successive pitches in the given spelling.
         '''
-        if self.ruleObject.augDimPenalty is False:
+        if not self.ruleObject.augDimPenalty:
             return 1
 
         intervalStr = ''

--- a/music21/analysis/neoRiemannian.py
+++ b/music21/analysis/neoRiemannian.py
@@ -97,7 +97,7 @@ def L(c, raiseException=True):
         transposeInterval = 'm2'
         changingPitch = c.fifth
     else:
-        if raiseException is True:
+        if raiseException:
             raise LRPException('Cannot perform L on this chord: not a major or minor triad')
         return c
 
@@ -134,7 +134,7 @@ def P(c, raiseException=True):
         transposeInterval = 'A1'
         changingPitch = c.third
     else:
-        if raiseException is True:
+        if raiseException:
             raise LRPException('Cannot perform P on this chord: not a Major or Minor triad')
         return c
 
@@ -171,7 +171,7 @@ def R(c, raiseException=True):
         transposeInterval = '-M2'
         changingPitch = c.root()
     else:
-        if raiseException is True:
+        if raiseException:
             raise LRPException('Cannot perform R on this chord: not a Major or Minor triad')
         return c
 
@@ -358,7 +358,7 @@ def LRP_combinations(c,
     '''
 
     if not c.isMajorTriad() and not c.isMinorTriad():  # First to avoid doing anything else if fail
-        if raiseException is True:
+        if raiseException:
             raise LRPException(
                 f'Cannot perform transformations on chord {c}: not a major or minor triad')
         return c
@@ -435,7 +435,7 @@ def completeHexatonic(c, simplifyEnharmonics=False, raiseException=True):
             hexatonicList.append(lastChord)
         return hexatonicList
     else:
-        if raiseException is True:
+        if raiseException:
             raise LRPException(
                 'Cannot perform transformations on this chord: not a major or minor triad')
 

--- a/music21/analysis/reduction.py
+++ b/music21/analysis/reduction.py
@@ -1121,7 +1121,7 @@ class Test(unittest.TestCase):
             s.insert(0, p)
             pCount += 1
 
-        if show is True:
+        if show:
             s.show()
 
         pr = analysis.reduction.PartReduction(s, normalize=False)
@@ -1140,7 +1140,7 @@ class Test(unittest.TestCase):
 
         self._matchWeightedData(match, target)
 
-        if show is True:
+        if show:
             p = graph.plot.Dolan(s, title='Dynamics')
             p.run()
 

--- a/music21/audioSearch/recording.py
+++ b/music21/audioSearch/recording.py
@@ -38,7 +38,8 @@ default_recordSampleRate = 44100
 default_recordChunkLength = 1024
 
 
-def samplesFromRecording(seconds=10.0, storeFile=True,
+def samplesFromRecording(seconds=10.0,
+                         storeFile: bool = True,
                          recordFormat=None,
                          recordChannels=default_recordChannels,
                          recordSampleRate=default_recordSampleRate,
@@ -77,7 +78,7 @@ def samplesFromRecording(seconds=10.0, storeFile=True,
     st.close()
     p_audio.terminate()
 
-    if storeFile is not False:
+    if not storeFile:
         if isinstance(storeFile, str):
             waveFilename = storeFile
         else:

--- a/music21/audioSearch/recording.py
+++ b/music21/audioSearch/recording.py
@@ -39,7 +39,7 @@ default_recordChunkLength = 1024
 
 
 def samplesFromRecording(seconds=10.0,
-                         storeFile: bool = True,
+                         storeFile: bool|str = True,
                          recordFormat=None,
                          recordChannels=default_recordChannels,
                          recordSampleRate=default_recordSampleRate,
@@ -78,7 +78,7 @@ def samplesFromRecording(seconds=10.0,
     st.close()
     p_audio.terminate()
 
-    if not storeFile:
+    if storeFile:
         if isinstance(storeFile, str):
             waveFilename = storeFile
         else:

--- a/music21/audioSearch/scoreFollower.py
+++ b/music21/audioSearch/scoreFollower.py
@@ -178,7 +178,7 @@ class ScoreFollower:
         # print('3')
         self.processing_time = time() - time_start
         environLocal.printDebug('and even to here.')
-        if END_OF_SCORE is True:
+        if END_OF_SCORE:
             exitType = 'endOfScore'  # 'endOfScore'
             return exitType
 
@@ -239,7 +239,7 @@ class ScoreFollower:
             if i.name != 'rest':
                 onlyRests = False
 
-        if onlyRests is True:
+        if onlyRests:
             self.silencePeriod = True
             self.notesCounter = 0
             self.silencePeriodCounter += 1

--- a/music21/audioSearch/transcriber.py
+++ b/music21/audioSearch/transcriber.py
@@ -19,8 +19,12 @@ from music21 import scale
 environLocal = environment.Environment('audioSearch.transcriber')
 
 
-def runTranscribe(show=True, plot=True, useMic=True,
-                  seconds=20.0, useScale=None, saveFile=True):  # pragma: no cover
+def runTranscribe(show: bool = True,
+                  plot: bool = True,
+                  useMic: bool = True,
+                  seconds: float = 20.0,
+                  useScale=None,
+                  saveFile: bool|str = True):  # pragma: no cover
     '''
     runs all the methods to record from audio for `seconds` length (default 10.0)
     and transcribe the resulting melody returning a music21.Score object
@@ -54,7 +58,7 @@ def runTranscribe(show=True, plot=True, useMic=True,
         waveFilename = saveFile
 
     # the rest of the score
-    if useMic is True:
+    if useMic:
         freqFromAQList = audioSearchBase.getFrequenciesFromMicrophone(
             length=seconds,
             storeWaveFilename=str(waveFilename))

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -4005,7 +4005,7 @@ class Chord(ChordBase):
         c2 = self.closedPosition(forceOctave=forceOctave,
                                  inPlace=inPlace,
                                  leaveRedundantPitches=leaveRedundantPitches)
-        if inPlace is True:
+        if inPlace:
             c2 = self
 
         # closedPosition() only returns None when inPlace=True, in which case c2
@@ -4028,7 +4028,7 @@ class Chord(ChordBase):
         c2.clearCache()
         c2.sortAscending(inPlace=True)
 
-        if inPlace is False:
+        if not inPlace:
             return c2
 
     def semitonesFromChordStep(self, chordStep, testRoot=None):

--- a/music21/converter/subConverters.py
+++ b/music21/converter/subConverters.py
@@ -100,7 +100,7 @@ class SubConverter:
         loading the file and putting the data into parseData then there is no need
         to implement this method.  Just set self.readBinary to True | False.
         '''
-        if self.readBinary is False:
+        if not self.readBinary:
             import locale
             with open(filePath, encoding=locale.getpreferredencoding()) as f:
                 dataStream = f.read()
@@ -289,7 +289,7 @@ class SubConverter:
         if fp is None:
             fp = self.getTemporaryFile()
 
-        if self.readBinary is False:
+        if not self.readBinary:
             writeFlags = 'w'
         else:
             writeFlags = 'wb'
@@ -330,7 +330,7 @@ class SubConverter:
         and return the object (str or bytes) returned.
         '''
         fp = self.write(obj, fmt=fmt, subformats=subformats, **keywords)
-        if self.readBinary is False:
+        if not self.readBinary:
             readFlags = 'r'
         else:
             readFlags = 'rb'

--- a/music21/defaults.py
+++ b/music21/defaults.py
@@ -17,6 +17,7 @@ import unittest
 import typing as t
 from music21 import _version
 
+
 # note: this module should not import any higher level modules
 type StepName = t.Literal['C', 'D', 'E', 'F', 'G', 'A', 'B']  # restating so as not to import.
 

--- a/music21/freezeThaw.py
+++ b/music21/freezeThaw.py
@@ -210,7 +210,7 @@ class StreamFreezer(StreamFreezeThawBase):
 
         self.subStreamFreezers = {}  # this will keep track of sub freezers for spanners
 
-        if streamObj is not None and fastButUnsafe is False:
+        if streamObj is not None and not fastButUnsafe:
             # deepcopy necessary because we mangle sites in the objects
             # before serialization
             self.stream = copy.deepcopy(streamObj)
@@ -267,7 +267,7 @@ class StreamFreezer(StreamFreezeThawBase):
         # might not work when recurse yields
         allEls = list(streamObj.recurse(restoreActiveSites=False))
 
-        if self.topLevel is True:
+        if self.topLevel:
             self.findActiveStreamIdsInHierarchy(streamObj)
 
         for el in allEls:
@@ -297,7 +297,7 @@ class StreamFreezer(StreamFreezeThawBase):
         # removing seems to create problems for jsonPickle with Spanners
         self.setupStoredElementOffsetTuples(streamObj)
 
-        if self.topLevel is True:
+        if self.topLevel:
             self.recursiveClearSites(streamObj)
 
     def removeStreamStatusClient(self, streamObj):
@@ -578,11 +578,11 @@ class StreamFreezer(StreamFreezeThawBase):
                                                   includeSelf=True)
         streamIds = [id(s) for s in streamsFoundGenerator]
 
-        if getSpanners is True:
+        if getSpanners:
             spannerBundle = streamObj.spannerBundle
             streamIds += spannerBundle.getSpannerStorageIds()
 
-        if getVariants is True:
+        if getVariants:
             for el in streamObj.recurse(includeSelf=True).getElementsByClass(variant.Variant):
                 streamIds += self.findActiveStreamIdsInHierarchy(el._stream)
 
@@ -853,7 +853,7 @@ class StreamThawer(StreamFreezeThawBase):
             streamObj.coreElementsChanged()
 
         for subElement in streamObj:
-            if subElement.isStream is True:
+            if subElement.isStream:
                 # note that the elements may have already been restored
                 # if the spanner stores a part or something in the Stream
                 # for instance in a StaffGroup object

--- a/music21/graph/axis.py
+++ b/music21/graph/axis.py
@@ -317,7 +317,7 @@ class PitchAxis(Axis):
 
     def __init__(self, client=None, axisName='x'):
         super().__init__(client, axisName)
-        self.showOctaves = 'few'
+        self.showOctaves: bool|t.Literal['few'] = 'few'
         self.showEnharmonic = True
         self.blankLabelUnused = True
         self.hideUnused = True
@@ -425,7 +425,7 @@ class PitchAxis(Axis):
                     sub.append(accidentalLabelToUnicode(name))
                 label = '/'.join(sub)
 
-            if self.showOctaves is False:
+            if not self.showOctaves:
                 label = re.sub(r'\d', '', label)
             elif self.showOctaves == 'few':
                 matchOctave = re.search(r'\d', label)
@@ -451,7 +451,7 @@ class PitchClassAxis(PitchAxis):
     quantities: tuple[str, ...] = ('pitchClass', 'pitchclass', 'pc')
 
     def __init__(self, client=None, axisName='x'):
-        self.showOctaves = False
+        self.showOctaves: bool|t.Literal['few'] = False
         super().__init__(client, axisName)
         self.minValue = 0
         self.maxValue = 11
@@ -1129,7 +1129,7 @@ class QuarterLengthAxis(PositionAxis):
 
     def __init__(self, client=None, axisName='x'):
         super().__init__(client, axisName)
-        self.useLogScale = True
+        self.useLogScale: bool|int = True
         self.useDurationNames = False
 
     def extractOneElement(self, n, formatDict):

--- a/music21/instrument.py
+++ b/music21/instrument.py
@@ -65,7 +65,7 @@ def unbundleInstruments(streamIn: stream.Stream,
     {1.0} <music21.instrument.Cowbell 'Cowbell'>
     {1.0} <music21.note.Unpitched 'Cowbell'>
     '''
-    if inPlace is True:
+    if inPlace:
         s = streamIn
     else:
         s = streamIn.coreCopyAsDerivation('unbundleInstruments')
@@ -78,7 +78,7 @@ def unbundleInstruments(streamIn: stream.Stream,
                 off = thisObj.offset
                 s.insert(off, i)
 
-    if inPlace is False:
+    if not inPlace:
         return s
 
 
@@ -106,7 +106,7 @@ def bundleInstruments(streamIn: stream.Stream,
     Cowbell
 
     '''
-    if inPlace is True:
+    if inPlace:
         s = streamIn
     else:
         s = streamIn.coreCopyAsDerivation('bundleInstruments')
@@ -120,7 +120,7 @@ def bundleInstruments(streamIn: stream.Stream,
         elif isinstance(thisObj, note.NotRest):
             thisObj.storedInstrument = lastInstrument
 
-    if inPlace is False:
+    if not inPlace:
         return s
 
 

--- a/music21/key.py
+++ b/music21/key.py
@@ -1295,7 +1295,7 @@ class Key(KeySignature, scale.DiatonicScale):
         >>> changingKey
         <music21.key.Key of g# minor>
         '''
-        if inPlace is True:
+        if inPlace:
             super().transpose(value, inPlace=inPlace)
             post = self
         else:

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -795,7 +795,7 @@ class XMLExporterBase:
         '''
         if isinstance(m21Object, style.Style):
             stObj = m21Object
-        elif m21Object.hasStyleInformation is False:
+        elif not m21Object.hasStyleInformation:
             return
         else:
             stObj = m21Object.style
@@ -1000,7 +1000,7 @@ class XMLExporterBase:
           <level reference="yes">hello</level>
         </note>
         '''
-        if m21Object.hasEditorialInformation is False:
+        if not m21Object.hasEditorialInformation:
             return
         # MusicXML allows only one footnote or level, so we take the first.
 
@@ -2186,9 +2186,9 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
             self.setPosition(mxGroupSymbol, staffGroup)
 
         mxGroupBarline = SubElement(mxPartGroup, 'group-barline')
-        if staffGroup.barTogether is True:
+        if staffGroup.barTogether is True:  # not a bool.
             mxGroupBarline.text = 'yes'
-        elif staffGroup.barTogether is False:
+        elif staffGroup.barTogether is False:  # not a bool.
             mxGroupBarline.text = 'no'
         elif staffGroup.barTogether == 'Mensurstrich':
             mxGroupBarline.text = 'Mensurstrich'
@@ -2268,7 +2268,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
             self.mxIdentification = mxId
 
         # creators
-        foundOne = False
+        foundOne: bool = False
         if self.scoreMetadata is not None:
             # We ignore the name ('namespace:name') here, and use
             # c.role instead so we can represent non-standard roles.
@@ -2282,7 +2282,7 @@ class ScoreExporter(XMLExporterBase, PartStaffExporterMixin):
                 mxId.append(mxCreator)
                 foundOne = True
 
-        if foundOne is False and defaults.author:
+        if not foundOne and defaults.author:
             mxCreator = SubElement(mxId, 'creator')
             mxCreator.set('type', 'composer')
             mxCreator.text = defaults.author
@@ -3417,12 +3417,12 @@ class MeasureExporter(XMLExporterBase):
                     parsedObject = True
                     break
 
-            if parsedObject is False:
+            if not parsedObject:
                 for className in classes:
                     if className in self.ignoreOnParseClasses:
                         parsedObject = True
                         break
-                if parsedObject is False:
+                if not parsedObject:
                     environLocal.printDebug(['did not convert object', obj])
 
         else:  # appendSpanners == AppendSpanners.RELATED_ONLY
@@ -3812,10 +3812,10 @@ class MeasureExporter(XMLExporterBase):
                     isFirstOrLast = True
                 # print('Trill is last')
 
-            if isFirstOrLast is False:
+            if not isFirstOrLast:
                 continue  # do not put a wavy-line tag on mid-trill notes
             ornaments.append(mxWavyLine)
-            if isFirstANDLast is True:
+            if isFirstANDLast:
                 # make another one:
                 mxWavyLine = Element('wavy-line')
                 mxWavyLine.set('number', str(su.idLocal))
@@ -4034,7 +4034,7 @@ class MeasureExporter(XMLExporterBase):
 
         TODO: Test with spanners
         '''
-        addChordTag = (noteIndexInChord != 0)
+        addChordTag: bool = (noteIndexInChord != 0)
         setb = setAttributeFromAttribute
 
         mxNote = Element('note')
@@ -4106,7 +4106,7 @@ class MeasureExporter(XMLExporterBase):
         elif n.isRest:
             SubElement(mxNote, 'rest')
 
-        if d.isGrace is not True:
+        if d.isGrace:
             mxDuration = self.durationXml(d)
             mxNote.append(mxDuration)
             # divisions only
@@ -4168,7 +4168,7 @@ class MeasureExporter(XMLExporterBase):
         stemDirection = None
         # if we are not in a chord, or we are the first note of a chord, get stem
         # direction from the chordOrNote object
-        if (addChordTag is False
+        if (not addChordTag
                 and isinstance(chordOrN, note.NotRest)
                 and chordOrN.stemDirection != 'unspecified'):
             chordOrN = t.cast(note.NotRest, chordOrN)
@@ -4211,7 +4211,7 @@ class MeasureExporter(XMLExporterBase):
         # TODO: notehead-text
 
         # beam
-        if addChordTag is False:
+        if not addChordTag:
             if isinstance(chordOrN, note.NotRest) and chordOrN.beams is not None:
                 nBeamsList = self.beamsToXml(chordOrN.beams)
                 for mxB in nBeamsList:
@@ -4220,7 +4220,7 @@ class MeasureExporter(XMLExporterBase):
         mxNotationsList = self.noteToNotations(n, noteIndexInChord, chordParent)
 
         # add tuplets if it's a note or the first <note> of a chord.
-        if addChordTag is False:
+        if not addChordTag:
             for i, tup in enumerate(d.tuplets):
                 tupTagList = self.tupletToXmlTuplet(tup, i + 1)
                 mxNotationsList.extend(tupTagList)
@@ -4231,7 +4231,7 @@ class MeasureExporter(XMLExporterBase):
                 mxNotations.append(mxN)
 
         # lyric
-        if addChordTag is False:
+        if not addChordTag:
             for lyricObj in chordOrN.lyrics:
                 if lyricObj.text is None:
                     continue  # happens sometimes!
@@ -4815,7 +4815,7 @@ class MeasureExporter(XMLExporterBase):
 
         Returns nothing.  The mxNote is modified in place.
         '''
-        foundANotehead = False
+        foundANotehead: bool = False
         if (isinstance(n, note.NotRest)
             and (n.notehead != 'normal'
                  or n.noteheadParenthesis
@@ -4825,7 +4825,7 @@ class MeasureExporter(XMLExporterBase):
             foundANotehead = True
             mxNotehead = self.noteheadToXml(n)
             mxNote.append(mxNotehead)
-        if foundANotehead is False and chordParent is not None:
+        if not foundANotehead and chordParent is not None:
             if (hasattr(chordParent, 'notehead')
                 and (chordParent.notehead != 'normal'
                      or chordParent.noteheadParenthesis
@@ -5737,7 +5737,7 @@ class MeasureExporter(XMLExporterBase):
             <type>quarter</type>
         </note>
         '''
-        if cs.writeAsChord is True:
+        if cs.writeAsChord:
             r = note.Rest(duration=cs.duration)
             return self.restToXml(r)
 

--- a/music21/musicxml/m21ToXml.py
+++ b/music21/musicxml/m21ToXml.py
@@ -4106,7 +4106,7 @@ class MeasureExporter(XMLExporterBase):
         elif n.isRest:
             SubElement(mxNote, 'rest')
 
-        if d.isGrace:
+        if not d.isGrace:
             mxDuration = self.durationXml(d)
             mxNote.append(mxDuration)
             # divisions only

--- a/music21/note.py
+++ b/music21/note.py
@@ -542,13 +542,13 @@ class Lyric(prebase.ProtoM21Object, style.StyleMixin):
             rawText = str(rawText)
 
         # check for hyphens
-        if applyRaw is False and rawText.startswith('-') and not rawText.endswith('-'):
+        if not applyRaw and rawText.startswith('-') and not rawText.endswith('-'):
             self.text = rawText[1:]
             self.syllabic = 'end'
-        elif applyRaw is False and not rawText.startswith('-') and rawText.endswith('-'):
+        elif not applyRaw and not rawText.startswith('-') and rawText.endswith('-'):
             self.text = rawText[:-1]
             self.syllabic = 'begin'
-        elif applyRaw is False and rawText.startswith('-') and rawText.endswith('-'):
+        elif not applyRaw and rawText.startswith('-') and rawText.endswith('-'):
             self.text = rawText[1:-1]
             self.syllabic = 'middle'
         else:  # assume single
@@ -823,7 +823,7 @@ class GeneralNote(base.Music21Object):
                     thisLyric.text = text
                     foundLyric = True
                     break
-            if foundLyric is False:
+            if not foundLyric:
                 self.lyrics.append(Lyric(text, lyricNumber,
                                          applyRaw=applyRaw, identifier=lyricIdentifier))
 

--- a/music21/repeat.py
+++ b/music21/repeat.py
@@ -452,7 +452,7 @@ def insertRepeatEnding(s, start, end, endingNumber: int = 1, *, inPlace=False):
     rbOffset = measures[0].getOffsetBySite(s)
     s.insert(rbOffset, rb)
 
-    if inPlace is True:
+    if inPlace:
         return
     else:
         return s
@@ -774,7 +774,7 @@ class Expander[StreamType: 'music21.stream.Stream']:
 
         # need to copy source measures, as may later measures before copying
         # them, and this can result in orphaned spanners
-        if deepcopy is not False:
+        if deepcopy:
             srcStream = self._srcMeasureStream.coreCopyAsDerivation('expandRepeats')
         else:
             srcStream = self._srcMeasureStream

--- a/music21/search/base.py
+++ b/music21/search/base.py
@@ -267,7 +267,7 @@ class StreamSearcher:
                         break
                 if result is False:
                     break
-                if result is True:
+                if result:
                     result = None
 
             if result is not False:

--- a/music21/stream/base.py
+++ b/music21/stream/base.py
@@ -351,7 +351,7 @@ class Stream[M21ObjType: base.Music21Object](core.StreamCore):
         self._atSoundingPitch: bool|t.Literal['unknown'] = 'unknown'
 
         # experimental
-        self._mutable = True
+        self._mutable: bool = True
 
         if givenElements is None:
             return
@@ -8295,7 +8295,7 @@ class Stream[M21ObjType: base.Music21Object](core.StreamCore):
         Clean this Stream: for self and all elements, purge all dead locations
         and remove all non-contained sites. Further, restore all active sites.
         '''
-        if self._mutable is not False:
+        if self._mutable:
             self.sort()  # must sort before making immutable
         for e in self.recurse(streamsOnly=True, includeSelf=False):
             # e.purgeLocations(rescanIsDead=True)
@@ -8308,6 +8308,10 @@ class Stream[M21ObjType: base.Music21Object](core.StreamCore):
         self._mutable = False
 
     def makeMutable(self, recurse=True):
+        '''
+        Soft-Deprecated -- this will return a New Stream at some point --
+        once immutable, never mutable.
+        '''
         self._mutable = True
         if recurse:
             for e in self.recurse(streamsOnly=True):

--- a/music21/stream/filters.py
+++ b/music21/stream/filters.py
@@ -361,15 +361,13 @@ class OffsetFilter(StreamFilter):
         super().__init__()
 
         self.offsetStart = opFrac(offsetStart)
+        self.zeroLengthSearch: bool = True
         if offsetEnd is None:
             self.offsetEnd = offsetStart
-            self.zeroLengthSearch = True
         else:
             self.offsetEnd = opFrac(offsetEnd)
             if offsetEnd > offsetStart:
                 self.zeroLengthSearch = False
-            else:
-                self.zeroLengthSearch = True
 
         self.mustFinishInSpan = mustFinishInSpan
         self.mustBeginInSpan = mustBeginInSpan
@@ -432,35 +430,35 @@ class OffsetFilter(StreamFilter):
         else:
             elementIsZeroLength = False
 
-        if self.zeroLengthSearch is True and elementIsZeroLength is True:
+        if self.zeroLengthSearch and elementIsZeroLength:
             # zero Length Searches -- include all zeroLengthElements
             return True
 
 
-        if self.mustFinishInSpan is True:
+        if self.mustFinishInSpan:
             if elementEnd > self.offsetEnd:
                 # environLocal.warn([elementEnd, offsetEnd, e])
                 return False
-            if self.includeEndBoundary is False:
+            if not self.includeEndBoundary:
                 # we include the end boundary if the search is zeroLength --
                 # otherwise nothing can be retrieved
                 if elementEnd == self.offsetEnd:
                     return False
 
-        if self.mustBeginInSpan is True:
+        if self.mustBeginInSpan:
             if offset < self.offsetStart:
                 return False
-            if self.includeEndBoundary is False and offset == self.offsetEnd:
+            if not self.includeEndBoundary and offset == self.offsetEnd:
                 return False
-        elif (elementIsZeroLength is False
+        elif (not elementIsZeroLength
                 and elementEnd == self.offsetEnd
-                and self.zeroLengthSearch is True):
+                and self.zeroLengthSearch):
             return False
 
-        if self.includeEndBoundary is False and offset == self.offsetEnd:
+        if not self.includeEndBoundary and offset == self.offsetEnd:
             return False
 
-        if self.includeElementsThatEndAtStart is False and elementEnd == self.offsetStart:
+        if not self.includeElementsThatEndAtStart and elementEnd == self.offsetStart:
             return False
 
         return True
@@ -473,7 +471,7 @@ class OffsetHierarchyFilter(OffsetFilter):
 
     Finds elements that match a given offset range in the hierarchy.
 
-    Do not call .stream() afterwards or unstable results can occur.
+    Do not call .stream() afterward or unstable results can occur.
     '''
     derivationStr = 'getElementsByOffsetInHierarchy'
 

--- a/music21/stream/iterator.py
+++ b/music21/stream/iterator.py
@@ -204,10 +204,10 @@ class StreamIterator[M21ObjType: base.Music21Object](prebase.ProtoM21Object, Seq
                 continue
 
             self.elementIndex += 1
-            if self.matchesFilters(e) is False:
+            if not self.matchesFilters(e):
                 continue
 
-            if self.restoreActiveSites is True:
+            if self.restoreActiveSites:
                 self.srcStream.coreSelfActiveSite(e)
 
             self.updateActiveInformation()
@@ -1827,10 +1827,10 @@ class RecursiveIterator[M21ObjType: base.Music21Object](
 
                 childRecursiveIterator.iteratorStartOffsetInHierarchy = newStartOffset
                 self.childRecursiveIterator = childRecursiveIterator
-            if self.matchesFilters(e) is False:
+            if not self.matchesFilters(e):
                 continue
 
-            if self.restoreActiveSites is True:
+            if self.restoreActiveSites:
                 self.srcStream.coreSelfActiveSite(e)
 
             self.updateActiveInformation()

--- a/music21/tree/verticality.py
+++ b/music21/tree/verticality.py
@@ -1051,7 +1051,7 @@ class Verticality(prebase.ProtoM21Object):
             if not hasattr(pairedMotion[0][0], 'pitches'):
                 continue  # not a PitchedTimespan
 
-            if includeNoMotion is False:
+            if not includeNoMotion:
                 if (pairedMotion[0][0].pitches == pairedMotion[0][1].pitches
                         and pairedMotion[1][0].pitches == pairedMotion[1][1].pitches):
                     continue
@@ -1070,7 +1070,7 @@ class Verticality(prebase.ProtoM21Object):
                 if not isAppropriate:
                     continue
 
-            if returnObjects is False:
+            if not returnObjects:
                 filteredList.append(pairedMotion)
             else:
                 n11 = pairedMotion[0][0].element
@@ -1160,15 +1160,15 @@ class Verticality(prebase.ProtoM21Object):
             if previousTs is None or not isinstance(previousTs, spans.PitchedTimespan):
                 continue  # first not in piece in this part
 
-            if includeRests is False:
+            if not includeRests:
                 if previousTs not in stopTss:
                     continue
-            if includeOblique is False and startingTs.pitches == previousTs.pitches:
+            if not includeOblique and startingTs.pitches == previousTs.pitches:
                 continue
             tsTuple = (previousTs, startingTs)
             allPairedMotions.append(tsTuple)
 
-        if includeOblique is True:
+        if includeOblique:
             for overlapTs in overlapTss:
                 if not isinstance(overlapTs, spans.PitchedTimespan):
                     continue

--- a/music21/variant.py
+++ b/music21/variant.py
@@ -773,7 +773,7 @@ def mergeVariantScores(aScore, vScore, variantName='variant', *, inPlace=False):
         raise VariantException(
             'These scores do not have the same number of parts and cannot be merged.')
 
-    if inPlace is True:
+    if inPlace:
         returnObj = aScore
     else:
         returnObj = aScore.coreCopyAsDerivation('mergeVariantScores')
@@ -781,7 +781,7 @@ def mergeVariantScores(aScore, vScore, variantName='variant', *, inPlace=False):
     for returnPart, vPart in zip(returnObj.parts, vScore.parts):
         mergeVariantMeasureStreams(returnPart, vPart, variantName, inPlace=True)
 
-    if inPlace is False:
+    if not inPlace:
         return returnObj
 
 
@@ -933,7 +933,7 @@ def mergeVariantMeasureStreams(streamX, streamY, variantName='variant', *, inPla
     >>> parisStream[variant.Variant][2].replacementQuarterLength
     8.0
     '''
-    if inPlace is True:
+    if inPlace:
         returnObj = streamX
     else:
         returnObj = streamX.coreCopyAsDerivation('mergeVariantMeasureStreams')
@@ -972,7 +972,7 @@ def mergeVariantMeasureStreams(streamX, streamY, variantName='variant', *, inPla
         addVariant(returnObj, startOffset, yRegion,
                    variantName=variantName, replacementQuarterLength=replacementQuarterLength)
 
-    if inPlace is True:
+    if inPlace:
         return
     else:
         return returnObj
@@ -1182,7 +1182,7 @@ def mergeVariantsEqualDuration(streams, variantNames, *, inPlace=False):
         which are of different lengths
     '''
 
-    if inPlace is True:
+    if inPlace:
         returnObj = streams[0]
     else:
         returnObj = streams[0].coreCopyAsDerivation('mergeVariantsEqualDuration')
@@ -1333,7 +1333,7 @@ def mergePartAsOssia(mainPart, ossiaPart, ossiaName,
     ...
 
     '''
-    if inPlace is True:
+    if inPlace:
         returnObj = mainPart
     else:
         returnObj = mainPart.coreCopyAsDerivation('mergePartAsOssia')
@@ -1376,7 +1376,7 @@ def mergePartAsOssia(mainPart, ossiaPart, ossiaName,
                                variantName=ossiaName, variantGroups=None,
                                replacementQuarterLength=None)
 
-    if inPlace is True:
+    if inPlace:
         return
     else:
         return returnObj
@@ -1598,7 +1598,7 @@ def refineVariant(s, sVariant, *, inPlace=False):
     if sVariant not in s.getElementsByClass(Variant):
         raise VariantException(f'{sVariant} not found in stream {s}.')
 
-    if inPlace is True:
+    if inPlace:
         returnObject = s
         variantRegion = sVariant
     else:
@@ -1689,7 +1689,7 @@ def _mergeVariantMeasureStreamsCarefully(streamX, streamY, variantName, *, inPla
 
     '''
     # stream that will be returned
-    if inPlace is True:
+    if inPlace:
         returnObject = streamX
         variantObject = streamY
     else:
@@ -2057,7 +2057,7 @@ def _mergeVariants(streamA, streamB, *, variantName=None, inPlace=False):
             '_mergeVariants cannot merge streams which are of different lengths'
         )
 
-    if inPlace is True:
+    if inPlace:
         returnObj = streamA
     else:
         returnObj = copy.deepcopy(streamA)
@@ -2138,7 +2138,7 @@ def _mergeVariants(streamA, streamB, *, variantName=None, inPlace=False):
         inVariant = False
         noteBuffer = []
 
-    if inPlace is True:
+    if inPlace:
         return None
     else:
         return returnObj
@@ -2237,7 +2237,7 @@ def makeAllVariantsReplacements(streamWithVariants,
 
     '''
 
-    if inPlace is True:
+    if inPlace:
         returnStream = streamWithVariants
     else:
         returnStream = copy.deepcopy(streamWithVariants)
@@ -2249,7 +2249,7 @@ def makeAllVariantsReplacements(streamWithVariants,
         _doVariantFixingOnStream(returnStream, variantNames=variantNames)
 
 
-    if inPlace is True:
+    if inPlace:
         return
     else:
         return returnStream


### PR DESCRIPTION
Replaces `x is True` / `x is False` comparisons with plain truthiness tests across the codebase, plus a few incidental typing annotations and comment typo fixes.

Two of the rewrites were sign flips — `is not True` and `is not False` are negations, not truthiness tests — and are fixed in the second commit:

- `m21ToXml.noteToXml`: `d.isGrace is not True` → `d.isGrace` meant `<duration>` was written only for grace notes (where MusicXML forbids it) and omitted from every ordinary note, making all MusicXML output invalid. 13 tests caught this.
- `recording.samplesFromRecording`: `storeFile is not False` → `not storeFile` meant the wave file was written only when the caller asked for no file. Not covered by tests (`# pragma: no cover`).

Full suite passes (5298 tests), `ruff check` and `mypy` clean.

AI-assisted (Claude)