### PR TITLE
Hand back a new pitch from getPitchFromNodeDegree

### DIFF
--- a/music21/scale/__init__.py
+++ b/music21/scale/__init__.py
@@ -557,7 +557,7 @@ class AbstractScale(Scale):
             alteredDegrees=self._alteredDegrees,
             equateTermini=equateTermini
         )
-        return copy.deepcopy(post)
+        return post
 
     def realizePitchByDegree(self,
                              pitchReference: _PitchOrStr,
@@ -654,7 +654,7 @@ class AbstractScale(Scale):
             maxPitch=maxPitch,
             alteredDegrees=self._alteredDegrees
         )
-        return copy.deepcopy(post)
+        return post
 
     # --------------------------------------------------------------------------
 

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -2707,15 +2707,19 @@ class IntervalNetwork:
                 # environLocal.printDebug(['comparing', realizedNId,
                 #   'nodeTargetId', nodeTargetId])
 
+                # Return a new object: the realization this pitch came out of
+                # may be held in _ascendingCache or _descendingCache, and a
+                # caller that writes to the pitch -- nextPitch() sets its
+                # octave -- would edit the cached scale itself.
                 if realizedNId == nodeTargetId.id:
-                    return realizedPitch[i]
+                    return copy.deepcopy(realizedPitch[i])
                 # NOTE: this condition may be too generous, and was added to solve
                 # a non-tracked problem.
                 # only match this generously if we are equating termini
                 if equateTermini:
                     if ((realizedNId in (Terminus.HIGH, Terminus.LOW))
                             and (nodeTargetId.id in (Terminus.HIGH, Terminus.LOW))):
-                        return realizedPitch[i]
+                        return copy.deepcopy(realizedPitch[i])
 
             # environLocal.printDebug(['getPitchFromNodeDegree() on trial', trial, ',
             #    failed to find node', nodeTargetId])

--- a/music21/scale/intervalNetwork.py
+++ b/music21/scale/intervalNetwork.py
@@ -2707,10 +2707,7 @@ class IntervalNetwork:
                 # environLocal.printDebug(['comparing', realizedNId,
                 #   'nodeTargetId', nodeTargetId])
 
-                # Return a new object: the realization this pitch came out of
-                # may be held in _ascendingCache or _descendingCache, and a
-                # caller that writes to the pitch -- nextPitch() sets its
-                # octave -- would edit the cached scale itself.
+                # realizedPitch may be a cached realization: hand back a copy
                 if realizedNId == nodeTargetId.id:
                     return copy.deepcopy(realizedPitch[i])
                 # NOTE: this condition may be too generous, and was added to solve

--- a/music21/scale/test_intervalNetwork.py
+++ b/music21/scale/test_intervalNetwork.py
@@ -627,6 +627,33 @@ class Test(unittest.TestCase):
         self.assertEqual(descending_melodic_minor_reversed[0].nameWithOctave, 'C4')  # was B-4
         self.assertEqual(descending_melodic_minor_reversed[-1].nameWithOctave, 'B-4')  # was C4
 
+    def test_get_pitch_from_node_degree_returns_a_new_pitch(self):
+        '''
+        A realization may be held in _ascendingCache or _descendingCache, so
+        the pitch taken out of one has to be the caller's own -- otherwise
+        writing to it edits the cached scale.
+        '''
+        net = IntervalNetwork()
+        net.fillBiDirectedEdges(['M2', 'M2', 'm2', 'M2', 'M2', 'M2', 'm2'])
+
+        first = net.getPitchFromNodeDegree('c4', 1, 1)
+        self.assertEqual(first.nameWithOctave, 'C4')
+        first.octave = 1
+
+        again = net.getPitchFromNodeDegree('c4', 1, 1)
+        self.assertEqual(again.nameWithOctave, 'C4')
+
+    def test_next_pitch_does_not_move_a_cached_degree(self):
+        '''
+        nextPitch() writes the origin's octave onto the pitch it gets back
+        from getPitchFromNodeDegree(), so walking the scale down near C1 used
+        to leave the tonic reading C1 ever after.
+        '''
+        sc = scale.RagAsawari('c4')
+        self.assertEqual(str(sc.pitchFromDegree(1)), 'C4')
+        self.assertEqual(str(sc.nextPitch('c1', Direction.ASCENDING)), 'D1')
+        self.assertEqual(str(sc.pitchFromDegree(1)), 'C4')
+
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/music21/scale/test_intervalNetwork.py
+++ b/music21/scale/test_intervalNetwork.py
@@ -644,11 +644,6 @@ class Test(unittest.TestCase):
         self.assertEqual(again.nameWithOctave, 'C4')
 
     def test_next_pitch_does_not_move_a_cached_degree(self):
-        '''
-        nextPitch() writes the origin's octave onto the pitch it gets back
-        from getPitchFromNodeDegree(), so walking the scale down near C1 used
-        to leave the tonic reading C1 ever after.
-        '''
         sc = scale.RagAsawari('c4')
         self.assertEqual(str(sc.pitchFromDegree(1)), 'C4')
         self.assertEqual(str(sc.nextPitch('c1', Direction.ASCENDING)), 'D1')

--- a/music21/scale/test_scale_main.py
+++ b/music21/scale/test_scale_main.py
@@ -456,7 +456,10 @@ class Test(unittest.TestCase):
                                           getNeighbor=Direction.DESCENDING)),
                          'F1')
 
-        self.assertEqual(str(sc.pitchFromDegree(1)), 'C1')
+        # the tonic, whatever has been asked for in between: walking the
+        # scale near another octave used to move it, since nextPitch() was
+        # writing an octave onto a pitch of the cached realization.
+        self.assertEqual(str(sc.pitchFromDegree(1)), 'C4')
         # there is no third step in ascending form
         self.assertEqual(str(sc.pitchFromDegree(3)), 'None')
         self.assertEqual(str(sc.pitchFromDegree(3, direction=Direction.DESCENDING)),

--- a/music21/scale/test_scale_main.py
+++ b/music21/scale/test_scale_main.py
@@ -456,9 +456,6 @@ class Test(unittest.TestCase):
                                           getNeighbor=Direction.DESCENDING)),
                          'F1')
 
-        # the tonic, whatever has been asked for in between: walking the
-        # scale near another octave used to move it, since nextPitch() was
-        # writing an octave onto a pitch of the cached realization.
         self.assertEqual(str(sc.pitchFromDegree(1)), 'C4')
         # there is no third step in ascending form
         self.assertEqual(str(sc.pitchFromDegree(3)), 'None')


### PR DESCRIPTION
realizeAscending() and realizeDescending() return the very list they put in _ascendingCache / _descendingCache, so the pitches inside it belong to the cache. getPitchFromNodeDegree() handed one of those pitches straight back, and nextPitch() writes the origin's octave onto the pitch it gets ("transfer octave from origin to new pitch derived from node"), so it was editing the cached realization in place.

The effect is that a scale answers differently depending on what has been asked of it before:

    >>> sc = scale.RagAsawari('c4')
    >>> str(sc.pitchFromDegree(1))
    'C4'
    >>> str(sc.nextPitch('c1', scale.Direction.ASCENDING))
    'D1'
    >>> str(sc.pitchFromDegree(1))
    'C1'

The cached entry for ('C4', 'C4', 'C5') has its first pitch moved from C4 to C1 by the walk near C1, and every later reader of that realization sees it. realize() already guards the list against this ("Make new objects, because this value might be cached ... and mutating it would be dangerous"); this is the same hazard one level down, on the pitches.

test_scale_main.testRagAsawari asserted the corrupted 'C1'. It asserts 'C4' now, which is what the same call returns earlier in that very test.