### PR TITLE
Cut down on Spammy-AI requests, find good new contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+<!-- What does this PR do, in a line or two? Reference the issue it addresses, if any. -->
+
+<!-- Pull requests created primarily with AI must be declared with (AI) or
+     (AI Generated) in the title. See CONTRIBUTING.md. -->
+
+<!-- If this is your first PR, an automated check of your account credentials will be
+     run and if there are any issues this will be posted publicly as a comment below. -->

--- a/.github/workflows/profile_contributors.yml
+++ b/.github/workflows/profile_contributors.yml
@@ -1,0 +1,74 @@
+# Profile the author of a PR from someone with no merged PR here yet, and comment
+# only when gh-profiler raises a yellow or red flag.
+#
+# gh-profiler is by Eric Matthes: https://github.com/ehmatthes/gh-profiler
+
+name: profile_contributors
+
+on:
+    # Never checks out or runs PR code; it reads the author's login and comments.
+    pull_request_target:
+        types: [opened]
+
+permissions:
+    pull-requests: write
+
+jobs:
+    profile:
+        # Dependabot and friends do not need profiling.
+        if: github.event.pull_request.user.type != 'Bot'
+        runs-on: ubuntu-latest
+        steps:
+        - name: Check whether contributor has a previously merged PR
+          id: previous
+          env:
+              GH_TOKEN: ${{ github.token }}
+              AUTHOR: ${{ github.event.pull_request.user.login }}
+              REPO: ${{ github.repository }}
+          run: |
+              count="$(gh pr list --repo "$REPO" --author "$AUTHOR" \
+                  --state merged --limit 1 --json number --jq 'length')"
+              echo "count=$count" >> "$GITHUB_OUTPUT"
+
+        - name: Install uv
+          if: steps.previous.outputs.count == '0'
+          uses: astral-sh/setup-uv@v7
+
+        - name: Profile contributor
+          if: steps.previous.outputs.count == '0'
+          id: profile
+          env:
+              GH_TOKEN: ${{ github.token }}
+              AUTHOR: ${{ github.event.pull_request.user.login }}
+          run: |
+              uvx gh-profiler==0.9.0 "$AUTHOR" --concise | tee profile.txt
+              echo '===================== Full profile ====================='
+              uvx gh-profiler==0.9.0 "$AUTHOR"
+
+              # A yellow on the profile section alone means only that the account is
+              # newish or has empty bio fields, which is not worth a public comment.
+              concern=false
+              if grep -q '🔴' profile.txt; then
+                  concern=true
+              elif grep -e 'recent PR activity' -e 'recent issue activity' profile.txt \
+                      | grep -q '🟡'; then
+                  concern=true
+              fi
+              echo "concern=$concern" >> "$GITHUB_OUTPUT"
+
+        - name: Comment on PR
+          if: steps.previous.outputs.count == '0' && steps.profile.outputs.concern == 'true'
+          env:
+              GH_TOKEN: ${{ github.token }}
+              PR: ${{ github.event.pull_request.number }}
+          run: |
+              {
+                  echo 'Contributor profile ([gh-profiler](https://github.com/ehmatthes/gh-profiler));'
+                  echo 'the full report is in this workflow'"'"'s log.'
+                  echo
+                  echo '```text'
+                  cat profile.txt
+                  echo '```'
+              } > comment.txt
+
+              gh pr comment "$PR" --body-file comment.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,11 @@
   branch such as `m21_9`. When a CI check fails but passes locally, "is my branch behind
   `master`?" should be one of the first things to check: fetch and merge `master`, then the
   newer types/code on `master` will reproduce the failure locally.
+- The issue and PR templates in `.github/` are requirements, not suggestions. Read and follow
+  them even when opening through the API or `gh`, which do not fill them in for you. An issue
+  or PR that ignores the template may be closed without comment.
+- A PR from an account with no merged PR here is profiled automatically, and anything flagged
+  is posted publicly as a comment on the PR.
 - All PRs and Issues that use AI to be declared AI-assisted. Just write "AI-assisted (Claude)" with short name of Agent replacing "Claude". No robot emoji under any circumstance.
 - 20 or more lines of code written by an agent needs to be declared as AI-assisted in the docstring.  
   Humans can remove and should remove this note when they do a review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,14 @@ In 2026 we welcome AI-Assisted contributions, but users must take responsibility
 they must match the code-style of the rest of the music21 project. "Slop that works somehow" will
 not be accepted.
 
+When opening an issue or pull request in Github, templates will appear to guide you in making
+the request.  If you are opening in a different way, like through an agent tool, those
+templates may not appear -- be sure your agent is reading them in `.github/` anyhow, since
+they are required to be used. Thanks!
+
+If this is your first PR, an automated check of your account credentials will be run and if
+there are any issues this will be posted publicly as a comment on the PR.
+
 ## Resources ##
 
 [Module Documentation and User's Guide](https://www.music21.org/music21docs/)


### PR DESCRIPTION
This repo, like many, has seen a big rise in first-time contributors.  Most are GREAT! and we're moving faster than in years.  But many are slop contributions; drive-by "i hope this works" etc.

Add a check for new contributors to see if there are problems with accounts.  Add disclosures that this will happen (since there doesn't seem to be an easy way to make the check results private).  Add info about templates being required.