### PR TITLE
Tell a negative octave from a flat in removeRedundantPitches

### DIFF
--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -3625,24 +3625,28 @@ class Chord(ChordBase):
         <music21.chord.Chord C2 E3 G4 C5>
 
         Pitches with extreme octaves (whose `.nameWithOctave`s
-        look identical) are still distinguished.
-        
-        >>> p1 = pitch.Pitch('B')
-        >>> p1.octave = -1
+        look identical) are still distinguished.  B-flat in octave 1 and
+        B-natural in octave -1 both spell 'B-1', the '-' being the flat sign
+        in the one and the minus sign in the other:
+
+        >>> p1 = pitch.Pitch('B-')
+        >>> p1.octave = 1
         >>> p2 = pitch.Pitch('B')
-        >>> p2.octave = 1
+        >>> p2.octave = -1
+        >>> p1.nameWithOctave == p2.nameWithOctave
+        True
 
         >>> c3 = chord.Chord([p1, p2])
         >>> c3
         <music21.chord.Chord B-1 B-1>
-        
+
         >>> removedPitches = c3.removeRedundantPitches(inPlace=True)
         >>> removedPitches
         []
         >>> c3
         <music21.chord.Chord B-1 B-1>
         >>> [(p.name, p.octave) for p in c3.pitches]
-        [('B', -1), ('B', 1)]
+        [('B-', 1), ('B', -1)]
 
         A pitch with no octave of its own is likewise not the same pitch as
         one placed in the default octave:

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -964,17 +964,26 @@ class Chord(ChordBase):
         '''
         Common method for stripping pitches based on redundancy of one pitch
         attribute. The `attribute` is provided by a string.
+
+        `'nameWithOctave'` is a special case: the string it gives spells
+        B-flat in octave 1 and B-natural in octave -1 alike, so two pitches
+        are compared by their name and octave instead of by it.
         '''
         if not inPlace:  # make a copy
             returnObj = copy.deepcopy(self)
         else:
             returnObj = self
 
-        uniquePitches = []
+        uniquePitches: list[t.Any] = []
         deleteComponents = []
         for comp in returnObj._notes:
-            if getattr(comp.pitch, attribute) not in uniquePitches:
-                uniquePitches.append(getattr(comp.pitch, attribute))
+            if attribute == 'nameWithOctave':
+                value = (comp.pitch.name, comp.pitch.octave, comp.pitch.octaveIsImplicit)
+            else:
+                value = getattr(comp.pitch, attribute)
+
+            if value not in uniquePitches:
+                uniquePitches.append(value)
             else:
                 deleteComponents.append(comp)
 
@@ -3615,41 +3624,35 @@ class Chord(ChordBase):
         >>> c2c
         <music21.chord.Chord C2 E3 G4 C5>
 
-        It is a known bug that because pitch.nameWithOctave gives
-        the same value for B-flat in octave 1 as B-natural in octave
-        negative 1, negative octaves can screw up this method.
-        With all the things left to do for music21, it doesn't seem
-        a bug worth squashing at this moment, but FYI:
+        Two pitches count as the same when they have the same name in the same
+        octave. Note that this is a finer distinction than
+        :attr:`~music21.pitch.Pitch.nameWithOctave`, whose '-' is the flat sign
+        and the minus sign both: B-flat in octave 1 and B-natural in octave -1
+        are two different pitches that spell alike, and both are kept.
 
         >>> p1 = pitch.Pitch('B-')
         >>> p1.octave = 1
         >>> p2 = pitch.Pitch('B')
         >>> p2.octave = -1
-        >>> c3 = chord.Chord([p1, p2])
-        >>> removedPitches = c3.removeRedundantPitches(inPlace=True)
-        >>> c3.pitches
-        (<music21.pitch.Pitch B-1>,)
-
-        >>> c3.pitches[0].name
-        'B-'
-        >>> c3.pitches[0].octave
-        1
-        >>> removedPitches
-        [<music21.pitch.Pitch B-1>]
-        >>> removedPitches[0].name
-        'B'
-        >>> removedPitches[0].octave
-        -1
-
-        The first pitch survives:
-
-        >>> c3.pitches[0] is p1
+        >>> p1.nameWithOctave == p2.nameWithOctave
         True
 
-        >>> c3.pitches[0] is p2
-        False
+        >>> c3 = chord.Chord([p1, p2])
+        >>> c3.removeRedundantPitches(inPlace=True)
+        []
+        >>> [(p.name, p.octave) for p in c3.pitches]
+        [('B-', 1), ('B', -1)]
+
+        A pitch with no octave of its own is likewise not the same pitch as
+        one placed in the default octave:
+
+        >>> c4 = chord.Chord([pitch.Pitch('C'), pitch.Pitch('C4')])
+        >>> c4.removeRedundantPitches()
+        <music21.chord.Chord C C4>
 
         * Changed in v6: inPlace defaults to False.
+        * Changed in v11: a negative octave is no longer read as a flat, so
+          B-natural in octave -1 survives beside B-flat in octave 1.
         '''
         return self._removePitchByRedundantAttribute('nameWithOctave',
                                                      inPlace=inPlace)

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -3625,14 +3625,12 @@ class Chord(ChordBase):
         <music21.chord.Chord C2 E3 G4 C5>
 
         Pitches with extreme octaves (whose `.nameWithOctave`s
-        look identical) are still distinguished.  B-flat in octave 1 and
-        B-natural in octave -1 both spell 'B-1', the '-' being the flat sign
-        in the one and the minus sign in the other:
+        look identical) are still distinguished.
 
-        >>> p1 = pitch.Pitch('B-')
-        >>> p1.octave = 1
-        >>> p2 = pitch.Pitch('B')
-        >>> p2.octave = -1
+        >>> p1 = pitch.Pitch('B')
+        >>> p1.octave = -1
+        >>> p2 = pitch.Pitch('B-')
+        >>> p2.octave = 1
         >>> p1.nameWithOctave == p2.nameWithOctave
         True
 
@@ -3646,7 +3644,7 @@ class Chord(ChordBase):
         >>> c3
         <music21.chord.Chord B-1 B-1>
         >>> [(p.name, p.octave) for p in c3.pitches]
-        [('B-', 1), ('B', -1)]
+        [('B', -1), ('B-', 1)]
 
         A pitch with no octave of its own is likewise not the same pitch as
         one placed in the default octave:

--- a/music21/chord/__init__.py
+++ b/music21/chord/__init__.py
@@ -965,25 +965,25 @@ class Chord(ChordBase):
         Common method for stripping pitches based on redundancy of one pitch
         attribute. The `attribute` is provided by a string.
 
-        `'nameWithOctave'` is a special case: the string it gives spells
-        B-flat in octave 1 and B-natural in octave -1 alike, so two pitches
-        are compared by their name and octave instead of by it.
+        attribute `'nameWithOctave'` uses a special case to make comparisons with
+        negative octaves work properly
         '''
         if not inPlace:  # make a copy
             returnObj = copy.deepcopy(self)
         else:
             returnObj = self
 
-        uniquePitches: list[t.Any] = []
+        uniquePitches: set[t.Any] = set()
         deleteComponents = []
         for comp in returnObj._notes:
             if attribute == 'nameWithOctave':
+                # for comparing with negative octaves etc.
                 value = (comp.pitch.name, comp.pitch.octave, comp.pitch.octaveIsImplicit)
             else:
                 value = getattr(comp.pitch, attribute)
 
             if value not in uniquePitches:
-                uniquePitches.append(value)
+                uniquePitches.add(value)
             else:
                 deleteComponents.append(comp)
 
@@ -3624,24 +3624,25 @@ class Chord(ChordBase):
         >>> c2c
         <music21.chord.Chord C2 E3 G4 C5>
 
-        Two pitches count as the same when they have the same name in the same
-        octave. Note that this is a finer distinction than
-        :attr:`~music21.pitch.Pitch.nameWithOctave`, whose '-' is the flat sign
-        and the minus sign both: B-flat in octave 1 and B-natural in octave -1
-        are two different pitches that spell alike, and both are kept.
-
-        >>> p1 = pitch.Pitch('B-')
-        >>> p1.octave = 1
+        Pitches with extreme octaves (whose `.nameWithOctave`s
+        look identical) are still distinguished.
+        
+        >>> p1 = pitch.Pitch('B')
+        >>> p1.octave = -1
         >>> p2 = pitch.Pitch('B')
-        >>> p2.octave = -1
-        >>> p1.nameWithOctave == p2.nameWithOctave
-        True
+        >>> p2.octave = 1
 
         >>> c3 = chord.Chord([p1, p2])
-        >>> c3.removeRedundantPitches(inPlace=True)
+        >>> c3
+        <music21.chord.Chord B-1 B-1>
+        
+        >>> removedPitches = c3.removeRedundantPitches(inPlace=True)
+        >>> removedPitches
         []
+        >>> c3
+        <music21.chord.Chord B-1 B-1>
         >>> [(p.name, p.octave) for p in c3.pitches]
-        [('B-', 1), ('B', -1)]
+        [('B', -1), ('B', 1)]
 
         A pitch with no octave of its own is likewise not the same pitch as
         one placed in the default octave:
@@ -3651,8 +3652,7 @@ class Chord(ChordBase):
         <music21.chord.Chord C C4>
 
         * Changed in v6: inPlace defaults to False.
-        * Changed in v11: a negative octave is no longer read as a flat, so
-          B-natural in octave -1 survives beside B-flat in octave 1.
+        * Changed in v11: works properly with negative octaves
         '''
         return self._removePitchByRedundantAttribute('nameWithOctave',
                                                      inPlace=inPlace)

--- a/music21/test/test_chord.py
+++ b/music21/test/test_chord.py
@@ -739,6 +739,34 @@ class Test(unittest.TestCase):
             # noinspection PyTypeChecker
             Chord([note.Unpitched()])  # type: ignore
 
+    def testRemoveRedundantPitchesTellsNegativeOctavesFromFlats(self):
+        '''
+        nameWithOctave spells both B-flat in octave 1 and B-natural in
+        octave -1 as 'B-1', so comparing pitches by that string made the
+        second look like a repeat of the first.
+        '''
+        flat = pitch.Pitch('B-')
+        flat.octave = 1
+        natural = pitch.Pitch('B')
+        natural.octave = -1
+        self.assertEqual(flat.nameWithOctave, natural.nameWithOctave)
+
+        ch = Chord([flat, natural])
+        self.assertEqual(ch.removeRedundantPitches(inPlace=True), [])
+        self.assertEqual([(p.name, p.octave) for p in ch.pitches],
+                         [('B-', 1), ('B', -1)])
+
+        # a real repeat still goes, whatever octave it is in
+        repeated = Chord([flat, natural, pitch.Pitch('B-1')])
+        removed = repeated.removeRedundantPitches(inPlace=True)
+        self.assertEqual([p.nameWithOctave for p in removed], ['B-1'])
+        self.assertEqual(len(repeated.pitches), 2)
+
+        # and a pitch with no octave is not the one in the default octave
+        octaveless = Chord([pitch.Pitch('C'), pitch.Pitch('C4')])
+        self.assertEqual(octaveless.removeRedundantPitches(inPlace=True), [])
+        self.assertEqual(len(octaveless.pitches), 2)
+
     def testCacheClearedOnAdd(self):
         ch = chord.Chord('C4 E4 G4')
         self.assertTrue(ch.isConsonant())


### PR DESCRIPTION
`Pitch.nameWithOctave` spells both B-flat in octave 1 and B-natural in octave -1 as `'B-1'`, because the `'-'` is the flat sign and the minus sign both. `removeRedundantPitches` compared pitches by that string, so the second read as a repeat of the first and was thrown away.

Revised after review: `_removePitchByRedundantAttribute` now has the special knowledge of `'nameWithOctave'` itself and compares by name and octave in its place. Its signature is unchanged, no tuple form is exposed, and both call sites and the pitch-class and pitch-name reductions are exactly as they were.

While rewriting it I noticed the earlier version had a second problem, so this one also pins it: the octave is compared together with `octaveIsImplicit`, so a pitch given no octave stays distinct from one placed in the default octave. `nameWithOctave` already made that distinction (`'C'` against `'C4'`), and since v11 `Pitch.octave` returns 4 for both, comparing the octave alone would have quietly merged them. There is a doctest and a test case for it.

The docstring documented the old behaviour as a known bug ("doesn't seem a bug worth squashing at this moment"); it now documents what the method does, and `test_chord` carries a regression test.
